### PR TITLE
Rabbit hud + Mindshield 

### DIFF
--- a/code/modules/clothing/outfits/ert.dm
+++ b/code/modules/clothing/outfits/ert.dm
@@ -6,6 +6,8 @@
 	shoes = /obj/item/clothing/shoes/combat/swat
 	gloves = /obj/item/clothing/gloves/combat
 	ears = /obj/item/radio/headset/headset_cent/alt
+	implants = list(/obj/item/implant/mindshield/implant)
+	implants = list(/obj/item/organ/cyberimp/eyes/hud/security)
 
 /datum/outfit/centcom/ert/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	if(visualsOnly)
@@ -447,7 +449,7 @@
 
 	suit = /obj/item/clothing/suit/space/hardsuit/rabbit/leader
 	suit_store = /obj/item/gun/energy/e_gun/rabbit
-	glasses = /obj/item/clothing/glasses/night
+	glasses = /obj/item/clothing/glasses/hud/health/night
 	back = /obj/item/storage/backpack/ert
 	belt = /obj/item/storage/belt/security/full
 	backpack_contents = list(/obj/item/storage/box/survival/engineer=1)
@@ -466,7 +468,7 @@
 	name = "Rabbit Team"
 	suit = /obj/item/clothing/suit/space/hardsuit/rabbit
 	suit_store = /obj/item/gun/energy/e_gun/rabbit
-	glasses = /obj/item/clothing/glasses/night
+	glasses = /obj/item/clothing/glasses/hud/health/night
 	l_pocket = /obj/item/ego_weapon/rabbit_blade
 	r_pocket = /obj/item/melee/classic_baton/telescopic
 	belt = /obj/item/storage/belt/security/full

--- a/code/modules/clothing/outfits/ert.dm
+++ b/code/modules/clothing/outfits/ert.dm
@@ -6,8 +6,7 @@
 	shoes = /obj/item/clothing/shoes/combat/swat
 	gloves = /obj/item/clothing/gloves/combat
 	ears = /obj/item/radio/headset/headset_cent/alt
-	implants = list(/obj/item/implant/mindshield/implant)
-	implants = list(/obj/item/organ/cyberimp/eyes/hud/security)
+	implants = list(/obj/item/implant/mindshield, /obj/item/organ/cyberimp/eyes/hud/security)
 
 /datum/outfit/centcom/ert/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	if(visualsOnly)

--- a/code/modules/projectiles/guns/energy/energy_gun.dm
+++ b/code/modules/projectiles/guns/energy/energy_gun.dm
@@ -160,6 +160,7 @@
 		)
 	can_charge = FALSE
 	weapon_weight = WEAPON_HEAVY // No dual wielding
+	pin = /obj/item/firing_pin/implant/mindshield
 
 /obj/item/gun/energy/e_gun/rabbit/Initialize()
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Rabbit get a sec hud implant+mindshield implant.
Medhud nightvision
Rabbit gun now use a mindshield pin.

![image](https://user-images.githubusercontent.com/82665345/180617487-be8746f1-8f94-44cc-ba53-374786fbfdcc.png)


## Why It's Good For The Game

LC employees shouldn't get as powerfull of a weapon that is rabbit gun.
Sec/med hud  are better  to see who is who and seing if you are going to win or die.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Unoki
tweak: Gave rabbit sec/med hud.
balance: Mindshield pin for Rabbit gun
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
