### PR TITLE
Sleeper tweak, pistol buff [BETACORP HOTFIXES]

### DIFF
--- a/_maps/map_files/Beta/betacorp.dmm
+++ b/_maps/map_files/Beta/betacorp.dmm
@@ -220,13 +220,9 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/item/paper/guides/jobs/zayin/guide/wellcheers,
+/obj/item/storage/box/drinkingglasses,
 /turf/open/floor/carpet/royalblue,
 /area/department_main/welfare)
-"bm" = (
-/obj/structure/table/wood,
-/turf/open/floor/carpet/orange,
-/area/department_main/training)
 "bn" = (
 /obj/effect/turf_decal/siding/red{
 	dir = 6
@@ -335,15 +331,6 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/showroomfloor,
 /area/department_main/safety)
-"cd" = (
-/obj/effect/turf_decal/siding/yellow{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/facility_hallway/north)
 "ch" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -414,6 +401,10 @@
 /obj/machinery/medical_kiosk,
 /turf/open/floor/carpet/green,
 /area/department_main/safety)
+"cC" = (
+/obj/machinery/telecomms/server/presets/engineering,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/department_main/information)
 "cP" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#3234B9";
@@ -459,6 +450,9 @@
 /area/department_main/control)
 "db" = (
 /obj/structure/closet/crate/freezer/surplus_limbs,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/carpet/purple,
 /area/department_main/information)
 "de" = (
@@ -562,7 +556,7 @@
 	id = "managerlockdown";
 	name = "Manager's Office Lockdown Blast Door"
 	},
-/turf/open/floor/wood,
+/turf/open/floor/plating,
 /area/department_main/control)
 "dQ" = (
 /obj/structure/mirror{
@@ -602,6 +596,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/facility_hallway/north)
+"ei" = (
+/obj/machinery/telecomms/processor/preset_two,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/department_main/control)
 "ej" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -736,6 +734,10 @@
 /obj/effect/turf_decal/siding/green,
 /turf/open/floor/plasteel,
 /area/facility_hallway/north)
+"eU" = (
+/obj/machinery/ntnet_relay,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/department_main/information)
 "eV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -764,6 +766,10 @@
 /obj/item/storage/box/masks,
 /turf/open/floor/carpet/green,
 /area/department_main/safety)
+"fd" = (
+/obj/machinery/telecomms/processor/preset_one,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/department_main/control)
 "ff" = (
 /obj/effect/spawner/abnormality_room,
 /turf/closed/indestructible/reinforced,
@@ -814,6 +820,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/department_main/welfare)
+"fx" = (
+/obj/machinery/telecomms/broadcaster/preset_left,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/department_main/control)
 "fy" = (
 /obj/effect/turf_decal/siding/green{
 	dir = 8
@@ -841,7 +851,6 @@
 /obj/structure/closet/secure_closet/personal{
 	anchored = 1
 	},
-/obj/item/toy/plush/netzach,
 /turf/open/floor/plasteel/dark,
 /area/department_main/safety)
 "fL" = (
@@ -892,16 +901,20 @@
 	dir = 1
 	},
 /obj/machinery/computer/shuttle/mining{
-	dir = 4;
 	name = "elevator console";
+	shuttleId = "manager";
 	possible_destinations = "elevator_home;elevator_away";
-	shuttleId = "manager"
+	dir = 4
 	},
 /obj/machinery/light{
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "managerlockdown";
+	name = "Manager's Office Lockdown Blast Door"
 	},
 /turf/open/floor/wood,
 /area/department_main/control)
@@ -916,7 +929,7 @@
 /area/department_main/safety)
 "gx" = (
 /obj/effect/landmark/xeno_spawn,
-/obj/structure/disposalpipe/junction/flip,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/facility_hallway/north)
 "gA" = (
@@ -977,7 +990,6 @@
 /obj/structure/closet/secure_closet/personal{
 	anchored = 1
 	},
-/obj/item/toy/plush/netzach,
 /turf/open/floor/plasteel/dark,
 /area/department_main/safety)
 "gI" = (
@@ -1026,6 +1038,10 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/caution/stand_clear,
+/obj/machinery/door/poddoor/preopen{
+	id = "managerlockdown";
+	name = "Manager's Office Lockdown Blast Door"
+	},
 /turf/open/floor/wood,
 /area/department_main/control)
 "hf" = (
@@ -1102,9 +1118,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/facility_hallway/north)
+"hG" = (
+/obj/machinery/telecomms/server/presets/command,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/department_main/control)
 "hI" = (
 /obj/structure/table/wood,
-/obj/item/paper/guides/jobs/teth/guide/spiderbud,
+/obj/item/book/random{
+	pixel_x = 4
+	},
 /turf/open/floor/carpet/orange,
 /area/department_main/training)
 "hJ" = (
@@ -1186,7 +1208,6 @@
 /obj/structure/closet/secure_closet/personal{
 	anchored = 1
 	},
-/obj/item/toy/plush/netzach,
 /turf/open/floor/plasteel/dark,
 /area/department_main/safety)
 "ia" = (
@@ -1285,6 +1306,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/door/poddoor/preopen{
+	id = "managerlockdown";
+	name = "Manager's Office Lockdown Blast Door"
+	},
 /turf/open/floor/wood,
 /area/department_main/control)
 "iX" = (
@@ -1364,10 +1389,8 @@
 /turf/open/floor/carpet/orange,
 /area/department_main/training)
 "jw" = (
-/obj/machinery/announcement_system,
-/obj/effect/turf_decal/bot,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/solarpanel,
+/obj/machinery/telecomms/processor/preset_three,
+/turf/open/floor/circuit/telecomms/mainframe,
 /area/department_main/information)
 "jx" = (
 /obj/effect/turf_decal/siding/red{
@@ -1385,6 +1408,10 @@
 	},
 /turf/open/floor/carpet/stellar,
 /area/department_main/command)
