### PR TITLE
Alt title tweaks

### DIFF
--- a/ModularTegustation/altjobtitles/LC13.dm
+++ b/ModularTegustation/altjobtitles/LC13.dm
@@ -6,8 +6,8 @@
 
 /datum/job/agent/captain
 	alt_titles = list()
-	senior_title = null
-	ultra_senior_title = null
+	senior_title = "Senior Agent Captain"
+	ultra_senior_title = "Veteran Agent Captain"
 
 /// Service
 /datum/job/assistant

--- a/code/modules/jobs/access.dm
+++ b/code/modules/jobs/access.dm
@@ -373,7 +373,7 @@
 			return "Code Scotch"
 
 /proc/get_all_jobs()
-	return list("Clerk", "Agent", "Senior Agent", "Agent Captain", "Explorer", "Fixer", "Pathfinder", "Sephirah", "Records Officer", "Extraction Officer", "Manager", "Rabbit Team", "Rabbit Team Leader")
+	return list("Clerk", "Agent", "Senior Agent", "Veteran Agent", "Agent Captain", "Explorer", "Fixer", "Pathfinder", "Sephirah", "Records Officer", "Extraction Officer", "Manager", "Rabbit Team", "Rabbit Team Leader")
 
 /proc/get_all_job_icons() //For all existing HUD icons
 	return get_all_jobs() + list("Emergency Response Team Commander", "Security Response Officer", "Engineering Response Officer", "Medical Response Officer", "Entertainment Response Officer", "Religious Response Officer", "Janitorial Response Officer", "Death Commando", "Syndicate Captain", "Syndicate Medical Doctor", "Syndicate Assault Operative", "Syndicate Engineer", "Syndicate Operative", "TerraGov Official", "TerraGov Marine") //Tegu edit right there


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Fixes veteran agent icon.
- Gives agent captain a few senior titles.

## Why It's Good For The Game

- The icon for veteran agent title will now properly show up.
- Dedicated captain players can now show others just how *experienced* they are, I guess.
