### PR TITLE
Add a clerk only hypo spray

### DIFF
--- a/_maps/map_files/Alpha/alphacorp.dmm
+++ b/_maps/map_files/Alpha/alphacorp.dmm
@@ -2624,6 +2624,16 @@
 "zy" = (
 /obj/structure/table/glass,
 /obj/machinery/light,
+/obj/item/reagent_containers/hypospray/emais,
+/obj/item/reagent_containers/hypospray/emais,
+/obj/item/reagent_containers/hypospray/emais,
+/obj/item/reagent_containers/hypospray/emais,
+/obj/item/reagent_containers/hypospray/emais,
+/obj/item/reagent_containers/hypospray/emais,
+/obj/item/reagent_containers/hypospray/emais,
+/obj/item/reagent_containers/hypospray/emais,
+/obj/item/reagent_containers/hypospray/emais,
+/obj/item/reagent_containers/hypospray/emais,
 /turf/open/floor/carpet/green,
 /area/department_main/safety)
 "zB" = (

--- a/_maps/map_files/Beta/betacorp.dmm
+++ b/_maps/map_files/Beta/betacorp.dmm
@@ -2747,6 +2747,16 @@
 /obj/item/reagent_containers/hypospray/medipen/salacid,
 /obj/item/reagent_containers/hypospray/medipen/salacid,
 /obj/structure/table/reinforced,
+/obj/item/reagent_containers/hypospray/emais,
+/obj/item/reagent_containers/hypospray/emais,
+/obj/item/reagent_containers/hypospray/emais,
+/obj/item/reagent_containers/hypospray/emais,
+/obj/item/reagent_containers/hypospray/emais,
+/obj/item/reagent_containers/hypospray/emais,
+/obj/item/reagent_containers/hypospray/emais,
+/obj/item/reagent_containers/hypospray/emais,
+/obj/item/reagent_containers/hypospray/emais,
+/obj/item/reagent_containers/hypospray/emais,
 /turf/open/floor/carpet/green,
 /area/department_main/safety)
 "qG" = (

--- a/code/game/objects/items/clerks/hypo/hypo.dm
+++ b/code/game/objects/items/clerks/hypo/hypo.dm
@@ -140,8 +140,8 @@
 /obj/item/reagent_containers/hypospray/emais/attackby(obj/item/I, mob/living/user, params)
 	if(istype(I,/obj/item/hypo_upgrade))
 		var/obj/item/hypo_upgrade/H = I
-		if (H?.add_upgrade(src,user))
-			qdel(H)
+		H.add_upgrade(src,user)
+
 
 /obj/item/reagent_containers/hypospray/emais/proc/clerk_check(var/mob/living/carbon/human/H)
 	if(istype(H) && (H?.mind?.assigned_role == "Clerk"))

--- a/code/game/objects/items/clerks/hypo/hypo.dm
+++ b/code/game/objects/items/clerks/hypo/hypo.dm
@@ -143,7 +143,7 @@
 		H.add_upgrade(src,user)
 
 
-/obj/item/reagent_containers/hypospray/emais/proc/clerk_check(var/mob/living/carbon/human/H)
+/obj/item/reagent_containers/hypospray/emais/proc/clerk_check(mob/living/carbon/human/H)
 	if(istype(H) && (H?.mind?.assigned_role == "Clerk"))
 		return TRUE
 	return FALSE

--- a/code/game/objects/items/clerks/hypo/hypo.dm
+++ b/code/game/objects/items/clerks/hypo/hypo.dm
@@ -1,5 +1,3 @@
-#define C2NAMEREAGENT	"[initial(reagent.name)] (Has Side-Effects)"
-
 /obj/item/reagent_containers/hypospray/emais
 	name = "E.M.A.I.S"
 	desc = "The Emergency Medical Aid Injector and Synthesiser is a lobotomy corp favored medical device, used by the safety department to keep all employe's healthy and happy in emergency cases."
@@ -44,17 +42,11 @@
 
 	modes[reagent] = modes.len + 1
 
-	if(initial(reagent.harmful))
-		reagent_names[C2NAMEREAGENT] = reagent
-	else
-		reagent_names[initial(reagent.name)] = reagent
+	reagent_names[initial(reagent.name)] = reagent
 
 /obj/item/reagent_containers/hypospray/emais/proc/del_reagent(datum/reagent/reagent)
 	reagent_ids -= reagent
-	if(istype(reagent, /datum/reagent/medicine/c2))
-		reagent_names -= C2NAMEREAGENT
-	else
-		reagent_names -= initial(reagent.name)
+	reagent_names -= initial(reagent.name)
 	var/datum/reagents/RG
 	var/datum/reagents/TRG
 	for(var/i in 1 to reagent_ids.len)

--- a/code/game/objects/items/clerks/hypo/hypo.dm
+++ b/code/game/objects/items/clerks/hypo/hypo.dm
@@ -2,7 +2,7 @@
 
 /obj/item/reagent_containers/hypospray/emais
 	name = "E.M.A.I.S"
-	desc = "The Emergency Medical Aid injector and synthesiser is a lobotomy corp favored medical device, used by the safety department to keep all employe's healthy and happy in emergency cases."
+	desc = "The Emergency Medical Aid Injector and Synthesiser is a lobotomy corp favored medical device, used by the safety department to keep all employe's healthy and happy in emergency cases."
 	reagent_flags = DRAINABLE
 	var/list/reagent_ids = list(/datum/reagent/medicine/mental_stabilizator,/datum/reagent/medicine/sal_acid,/datum/reagent/medicine/epinephrine)
 	var/list/reagent_names = list()

--- a/code/game/objects/items/clerks/hypo/hypo.dm
+++ b/code/game/objects/items/clerks/hypo/hypo.dm
@@ -1,0 +1,149 @@
+#define C2NAMEREAGENT	"[initial(reagent.name)] (Has Side-Effects)"
+
+/obj/item/reagent_containers/hypospray/emais
+	name = "E.M.A.I.S"
+	desc = "The Emergency Medical Aid injector and synthesiser is a lobotomy corp favored medical device, used by the safety department to keep all employe's healthy and happy in emergency cases."
+	reagent_flags = DRAINABLE
+	var/list/reagent_ids = list(/datum/reagent/medicine/mental_stabilizator,/datum/reagent/medicine/sal_acid,/datum/reagent/medicine/epinephrine)
+	var/list/reagent_names = list()
+	var/chem_capacity = 30
+	var/list/datum/reagents/reagent_list = list()
+	var/list/datum/hypo_upgrade/upgrades = list()
+	var/list/modes = list()
+	var/mode = 1
+	var/bypass_protection = FALSE
+	var/recharge_time = 10
+	var/charge_timer = 0
+	var/locked = TRUE //clerks only
+
+/obj/item/reagent_containers/hypospray/emais/Initialize()
+	. = ..()
+
+	for(var/R in reagent_ids)
+		add_reagent(R)
+
+	START_PROCESSING(SSobj, src)
+
+
+/obj/item/reagent_containers/hypospray/emais/Destroy()
+	STOP_PROCESSING(SSobj, src)
+	return ..()
+
+/obj/item/reagent_containers/hypospray/emais/process(delta_time) //Every [recharge_time] seconds, recharge some reagents for the cyborg
+	regenerate_reagents()
+	return 1
+
+/obj/item/reagent_containers/hypospray/emais/proc/add_reagent(datum/reagent/reagent)
+	reagent_ids |= reagent
+	var/datum/reagents/RG = new(chem_capacity)
+	RG.my_atom = src
+	reagent_list += RG
+
+	var/datum/reagents/R = reagent_list[reagent_list.len]
+	R.add_reagent(reagent, chem_capacity)
+
+	modes[reagent] = modes.len + 1
+
+	if(initial(reagent.harmful))
+		reagent_names[C2NAMEREAGENT] = reagent
+	else
+		reagent_names[initial(reagent.name)] = reagent
+
+/obj/item/reagent_containers/hypospray/emais/proc/del_reagent(datum/reagent/reagent)
+	reagent_ids -= reagent
+	if(istype(reagent, /datum/reagent/medicine/c2))
+		reagent_names -= C2NAMEREAGENT
+	else
+		reagent_names -= initial(reagent.name)
+	var/datum/reagents/RG
+	var/datum/reagents/TRG
+	for(var/i in 1 to reagent_ids.len)
+		TRG = reagent_list[i]
+		if (TRG.has_reagent(reagent))
+			RG = TRG
+			break
+	if (RG)
+		reagent_list -= RG
+		RG.del_reagent(reagent)
+
+		modes[reagent] = modes.len - 1
+
+/obj/item/reagent_containers/hypospray/emais/proc/regenerate_reagents()
+	for(var/i in 1 to reagent_ids.len)
+		var/datum/reagents/RG = reagent_list[i]
+		if(RG.total_volume < RG.maximum_volume) 	//Don't recharge reagents and drain power if the storage is full.
+			RG.add_reagent(reagent_ids[i], 5)		//And fill hypo with reagent.
+
+/obj/item/reagent_containers/hypospray/emais/attack(mob/living/carbon/M, mob/user)
+	if(!clerk_check(user))
+		to_chat(user,"<span class='warning'>You don't know how to use this.</span>")
+		return
+	var/datum/reagents/R = reagent_list[mode]
+	if(!R.total_volume)
+		to_chat(user, "<span class='warning'>The injector is empty!</span>")
+		return
+	if(!istype(M))
+		return
+	if(R.total_volume && M.can_inject(user, 1, user.zone_selected,bypass_protection))
+		to_chat(M, "<span class='warning'>You feel a tiny prick!</span>")
+		to_chat(user, "<span class='notice'>You inject [M] with the injector.</span>")
+		if(M.reagents)
+			var/trans = R.trans_to(M, amount_per_transfer_from_this, transfered_by = user, methods = INJECT)
+			to_chat(user, "<span class='notice'>[trans] unit\s injected. [R.total_volume] unit\s remaining.</span>")
+
+	var/list/injected = list()
+	for(var/datum/reagent/RG in R.reagent_list)
+		injected += RG.name
+	log_combat(user, M, "injected", src, "(CHEMICALS: [english_list(injected)])")
+
+
+/obj/item/reagent_containers/hypospray/emais/attack_self(mob/user)
+	var/chosen_reagent = modes[reagent_names[input(user, "What reagent do you want to dispense?") as null|anything in sortList(reagent_names)]]
+	if(!chosen_reagent)
+		return
+	mode = chosen_reagent
+	playsound(loc, 'sound/effects/pop.ogg', 50, FALSE)
+	var/datum/reagent/R = GLOB.chemical_reagents_list[reagent_ids[mode]]
+	to_chat(user, "<span class='notice'>[src] is now dispensing '[R.name]'.</span>")
+	return
+
+/obj/item/reagent_containers/hypospray/emais/examine(mob/user)
+	. = ..()
+	. += DescribeContents()	//Because using the standardized reagents datum was just too cool for whatever fuckwit wrote this
+	var/datum/reagent/loaded = modes[mode]
+	. += "Currently loaded: [initial(loaded.name)]. [initial(loaded.description)]"
+	. += "<span class='notice'><i>Alt+Click</i> to change transfer amount. Currently set to [amount_per_transfer_from_this == 5 ? "dose normally (5u)" : "microdose (2u)"].</span>"
+
+/obj/item/reagent_containers/hypospray/emais/proc/DescribeContents()
+	. = list()
+	var/empty = TRUE
+
+	for(var/datum/reagents/RS in reagent_list)
+		var/datum/reagent/R = locate() in RS.reagent_list
+		if(R)
+			. += "<span class='notice'>It currently has [R.volume] unit\s of [R.name] stored.</span>"
+			empty = FALSE
+
+	if(empty)
+		. += "<span class='warning'>It is currently empty! Allow some time for the internal synthesizer to produce more.</span>"
+
+/obj/item/reagent_containers/hypospray/emais/AltClick(mob/living/user)
+	. = ..()
+	if(user.stat == DEAD || user != loc)
+		return //IF YOU CAN HEAR ME SET MY TRANSFER AMOUNT TO 1
+	if(amount_per_transfer_from_this == 5)
+		amount_per_transfer_from_this = 2
+	else
+		amount_per_transfer_from_this = 5
+	to_chat(user,"<span class='notice'>[src] is now set to [amount_per_transfer_from_this == 5 ? "dose normally" : "microdose"].</span>")
+
+/obj/item/reagent_containers/hypospray/emais/attackby(obj/item/I, mob/living/user, params)
+	if(istype(I,/obj/item/hypo_upgrade))
+		var/obj/item/hypo_upgrade/H = I
+		if (H?.add_upgrade(src,user))
+			qdel(H)
+
+/obj/item/reagent_containers/hypospray/emais/proc/clerk_check(var/mob/living/carbon/human/H)
+	if(istype(H) && (H?.mind?.assigned_role == "Clerk"))
+		return TRUE
+	return FALSE

--- a/code/game/objects/items/clerks/hypo/hypo_upgrades.dm
+++ b/code/game/objects/items/clerks/hypo/hypo_upgrades.dm
@@ -1,0 +1,40 @@
+/datum/hypo_upgrade
+	var/name = "Hypo upgrade"
+	var/desc = "This upgrade does nothing, kinda neat right?"
+
+/datum/hypo_upgrade/proc/add_upgrade(var/obj/item/reagent_containers/hypospray/emais/H,var/atom/movable/A)
+	if(!istype(H))
+		return FALSE
+	H.upgrades += src
+	return TRUE
+
+/datum/hypo_upgrade/proc/remove_upgrade(var/obj/item/reagent_containers/hypospray/emais/H,var/atom/movable/A)
+	H.upgrades -= src
+	return TRUE
+
+/datum/hypo_upgrade/cap_increase
+	name = "Capacity upgrade"
+	desc = "Increase injector capacity"
+
+/datum/hypo_upgrade/cap_increase/add_upgrade(var/obj/item/reagent_containers/hypospray/emais/H,var/atom/movable/A)
+	H.chem_capacity = H.chem_capacity * 2
+	..()
+
+/datum/hypo_upgrade/cap_increase/remove_upgrade(var/obj/item/reagent_containers/hypospray/emais/H,var/atom/movable/A)
+	H.chem_capacity = H.chem_capacity / 2
+	..()
+
+/obj/item/hypo_upgrade
+	name = "Hypo upgrade"
+	desc = "This upgrade does nothing, kinda neat right?"
+	icon_state = "nucleardisk"
+	var/datum/hypo_upgrade/upgrade_datum
+
+/obj/item/hypo_upgrade/proc/add_upgrade(var/obj/item/reagent_containers/hypospray/emais/H,var/atom/movable/A)
+	upgrade_datum.add_upgrade(H,A)
+
+/obj/item/hypo_upgrade/cap_increase
+	name = "Capacity upgrade"
+	desc = "Increase injector capacity"
+	upgrade_datum = new /datum/hypo_upgrade/cap_increase
+

--- a/code/game/objects/items/clerks/hypo/hypo_upgrades.dm
+++ b/code/game/objects/items/clerks/hypo/hypo_upgrades.dm
@@ -15,7 +15,7 @@
 		return FALSE
 	return TRUE
 
-/datum/hypo_upgrade/proc/remove_upgrade(obj/item/reagent_containers/hypospray/emais/H,var/atom/movable/A)
+/datum/hypo_upgrade/proc/remove_upgrade(obj/item/reagent_containers/hypospray/emais/H,atom/movable/A)
 	H.upgrades -= src
 	return TRUE
 

--- a/code/game/objects/items/clerks/hypo/hypo_upgrades.dm
+++ b/code/game/objects/items/clerks/hypo/hypo_upgrades.dm
@@ -1,27 +1,41 @@
 /datum/hypo_upgrade
 	var/name = "Hypo upgrade"
 	var/desc = "This upgrade does nothing, kinda neat right?"
+	var/stackable = FALSE
 
-/datum/hypo_upgrade/proc/add_upgrade(var/obj/item/reagent_containers/hypospray/emais/H,var/atom/movable/A)
-	if(!istype(H))
-		return FALSE
+/datum/hypo_upgrade/proc/add_upgrade(obj/item/reagent_containers/hypospray/emais/H,atom/movable/A)
 	H.upgrades += src
 	return TRUE
 
-/datum/hypo_upgrade/proc/remove_upgrade(var/obj/item/reagent_containers/hypospray/emais/H,var/atom/movable/A)
+/datum/hypo_upgrade/proc/upgrade_check(obj/item/reagent_containers/hypospray/emais/H)
+	if(!istype(H))
+		return FALSE
+	if(!stackable && (src in H?.upgrades))
+		to_chat(H,"<span class='warning'>This upgrade is already effective!</span>")
+		return FALSE
+	return TRUE
+
+/datum/hypo_upgrade/proc/remove_upgrade(obj/item/reagent_containers/hypospray/emais/H,var/atom/movable/A)
 	H.upgrades -= src
 	return TRUE
 
 /datum/hypo_upgrade/cap_increase
 	name = "Capacity upgrade"
 	desc = "Increase injector capacity"
+	var/cap_multiplier = 2
 
-/datum/hypo_upgrade/cap_increase/add_upgrade(var/obj/item/reagent_containers/hypospray/emais/H,var/atom/movable/A)
-	H.chem_capacity = H.chem_capacity * 2
+/datum/hypo_upgrade/cap_increase/add_upgrade(obj/item/reagent_containers/hypospray/emais/H,atom/movable/A)
+	if(!upgrade_check(H))
+		return FALSE
+	H.chem_capacity = H.chem_capacity * cap_multiplier
+	for(var/datum/reagents/R in H.reagent_list)
+		R.maximum_volume = R.maximum_volume * cap_multiplier
 	..()
 
-/datum/hypo_upgrade/cap_increase/remove_upgrade(var/obj/item/reagent_containers/hypospray/emais/H,var/atom/movable/A)
-	H.chem_capacity = H.chem_capacity / 2
+/datum/hypo_upgrade/cap_increase/remove_upgrade(obj/item/reagent_containers/hypospray/emais/H,atom/movable/A)
+	H.chem_capacity = initial(H.chem_capacity)
+	for(var/datum/reagents/R in H.reagent_list)
+		R.maximum_volume = initial(H.chem_capacity)
 	..()
 
 /obj/item/hypo_upgrade
@@ -29,9 +43,12 @@
 	desc = "This upgrade does nothing, kinda neat right?"
 	icon_state = "nucleardisk"
 	var/datum/hypo_upgrade/upgrade_datum
+	var/reusable = FALSE
 
-/obj/item/hypo_upgrade/proc/add_upgrade(var/obj/item/reagent_containers/hypospray/emais/H,var/atom/movable/A)
+/obj/item/hypo_upgrade/proc/add_upgrade(obj/item/reagent_containers/hypospray/emais/H,atom/movable/A)
 	upgrade_datum.add_upgrade(H,A)
+	if(!reusable)
+		qdel(src)
 
 /obj/item/hypo_upgrade/cap_increase
 	name = "Capacity upgrade"

--- a/lobotomy-corp13.dme
+++ b/lobotomy-corp13.dme
@@ -1147,6 +1147,8 @@
 #include "code\game\objects\items\circuitboards\circuitboard.dm"
 #include "code\game\objects\items\circuitboards\computer_circuitboards.dm"
 #include "code\game\objects\items\circuitboards\machine_circuitboards.dm"
+#include "code\game\objects\items\clerks\hypo\hypo.dm"
+#include "code\game\objects\items\clerks\hypo\hypo_upgrades.dm"
 #include "code\game\objects\items\devices\aicard.dm"
 #include "code\game\objects\items\devices\anomaly_neutralizer.dm"
 #include "code\game\objects\items\devices\beacon.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a new hypospray for clerks only to use, this should make safety team clerks objecticly beter at being support. It works in the same way as the borg spray recharging chems over time.

Also adds some code to implement hypo upgrades. Which may be neat for a "department research" mechanic. Mostly scafold code for now

There will be 10 on the safety teams table, this is fine since agents cant use these.

## Why It's Good For The Game

First step into making clerks better supports. This is probably not balanced without removing clerk leveling(if thats a thing) but atomizing.

## Changelog
:cl:
add: Trough extra funding of the safety department, clerks can use the "E.M.A.I.S". A innovative medical injector
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
