### PR TITLE
Correctional Shotgun is now slightly less comically powerful

### DIFF
--- a/code/modules/projectiles/projectile/ego_bullets/waw.dm
+++ b/code/modules/projectiles/projectile/ego_bullets/waw.dm
@@ -1,6 +1,6 @@
 /obj/projectile/ego_bullet/ego_correctional
 	name = "correctional"
-	damage = 15
+	damage = 9
 	damage_type = BLACK_DAMAGE
 
 /obj/projectile/ego_bullet/ego_hornet


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Nerfs Correctional from fucking 90. **NINE ZERO** to 54. Hornet does 40 (a reasonable amount)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I used the correctional, you know why? Cause the Correctional doesn’t miss: and unlike the shitty fourth match, it stops a abnormality in their tracks in two hits. Bang: bang: and they’re fucking done. I use four shots just to make damn sure. Because: once again: I’m not there to coddle a buncha [CENSORED] sucking ***: I’m there to 1) Survive the fucking round. 2) Grind my stats.

Originally it was intended to do 36 damage, but when the pellets were added the damage of each individual pellet wasn't nerfed
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Nerfed Correctional to be slightly less comically powerful
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