+"jD" = (
+/obj/machinery/telecomms/receiver/preset_right,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/department_main/control)
 "jE" = (
 /obj/effect/turf_decal/siding/yellow,
 /obj/structure/disposalpipe/segment,
@@ -1626,11 +1653,6 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/department_main/discipline)
-"lg" = (
-/obj/structure/table/wood,
-/obj/item/paper/guides/jobs/teth/lore,
-/turf/open/floor/carpet/orange,
-/area/department_main/training)
 "lh" = (
 /obj/machinery/aug_manipulator,
 /turf/open/floor/carpet/purple,
@@ -1812,6 +1834,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/facility_hallway/discipline)
+"lV" = (
+/obj/structure/reagent_dispensers/water_cooler,
+/turf/open/floor/carpet/orange,
+/area/department_main/training)
+"lW" = (
+/obj/machinery/telecomms/broadcaster/preset_right,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/department_main/control)
 "mc" = (
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/effect/turf_decal/tile/blue{
@@ -1830,7 +1860,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/bot,
-/obj/item/toy/plush/chesed,
 /turf/open/floor/plasteel/dark,
 /area/department_main/welfare)
 "md" = (
@@ -2036,10 +2065,6 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/dark,
 /area/facility_hallway/welfare)
-"ni" = (
-/obj/structure/disposalpipe/junction/flip,
-/turf/open/floor/plasteel,
-/area/facility_hallway/north)
 "nj" = (
 /obj/effect/turf_decal/siding/blue/corner{
 	color = "#3234B9";
@@ -2187,6 +2212,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/facility_hallway/north)
+"ob" = (
+/obj/machinery/telecomms/server/presets/medical,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/department_main/information)
 "oc" = (
 /obj/effect/turf_decal/siding/green,
 /turf/open/floor/plasteel/showroomfloor,
@@ -2917,11 +2946,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/department_main/welfare)
-"sp" = (
-/obj/structure/table/wood,
-/obj/item/storage/box/drinkingglasses,
-/turf/open/floor/carpet/royalblue,
-/area/department_main/welfare)
+"sn" = (
+/obj/machinery/telecomms/server/presets/service,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/department_main/control)
 "sq" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/highsecurity{
@@ -3007,13 +3035,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/department_main/training)
-"sL" = (
-/obj/effect/spawner/structure/window/reinforced/indestructable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/facility_hallway/north)
 "sM" = (
 /obj/effect/turf_decal/siding/blue{
 	color = "#3234B9"
@@ -3041,10 +3062,8 @@
 /turf/open/floor/carpet,
 /area/department_main/control)
 "sV" = (
-/obj/machinery/telecomms/allinone/indestructable,
-/obj/effect/turf_decal/bot,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/solarpanel,
+/obj/machinery/announcement_system,
+/turf/open/floor/circuit/telecomms/mainframe,
 /area/department_main/information)
 "sW" = (
 /turf/open/floor/plasteel/dark,
@@ -3484,7 +3503,6 @@
 /area/facility_hallway/north)
 "vh" = (
 /obj/structure/table/wood,
-/obj/item/paper/guides/jobs/zayin/lore,
 /turf/open/floor/carpet/orange,
 /area/department_main/training)
 "vj" = (
@@ -3503,11 +3521,9 @@
 /turf/open/floor/carpet/royalblue,
 /area/department_main/welfare)
 "vo" = (
-/obj/machinery/ntnet_relay,
-/obj/effect/turf_decal/bot,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/solarpanel,
-/area/department_main/information)
+/obj/machinery/telecomms/bus/preset_one,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/department_main/control)
 "vp" = (
 /obj/machinery/light{
 	dir = 8
@@ -3568,7 +3584,6 @@
 	dir = 1
 	},
 /obj/structure/table/reinforced,
-/obj/item/paper/guides/jobs/zayin/guide,
 /obj/item/wrench,
 /turf/open/floor/plasteel/dark,
 /area/department_main/control)
@@ -3676,9 +3691,6 @@
 /obj/machinery/camera/autoname{
 	dir = 5
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
 /turf/open/floor/plasteel,
 /area/facility_hallway/north)
 "wX" = (
@@ -3736,12 +3748,6 @@
 /obj/effect/spawner/abnormality_room,
 /turf/closed/indestructible/reinforced,
 /area/facility_hallway/south)
-"xi" = (
-/obj/structure/disposalpipe/junction{
-	dir = 2
-	},
-/turf/open/floor/plasteel,
-/area/facility_hallway/north)
 "xj" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/siding/red{
@@ -3790,6 +3796,7 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
+/obj/machinery/icecream_vat,
 /turf/open/floor/plasteel/showroomfloor,
 /area/department_main/training)
 "xA" = (
@@ -3936,6 +3943,10 @@
 /obj/effect/spawner/abnormality_room,
 /turf/closed/indestructible/reinforced,
 /area/department_main/control)
+"yt" = (
+/obj/structure/disposalpipe/junction/flip,
+/turf/open/floor/plasteel,
+/area/facility_hallway/north)
 "yw" = (
 /obj/machinery/door/poddoor/shutters/window/preopen{
 	id = cellthree
@@ -4062,6 +4073,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/facility_hallway/north)
+"zu" = (
+/obj/machinery/telecomms/server/presets/supply,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/department_main/control)
 "zv" = (
 /obj/structure/table/glass,
 /obj/machinery/light{
@@ -4078,12 +4093,15 @@
 /area/department_main/command)
 "zD" = (
 /obj/machinery/disposal/bin,
-/obj/structure/sign/warning/bodysposal{
+/obj/structure/sign/departments/custodian{
 	pixel_x = -32
 	},
 /obj/effect/turf_decal/tile/blue{
+	color = "#3234B9"
+	},
+/obj/effect/turf_decal/tile/blue{
 	color = "#3234B9";
-	dir = 4
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	color = "#3234B9";
@@ -4091,15 +4109,9 @@
 	},
 /obj/effect/turf_decal/tile/blue{
 	color = "#3234B9";
-	dir = 1
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#3234B9"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/camera/autoname{
-	dir = 5
-	},
+/obj/effect/turf_decal/bot,
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/plasteel/dark,
 /area/department_main/training)
@@ -4260,6 +4272,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/door/poddoor/preopen{
+	id = "managerlockdown";
+	name = "Manager's Office Lockdown Blast Door"
+	},
 /turf/open/floor/wood,
 /area/department_main/control)
 "Ay" = (
@@ -4315,7 +4331,11 @@
 "AV" = (
 /obj/effect/turf_decal/siding/red,
 /obj/structure/table/reinforced,
-/obj/item/paper/guides/jobs/teth/guide,
+/obj/item/melee/classic_baton,
+/obj/item/melee/classic_baton,
+/obj/item/melee/classic_baton,
+/obj/item/melee/classic_baton,
+/obj/item/melee/classic_baton,
 /obj/item/melee/classic_baton,
 /turf/open/floor/plasteel/dark,
 /area/department_main/control)
@@ -4438,6 +4458,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/facility_hallway/south)
+"BJ" = (
+/obj/machinery/telecomms/bus/preset_four,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/department_main/information)
 "BM" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/wood,
@@ -4481,6 +4505,10 @@
 /obj/item/reagent_containers/hypospray/medipen/mental,
 /turf/open/floor/carpet/royalblue,
 /area/department_main/welfare)
+"Cd" = (
+/obj/machinery/telecomms/server/presets/science,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/department_main/information)
 "Ce" = (
 /obj/structure/chair/sofa/corp/left,
 /turf/open/floor/carpet/royalblue,
@@ -4515,6 +4543,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/facility_hallway/south)
+"Cn" = (
+/obj/machinery/telecomms/bus/preset_two,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/department_main/information)
 "Co" = (
 /obj/effect/turf_decal/siding/red{
 	dir = 9
@@ -4580,6 +4612,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/facility_hallway/north)
+"CO" = (
+/turf/closed/indestructible/fakeglass,
+/area/department_main/control)
 "CS" = (
 /obj/effect/turf_decal/siding/purple{
 	dir = 1
@@ -4687,32 +4722,6 @@
 /obj/item/storage/box/handcuffs,
 /turf/open/floor/plasteel/dark,
 /area/department_main/discipline)
-"DG" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#3234B9";
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#3234B9";
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#3234B9";
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#3234B9"
-	},
-/obj/effect/turf_decal/bot,
-/obj/structure/sign/departments/custodian{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/dark,
-/area/facility_hallway/north)
 "DJ" = (
 /obj/structure/chair/sofa/corp{
 	dir = 4
@@ -4816,7 +4825,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 6
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/facility_hallway/north)
@@ -4888,13 +4897,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/facility_hallway/north)
-"EY" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/facility_hallway/north)
 "Fa" = (
@@ -5246,6 +5248,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/facility_hallway/north)
+"HE" = (
+/obj/machinery/telecomms/hub/preset,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/department_main/information)
 "HG" = (
 /obj/effect/turf_decal/siding/brown{
 	dir = 8
@@ -5504,6 +5510,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/facility_hallway/north)
+"Jy" = (
+/obj/machinery/telecomms/server/presets/common,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/department_main/information)
 "JB" = (
 /turf/closed/indestructible/rock,
 /area/space)
@@ -5522,19 +5532,8 @@
 /area/facility_hallway/welfare)
 "JU" = (
 /obj/machinery/telecomms/message_server/preset,
-/obj/effect/turf_decal/bot,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/solarpanel,
+/turf/open/floor/circuit/telecomms/mainframe,
 /area/department_main/information)
-"JV" = (
-/obj/structure/rack,
-/obj/item/melee/classic_baton,
-/obj/item/melee/classic_baton,
-/obj/item/melee/classic_baton,
-/obj/item/melee/classic_baton,
-/obj/item/melee/classic_baton,
-/turf/open/floor/carpet,
-/area/department_main/control)
 "Kd" = (
 /obj/effect/spawner/structure/window/reinforced/indestructable,
 /turf/open/floor/wood,
@@ -5661,22 +5660,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/department_main/welfare)
-"Kt" = (
-/obj/effect/turf_decal/siding/yellow{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/facility_hallway/north)
 "Kw" = (
 /obj/effect/turf_decal/siding/brown/corner,
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 6
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/facility_hallway/north)
 "Kx" = (
@@ -5790,10 +5778,10 @@
 /area/department_main/control)
 "Li" = (
 /obj/docking_port/stationary{
+	name = "facility floor";
+	id = "elevator_home";
 	dwidth = 3;
 	height = 5;
-	id = "elevator_home";
-	name = "facility floor";
 	roundstart_template = /datum/map_template/shuttle/manager/elevator;
 	width = 6
 	},
@@ -6062,6 +6050,10 @@
 	},
 /turf/open/floor/noslip,
 /area/facility_hallway/north)
+"Nb" = (
+/obj/machinery/telecomms/server/presets/security,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/department_main/control)
 "Nc" = (
 /obj/machinery/light/cold{
 	dir = 8
@@ -6327,6 +6319,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/department_main/control)
+"Pc" = (
+/obj/machinery/telecomms/receiver/preset_left,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/department_main/control)
 "Pe" = (
 /turf/open/floor/carpet/green,
 /area/department_main/safety)
@@ -6377,7 +6373,6 @@
 /area/department_main/command)
 "Pw" = (
 /obj/structure/table/wood,
-/obj/item/paper/guides/jobs/teth/lore/spiderbud,
 /obj/item/folder/blue{
 	pixel_x = -6
 	},
@@ -6464,6 +6459,10 @@
 /obj/machinery/door/airlock/wood/glass,
 /turf/open/floor/plasteel/dark,
 /area/department_main/training)
+"Qr" = (
+/obj/machinery/telecomms/bus/preset_three,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/department_main/control)
 "Qs" = (
 /obj/effect/turf_decal/siding/purple,
 /turf/open/floor/plasteel,
@@ -6610,15 +6609,12 @@
 /area/facility_hallway/north)
 "Rs" = (
 /obj/machinery/disposal/bin,
-/obj/structure/sign/departments/custodian{
+/obj/structure/sign/warning/bodysposal{
 	pixel_x = -32
 	},
 /obj/effect/turf_decal/tile/blue{
-	color = "#3234B9"
-	},
-/obj/effect/turf_decal/tile/blue{
 	color = "#3234B9";
-	dir = 1
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
 	color = "#3234B9";
@@ -6626,9 +6622,15 @@
 	},
 /obj/effect/turf_decal/tile/blue{
 	color = "#3234B9";
-	dir = 4
+	dir = 1
 	},
-/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/blue{
+	color = "#3234B9"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/camera/autoname{
+	dir = 5
+	},
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
@@ -6870,9 +6872,6 @@
 /area/department_main/control)
 "SF" = (
 /obj/machinery/rnd/server,
-/obj/machinery/light{
-	dir = 1
-	},
 /turf/open/floor/carpet/purple,
 /area/department_main/information)
 "SJ" = (
@@ -6914,6 +6913,10 @@
 	},
 /turf/open/floor/plating,
 /area/space)
+"SW" = (
+/obj/machinery/telecomms/processor/preset_four,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/department_main/information)
 "SY" = (
 /turf/closed/indestructible/reinforced,
 /area/department_main/training)
@@ -7295,13 +7298,6 @@
 /obj/structure/disposalpipe/junction/yjunction,
 /turf/open/floor/plasteel,
 /area/facility_hallway/north)
-"Vn" = (
-/obj/effect/turf_decal/siding/yellow{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/facility_hallway/north)
 "Vq" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#3234B9";
@@ -7426,15 +7422,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/department_main/command)
-"VS" = (
-/obj/effect/turf_decal/siding/yellow{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/facility_hallway/north)
 "VV" = (
 /obj/structure/chair/wood,
 /turf/open/floor/carpet/stellar,
@@ -7446,11 +7433,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/department_main/information)
-"VY" = (
-/obj/structure/table/wood,
-/obj/item/paper/guides/jobs/zayin/lore/wellcheers,
-/turf/open/floor/carpet/royalblue,
-/area/department_main/welfare)
 "Wa" = (
 /obj/effect/turf_decal/siding/yellow{
 	dir = 8
@@ -7624,32 +7606,6 @@
 /obj/effect/turf_decal/siding/yellow/corner,
 /turf/open/floor/carpet/stellar,
 /area/department_main/command)
-"Xp" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#3234B9";
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#3234B9";
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#3234B9";
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#3234B9"
-	},
-/obj/effect/turf_decal/bot,
-/obj/structure/sign/departments/custodian{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/dark,
-/area/facility_hallway/north)
 "Xq" = (
 /obj/machinery/light{
 	dir = 8
@@ -31043,11 +30999,11 @@ JB
 JB
 JB
 JB
-JB
-JB
-JB
-JB
-JB
+jF
+jF
+jF
+jF
+jF
 jF
 Gp
 px
@@ -31300,11 +31256,11 @@ JB
 JB
 JB
 JB
-JB
-JB
-JB
-JB
-JB
+jF
+hG
+fd
+Nb
+jF
 Cu
 Uz
 rZ
@@ -31558,9 +31514,9 @@ jF
 jF
 jF
 jF
-JB
-JB
-JB
+Pc
+vo
+fx
 jF
 jF
 Ht
@@ -31815,12 +31771,12 @@ jM
 jM
 go
 jF
-jF
-jF
-jF
+CO
+CO
+CO
 jF
 CT
-JV
+RZ
 mg
 mg
 vT
@@ -32843,9 +32799,9 @@ jM
 jM
 Ax
 jF
-jF
-jF
-jF
+CO
+CO
+CO
 jF
 Dh
 RZ
@@ -33100,9 +33056,9 @@ jF
 jF
 jF
 jF
-JB
-JB
-JB
+jD
+Qr
+lW
 jF
 jF
 Nv
@@ -33356,11 +33312,11 @@ JB
 JB
 JB
 JB
-JB
-JB
-JB
-JB
-JB
+jF
+sn
+ei
+zu
+jF
 Ej
 OZ
 Eu
@@ -33613,11 +33569,11 @@ JB
 JB
 JB
 JB
-JB
-JB
-JB
-JB
-JB
+jF
+jF
+jF
+jF
+jF
 jF
 mA
 Oy
@@ -38001,7 +37957,7 @@ kK
 Nq
 Rc
 Rc
-DG
+yS
 yS
 yS
 Rc
@@ -38258,7 +38214,7 @@ kK
 Nq
 Rc
 Rc
-sL
+Kd
 xL
 Kd
 Rc
@@ -38515,9 +38471,9 @@ cs
 hE
 gO
 MD
-cd
-Vn
-Kt
+zi
+zi
+OU
 wW
 MD
 MD
@@ -38563,7 +38519,7 @@ hl
 hl
 hl
 vN
-Xh
+CA
 Xh
 Xh
 Xh
@@ -38775,7 +38731,7 @@ bP
 bP
 bP
 bP
-EY
+bP
 bP
 bP
 Nx
@@ -39032,7 +38988,7 @@ gY
 gY
 gY
 gY
-kK
+gY
 gY
 eO
 gY
@@ -39286,10 +39242,10 @@ Lq
 bP
 bP
 bP
-ni
 bP
 bP
-xi
+bP
+bP
 bP
 bP
 Os
@@ -39543,7 +39499,7 @@ kK
 ki
 HB
 DB
-VS
+yL
 yL
 Pm
 PL
@@ -39800,7 +39756,7 @@ kK
 Nq
 Rc
 Rc
-sL
+Kd
 xL
 Kd
 Rc
@@ -39851,7 +39807,7 @@ vN
 dl
 Xh
 Wy
-sp
+Zq
 Zq
 Gf
 LI
@@ -40057,7 +40013,7 @@ kK
 Nq
 Rc
 Rc
-Xp
+yS
 yS
 yS
 Rc
@@ -40108,7 +40064,7 @@ vN
 SS
 Xh
 Wy
-VY
+Zq
 Zq
 Gf
 Bn
@@ -41386,8 +41342,8 @@ Io
 Io
 Io
 Io
-JB
-JB
+Io
+Io
 JB
 JB
 JB
@@ -41642,9 +41598,9 @@ Hx
 QO
 RC
 gd
+Zg
+Jy
 Io
-JB
-JB
 JB
 JB
 JB
@@ -41899,9 +41855,9 @@ Hx
 QO
 LH
 vD
+Zg
+Cn
 Io
-JB
-JB
 JB
 JB
 JB
@@ -42105,7 +42061,7 @@ bP
 bP
 bP
 bP
-bP
+yt
 bP
 gx
 mt
@@ -42156,9 +42112,9 @@ Hx
 QO
 hD
 MP
+Zg
+cC
 Io
-JB
-JB
 JB
 JB
 JB
@@ -42363,7 +42319,7 @@ rJ
 Al
 HH
 Er
-bP
+gY
 Kw
 xV
 ON
@@ -42415,7 +42371,7 @@ hD
 EO
 Io
 Io
-JB
+Io
 JB
 JB
 JB
@@ -42915,8 +42871,8 @@ JB
 JB
 JB
 Io
-Io
-Io
+HE
+Zg
 SF
 Ug
 DD
@@ -43172,8 +43128,8 @@ JB
 JB
 JB
 Io
-vo
-Zg
+Io
+Io
 db
 Ui
 CE
@@ -43443,7 +43399,7 @@ WI
 Bh
 Io
 Io
-JB
+Io
 JB
 JB
 JB
@@ -43686,8 +43642,8 @@ JB
 JB
 JB
 Io
-Io
-Io
+eU
+Zg
 MP
 pH
 hD
@@ -43698,9 +43654,9 @@ Hx
 QO
 hD
 QC
+Zg
+Cd
 Io
-JB
-JB
 JB
 JB
 JB
@@ -43942,9 +43898,9 @@ JB
 JB
 JB
 JB
-JB
-JB
 Io
+SW
+Zg
 lh
 hD
 hD
@@ -43955,9 +43911,9 @@ Hx
 QO
 hD
 KM
+Zg
+BJ
 Io
-JB
-JB
 JB
 JB
 JB
@@ -44199,8 +44155,8 @@ JB
 JB
 JB
 JB
-JB
-JB
+Io
+Io
 Io
 mp
 aB
@@ -44212,9 +44168,9 @@ nV
 QO
 ay
 Bh
+Zg
+ob
 Io
-JB
-JB
 JB
 JB
 JB
@@ -44470,8 +44426,8 @@ Io
 Io
 Io
 Io
-JB
-JB
+Io
+Io
 JB
 JB
 JB
@@ -45955,7 +45911,7 @@ SY
 SY
 SY
 IE
-bm
+vh
 KO
 KO
 KO
@@ -45965,7 +45921,7 @@ Hz
 Fs
 MM
 KO
-pu
+lV
 KO
 uA
 QV
@@ -46212,7 +46168,7 @@ vp
 sW
 li
 KO
-lg
+vh
 KO
 Ib
 Ib

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -107,12 +107,6 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel,
 /area/centcom/hub)
-"aB" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/carpet/royalblack,
-/area/department_main/control)
 "aG" = (
 /obj/structure/table,
 /obj/item/gun/ballistic/automatic/pistol/m1911,
@@ -256,10 +250,6 @@
 /obj/machinery/recharger,
 /turf/open/floor/plasteel,
 /area/centcom/hub)
-"cl" = (
-/obj/structure/chair/stool,
-/turf/open/floor/wood,
-/area/department_main/control)
 "cn" = (
 /turf/open/floor/wood,
 /area/centcom/hub)
@@ -293,6 +283,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/hub)
+"cY" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/carpet/royalblack,
+/area/department_main/control)
 "cZ" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -312,16 +308,6 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel,
 /area/centcom/hub)
-"dh" = (
-/obj/structure/plaque/static_plaque/golden{
-	pixel_y = 32
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/computer/communications,
-/turf/open/floor/carpet/royalblack,
-/area/department_main/control)
 "dj" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -454,6 +440,11 @@
 /obj/effect/spawner/lootdrop/refreshing_beverage,
 /turf/open/floor/plasteel/cafeteria,
 /area/centcom/hub)
+"eD" = (
+/obj/structure/railing,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/wood,
+/area/department_main/control)
 "eG" = (
 /obj/structure/sink{
 	dir = 4;
@@ -461,13 +452,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/centcom/hub)
-"eH" = (
-/obj/structure/table/wood,
-/obj/item/toy/figure/scientist{
-	pixel_x = 8;
-	pixel_y = 8;
-	toysay = "Face the fear, build the future!"
+"eS" = (
+/obj/machinery/light{
+	dir = 1
 	},
+/obj/machinery/computer/crew,
 /turf/open/floor/carpet/royalblack,
 /area/department_main/control)
 "eW" = (
@@ -490,6 +479,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/tdome/arena_source)
+"fb" = (
+/obj/machinery/door/window/brigdoor/southright,
+/turf/open/floor/carpet/royalblack,
+/area/department_main/control)
 "ff" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -562,9 +555,6 @@
 	},
 /turf/open/space/basic,
 /area/space)
-"fT" = (
-/turf/open/floor/wood,
-/area/department_main/control)
 "fX" = (
 /turf/closed/indestructible/riveted,
 /area/start)
@@ -1526,10 +1516,6 @@
 /obj/structure/sign/warning/securearea,
 /turf/closed/indestructible/riveted,
 /area/centcom/prison)
-"iL" = (
-/obj/machinery/door/window/brigdoor/southleft,
-/turf/open/floor/carpet/royalblack,
-/area/department_main/control)
 "iR" = (
 /obj/machinery/light{
 	dir = 4
@@ -1657,6 +1643,11 @@
 	name = "CentCom Warehouse"
 	},
 /area/centcom/supply)
+"ka" = (
+/obj/structure/table/wood,
+/obj/item/toy/plush/angela,
+/turf/open/floor/carpet/royalblack,
+/area/department_main/control)
 "ke" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/dark,
@@ -1924,14 +1915,6 @@
 	},
 /turf/open/floor/plating/asteroid/snow/airless,
 /area/syndicate_mothership)
