### PR TITLE
Nerfs Daredevil, Buffs Lutemis

### DIFF
--- a/code/modules/clothing/suits/ego_gear/he.dm
+++ b/code/modules/clothing/suits/ego_gear/he.dm
@@ -33,7 +33,7 @@
 	desc = "Let's all dangle down."
 	icon_state = "lutemis"
 	//White armor, weak to red. Red is pretty valuable.
-	armor = list(RED_DAMAGE = -20, WHITE_DAMAGE = 50, BLACK_DAMAGE = 20, PALE_DAMAGE = 25) // 75
+	armor = list(RED_DAMAGE = -20, WHITE_DAMAGE = 65, BLACK_DAMAGE = 20, PALE_DAMAGE = 20) // 85, Special armor.
 	attribute_requirements = list(
 							PRUDENCE_ATTRIBUTE = 40
 							)

--- a/code/modules/clothing/suits/ego_gear/teth.dm
+++ b/code/modules/clothing/suits/ego_gear/teth.dm
@@ -48,7 +48,7 @@
 	name = "life for a daredevil"
 	desc = "The fear of death is natural, but in denying it you shall find untold strength."
 	icon_state = "daredevil"
-	armor = list(RED_DAMAGE = 40, WHITE_DAMAGE = 25, BLACK_DAMAGE = 25, PALE_DAMAGE = -100) // -10
+	armor = list(RED_DAMAGE = 30, WHITE_DAMAGE = 20, BLACK_DAMAGE = 20, PALE_DAMAGE = -50) // -30
 
 /obj/item/clothing/suit/armor/ego_gear/noise
 	name = "noise"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Daredevil was 4/2.5/2.5/-X.
This PR nerfs it to 3/2/2/-5.

Lutemis has been buffed by 10 points to -2/6.5/2/2.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Lutemis is supposed to be the white version of blind fury. But it requires a sacrifice, and white resistance is less useful than red.

Daredevil is, let's face it, the best teth. 
the -100 pale is not really a negative, especially early game.
Still critically weak to pale, but the other stats aren't SO GOOD that it is busted.


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: daredevil and lutemis have been balanced.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
