### PR TITLE
Regenerator Dead Body Fix

### DIFF
--- a/code/game/machinery/regenerator.dm
+++ b/code/game/machinery/regenerator.dm
@@ -34,7 +34,7 @@
 		return
 	var/regen_amt = regeneration_amount
 	for(var/mob/living/L in A)
-		if(!("neutral" in L.faction)) // Enemy spotted
+		if(!("neutral" in L.faction) && L.stat != DEAD) // Enemy spotted
 			regen_amt *= 0.5
 			break
 	if(burst)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Stops dead bodies (ordeals) from counting against the Regenerator's full healing. This genuinely shouldn't be a thing and I'm assuming it was an oversight.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Healing halved because a dead body is in a doorway is dumb.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added a check for if the hostile entity is dead or not before halving regenerator healing.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