-"me" = (
-/obj/structure/railing{
-	dir = 10
-	},
-/obj/structure/table/wood,
-/obj/item/clipboard,
-/turf/open/floor/carpet/royalblack,
-/area/department_main/control)
 "mm" = (
 /obj/machinery/light{
 	dir = 1
@@ -2134,9 +2117,6 @@
 "nz" = (
 /turf/closed/indestructible/opsglass,
 /area/syndicate_mothership/control)
-"nC" = (
-/turf/closed/indestructible/reinforced,
-/area/department_main/control)
 "nD" = (
 /obj/effect/turf_decal/tile{
 	color = "#CC5500"
@@ -2170,12 +2150,10 @@
 /turf/open/floor/plasteel/dark,
 /area/centcom/ferry)
 "nR" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/computer/crew,
-/turf/open/floor/carpet/royalblack,
-/area/department_main/control)
+/obj/structure/table/reinforced,
+/obj/item/toy/plush/myo,
+/turf/open/floor/engine,
+/area/centcom/ferry)
 "nT" = (
 /obj/machinery/status_display/ai,
 /turf/closed/indestructible/riveted,
@@ -2287,10 +2265,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/centcom/supply)
-"pn" = (
-/obj/structure/chair/office,
-/turf/open/floor/carpet/royalblack,
-/area/department_main/control)
 "pq" = (
 /obj/machinery/vending/cola/shamblers,
 /turf/open/floor/plasteel/dark,
@@ -2422,15 +2396,6 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/dark,
 /area/centcom/ferry)
-"qs" = (
-/obj/machinery/computer/ego_purchase,
-/obj/machinery/button/door/indestructible{
-	id = "facilitylockdown";
-	name = "Facility Lockdown button";
-	pixel_y = 32
-	},
-/turf/open/floor/carpet/royalblack,
-/area/department_main/control)
 "qw" = (
 /obj/machinery/light{
 	dir = 4
@@ -2663,16 +2628,20 @@
 /obj/machinery/vending/snack/blue,
 /turf/open/floor/plasteel/dark,
 /area/centcom/evac)
-"rP" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/carpet/royalblack,
-/area/department_main/control)
 "rS" = (
 /obj/machinery/status_display/evac,
 /turf/closed/indestructible/riveted,
 /area/centcom/evac)
+"rV" = (
+/obj/structure/filingcabinet{
+	pixel_x = 10
+	},
+/obj/structure/filingcabinet,
+/obj/structure/filingcabinet/employment{
+	pixel_x = -10
+	},
+/turf/open/floor/carpet/royalblack,
+/area/department_main/control)
 "rW" = (
 /obj/machinery/light{
 	dir = 8
@@ -3053,12 +3022,6 @@
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel/dark,
 /area/centcom/hub)
-"uh" = (
-/obj/structure/railing/corner,
-/obj/structure/table/wood,
-/obj/item/modular_computer/laptop/preset/civilian,
-/turf/open/floor/carpet/royalblack,
-/area/department_main/control)
 "ui" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -3194,11 +3157,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/ferry)
-"vg" = (
-/obj/structure/railing,
-/obj/structure/table/wood,
-/turf/open/floor/carpet/royalblack,
-/area/department_main/control)
 "vh" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -3584,16 +3542,6 @@
 /obj/item/food/burger/cheese,
 /turf/open/floor/plasteel/cafeteria,
 /area/centcom/hub)
