### PR TITLE
Fixes WCCA EGO cost

### DIFF
--- a/code/datums/abnormality/_ego_datum/zayin.dm
+++ b/code/datums/abnormality/_ego_datum/zayin.dm
@@ -46,8 +46,8 @@
 // We can change anything - Change
 /datum/ego_datum/weapon/change
 	item_path = /obj/item/ego_weapon/change
-	cost = 20
+	cost = 12
 
 /datum/ego_datum/armor/change
 	item_path = /obj/item/clothing/suit/armor/ego_gear/change
-	cost = 20
+	cost = 12


### PR DESCRIPTION
WCCA EGO had teth cost instead of zayin cost

changes: WCCA EGO cost from 20 to 12 like all the other zayins