### PR TITLE
Observation Bonuses

### DIFF
--- a/code/game/machinery/computer/abnormality_work.dm
+++ b/code/game/machinery/computer/abnormality_work.dm
@@ -53,6 +53,8 @@
 	dat += "<b><span style='color: [THREAT_TO_COLOR[datum_reference.threat_level]]'>\[[THREAT_TO_NAME[datum_reference.threat_level]]\]</span> [datum_reference.name]</b><br>"
 	if(datum_reference.overload_chance != 0)
 		dat += "<span style='color: [COLOR_VERY_SOFT_YELLOW]'>Current success chance is modified by [datum_reference.overload_chance]%</span><br>"
+	if(datum_reference.understanding != 0)
+		dat += "<span style='color: [COLOR_BLUE_LIGHT]'>Current Understanding is: [round((datum_reference.understanding/datum_reference.max_understanding)*100, 0.01)]%, granting a [datum_reference.understanding]% Work Success and Speed bonus.</span>"
 	dat += "<br>"
 	for(var/wt in datum_reference.available_work)
 		if(HAS_TRAIT(user, TRAIT_WORK_KNOWLEDGE)) // Might be temporary until we add upgrades
@@ -114,7 +116,7 @@
 	update_icon()
 	working = TRUE
 	var/work_chance = datum_reference.get_work_chance(work_type, user)
-	var/work_speed = 2 SECONDS / (1 + (get_attribute_level(user, TEMPERANCE_ATTRIBUTE) / 100))
+	var/work_speed = 2 SECONDS / (1 + ((get_attribute_level(user, TEMPERANCE_ATTRIBUTE) + datum_reference.understanding) / 100))
 	var/success_boxes = 0
 	for(var/i = 1 to work_time)
 		user.Stun(work_speed) // TODO: Probably temporary


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
So, we lacked the wonderful mechanic that was Observation Bonuses from Lobotomy Corporation, right? But how do we do that when we just kinda know all the Abno info as is? Simple! Make the Observation bonuses a  reward for working on the Abnormality! With this change, work on Abnormalities will become slightly easier and faster the better work is done on it. Though the more dangerous the Abnormality, the harder it is to truly understand it. Zayins and Teths get up to a +10% bonus to work speed and success rate, while HEs get up to +8%, and WAWs and Alephs get up to +6%. All of these build up at the same rate (10 Good Results, 20 Neutral Results, or any mix of the two), and at Max rating, the abnormality gains a 50% increased gift chance (So a Zayin would have 7.5% instead of 5%).
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Works were overall a little more dangerous than they should've been, and this should help fix that issue. The longer an Abnormality is in the facility and actively worked with, the less dangerous it'll be to those who need to work on it... usually. Some abnormalities are just that temperamental and this doesn't really interfere with that.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added the "Understanding" mechanic.
add: Added "Understanding" progress to the pop-up for Abnormality Consoles.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