-"wX" = (
-/obj/structure/filingcabinet{
-	pixel_x = 10
-	},
-/obj/structure/filingcabinet,
-/obj/structure/filingcabinet/employment{
-	pixel_x = -10
-	},
-/turf/open/floor/carpet/royalblack,
-/area/department_main/control)
 "wY" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Equipment Room";
@@ -3622,6 +3570,15 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/centcom/ferry)
+"xe" = (
+/obj/machinery/computer/ego_purchase,
+/obj/machinery/button/door/indestructible{
+	id = "facilitylockdown";
+	name = "Facility Lockdown button";
+	pixel_y = 32
+	},
+/turf/open/floor/carpet/royalblack,
+/area/department_main/control)
 "xf" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/centcom{
@@ -3975,6 +3932,10 @@
 /obj/item/seeds/cherry/bomb,
 /turf/open/floor/wood,
 /area/centcom/holding)
+"yP" = (
+/obj/structure/chair/stool,
+/turf/open/floor/wood,
+/area/department_main/control)
 "yU" = (
 /obj/structure/chair/plastic{
 	dir = 4
@@ -4221,11 +4182,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/supplypod/loading/three)
-"zI" = (
-/obj/structure/railing,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/wood,
-/area/department_main/control)
 "zM" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -4474,6 +4430,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/supply)
