### PR TITLE
[DNM]100% More lore accurate (Removes black people and Gender)

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -140,18 +140,7 @@
 	return pick(GLOB.skin_tones)
 
 GLOBAL_LIST_INIT(skin_tones, sortList(list(
-	"albino",
-	"caucasian1",
-	"caucasian2",
-	"caucasian3",
-	"latino",
-	"mediterranean",
-	"asian1",
-	"asian2",
-	"arab",
-	"indian",
-	"african1",
-	"african2"
+	"caucasian1"
 	)))
 
 GLOBAL_LIST_EMPTY(species_list)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -20,7 +20,8 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 	var/default_color = "#FFF"
 
 	///Whether or not the race has sexual characteristics (biological genders). At the moment this is only FALSE for skeletons and shadows
-	var/sexes = TRUE
+	var/sexes = FALSE
+	//No more gender for humans
 
 	///Clothing offsets. If a species has a different body than other species, you can offset clothing so they look less weird.
 	var/list/offset_features = list(OFFSET_UNIFORM = list(0,0), OFFSET_ID = list(0,0), OFFSET_GLOVES = list(0,0), OFFSET_GLASSES = list(0,0), OFFSET_EARS = list(0,0), OFFSET_SHOES = list(0,0), OFFSET_S_STORE = list(0,0), OFFSET_FACEMASK = list(0,0), OFFSET_HEAD = list(0,0), OFFSET_FACE = list(0,0), OFFSET_BELT = list(0,0), OFFSET_BACK = list(0,0), OFFSET_SUIT = list(0,0), OFFSET_NECK = list(0,0))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
![image](https://user-images.githubusercontent.com/77302679/180609745-35777853-f3e2-4242-b87f-248b0f0710f7.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
People keep asking me to be 100% more lore accurate.

I'm fucking sick of it.
I'm sick of these fucking jokers thinking that just because everything is extremely accurate makes it good.
Shut up. Shut the fuck up.
It's almost as if every single time we tried to be more lore accurate, it failed, and is not fun.

See - Rabbit test.
See - TSO taking every single one of your boxes

Literally shut the fuck up.
I hate these fucking people that don't know a thing about game design trying to tell me to just make everything 100% as it is in the game and lore accurate, when that would make a significantly worse game.


So you know what? I'm going to make a fucking point.
This PR is going up, everyone can read my schizo ramblings because some random fucking guy on the discord thinks it's a good idea.

Do Not Merge.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Removed black people
del: Removed male and female
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
