### PR TITLE
Abnorm changes

### DIFF
--- a/code/datums/abnormality/datum/abnormality.dm
+++ b/code/datums/abnormality/datum/abnormality.dm
@@ -92,7 +92,7 @@
 	return TRUE
 
 /datum/abnormality/proc/work_complete(mob/living/carbon/human/user, work_type, pe, max_pe, work_time)
-	current.work_complete(user, work_type, pe, success_boxes, work_time) // Cross-referencing gone wrong
+	current.work_complete(user, work_type, pe, work_time) // Cross-referencing gone wrong
 	stored_boxes += pe
 	SSlobotomy_corp.WorkComplete(pe)
 	if(overload_chance > overload_chance_limit)

--- a/code/datums/ai/sanity/_sanityloss_controller.dm
+++ b/code/datums/ai/sanity/_sanityloss_controller.dm
@@ -203,6 +203,7 @@
 /datum/ai_controller/insane/wander
 	lines_type = /datum/ai_behavior/say_line/insanity_wander
 	var/last_message
+	var/suicide_enter = 0
 
 /datum/ai_controller/insane/wander/PerformIdleBehavior(delta_time)
 	var/mob/living/living_pawn = pawn
@@ -212,6 +213,14 @@
 	if(DT_PROB(10, delta_time) && world.time + 5 SECONDS > last_message)
 		last_message = world.time
 		current_behaviors += GET_AI_BEHAVIOR(lines_type)
+	if(world.time > suicide_enter)
+		if(DT_PROB(10, delta_time))
+			living_pawn.visible_message("<span class='danger'>[living_pawn] freezes with an expression of despair on their face!</span>")
+			QDEL_NULL(living_pawn.ai_controller)
+			living_pawn.ai_controller = /datum/ai_controller/insane/suicide
+			living_pawn.InitializeAIController()
+		else
+			suicide_enter = world.time + 30 SECONDS
 
 /datum/ai_controller/insane/release
 	lines_type = /datum/ai_behavior/say_line/insanity_release
@@ -231,6 +240,8 @@
 		if(!AC.datum_reference)
 			continue
 		if(!(AC.datum_reference.current.status_flags & GODMODE))
+			continue
+		if(blackboard[BB_INSANE_BLACKLISTITEMS][AC] > world.time)
 			continue
 		if((AC.datum_reference.qliphoth_meter_max > 0) && (AC.datum_reference.qliphoth_meter > 0))
 			if(get_dist(pawn, AC) < 40)

--- a/code/datums/ai/sanity/sanityloss_behaviors.dm
+++ b/code/datums/ai/sanity/sanityloss_behaviors.dm
@@ -4,14 +4,14 @@
 				"You left me behind!",
 				"You are the problem, YOU!!",
 				"I'll destroy everything...",
