### PR TITLE
Allow Manager to change the current alert level.

### DIFF
--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -138,7 +138,7 @@
 					return
 
 			var/new_sec_level = seclevel2num(params["newSecurityLevel"])
-			if (new_sec_level != SEC_LEVEL_GREEN && new_sec_level != SEC_LEVEL_BLUE)
+			if (new_sec_level != SEC_LEVEL_GREEN && new_sec_level != SEC_LEVEL_BLUE && new_sec_level != SEC_LEVEL_RED && new_sec_level != SEC_LEVEL_DELTA)
 				return
 			if (GLOB.security_level == new_sec_level)
 				return

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -74,12 +74,12 @@ HUMANS_NEED_SURNAMES
 
 
 ## ALERT LEVELS ###
-ALERT_GREEN All threats to the station have passed. Security may not have weapons visible, privacy laws are once again fully enforced.
-ALERT_BLUE_UPTO The station has received reliable information about possible hostile activity on the station. Security staff may have weapons visible, searches are permitted within a reason.
-ALERT_BLUE_DOWNTO The immediate threat has passed. Security may no longer have weapons drawn at all times, but may continue to have them visible. Random searches are still allowed.
-ALERT_RED_UPTO There is an immediate serious threat to the station. Security may have weapons unholstered at all times. Random searches are allowed and advised. Additionally, access requirements on some doors have been lifted.
-ALERT_RED_DOWNTO The station's destruction has been averted. There is still however an immediate serious threat to the station. Security may have weapons unholstered at all times, random searches are allowed and advised.
-ALERT_DELTA Destruction of the station is imminent. All crew are instructed to obey all instructions given by heads of staff. Any violations of these orders can be punished by death. This is not a drill.
+ALERT_GREEN Warning level has been reset. All dangerous abnormalities have been re-contained and situation is under control.
+ALERT_BLUE_UPTO First warning level achieved. Few dangerous abnormalities have breached the containment.
+ALERT_BLUE_DOWNTO Warning level reset to first. Most dangerous abnormalities have been re-contained, but situation is still threatening.
+ALERT_RED_UPTO Second warning level achieved. Most dangerous abnormalities have breached containment and several agents might be dead or out of control.
+ALERT_RED_DOWNTO Warning level reset to second. Facility's integrity is no longer in danger, but most abnormalities are still not re-contained.
+ALERT_DELTA Warning level three achieved. Facility's integrity is in danger. Most if not all of the dangerous abnormalities have breached containment and many agents have been lost.
 
 ## INFILTRATOR SPAWN MESSAGES ###
 INFILTRATOR_SYNDICATE_MESSAGE You are a syndicate infiltrator, and you are free to complete your objectives in any way you desire, as long as it helps to finish them, of course.

--- a/tgui/packages/tgui/interfaces/CommunicationsConsole.js
+++ b/tgui/packages/tgui/interfaces/CommunicationsConsole.js
@@ -380,22 +380,30 @@ const PageMain = (props, context) => {
 
       {!!canSetAlertLevel && (
         <Section title="Alert Level">
-          <Flex justify="space-between">
-            <Flex.Item>
-              <Box>
-                Currently on <b>{capitalize(alertLevel)}</b> Alert
-              </Box>
-            </Flex.Item>
-
+          <Flex.Item>
+            <Box>
+              Currently on <b>{capitalize(alertLevel)}</b>.
+            </Box>
+          </Flex.Item>
+          <Flex justify="center">
             <Flex.Item>
               <AlertButton
-                alertLevel="green"
+                alertLevel="no warning"
                 showAlertLevelConfirm={showAlertLevelConfirm}
                 setShowAlertLevelConfirm={setShowAlertLevelConfirm}
               />
-
               <AlertButton
-                alertLevel="blue"
+                alertLevel="first warning"
+                showAlertLevelConfirm={showAlertLevelConfirm}
+                setShowAlertLevelConfirm={setShowAlertLevelConfirm}
+              />
+              <AlertButton
+                alertLevel="second warning"
+                showAlertLevelConfirm={showAlertLevelConfirm}
+                setShowAlertLevelConfirm={setShowAlertLevelConfirm}
+              />
+              <AlertButton
+                alertLevel="third warning"
                 showAlertLevelConfirm={showAlertLevelConfirm}
                 setShowAlertLevelConfirm={setShowAlertLevelConfirm}
               />


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This pr allow the manager to change the current level.



https://user-images.githubusercontent.com/82665345/185655082-ea8406ad-c0bd-447d-ac5a-5d04c75f5698.mp4




<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Avoid having to use admin to change warning level.
Avoid having 20 minutes shuttle when no admin and everyone is dead.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Unoki
tweak : Manager can now change the alert level.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
