### PR TITLE
Rudolta Buff

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/he/rudolta.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/rudolta.dm
@@ -34,8 +34,8 @@
 		)
 	gift_type =  /datum/ego_gifts/christmas
 	var/pulse_cooldown
-	var/pulse_cooldown_time = 3 SECONDS
-	var/pulse_damage = 20 // Scales with distance
+	var/pulse_cooldown_time = 1.8 SECONDS
+	var/pulse_damage = 20
 
 /mob/living/simple_animal/hostile/abnormality/rudolta/neutral_effect(mob/living/carbon/human/user, work_type, pe)
 	if(prob(40))
@@ -59,8 +59,6 @@
 
 /mob/living/simple_animal/hostile/abnormality/rudolta/proc/WhitePulse()
 	pulse_cooldown = world.time + pulse_cooldown_time
-	if(prob(25))
-		new /obj/effect/gibspawner/generic/silent(get_turf(src))
 	playsound(src, 'sound/abnormalities/rudolta/throw.ogg', 50, FALSE, 4)
 	for(var/mob/living/L in livinginview(8, src))
 		if(faction_check_mob(L))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Buffs Rudolta to be more of a threat.
Reduces his charge time from 3 to 1.8 Seconds
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
He was kinda a joke, and clerks would suppress him.
Maybe white damage will be more useful for work now.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: reduced the time it took for rudolta to pulse
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