+"Bw" = (
+/obj/structure/chair/office,
+/turf/open/floor/carpet/royalblack,
+/area/department_main/control)
 "Bx" = (
 /obj/structure/table/reinforced,
 /obj/item/clipboard,
@@ -4553,14 +4513,15 @@
 /obj/item/toy/figure/syndie,
 /turf/open/floor/plating/asteroid/snow/airless,
 /area/syndicate_mothership)
-"BZ" = (
-/turf/open/floor/carpet/royalblack,
-/area/department_main/control)
 "Ca" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/firstaid/revival,
 /turf/open/floor/engine,
 /area/centcom/ferry)
+"Cb" = (
+/obj/machinery/door/window/brigdoor/southleft,
+/turf/open/floor/carpet/royalblack,
+/area/department_main/control)
 "Cd" = (
 /obj/effect/turf_decal/stripes/end,
 /obj/machinery/conveyor/inverted{
@@ -4904,20 +4865,6 @@
 /obj/item/ego_weapon/rabbit_blade,
 /turf/open/floor/plasteel,
 /area/tdome/arena)
-"EI" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/computer/shuttle/mining{
-	name = "elevator console";
-	shuttleId = "manager";
-	possible_destinations = "elevator_home;elevator_away";
-	dir = 1
-	},
-/obj/structure/railing,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/wood,
-/area/department_main/control)
 "EJ" = (
 /obj/effect/turf_decal/tile{
 	color = "#CC5500"
@@ -5037,6 +4984,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/tdome/tdomeadmin)
+"Fw" = (
+/obj/machinery/button/door/indestructible{
+	id = "managerlockdown";
+	name = "Manager's Office Lockdown button";
+	pixel_y = 32
+	},
+/obj/machinery/computer/camera_advanced/manager,
+/turf/open/floor/carpet/royalblack,
+/area/department_main/control)
 "FE" = (
 /obj/item/stack/package_wrap,
 /obj/item/hand_labeler,
@@ -5277,6 +5233,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/ferry)
+"Ia" = (
+/obj/structure/plaque/static_plaque/golden{
+	pixel_y = 32
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/computer/communications,
+/turf/open/floor/carpet/royalblack,
+/area/department_main/control)
 "Ie" = (
 /turf/closed/indestructible/riveted,
 /area/tdome/arena)
@@ -5769,6 +5735,20 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/dark,
 /area/centcom/hub)
+"JX" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/computer/shuttle/mining{
+	name = "elevator console";
+	shuttleId = "manager";
+	possible_destinations = "elevator_home;elevator_away";
+	dir = 1
+	},
+/obj/structure/railing,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/wood,
+/area/department_main/control)
 "Ka" = (
 /obj/machinery/light{
 	dir = 1
@@ -5852,6 +5832,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/tdome/tdomeadmin)
+"Kz" = (
+/obj/structure/table/wood,
+/obj/item/toy/figure/scientist{
+	pixel_x = 8;
+	pixel_y = 8;
+	toysay = "Face the fear, build the future!"
+	},
+/turf/open/floor/carpet/royalblack,
+/area/department_main/control)
 "KC" = (
 /obj/machinery/status_display/evac,
 /turf/closed/indestructible/riveted,
@@ -6452,10 +6441,23 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/carpet/black,
 /area/centcom/holding)
+"MN" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/carpet/royalblack,
+/area/department_main/control)
 "MQ" = (
-/obj/structure/railing,
 /obj/structure/table/wood,
-/obj/item/food/grown/star_cactus,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
+	pixel_x = -7
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
+	pixel_x = 7
+	},
+/obj/item/reagent_containers/food/drinks/bottle/champagne{
+	pixel_y = 17
+	},
 /turf/open/floor/carpet/royalblack,
 /area/department_main/control)
 "MR" = (
@@ -6592,6 +6594,11 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/grass,
 /area/centcom/hub)
