### PR TITLE
Fix blue star sprite not showing

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/aleph/blue_star.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/blue_star.dm
@@ -8,8 +8,8 @@
 	pixel_y = -16
 	base_pixel_y = -16
 	icon = 'ModularTegustation/Teguicons/96x96.dmi'
-	icon_state = "bluestar"
-	icon_living = "bluestar"
+	icon_state = "blue_star"
+	icon_living = "blue_star"
 	damage_coeff = list(BRUTE = 1, RED_DAMAGE = 0.4, WHITE_DAMAGE = 0.2, BLACK_DAMAGE = 0.8, PALE_DAMAGE = 0.1)
 	is_flying_animal = TRUE
 	can_breach = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Bug fix of blue star sprite not showing
Before
![image](https://user-images.githubusercontent.com/82665345/180988853-a5ded596-82eb-464d-9608-4742b28a66f8.png)
Now
![image](https://user-images.githubusercontent.com/82665345/180988902-94fce142-c2ae-49bc-be2c-2f2fd3e6e1ed.png)
## Why It's Good For The Game
We need to see those legs
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Unoki
fix : Blue star sprite not showing
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
