### PR TITLE
Ordeal tweaks

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/ordeal/_ordeal.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/_ordeal.dm
@@ -1,8 +1,10 @@
 /mob/living/simple_animal/hostile/ordeal
 	robust_searching = TRUE
 	stat_attack = HARD_CRIT
-	move_resist = MOVE_FORCE_STRONG
 	a_intent = INTENT_HARM
+	see_in_dark = 7
+	vision_range = 12
+	aggro_vision_range = 20
 	var/datum/ordeal/ordeal_reference
 	var/ordeal_remove_ondeath = TRUE
 

--- a/code/modules/mob/living/simple_animal/hostile/ordeal/green.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/green.dm
@@ -179,7 +179,7 @@
 	butcher_results = list(/obj/item/food/meat/slab/human/mutant/robot = 3)
 	guaranteed_butcher_results = list(/obj/item/food/meat/slab/human/mutant/robot = 2)
 
-	var/spawn_progress = 10
+	var/spawn_progress = 18
 	var/list/spawned_mobs = list()
 
 /mob/living/simple_animal/hostile/ordeal/green_dusk/Initialize()

--- a/code/modules/ordeals/violet_ordeals.dm
+++ b/code/modules/ordeals/violet_ordeals.dm
@@ -10,6 +10,7 @@
 	spawn_type = /mob/living/simple_animal/hostile/ordeal/violet_fruit
 	place_player_multiplicator = 0.05
 	spawn_player_multiplicator = 0.025
+	color = "#B642F5"
 
 // Noon
 /datum/ordeal/violet_noon
@@ -19,6 +20,7 @@
 	end_sound = 'sound/effects/ordeals/violet_end.ogg'
 	level = 2
 	reward_percent = 0.15
+	color = "#B642F5"
 	var/spawn_amount = 4
 
 /datum/ordeal/violet_noon/Run()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Fixes color for violet ordeals.
- Green dusk will spawn 3 robots on creation, instead of waiting for ~10 seconds.
- All ordeals have higher view range and can be moved again.

## Why It's Good For The Game

- Fix.
- Green dusk was nerfed TOO hard.
- Helps against some forms of cheesing, also allows you to move corpses once again.
