### PR TITLE
Adoration and ML melting blob attack tweak

### DIFF
--- a/code/datums/abnormality/_ego_datum/aleph.dm
+++ b/code/datums/abnormality/_ego_datum/aleph.dm
@@ -42,7 +42,7 @@
 // Melting Love - Adoration
 /datum/ego_datum/weapon/adoration
 	item_path = /obj/item/gun/ego_gun/adoration
-	cost = 122
+	cost = 100
 
 /datum/ego_datum/armor/adoration
 	item_path = /obj/item/clothing/suit/armor/ego_gear/adoration

--- a/code/modules/projectiles/projectile/ego_bullets/aleph.dm
+++ b/code/modules/projectiles/projectile/ego_bullets/aleph.dm
@@ -12,14 +12,12 @@
 	damage = 88
 	damage_type = BLACK_DAMAGE
 	flag = BLACK_DAMAGE
-	spread = 10
-	speed = 1.2
 	hitsound = "sound/effects/footstep/slime1.ogg"
 
 /obj/projectile/ego_bullet/melting_blob/on_hit(target)
 	var/mob/living/H = target
-	H.visible_message("<span class='warning'>[target] is hit by [src], they seem to wither away!</span>")
 	if(!isbot(H) && isliving(H))
+		H.visible_message("<span class='warning'>[target] is hit by [src], they seem to wither away!</span>")
 		for(var/i = 1 to 10)
 			addtimer(CALLBACK(H, /mob/living/proc/apply_damage, rand(4,6), BLACK_DAMAGE, null, H.run_armor_check(null, BLACK_DAMAGE)), 2 SECONDS * i)
 		return BULLET_ACT_HIT

--- a/code/modules/projectiles/projectile/magic/abnormality.dm
+++ b/code/modules/projectiles/projectile/magic/abnormality.dm
@@ -39,8 +39,6 @@
 	icon_state = "slime"
 	desc = "A glob of infectious slime. It's going for your heart."
 	nodamage = TRUE
-	spread = 10
-	speed = 1.2
 	hitsound = "sound/effects/footstep/slime1.ogg"
 	var/maxdmg = null
 	var/mindmg = null
@@ -65,9 +63,9 @@
 			H.gib()
 			new /mob/living/simple_animal/hostile/slime(T)
 			return BULLET_ACT_HIT
-		H.visible_message("<span class='warning'>[target] is hit by [src], they seem to wither away!</span>")
 		H.apply_damage(rand(mindmg,maxdmg), BLACK_DAMAGE, null, H.run_armor_check(null, BLACK_DAMAGE))
 		if(!isbot(H) && isliving(H))
+			H.visible_message("<span class='warning'>[target] is hit by [src], they seem to wither away!</span>")
 			for(var/i = 1 to 10)
 				addtimer(CALLBACK(H, /mob/living/proc/apply_damage, rand(4,6), BLACK_DAMAGE, null, H.run_armor_check(null, BLACK_DAMAGE)), 2 SECONDS * i)
 			return BULLET_ACT_HIT


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Melting Love can be kited very easily, so I removed the speed Nerf and its spread.
Likewise for adoration, it is one of the worst aleph weapon and never used because of lack of accuracy.
Also reduce adoration price to follow other aleph gear

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Make ML less kiteable 
Make adoration a little bit better to use
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Unoki
balance Melting Blob and adoration
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
