### PR TITLE
Correctional Armor is no longer Worse Lamp

### DIFF
--- a/code/modules/clothing/suits/ego_gear/waw.dm
+++ b/code/modules/clothing/suits/ego_gear/waw.dm
@@ -21,11 +21,9 @@
 	name = "correctional armor"
 	desc = "A white, lightly bloodstained coat. it goes all the way down to your ankles."
 	icon_state = "correctional"
-	armor = list(RED_DAMAGE = 10, WHITE_DAMAGE = 10, BLACK_DAMAGE = 60, PALE_DAMAGE = 50)
+	armor = list(RED_DAMAGE = 50, WHITE_DAMAGE = -20, BLACK_DAMAGE = 60, PALE_DAMAGE = 30)		//Like Lamp and Hornet put together but if you are hit by white you fucking die
 	attribute_requirements = list(
 							FORTITUDE_ATTRIBUTE = 40,
-							PRUDENCE_ATTRIBUTE = 40,
-							TEMPERANCE_ATTRIBUTE = 60,
 							JUSTICE_ATTRIBUTE = 60)
 
 /obj/item/clothing/suit/armor/ego_gear/despair


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Correctional Armor is now a very good generalist armor, but is weak to white.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Correctional was honestly just worse Lamp for a while, I want it to be good against red and black, and weak to white. Not as comically good as Aleph armor but not just a worse lamp armor
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Correctional is now a lot more situational
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
