### PR TITLE
No more Negative cake

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/zayin/bottle.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/bottle.dm
@@ -47,7 +47,7 @@
 			animate(user, alpha = 0, time = 2 SECONDS)
 			QDEL_IN(user, 3.5 SECONDS)
 
-		else
+		if(cake > 0)
 			user.adjustBruteLoss(-500) // It heals you to full if you eat it
 			icon_state = "bottle2"	//cake looks eaten
 


### PR DESCRIPTION
You can no longer eat negative cake

## Changelog
:cl:
fix: You now have to eat existing cake
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
