### PR TITLE
Agents become BatB upon killing her

### DIFF
--- a/code/datums/abnormality/datum/abnormality.dm
+++ b/code/datums/abnormality/datum/abnormality.dm
@@ -44,6 +44,8 @@
 	var/max_understanding = 0
 	/// A list of performed works on it
 	var/list/work_logs = list()
+	///a list of variable the abno wants to remember after death
+	var/list/transferable_var
 
 /datum/abnormality/New(obj/effect/landmark/abnormality_spawn/new_landmark, mob/living/simple_animal/hostile/abnormality/new_type = null)
 	if(!istype(new_landmark))
@@ -96,6 +98,7 @@
 	if (understanding == max_understanding && max_understanding > 0)
 		current.gift_chance *= 1.5
 	overload_chance_limit = overload_chance_amount * 10
+	current.PostSpawn()
 
 /datum/abnormality/proc/FillEgoList()
 	if(!current || !current.ego_list)
@@ -105,6 +108,7 @@
 		ego_datums += ED
 		GLOB.ego_datums["[ED.name][ED.item_category]"] = ED
 	return TRUE
+
 
 /datum/abnormality/proc/work_complete(mob/living/carbon/human/user, work_type, pe, work_time)
 	current.work_complete(user, work_type, pe, work_time) // Cross-referencing gone wrong

--- a/code/modules/mob/living/simple_animal/abnormality/_abnormality.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_abnormality.dm
@@ -127,6 +127,23 @@
 				to_chat(H, "<span class='userdanger'>I'm not ready for this!")
 	return
 
+// Called by datum_reference when the abnormality has been fully spawned
+/mob/living/simple_animal/hostile/abnormality/proc/PostSpawn()
+	return
+
+// transfers a var to the datum to be used later
+/mob/living/simple_animal/hostile/abnormality/proc/TransferVar(index, value)
+	if(isnull(datum_reference))
+		return
+	LAZYSET(datum_reference.transferable_var, value, index)
+
+// Access an item in the "transferable_var" list of the abnormality's datum
+/mob/living/simple_animal/hostile/abnormality/proc/RememberVar(index)
+	if(isnull(datum_reference))
+		return
+	return LAZYACCESS(datum_reference.transferable_var, index)
+
+
 // Modifiers for work chance
 /mob/living/simple_animal/hostile/abnormality/proc/work_chance(mob/living/carbon/human/user, chance)
 	return chance

--- a/code/modules/mob/living/simple_animal/abnormality/teth/beauty_beast.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/beauty_beast.dm
@@ -29,6 +29,20 @@
 	gift_type =  /datum/ego_gifts/horn
 	var/injured = FALSE
 
+//it needs to use PostSpawn or we can't get the datum of beauty
+/mob/living/simple_animal/hostile/abnormality/beauty/PostSpawn()
+	var/cursed = RememberVar(1)
+	if(!cursed)
+		return
+	for(var/mob/dead/observer/O in GLOB.player_list) //we grab the last person that died to beauty and yeet them in there
+		if(O.ckey == cursed)
+			O.mind.transfer_to(src)
+			src.ckey = cursed
+			to_chat(src, "<span class='userdanger'>You begin to have hundreds of eyes burst from your mouth, while a pair of horns expel from your eye sockets, adorning themselves with flowers. Now the Beast, you forever search for someone to lift your curse.</span>")
+			to_chat(src, "<span class='notice'>(If you wish to leave this body you can simply ghost with the ooc tab > ghost, there is no consequence for doing so.)</span>")
+			TransferVar(1, null) //we reset the cursed just in case
+			return
+
 /mob/living/simple_animal/hostile/abnormality/beauty/death(gibbed)
 	density = FALSE
 	animate(src, alpha = 0, time = 10 SECONDS)
@@ -43,6 +57,7 @@
 			icon_state = "beauty_injured"
 
 		else if (!(GODMODE in user.status_flags))//If you already did repression, die.
+			TransferVar(1, user.ckey)
 			user.gib()
 			death()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

When someone "kills" beauty their ghost is forcefully yeeted into the newly respawned beauty that comes after.
in order to remember who was killed by beauty.

I had to add a new list system to the abnormality datum so that I could add variables to transfer later. the reason I made it a list even though only one var needs to be transfered is because it'd be nice to have some way for abnormalities to keep some data after death. which may include multiple variables. 

it's a VERY shoddy solution but I couldn't think of anything better. I also added a "PostSpawn" proc to the abnormality datum as some variables aren't accessible on Initialize like the datum_reference

also the player that's "in place" of beauty can only talk, they can't move or do anything other than nuzzle people, so it doesn't actually do anything balance wise. (actually they can pull people that get close but they can't aggro grab them so it's not that bad)

## Why It's Good For The Game

I think giving more personality to abnormalities beyond just "they kill you" is always good and make each interaction with them feel a little more special. agents becoming beauty is canon to the original story and adds a lot of flair to what is a relatively simple abno to work on.

## Changelog
:cl:
tweak: Dying to beauty now turns you into beauty
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