-				"It will end quickly, so relax. I’ll free you from this prison we call flesh."
+				"It will end quickly, so relax. Iâ€™ll free you from this prison we call flesh."
 				)
 
 /datum/ai_behavior/say_line/insanity_suicide
 	lines = list(
-				"It's all my fault. It’s my responsibility...",
-				"I can hear someone. It’s the sound of back home. I just can’t stop hearing it…",
-				"There’s no hope left. My mind’s collapsing. Everything’s collapsing...",
+				"It's all my fault. Itâ€™s my responsibility...",
+				"I can hear someone. Itâ€™s the sound of back home. I just canâ€™t stop hearing it",
+				"Thereâ€™s no hope left. My mindâ€™s collapsing. Everythingâ€™s collapsing...",
 				"We will all sink and perish, devoured by madness...",
 				"There is no hope left...",
 				"It will all end, soon..."
@@ -21,7 +21,7 @@
 	lines = list(
 				"Manager?! Manager! Open the emergency door! PLEASE LET ME OUT!!",
 				"HELP ME!!",
-				"DON'T SEND ME IN THERE! DON’T KILL ME!!",
+				"DON'T SEND ME IN THERE! DONâ€™T KILL ME!!",
 				"AHAHAHAHAHAHAHAHAHAHAHAHAHAHAHAHAHAHAHAHA!!",
 				"I will never get out of here..."
 				)
@@ -38,10 +38,10 @@
 /datum/ai_behavior/say_line/insanity_release
 	lines = list(
 				"Let us find peace from them.",
-				"I’m so sorry dear friends, I’ll let you out now.",
+				"Iâ€™m so sorry dear friends, Iâ€™ll let you out now.",
 				"We will find our redemption through the Abnormalities.",
 				"Let us reach the paradise beyond death, together with the Abnormalities.",
-				"Let me introduce you to my imaginary friends! They asked me to! They’re screaming to be let out!"
+				"Let me introduce you to my imaginary friends! They asked me to! Theyâ€™re screaming to be let out!"
 				)
 
 /datum/ai_behavior/insanity_attack_mob
@@ -174,12 +174,17 @@
 	if(!istype(target) || !istype(target.datum_reference))
 		finish_action(controller, FALSE)
 		return
-	if(DT_PROB(5, delta_time) && living_pawn.Adjacent(target) && isturf(target.loc))
-		living_pawn.visible_message("<span class='danger'>[living_pawn] smashes panel on \the [target]!</span>")
+	if(DT_PROB(5*get_user_level(living_pawn), delta_time) && living_pawn.Adjacent(target) && isturf(target.loc))
+		living_pawn.visible_message("<span class='danger'>[living_pawn] smashes the panel on \the [target]!</span>")
 		playsound(living_pawn.loc, 'sound/effects/hit_on_shattered_glass.ogg', 75, TRUE, -1)
-		if(!target.finish_work(living_pawn))
+		if(target.datum_reference.qliphoth_meter == 1)
+			target.datum_reference.qliphoth_change(-1)
 			finish_action(controller, TRUE)
+			return
+		target.datum_reference.qliphoth_change(-1)
 
 /datum/ai_behavior/insanity_smash_console/finish_action(datum/ai_controller/controller, succeeded)
 	. = ..()
+	var/obj/machinery/computer/abnormality/target = controller.blackboard[BB_INSANE_CURRENT_ATTACK_TARGET]
+	controller.blackboard[BB_INSANE_BLACKLISTITEMS][target] = world.time + 60 SECONDS
 	controller.blackboard[BB_INSANE_CURRENT_ATTACK_TARGET] = null

--- a/code/game/machinery/computer/abnormality_work.dm
+++ b/code/game/machinery/computer/abnormality_work.dm
@@ -150,7 +150,7 @@
 		if(!training)
 			datum_reference.work_complete(user, work_type, pe, max_pe, work_speed*max_pe)
 		else
-			datum_reference.current.work_complete(user, work_type, pe, datum_reference.success_boxes, work_speed*max_pe)
+			datum_reference.current.work_complete(user, work_type, pe, work_speed*max_pe)
 	if((datum_reference.qliphoth_meter_max > 0) && (datum_reference.qliphoth_meter <= 0))
 		visible_message("<span class='danger'>Warning! Qliphoth level reduced to 0!")
 		playsound(src, 'sound/effects/alertbeep.ogg', 50, FALSE)

--- a/code/modules/clothing/suits/ego_gear/he.dm
+++ b/code/modules/clothing/suits/ego_gear/he.dm
@@ -69,8 +69,7 @@
 
 /obj/item/clothing/suit/armor/ego_gear/magicbullet
 	name = "magic bullet"
-	desc = "The Devil ultimately wished for despair.\
-		For despair wears down the mind and drains one's will to go forward. When one feels there's nothing left to go for, their soul falls down to Hell, the Devil's domain."
+	desc = "The Devil ultimately wished for despair. For despair wears down the mind and drains one's will to go forward. When one feels there's nothing left to go for, their soul falls down to Hell, the Devil's domain."
 	icon_state = "magic_bullet"
 	// Magic Bullet has WAW-tier requirements and goes with a WAW-tier gun, but is not quite WAW-tier itself. Still, valuable if you're a well-rounded agent doing well-rounded work. - NB
 	// I kept it well-rounded, and lowered the requirements, It's now LIKE a waw with it's good, well-rounded defenses, but it was generally lowered.

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/blue_star.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/blue_star.dm
@@ -92,14 +92,28 @@
 	SLEEP_CHECK_DEATH(3)
 	animate(src, transform = init_transform, time = 5)
 
+/mob/living/simple_animal/hostile/abnormality/bluestar/attempt_work(mob/living/carbon/human/user, work_type)
+	if(get_attribute_level(user, TEMPERANCE_ATTRIBUTE) < 80)
+		datum_reference.qliphoth_change(-1)
+		playsound(src, 'sound/abnormalities/bluestar/pulse.ogg', 25, FALSE, 28)
+		user.death()
+		animate(user, transform = user.transform*0.01, time = 5)
+		QDEL_IN(user, 5)
+		return FALSE
+	return TRUE
+
 /mob/living/simple_animal/hostile/abnormality/bluestar/work_complete(mob/living/carbon/human/user, work_type, pe, work_time)
 	..()
-	if(get_attribute_level(user, PRUDENCE_ATTRIBUTE) < 80)
-		datum_reference.qliphoth_change(-1)
-	if(work_time > 40 SECONDS)
+	if(get_attribute_level(user, PRUDENCE_ATTRIBUTE) < 100)
 		datum_reference.qliphoth_change(-1)
 	if(user.sanity_lost)
 		datum_reference.qliphoth_change(-1)
+	if(work_time > 40 SECONDS)
+		datum_reference.qliphoth_change(-1)
+		playsound(src, 'sound/abnormalities/bluestar/pulse.ogg', 25, FALSE, 28)
+		user.death()
+		animate(user, transform = user.transform*0.01, time = 5)
+		QDEL_IN(user, 5)
 	return
 
 /mob/living/simple_animal/hostile/abnormality/bluestar/breach_effect(mob/living/carbon/human/user)

--- a/code/modules/mob/living/simple_animal/abnormality/he/der_freischutz.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/der_freischutz.dm
@@ -40,7 +40,7 @@
 	var/targetx
 	var/targety
 	for(var/mob/M in GLOB.mob_living_list)
-		if(istype(M,/mob/living/simple_animal/bot) || istype(M,/mob/living/simple_animal/hostile/abnormality/der_freischutz) || (src.z != M.z) || (M.stat == DEAD))
+		if(istype(M,/mob/living/simple_animal/bot) || (src.z != M.z) || (M.stat == DEAD) || (M.status_flags & GODMODE))
 			continue
 		targets += M
 	var/mob/target = pick(targets)

--- a/code/modules/mob/living/simple_animal/abnormality/he/rudolta.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/rudolta.dm
@@ -59,7 +59,8 @@
 
 /mob/living/simple_animal/hostile/abnormality/rudolta/proc/WhitePulse()
 	pulse_cooldown = world.time + pulse_cooldown_time
-	new /obj/effect/gibspawner/generic/silent(get_turf(src))
+	if(prob(25))
+		new /obj/effect/gibspawner/generic/silent(get_turf(src))
 	playsound(src, 'sound/abnormalities/rudolta/throw.ogg', 50, FALSE, 4)
 	for(var/mob/living/L in livinginview(8, src))
 		if(faction_check_mob(L))

--- a/code/modules/mob/living/simple_animal/abnormality/he/silent_girl.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/silent_girl.dm
@@ -65,7 +65,7 @@
 	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/silent_girl/proc/Guilt_Effect(mob/living/carbon/human/user)
-	if (user in guilty_people)
+	if ((user.stat == DEAD) || (user in guilty_people))
 		return
 	datum_reference.qliphoth_change(-1)
 	guilty_people += user

--- a/code/modules/mob/living/simple_animal/abnormality/teth/crumbling_armor.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/crumbling_armor.dm
@@ -55,7 +55,7 @@
 		head.dismember()
 		user.adjustBruteLoss(500)
 		return
-	if(work_type == ABNORMALITY_WORK_REPRESSION)
+	if(user.stat != DEAD && work_type == ABNORMALITY_WORK_REPRESSION)
 		if (src.icon_state == "megalovania")
 			if(istype(user.ego_gift_list[HAT], /datum/ego_gifts/phase1)) // From Courage to Recklessness
 				playsound(get_turf(user), 'sound/abnormalities/crumbling/megalovania.ogg', 50, 0, 2)

--- a/code/modules/mob/living/simple_animal/abnormality/teth/spider_bud.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/spider_bud.dm
@@ -27,7 +27,12 @@
 	// If you do insight or have low prudence, fuck you and die for stepping on a spider
 	if((get_attribute_level(user, PRUDENCE_ATTRIBUTE) < 40 || work_type == ABNORMALITY_WORK_INSIGHT) && !(GODMODE in user.status_flags))
 		icon_state = "spider_open"
-		user.gib()
+		var/obj/structure/spider/cocoon/casing = new(src.loc)
+		casing.Move(get_step(casing, pick(GLOB.alldirs)))
+		user.death()
+		user.forceMove(casing)
+		casing.icon_state = pick("cocoon_large1","cocoon_large2","cocoon_large3")
+		casing.density = FALSE
 		SLEEP_CHECK_DEATH(50)
 		icon_state = "spider_closed"
 		return

--- a/code/modules/mob/living/simple_animal/abnormality/waw/despair_knight.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/despair_knight.dm
@@ -126,7 +126,7 @@
 	forceMove(teleport_target)
 
 /mob/living/simple_animal/hostile/abnormality/despair_knight/success_effect(mob/living/carbon/human/user, work_type, pe)
-	if(!blessed_human && istype(user))
+	if(user.stat != DEAD && !blessed_human && istype(user))
 		blessed_human = user
 		RegisterSignal(user, COMSIG_LIVING_DEATH, .proc/BlessedDeath)
 		RegisterSignal(user, COMSIG_HUMAN_INSANE, .proc/BlessedDeath)

--- a/code/modules/mob/living/simple_animal/abnormality/waw/hatred_queen.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/hatred_queen.dm
@@ -109,7 +109,7 @@
 		var/obj/effect/qoh_sygil/S = new(my_turf)
 		S.icon_state = "qoh2"
 		addtimer(CALLBACK(S, .obj/effect/qoh_sygil/proc/fade_out), 5 SECONDS)
-	..()
+	addtimer(CALLBACK(src, ..(), gibbed), 1) //parent call
 	animate(src, alpha = 0, time = 10 SECONDS)
 	QDEL_IN(src, 10 SECONDS)
 	QDEL_NULL(beamloop)
@@ -275,6 +275,10 @@
 					M.Scale(6, 1)
 					current_beam.visuals.transform = M
 					current_beam.visuals.color = COLOR_SOFT_RED
+		for(var/turf/TF in range((beam_stage-1), MT))
+			if((TF != get_turf(src)) && (TF != MT))
+				var/obj/effect/temp_visual/L = new /obj/effect/temp_visual/revenant(TF)
+				L.color = current_beam.visuals.color
 		for(var/turf/TF in hit_line)
 			for(var/mob/living/L in range(beam_stage-1, TF))
 				if(L.status_flags & GODMODE)
@@ -337,6 +341,8 @@
 		if(!faction_check_mob(L) && L.stat != DEAD)
 			teleport_potential += T
 	if(!LAZYLEN(teleport_potential))
+		if(!LAZYLEN(GLOB.department_centers))
+			return
 		var/turf/P = pick(GLOB.department_centers)
 		teleport_potential += P
 	var/turf/teleport_target = pick(teleport_potential)

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/fairy_festival.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/fairy_festival.dm
@@ -39,7 +39,7 @@
 	return
 
 /mob/living/simple_animal/hostile/abnormality/fairy_festival/success_effect(mob/living/carbon/human/user, work_type, pe)
-	if(istype(user))
+	if(user.stat != DEAD && istype(user))
 		if(user in protected_people)
 			return
 		protected_people += user

--- a/code/modules/mob/living/simple_animal/hostile/ordeal/crimson.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/crimson.dm
@@ -79,7 +79,7 @@
 	teleporting = FALSE
 
 /mob/living/simple_animal/hostile/ordeal/crimson_clown/proc/CanTeleportTo(obj/machinery/computer/abnormality/CA)
-	if(CA.meltdown || !CA.datum_reference || !CA.datum_reference.current || !CA.datum_reference.qliphoth_meter)
+	if(!CA.can_meltdown || CA.meltdown || !CA.datum_reference || !CA.datum_reference.current || !CA.datum_reference.qliphoth_meter)
 		return FALSE
 	return TRUE
 

--- a/code/modules/paperwork/records/info/aleph.dm
+++ b/code/modules/paperwork/records/info/aleph.dm
@@ -23,6 +23,7 @@
 	Risk Class : Aleph	<br>
 	Max PE Boxes : 30	<br>
 	Qliphoth Counter : 2	<br>
+	- "Agents with Temperance Level 3 or lower immediately threw themselves into Blue Star upon working with the Abnormality."
 	- When an Agent with Prudence Level 4 or lower completed their work, the Qliphoth Counter lowered.	<br>
 	- When more than 40 seconds of work time had taken place, the Qliphoth Counter lowered by 1, and the Agent who was working with Blue Star threw themself in.	<br>
 	- While Blue Star is outside of its containment, all sounds will be reduced to silence, with a low pitched tone emerging. The pitch will accompany a visually disruptive effect.	<br>

--- a/code/modules/paperwork/records/info/teth.dm
+++ b/code/modules/paperwork/records/info/teth.dm
@@ -128,14 +128,14 @@
 	<h4>Repression:</h4> Common<br>"}
 
 //Crumbling Armor
-/obj/item/paper/fluff/info/teth/mhz
+/obj/item/paper/fluff/info/teth/crumbling
 	name = "O-05-61"
 	info = {"<h1><center>O-05-61</center></h1>	<br>
 	Name : Crumbling Armor	<br>
 	Risk Class : Teth	<br>
 	Max PE Boxes : 12	<br>
 	Qliphoth Counter : X	<br>
-	- When an Agent with less than 2 Fortitude completed the work, they were found with their head cut clean off.	<br>
+	- When an Agent with Level 1 Fortitude completed the work, they were found with their head cut clean off.	<br>
 	- Upon completing a Repression work with Crumbling Armor, the Agent gained a glowing aura.	<br>
 	- This aura seemed to grant them an increase to their Justice attribute.	<br>
 	- As the employee completed more Repression work with Crumbling Armor, the aura intensified.	<br>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Blue Star:
- Attempting work with Temperance 3 or lower will immediately kill you and lower Qliphoth counter (this now renders work speed check impossible to satisfy, rework needed)

Queen of Hatred:
- Hostile beam blowback now has particle effects, no more invisible death

Wander Insanity:
- 10% chance every 30 seconds to become suicide insanity

Release Insanity:
- Now depletes Qliphoth counter instead of spamming works and progressing meltdowns

Spider Bud:
- Getting killed cocoons you

Rudolta:
- Pulses now have probability of releasing gibs instead of guaranteed, should hopefully reduce lag piles

All gift givers now check whether user is dead or not.

## Why It's Good For The Game
Small changes to multiple abnorms, as well as some minor fixes.

## Changelog
:cl:
add: blue star temp check
add: neat spider bud death
tweak: visible qoh blowback
tweak: less rudolta gibs
fix: dead people can't get gifts anymore
:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