+"NI" = (
+/obj/machinery/door/window/brigdoor/southright,
+/obj/effect/turf_decal/caution/stand_clear,
+/turf/open/floor/wood,
+/area/department_main/control)
 "NJ" = (
 /obj/structure/table,
 /obj/item/book/manual/hydroponics_pod_people,
@@ -6624,19 +6631,6 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/holding)
-"NV" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
-	pixel_x = -7
-	},
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
-	pixel_x = 7
-	},
-/obj/item/reagent_containers/food/drinks/bottle/champagne{
-	pixel_y = 17
-	},
-/turf/open/floor/carpet/royalblack,
-/area/department_main/control)
 "NZ" = (
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/red{
@@ -6662,6 +6656,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/centcom/hub)
+"Of" = (
+/obj/machinery/telecomms/relay/preset/station,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/department_main/control)
 "Ok" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/tile/blue{
@@ -6802,11 +6800,6 @@
 /obj/item/book/manual/chef_recipes,
 /turf/open/floor/plasteel/cafeteria,
 /area/centcom/holding)
-"Pt" = (
-/obj/structure/table/wood,
-/obj/item/toy/plush/angela,
-/turf/open/floor/carpet/royalblack,
-/area/department_main/control)
 "Pv" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
@@ -6816,17 +6809,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/supplypod/loading/four)
-"Pw" = (
-/obj/docking_port/stationary{
-	name = "manager floor";
-	id = "elevator_away";
-	dwidth = 3;
-	height = 5;
-	width = 6;
-	dir = 2
-	},
-/turf/open/floor/wood,
-/area/department_main/control)
 "Px" = (
 /obj/structure/table,
 /obj/machinery/chem_dispenser/drinks/fullupgrade{
@@ -6840,6 +6822,9 @@
 	},
 /turf/open/floor/carpet/black,
 /area/centcom/holding)
+"PB" = (
+/turf/open/floor/wood,
+/area/department_main/control)
 "PI" = (
 /obj/machinery/biogenerator,
 /obj/effect/turf_decal/tile/green{
@@ -7286,6 +7271,14 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/centcom/supplypod/loading/two)
+"Sh" = (
+/obj/structure/railing{
+	dir = 6
+	},
+/obj/structure/table/wood,
+/obj/item/folder/red,
+/turf/open/floor/carpet/royalblack,
+/area/department_main/control)
 "Si" = (
 /turf/open/floor/plasteel,
 /area/centcom/supplypod/loading/two)
@@ -7382,15 +7375,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/centcom/holding)
-"SY" = (
-/obj/machinery/computer/camera_advanced,
-/obj/machinery/button/door/indestructible{
-	id = "managerlockdown";
-	name = "Manager's Office Lockdown button";
-	pixel_y = 32
-	},
-/turf/open/floor/carpet/royalblack,
-/area/department_main/control)
 "Tb" = (
 /obj/structure/closet/crate/freezer/blood,
 /turf/open/floor/wood,
@@ -7647,6 +7631,9 @@
 /obj/effect/spawner/randomarcade,
 /turf/open/floor/wood,
 /area/centcom/holding)
