### PR TITLE
Abno Working Rework

### DIFF
--- a/code/controllers/subsystem/lobotomy_corp.dm
+++ b/code/controllers/subsystem/lobotomy_corp.dm
@@ -129,7 +129,7 @@ SUBSYSTEM_DEF(lobotomy_corp)
 	for(var/obj/machinery/computer/abnormality/cmp in shuffle(GLOB.abnormality_consoles))
 		if(!cmp.can_meltdown)
 			continue
-		if(cmp.meltdown || cmp.working)
+		if(cmp.meltdown || cmp.datum_reference.working)
 			continue
 		if(!cmp.datum_reference || !cmp.datum_reference.current)
 			continue

--- a/code/datums/abnormality/datum/abnormality.dm
+++ b/code/datums/abnormality/datum/abnormality.dm
@@ -44,6 +44,12 @@
 	var/max_understanding = 0
 	/// A list of performed works on it
 	var/list/work_logs = list()
+	/*
+	* Moved this variable from work Console for a two reasons
+	* First, this allows both the console AND the abnormality to check on the current working status. Useful overall.
+	* Second, there's no real reason for it to NOT be here unless we SOMEHOW, for SOME REASON, get duplicate abnormalities. Even then I don't know if that'd conflict.
+	*/
+	var/working = FALSE
 	///a list of variable the abno wants to remember after death
 	var/list/transferable_var
 
@@ -160,6 +166,12 @@
 		playsound(get_turf(current), 'sound/effects/alertbeep.ogg', 50, FALSE)
 		return
 	if(pre_qlip != qliphoth_meter)
+		if(pre_qlip < qliphoth_meter) // Alerts on change of counter. It's just nice to know instead of inspecting the console every time. Also helps for those nearby if something goes to shit.
+			current?.visible_message("<span class='notice'>Qliphoth level increased by [qliphoth_meter-pre_qlip]!</span>")
+			playsound(get_turf(current), 'sound/machines/synth_yes.ogg', 50, FALSE)
+		else
+			current?.visible_message("<span class='warning'>Qliphoth level decreased by [pre_qlip-qliphoth_meter]!</span>")
+			playsound(get_turf(current), 'sound/machines/synth_no.ogg', 50, FALSE)
 		current?.OnQliphothChange(user)
 
 /datum/abnormality/proc/get_work_chance(workType, mob/living/carbon/human/user)

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/staining_rose.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/staining_rose.dm
@@ -64,7 +64,7 @@
 
 /mob/living/simple_animal/hostile/abnormality/staining_rose/Life()
 	. = ..()
-	if(meltdown_cooldown < world.time)
+	if(meltdown_cooldown < world.time && !datum_reference.working)
 		meltdown_cooldown = world.time + meltdown_cooldown_time
 		datum_reference.qliphoth_change(-1)
 

--- a/code/modules/mob/living/simple_animal/abnormality/teth/old_lady.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/old_lady.dm
@@ -28,7 +28,7 @@
 
 /mob/living/simple_animal/hostile/abnormality/old_lady/Life()
 	. = ..()
-	if(meltdown_cooldown < world.time)
+	if(meltdown_cooldown < world.time && !datum_reference.working) // Doesn't decrease while working but will afterwards
 		meltdown_cooldown = world.time + meltdown_cooldown_time
 		datum_reference.qliphoth_change(-1)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
So, this makes it so that working on an Abno gives a Progress bar per-work tic so you can see how fast you work and also allows you to cancel your work by moving away, but this comes with some downsides. Unless the Abno is breached, you're panicked or dying, or any other issues, you get SLAPPED for quitting work early. First of all: It's a bad result. You make 0 PE, which also curbs your leveling benefits and calls any bad-result effect it may have. You take damage equal to how many works you would've failed remaining at a halved work success rate. So if you had 8 Ticks remaining and a 50% chance, you fail 75% of the remaining, so you take 6 boxes worth of damage.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This can help allow people to get OFF of abnos when a danger is present or there really is just a more pressing matter and they can afford a bad result. It's also nicer than stunning the player during work and fixes the issue of Epi letting people walk around while working. This also fixes people from being dragged away from their work.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Changed how "working" happens
tweak: Moved the location of the working variable to the Abnormality Datum so that both the Abnormality and the Console can access it without excessive searching.
tweak: Staining Rose and Old Lady will no longer decrease their counter automatically while being worked on, but will do so at the end of work if they would have done so during the work.
add: Visible Messages when the Qliphoth of an Abnormality decreases.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
