### PR TITLE
EGO Weapon disappearing no more !

### DIFF
--- a/code/modules/mob/living/carbon/death.dm
+++ b/code/modules/mob/living/carbon/death.dm
@@ -21,7 +21,7 @@
 	M.Scale(1.8, 1.2)
 	animate(src, time = 40, transform = M, easing = SINE_EASING)
 
-/mob/living/carbon/gib(no_brain, no_organs, no_bodyparts, safe_gib = FALSE)
+/mob/living/carbon/gib(no_brain, no_organs, no_bodyparts, safe_gib = TRUE)
 	if(safe_gib) // If you want to keep all the mob's items and not have them deleted
 		for(var/obj/item/W in src)
 			dropItemToGround(W)


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Set safe_gib to True 
When on True
![Capture d’écran 2022-07-20 110329](https://user-images.githubusercontent.com/82665345/179944773-e1f555f1-0008-4163-b361-a7655c188ab4.png)
When on False 
![image](https://user-images.githubusercontent.com/82665345/179945596-234ed179-6384-41b8-9b2e-ed3963a2f568.png)


## Why It's Good For The Game

Ego weapons are already hard to come by due to a lot of circumstances (Lack of PE boxes, High pop, Gibbing(people store their weapons in backpacks), So deleting gibbing from this list would help a lot !

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Unoki
balance: Death by gibbing doesn't delete backpack.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