+"UX" = (
+/turf/open/floor/carpet/royalblack,
+/area/department_main/control)
 "Vc" = (
 /obj/vehicle/ridden/secway,
 /obj/effect/turf_decal/bot,
@@ -7756,12 +7743,23 @@
 "VQ" = (
 /turf/closed/indestructible/riveted,
 /area/centcom/hub)
+"VR" = (
+/turf/closed/indestructible/reinforced,
+/area/department_main/control)
 "Wb" = (
-/obj/structure/railing{
-	dir = 6
-	},
+/obj/structure/railing/corner,
 /obj/structure/table/wood,
-/obj/item/folder/red,
+/obj/item/modular_computer/laptop/preset/civilian,
+/turf/open/floor/carpet/royalblack,
+/area/department_main/control)
+"We" = (
+/obj/item/clothing/suit/toggle/labcoat{
+	pixel_y = 4
+	},
+/obj/item/storage/lockbox/medal,
+/obj/structure/closet/secure_closet/personal{
+	anchored = 1
+	},
 /turf/open/floor/carpet/royalblack,
 /area/department_main/control)
 "Wh" = (
@@ -7782,14 +7780,6 @@
 	},
 /turf/open/floor/carpet/black,
 /area/centcom/holding)
-"Wp" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/railing,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/wood,
-/area/department_main/control)
 "Wt" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -7820,6 +7810,19 @@
 /obj/effect/turf_decal/tile/green,
 /turf/open/floor/plasteel/dark,
 /area/centcom/hub)
+"WF" = (
+/obj/structure/railing,
+/obj/structure/table/wood,
+/turf/open/floor/carpet/royalblack,
+/area/department_main/control)
+"WI" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/railing,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/wood,
+/area/department_main/control)
 "WJ" = (
 /turf/open/floor/plasteel/dark,
 /area/tdome/tdomeadmin)
@@ -8035,16 +8038,6 @@
 /obj/structure/table/reinforced/ctf,
 /turf/open/floor/plasteel/dark,
 /area/ctf)
-"Ye" = (
-/obj/item/clothing/suit/toggle/labcoat{
-	pixel_y = 4
-	},
-/obj/item/storage/lockbox/medal,
-/obj/structure/closet/secure_closet/personal{
-	anchored = 1
-	},
-/turf/open/floor/carpet/royalblack,
-/area/department_main/control)
 "Yf" = (
 /obj/structure/table/wood,
 /obj/item/food/chawanmushi,
@@ -8067,6 +8060,12 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/holding)
+"Yi" = (
+/obj/structure/railing,
+/obj/structure/table/wood,
+/obj/item/food/grown/star_cactus,
+/turf/open/floor/carpet/royalblack,
+/area/department_main/control)
 "Ym" = (
 /obj/machinery/computer/arcade/orion_trail,
 /turf/open/floor/wood,
@@ -8107,15 +8106,6 @@
 /obj/structure/closet/secure_closet/freezer/fridge/open,
 /turf/open/floor/plasteel/cafeteria,
 /area/centcom/holding)
-"Yy" = (
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/obj/structure/table/wood,
-/obj/item/paper_bin,
-/obj/item/pen/fourcolor,
-/turf/open/floor/carpet/royalblack,
-/area/department_main/control)
 "YA" = (
 /turf/closed/indestructible/fakeglass,
 /area/centcom/hub)
@@ -8123,6 +8113,17 @@
 /obj/structure/dresser,
 /turf/open/floor/wood,
 /area/centcom/hub)
