### PR TITLE
Aleph Tweaks, Revised

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/aleph/melting_love.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/melting_love.dm
@@ -65,6 +65,7 @@
 	desc = "A pink hunched creature with long arms, there are also visible bones coming from insides of the slime."
 	return
 
+
 /mob/living/simple_animal/hostile/abnormality/melting_love/death(gibbed)
 	density = FALSE
 	animate(src, alpha = 0, time = 10 SECONDS)

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/silent_orchestra.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/silent_orchestra.dm
@@ -31,7 +31,7 @@
 		)
 	gift_type =  /datum/ego_gifts/dacapo
 	/// Range of the damage
-	var/symphony_range = 18
+	var/symphony_range = 20
 	/// Amount of white damage
 	var/symphony_damage = 8
 	/// When to perform next movement

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/white_night.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/white_night.dm
@@ -237,6 +237,7 @@ GLOBAL_LIST_EMPTY(apostles)
 	mob_size = MOB_SIZE_HUGE
 	blood_volume = BLOOD_VOLUME_NORMAL
 	var/can_act = TRUE
+	var/death_counter = 0
 
 /mob/living/simple_animal/hostile/apostle/Move()
 	if(!can_act)
@@ -245,11 +246,13 @@ GLOBAL_LIST_EMPTY(apostles)
 
 /mob/living/simple_animal/hostile/apostle/death(gibbed)
 	invisibility = 30 // So that other mobs cannot attack them
+	death_counter = clamp(death_counter + 1, 0, 3)
 	return ..()
 
 /mob/living/simple_animal/hostile/apostle/revive(full_heal = FALSE, admin_revive = FALSE, excess_healing = 0)
 	invisibility = 0 // Visible again
 	can_act = TRUE // In case we died while performing special attack
+	adjustBruteLoss(maxHealth * (0.25 + (death_counter * 0.15)), TRUE)
 	return ..()
 
 /mob/living/simple_animal/hostile/apostle/gib(no_brain, no_organs, no_bodyparts)
@@ -317,7 +320,9 @@ GLOBAL_LIST_EMPTY(apostles)
 	armortype = PALE_DAMAGE
 	damage_coeff = list(BRUTE = 1, RED_DAMAGE = 0.5, WHITE_DAMAGE = 0.5, BLACK_DAMAGE = 0.5, PALE_DAMAGE = 1.5)
 	scythe_range = 3
+	scythe_cooldown_time = 8 SECONDS // More often, since the damage increase was disliked.
 	scythe_damage_type = PALE_DAMAGE
+	scythe_damage = 150 // It's a big AoE unlike base game where it's smaller and as it is you straight up die unless you have 7+ Pale resist. You also have TWO of these AND WN hitting you for ~80 Pale at this range.
 
 /mob/living/simple_animal/hostile/apostle/spear
 	name = "spear apostle"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The overall goal of this is to make certain Alephs a little better overall. Nothing There gets his Regen and Hello pierces one turf (See: Single Turf Corners and Doorways). Mountain heals and gets progress toward growth from Blood and Limbs, as well as creating filth all over the place. Silent Orchestra gets a slightly expanded range (+2). Melting Love faces South when contained. White Night's Apostles respawn with less health every time they respawn, up to a cap, to give the incentive to suppress them (makes suppressing them easier in the future), and the Guardian Apostles do less Pale AoE, but more Pale melee (The AoE was straight up unsurvivable unless you had Justitia, Either Staining Rose armor, Paradise Lost, or TWILIGHT.)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This should make Alephs better overall and make WN Suppression more... feasible now. I've only seen it suppressed twice recently and once was a guy in Full-Twilight and the other was someone abusing an exploit to be immune to damage. At the moment I'm uncertain the exact cooldown that's needed for NT's heal when he takes damage, but it is described as a "short time" by the wiki for when he starts healing.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added filth to Mountain of Smiling Bodies
tweak: Nothing There's "Hello" attack pieces a single tile now.
tweak: Melting Love faces the South direction while contained, hail the sprite work!
balance: Silent Orchestra has +2 range.
balance: Guardian Apostles do less AoE damage but deal significantly more melee damage.
balance: Apostles respawn with less HP every time they're killed during the Suppression of White Night, up to a minimum of 30% Max HP. They can still be healed by WN above this, however.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
