### PR TITLE
emergency Der Freischutz fix

### DIFF
--- a/code/game/objects/effects/abnormality.dm
+++ b/code/game/objects/effects/abnormality.dm
@@ -79,6 +79,7 @@
 	var/obj/effect/frei_trail/trayl = new(src.loc)
 	trayl.dir = src.dir
 	src.forceMove(get_step(src,src.dir))
+	del(nearmiss)
 	return ..()
 
 /obj/effect/frei_magic


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Der Freischutz currently "grazes" you twice in addition to a direct hit from his bullet. The one line of code that prevents this is included in this PR.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Please do not deal 240 damage to someone with a hitscan projectile from across the map.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixed a bug in der freischutz' bullet hitboxes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