+"YC" = (
+/obj/docking_port/stationary{
+	name = "manager floor";
+	id = "elevator_away";
+	dwidth = 3;
+	height = 5;
+	width = 6;
+	dir = 2
+	},
+/turf/open/floor/wood,
+/area/department_main/control)
 "YI" = (
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 5
@@ -8178,10 +8179,14 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/holding)
-"Zb" = (
-/obj/machinery/door/window/brigdoor/southright,
-/obj/effect/turf_decal/caution/stand_clear,
-/turf/open/floor/wood,
+"Zd" = (
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/obj/item/pen/fourcolor,
+/turf/open/floor/carpet/royalblack,
 /area/department_main/control)
 "Zi" = (
 /obj/machinery/vending/snack/orange,
@@ -8258,8 +8263,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/hub)
-"ZH" = (
-/obj/machinery/door/window/brigdoor/southright,
+"ZI" = (
+/obj/structure/railing{
+	dir = 10
+	},
+/obj/structure/table/wood,
+/obj/item/clipboard,
 /turf/open/floor/carpet/royalblack,
 /area/department_main/control)
 "ZN" = (
@@ -37909,14 +37918,14 @@ aa
 aa
 aa
 aa
-nC
-nC
-nC
-nC
-nC
-nC
-nC
-nC
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -38166,21 +38175,21 @@ aa
 aa
 aa
 aa
-nC
-Ye
-BZ
-rP
-iL
-fT
-fT
-nC
-nC
-nC
-nC
-nC
-nC
-nC
-nC
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -38423,21 +38432,21 @@ aa
 aa
 aa
 aa
-nC
-dh
-BZ
-Pt
-vg
-fT
-fT
-fT
-Wp
-fT
-fT
-fT
-fT
-fT
-nC
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -38680,21 +38689,21 @@ aa
 aa
 aa
 aa
-nC
-qs
-BZ
-BZ
-Yy
-me
-fT
-fT
-zI
-fT
-fT
-fT
-fT
-fT
-nC
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -38937,21 +38946,21 @@ aa
 aa
 aa
 aa
-nC
-NV
-BZ
-BZ
-pn
-vg
-cl
-fT
-Zb
-Pw
-fT
-fT
-fT
-fT
-nC
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -39194,21 +39203,21 @@ aa
 aa
 aa
 aa
-nC
-SY
-BZ
-BZ
-uh
-Wb
-fT
-fT
-zI
-fT
-fT
-fT
-fT
-fT
-nC
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -39451,21 +39460,21 @@ aa
 aa
 aa
 aa
-nC
-nR
-BZ
-eH
-MQ
-fT
-fT
-fT
-EI
-fT
-fT
-fT
-fT
-fT
-nC
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -39708,21 +39717,21 @@ aa
 aa
 aa
 aa
-nC
-wX
-BZ
-aB
-ZH
-fT
-fT
-nC
-nC
-nC
-nC
-nC
-nC
-nC
-nC
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -39965,14 +39974,14 @@ aa
 aa
 aa
 aa
-nC
-nC
-nC
-nC
-nC
-nC
-nC
-nC
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -46539,7 +46548,7 @@ Qq
 Qq
 By
 AN
-AL
+nR
 AL
 Ac
 zA
@@ -57112,14 +57121,14 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+VR
+VR
+VR
+VR
+VR
+VR
+VR
+VR
 aa
 aa
 aa
@@ -57369,21 +57378,21 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+VR
+We
+UX
+cY
+Cb
+PB
+PB
+VR
+VR
+VR
+VR
+VR
+VR
+VR
+VR
 aa
 aa
 aa
@@ -57626,21 +57635,21 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+VR
+Ia
+UX
+ka
+WF
+PB
+PB
+PB
+WI
+PB
+PB
+PB
+PB
+PB
+VR
 aa
 aa
 aa
@@ -57883,21 +57892,21 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+VR
+xe
+UX
+UX
+Zd
+ZI
+PB
+PB
+eD
+PB
+PB
+PB
+PB
+PB
+VR
 aa
 aa
 aa
@@ -58140,21 +58149,21 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+VR
+MQ
+UX
+UX
+Bw
+WF
+yP
+PB
+NI
+YC
+PB
+PB
+PB
+PB
+VR
 aa
 aa
 aa
@@ -58397,21 +58406,21 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+VR
+Fw
+UX
+UX
+Wb
+Sh
+PB
+PB
+eD
+PB
+PB
+PB
+PB
+PB
+VR
 aa
 aa
 aa
@@ -58654,21 +58663,21 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+VR
+eS
+UX
+Kz
+Yi
+PB
+PB
+PB
+JX
+PB
+PB
+PB
+PB
+PB
+VR
 aa
 aa
 aa
@@ -58911,21 +58920,21 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+VR
+rV
+UX
+MN
+fb
+PB
+PB
+VR
+VR
+VR
+VR
+VR
+VR
+VR
+VR
 aa
 aa
 aa
@@ -59168,16 +59177,16 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+VR
+VR
+VR
+VR
+VR
+VR
+VR
+VR
+Of
+VR
 aa
 aa
 aa
@@ -59432,9 +59441,9 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
+VR
+VR
+VR
 aa
 aa
 aa

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -245,6 +245,8 @@
 	var/mob/living/mob_occupant = occupant
 	if(!mob_occupant || !mob_occupant.reagents)
 		return
+	if (chem == /datum/reagent/medicine/c2/probital) //probital stamina crits at ~14u, needs special check
+		return (mob_occupant.reagents.get_reagent_amount(chem) + 3 <= 10) //30s grace period before another probital inject
 	var/amount = mob_occupant.reagents.get_reagent_amount(chem) + 10 <= 20 * efficiency
 	var/occ_health = mob_occupant.health > min_health || chem == /datum/reagent/medicine/epinephrine
 	return amount && occ_health

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -236,7 +236,7 @@
 
 /obj/machinery/sleeper/proc/inject_chem(chem, mob/user)
 	if((chem in available_chems) && chem_allowed(chem))
-		if(chem == /datum/reagent/medicine/c2/pro)
+		if(chem == /datum/reagent/medicine/c2/probital)
 			occupant.reagents.add_reagent(chem_buttons[chem], 9.5)
 		else(occupant.reagents.add_reagent(chem_buttons[chem], 10))	//emag effect kicks in here so that the "intended" chem is used for all checks, for extra FUUU
 		if(user)
@@ -247,7 +247,7 @@
 	var/mob/living/mob_occupant = occupant
 	if(!mob_occupant || !mob_occupant.reagents)
 		return
-	if (chem == /datum/reagent/medicine/c2/probital) //probital stamina crits at ~10u, needs special check
+	if(chem == /datum/reagent/medicine/c2/probital) //probital stamina crits at ~10u, needs special check
 		return (mob_occupant.reagents.get_reagent_amount(chem) + 3.5 <= 10) //30s grace period before another probital inject
 	var/amount = mob_occupant.reagents.get_reagent_amount(chem) + 10 <= 20 * efficiency
 	var/occ_health = mob_occupant.health > min_health || chem == /datum/reagent/medicine/epinephrine

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -236,7 +236,9 @@
 
 /obj/machinery/sleeper/proc/inject_chem(chem, mob/user)
 	if((chem in available_chems) && chem_allowed(chem))
-		occupant.reagents.add_reagent(chem_buttons[chem], 10) //emag effect kicks in here so that the "intended" chem is used for all checks, for extra FUUU
+		if(chem == /datum/reagent/medicine/c2/pro)
+			occupant.reagents.add_reagent(chem_buttons[chem], 9.5)
+		else(occupant.reagents.add_reagent(chem_buttons[chem], 10))	//emag effect kicks in here so that the "intended" chem is used for all checks, for extra FUUU
 		if(user)
 			log_combat(user, occupant, "injected [chem] into", addition = "via [src]")
 		return TRUE
@@ -245,8 +247,8 @@
 	var/mob/living/mob_occupant = occupant
 	if(!mob_occupant || !mob_occupant.reagents)
 		return
-	if (chem == /datum/reagent/medicine/c2/probital) //probital stamina crits at ~14u, needs special check
-		return (mob_occupant.reagents.get_reagent_amount(chem) + 3 <= 10) //30s grace period before another probital inject
+	if (chem == /datum/reagent/medicine/c2/probital) //probital stamina crits at ~10u, needs special check
+		return (mob_occupant.reagents.get_reagent_amount(chem) + 3.5 <= 10) //30s grace period before another probital inject
 	var/amount = mob_occupant.reagents.get_reagent_amount(chem) + 10 <= 20 * efficiency
 	var/occ_health = mob_occupant.health > min_health || chem == /datum/reagent/medicine/epinephrine
 	return amount && occ_health

--- a/code/modules/projectiles/projectile/ego_bullets/zayin.dm
+++ b/code/modules/projectiles/projectile/ego_bullets/zayin.dm
@@ -1,12 +1,12 @@
 /obj/projectile/ego_bullet/ego_tough
 	name = "9mm tough bullet"
-	damage = 6
+	damage = 8
 	damage_type = WHITE_DAMAGE
 	flag = WHITE_DAMAGE
 
 /obj/projectile/ego_bullet/ego_soda
 	name = "9mm soda bullet"
-	damage = 6
+	damage = 8
 	damage_type = RED_DAMAGE
 
 /obj/projectile/ego_bullet/ego_clerk


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Sleepers will now only be able to inject 10 units of probital into someone without probital already. It is still possible to get stamina crit if you return for more probital, but ODs are no longer possible. Soda and Tough pistols have their damage buffed. Removed extra plushies from Safety/Welfare for consistency and added water cooler in Beta training because Alpha has one.

Revamps Tcomms so that the manager's office on Centcom Z-level can actually communicate.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Probital ODs from sleepers are stupid, and there have been too many times where it has ruined me (and other players as well). Pistols do twice the damage of clerk guns so they can have some use as a sidearm or when dual-wielded. Water and plushies are cool.

Manager needs to talk.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: water cooler to training
del: plushies (it had to be done)
tweak: sleepers can no longer give probital ODs (stamina crit still possible)
:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
