### PR TITLE
[READY] Extraction Officer Hud+Tablet, Agent Captain Tablete removal, Suit sensors to maximum by default.

### DIFF
--- a/code/modules/clothing/under/_under.dm
+++ b/code/modules/clothing/under/_under.dm
@@ -11,9 +11,9 @@
 	pickup_sound =  'sound/items/handling/cloth_pickup.ogg'
 	limb_integrity = 30
 	var/fitted = FEMALE_UNIFORM_FULL // For use in alternate clothing styles for women
-	var/has_sensor = HAS_SENSORS // For the crew computer
+	var/has_sensor = LOCKED_SENSORS // For the crew computer
 	var/random_sensor = TRUE
-	var/sensor_mode = NO_SENSORS
+	var/sensor_mode = SENSOR_COORDS
 	var/can_adjust = TRUE
 	var/adjusted = NORMAL_STYLE
 	var/alt_covers_chest = FALSE // for adjusted/rolled-down jumpsuits, FALSE = exposes chest and arms, TRUE = exposes arms only
@@ -56,7 +56,7 @@
 	. = ..()
 	if(random_sensor)
 		//make the sensor mode favor higher levels, except coords.
-		sensor_mode = pick(SENSOR_OFF, SENSOR_LIVING, SENSOR_LIVING, SENSOR_VITALS, SENSOR_VITALS, SENSOR_VITALS, SENSOR_COORDS, SENSOR_COORDS)
+		sensor_mode = SENSOR_COORDS
 
 /obj/item/clothing/under/emp_act()
 	. = ..()

--- a/code/modules/jobs/job_types/agent.dm
+++ b/code/modules/jobs/job_types/agent.dm
@@ -87,4 +87,3 @@
 	jobtype = /datum/job/agent/captain
 	head = /obj/item/clothing/head/hos/beret
 	ears = /obj/item/radio/headset/heads/hos/alt
-	r_pocket = /obj/item/modular_computer/tablet/preset/advanced/command

--- a/code/modules/jobs/job_types/command.dm
+++ b/code/modules/jobs/job_types/command.dm
@@ -35,3 +35,5 @@
 	backpack_contents = list(/obj/item/melee/classic_baton=1)
 	shoes = /obj/item/clothing/shoes/laceup
 	gloves = /obj/item/clothing/gloves/color/black
+	r_pocket = /obj/item/modular_computer/tablet/preset/advanced/command
+	implants = list(/obj/item/organ/cyberimp/eyes/hud/security)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Give Extraction officer hud+tablete
Agent Captain Tablete removed 
Suit sensors to maximum by default


## Why It's Good For The Game
They are command they should have those...
Only command should get tablets
Suit sensors to maximum by default(We don't have any antags)
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Unoki
add: Sechud for Extraction Officer/Tablete
tweak: Suit sensors to max.
/:cl: