### PR TITLE
Melting Love tweaks/balance

### DIFF
--- a/code/datums/abnormality/_ego_datum/aleph.dm
+++ b/code/datums/abnormality/_ego_datum/aleph.dm
@@ -42,7 +42,7 @@
 // Melting Love - Adoration
 /datum/ego_datum/weapon/adoration
 	item_path = /obj/item/gun/ego_gun/adoration
-	cost = 100
+	cost = 122
 
 /datum/ego_datum/armor/adoration
 	item_path = /obj/item/clothing/suit/armor/ego_gear/adoration

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/melting_love.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/melting_love.dm
@@ -13,17 +13,17 @@
 	attack_verb_simple = "glomp"
 	/* Stats */
 	threat_level = ALEPH_LEVEL
-	health = 3500
-	maxHealth = 3500
+	health = 4000
+	maxHealth = 4000
 	obj_damage = 600
 	damage_coeff = list(BRUTE = 1, RED_DAMAGE = -1, WHITE_DAMAGE = 1, BLACK_DAMAGE = 1.5, PALE_DAMAGE = 0.8)
 	melee_damage_type = BLACK_DAMAGE
-	melee_damage_lower = 32
-	melee_damage_upper = 40
+	melee_damage_lower = 30
+	melee_damage_upper = 50
 	projectiletype = /obj/projectile/melting_blob
 	ranged = TRUE
 	minimum_distance = 1
-	ranged_cooldown_time = 30
+	ranged_cooldown_time = 5 SECONDS
 	speed = 2
 	move_to_delay = 5
 	/* Works */
@@ -79,6 +79,25 @@
 			return FALSE
 	return ..()
 
+/mob/living/simple_animal/hostile/abnormality/melting_love/PickTarget(list/Targets) // We attack corpses first if there are any thanks mobs
+	var/list/highest_priority = list()
+	var/list/lower_priority = list()
+	for(var/mob/living/L in Targets)
+		if(!CanAttack(L))
+			continue
+		if(L.health < 0 || L.stat == DEAD)
+			if(ishuman(L))
+				highest_priority += L
+			else
+				lower_priority += L
+		else if(L.health < L.maxHealth*0.5)
+			lower_priority += L
+	if(LAZYLEN(highest_priority))
+		return pick(highest_priority)
+	if(LAZYLEN(lower_priority))
+		return pick(lower_priority)
+	return ..()
+
 /mob/living/simple_animal/hostile/abnormality/melting_love/AttackingTarget()
 	. = ..()
 	if(!ishuman(target))
@@ -115,6 +134,8 @@
 		to_chat(gifted_human, "<span class='userdanger'>You feel like you are about to burst !</span>")
 		gifted_human.emote("scream")
 		gifted_human.gib()
+	UnregisterSignal(gifted_human, COMSIG_LIVING_DEATH)
+	UnregisterSignal(gifted_human, COMSIG_WORK_COMPLETED)
 	breach_effect()
 	return
 
@@ -127,37 +148,43 @@
 
 /mob/living/simple_animal/hostile/abnormality/melting_love/work_complete(mob/living/carbon/human/user, work_type, pe)
 	..()
-	if(work_type != ABNORMALITY_WORK_REPRESSION)
-		if(!gifted_human && istype(user))
-			gifted_human = user
-			RegisterSignal(user, COMSIG_LIVING_DEATH, .proc/GiftedDeath)
-			to_chat(user, "<span class='nicegreen'>You feel like you received a gift...</span>")
-			user.adjust_attribute_buff(TEMPERANCE_ATTRIBUTE, 30)
-			user.add_overlay(mutable_appearance('icons/effects/32x64.dmi', "gift", -HALO_LAYER))
-			playsound(get_turf(user), 'sound/effects/footstep/slime1.ogg', 50, 0, 2)
-			return
-		if(user == gifted_human)
-			to_chat(gifted_human, "<span class='nicegreen'>Melting Love was happy to see you !</span>")
-			gifted_human.adjustSanityLoss(25)
+	if(!gifted_human && istype(user) && work_type != ABNORMALITY_WORK_REPRESSION && user.stat != DEAD)
+		gifted_human = user
+		RegisterSignal(user, COMSIG_LIVING_DEATH, .proc/GiftedDeath)
+		RegisterSignal(user, COMSIG_WORK_COMPLETED, .proc/GiftedAnger)
+		to_chat(user, "<span class='nicegreen'>You feel like you received a gift...</span>")
+		user.adjust_attribute_buff(TEMPERANCE_ATTRIBUTE, 30)
+		user.add_overlay(mutable_appearance('icons/effects/32x64.dmi', "gift", -HALO_LAYER))
+		playsound(get_turf(user), 'sound/effects/footstep/slime1.ogg', 50, 0, 2)
 		return
-	else
-		if(user == gifted_human)
-			to_chat(gifted_human, "<span class='danger'>Melting Love didn't like that !</span>")
-			datum_reference.qliphoth_change(-1)
+	if(istype(user) && user == gifted_human)
+		to_chat(gifted_human, "<span class='nicegreen'>Melting Love was happy to see you!</span>")
+		gifted_human.adjustSanityLoss(rand(25,35))
 		return
+
+/mob/living/simple_animal/hostile/abnormality/melting_love/proc/GiftedAnger(datum/source, datum/abnormality/datum_sent, mob/living/carbon/human/user, work_type)
+	SIGNAL_HANDLER
+	if (work_type == ABNORMALITY_WORK_REPRESSION)
+		to_chat(gifted_human, "<span class='userdanger'>Melting Love didn't like that!</span>")
+		datum_reference.qliphoth_change(-1)
 
 /mob/living/simple_animal/hostile/abnormality/melting_love/proc/sanityheal()
 	if(sanityheal_cooldown <= world.time)
 		gifted_human.adjustSanityLoss(30)
 		sanityheal_cooldown = (world.time + sanityheal_cooldown_base)
 
+/mob/living/simple_animal/hostile/abnormality/melting_love/work_chance(mob/living/carbon/human/user, chance)
+	if(user == gifted_human)
+		return chance + 10
+	return chance
+
 /* Checking if bigslime is dead or not and apply a damage buff if yes */
 /mob/living/simple_animal/hostile/abnormality/melting_love/proc/SlimeDeath(datum/source, gibbed)
 	SIGNAL_HANDLER
-	melee_damage_lower = 62
-	melee_damage_upper = 80
-	adjustBruteLoss(-maxHealth)
+	melee_damage_lower = 40
+	melee_damage_upper = 64
 	projectiletype = /obj/projectile/melting_blob/enraged
+	adjustBruteLoss(-maxHealth)
 	for(var/mob/M in GLOB.player_list)
 		if(M.z == z && M.client)
 			to_chat(M, "<span class='userdanger'>You can hear a gooey cry !</span>")
@@ -171,7 +198,7 @@
 	var /mob/living/simple_animal/hostile/slime/big/S = new(T)
 	RegisterSignal(S, COMSIG_LIVING_DEATH, .proc/SlimeDeath)
 
-/* Slimes */
+/* Slimes (HE) */
 /mob/living/simple_animal/hostile/slime
 	name = "Slime Pawn"
 	desc = "The skeletal remains of a former employee is floating in it..."
@@ -183,14 +210,16 @@
 	attack_verb_continuous = "glomps"
 	attack_verb_simple = "glomp"
 	/* Stats */
-	health = 800
-	maxHealth = 800
+	health = 400
+	maxHealth = 400
 	obj_damage = 200
-	damage_coeff = list(RED_DAMAGE = -1, WHITE_DAMAGE = 1, BLACK_DAMAGE = 2, PALE_DAMAGE = 1)
+	damage_coeff = list(BRUTE = 1, RED_DAMAGE = -1, WHITE_DAMAGE = 1, BLACK_DAMAGE = 2, PALE_DAMAGE = 1)
 	melee_damage_type = BLACK_DAMAGE
-	melee_damage_lower = 20
+	melee_damage_lower = 12
 	melee_damage_upper = 24
 	rapid_melee = 2
+	speed = 2
+	move_to_delay = 4
 	/* Sounds */
 	deathsound = 'sound/effects/blobattack.ogg'
 	attack_sound = 'sound/effects/attackblob.ogg'
@@ -214,6 +243,25 @@
 			return FALSE
 	return ..()
 
+/mob/living/simple_animal/hostile/slime/PickTarget(list/Targets) // We attack corpses first if there are any thanks mobs
+	var/list/highest_priority = list()
+	var/list/lower_priority = list()
+	for(var/mob/living/L in Targets)
+		if(!CanAttack(L))
+			continue
+		if(L.health < 0 || L.stat == DEAD)
+			if(ishuman(L))
+				highest_priority += L
+			else
+				lower_priority += L
+		else if(L.health < L.maxHealth*0.5)
+			lower_priority += L
+	if(LAZYLEN(highest_priority))
+		return pick(highest_priority)
+	if(LAZYLEN(lower_priority))
+		return pick(lower_priority)
+	return ..()
+
 /mob/living/simple_animal/hostile/slime/AttackingTarget()
 	. = ..()
 	if(!ishuman(target))
@@ -225,7 +273,7 @@
 	else
 		slimeconv(H)
 
-/* Big Slimes */
+/* Big Slimes (WAW) */
 /mob/living/simple_animal/hostile/slime/big
 	name = "Big Slime"
 	desc = "The skeletal remains of the former gifted employee is floating in it..."
@@ -237,9 +285,10 @@
 	/* Stats */
 	health = 2000
 	maxHealth = 2000
-	damage_coeff = list(RED_DAMAGE = -1, WHITE_DAMAGE = 1, BLACK_DAMAGE = 2.0, PALE_DAMAGE = 0.8)
-	melee_damage_lower = 34
-	melee_damage_upper = 38
+	damage_coeff = list(BRUTE = 1, RED_DAMAGE = -1, WHITE_DAMAGE = 1, BLACK_DAMAGE = 2.0, PALE_DAMAGE = 0.8)
+	melee_damage_lower = 24
+	melee_damage_upper = 40
+	move_to_delay = 3
 
 /mob/living/simple_animal/hostile/slime/big/Initialize()
 	. = ..()

--- a/code/modules/projectiles/guns/ego_gun/aleph.dm
+++ b/code/modules/projectiles/guns/ego_gun/aleph.dm
@@ -31,7 +31,7 @@
 	weapon_weight = WEAPON_HEAVY
 	fire_sound = 'sound/effects/attackblob.ogg'
 	fire_sound_volume = 50
-	fire_delay = 15
+	fire_delay = 5 SECONDS
 
 	attribute_requirements = list(
 							FORTITUDE_ATTRIBUTE = 80,

--- a/code/modules/projectiles/projectile/ego_bullets/aleph.dm
+++ b/code/modules/projectiles/projectile/ego_bullets/aleph.dm
@@ -9,8 +9,18 @@
 	name = "slime projectile"
 	icon_state = "slime"
 	desc = "A glob of infectious slime. It's going for your heart."
+	damage = 88
 	damage_type = BLACK_DAMAGE
 	flag = BLACK_DAMAGE
-	damage = 100
 	spread = 15
+	speed = 1.2
 	hitsound = "sound/effects/footstep/slime1.ogg"
+
+/obj/projectile/ego_bullet/melting_blob/on_hit(target)
+	var/mob/living/H = target
+	H.visible_message("<span class='warning'>[target] is hit by [src], they seem to wither away!</span>")
+	if(!isbot(H) && isliving(H))
+		for(var/i = 1 to 10)
+			addtimer(CALLBACK(H, /mob/living/proc/apply_damage, rand(4,6), BLACK_DAMAGE, null, H.run_armor_check(null, BLACK_DAMAGE)), 2 SECONDS * i)
+		return BULLET_ACT_HIT
+	. = ..()

--- a/code/modules/projectiles/projectile/magic/abnormality.dm
+++ b/code/modules/projectiles/projectile/magic/abnormality.dm
@@ -38,15 +38,35 @@
 	name = "slime projectile"
 	icon_state = "slime"
 	desc = "A glob of infectious slime. It's going for your heart."
-	damage_type = BLACK_DAMAGE
-	flag = BLACK_DAMAGE
-	damage = 100
+	damage = 0
 	spread = 15
+	speed = 1.2
 	hitsound = "sound/effects/footstep/slime1.ogg"
+	var/maxdmg = null
+	var/mindmg = null
+	maxdmg = 90
+	mindmg = 50
 
 /obj/projectile/melting_blob/enraged
-	damage = 200
-	spread = 15
+	desc = "A glob of infectious slime. It's going for your heart, It seems bigger..."
+	maxdmg = 120
+	mindmg = 60
+
+/obj/projectile/melting_blob/on_hit(target)
+	if(ismob(target))
+		var/mob/living/H = target
+		if("slime" in H.faction)
+			H.visible_message("<span class='warning'>[src] vanishes on contact with [target]!</span>")
+			qdel(src)
+			return BULLET_ACT_BLOCK
+		else
+			H.visible_message("<span class='warning'>[target] is hit by [src], they seem to wither away!</span>")
+			H.apply_damage(rand(mindmg,maxdmg), BLACK_DAMAGE, null, H.run_armor_check(null, BLACK_DAMAGE))
+			if(!isbot(H) && isliving(H))
+				for(var/i = 1 to 10)
+					addtimer(CALLBACK(H, /mob/living/proc/apply_damage, rand(4,6), BLACK_DAMAGE, null, H.run_armor_check(null, BLACK_DAMAGE)), 2 SECONDS * i)
+				return BULLET_ACT_HIT
+	. = ..()
 
 /obj/projectile/mountain_spit
 	name = "spit"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Melting Love go for corpses first
- Reduce Slime pawn/Big slime speed
- Reduce the health of Slime Pawn
- Tweak damage for all of them
- Buff ML health to follow other Aleph standards 
- Adoration and Melting Love get dot damage increase the price of adoration (Very good weapon now)
- Repression work on any abnos makes ML mad reducing the counter by 1
- Gifted has increase work chance on ML

Thanks for @PotatoTomahto help.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Melting Love was a bit overtune... Might tweak her again later if she become too weak.
New mechanics etc
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Unoki, PotatoTomahto
balance: ML/Slimes target dead bodies first, Slower slimepawn/bigslime, Damage and health balance, adoration more damage+dot
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
