### PR TITLE
Shepherd can now lie (again)

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -31,6 +31,8 @@
 #define COMSIG_GLOB_HUMAN_INSANE "!human_insane"
 /// a lobotomy_corp subsystem meltdown occured
 #define COMSIG_GLOB_MELTDOWN_START "!meltdown_started"
+/// a new abnormality has spawned with their room (/datum/abnormality)
+#define COMSIG_GLOB_ABNORMALITY_SPAWN "!abno_spawned"
 
 /// signals from globally accessible objects
 

--- a/code/controllers/subsystem/lobotomy_corp.dm
+++ b/code/controllers/subsystem/lobotomy_corp.dm
@@ -74,6 +74,7 @@ SUBSYSTEM_DEF(lobotomy_corp)
 	if(!istype(new_abno))
 		return FALSE
 	all_abnormality_datums += new_abno
+	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_ABNORMALITY_SPAWN, new_abno)
 	return TRUE
 
 /datum/controller/subsystem/lobotomy_corp/proc/WorkComplete(amount = 0, qliphoth_change = TRUE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
(I messed up a proper squash on the original PR which included a bunch of commits from other people and I couldn't find a way to undo it so I had to redo the PR, the code is the exact same as before though)
## About The Pull Request


Whenever a work on shepherd is finished, he will have a 30% chance of lying and 70% chance of saying the truth, as of now shepherd is only capable of mentioning people's death/life or if an abnormality is breaching/contained
originally I wanted to make it a 50% chance of lying, however him saying the truth most of the time means the lies are more likely to be believed.

I haven't coded in a while, so do expect some shitcode and really hacky solutions. But there isn't any runtime and it accounts for most scenarios in which the lies are relevant so there shouldn't be any problems functionally.

ADDITIONALLY there is now a GLOBAL SIGNAL sent whenever an abno spawns, it sends the abno datum as an argument and stuff so other coders can use that for other shenanigans I guess. (I didn't end up using it in the PR so i'll see if I remove it or not, but i'll probably use it in another PR anyway)

## Why It's Good For The Game

A huge part of shepherd personality in WL is the fact that he's constantly mixing truth with lies, that feature not only gives him some personality but it can also make people a little bit more paranoid as to what has and hasn't breached or who is and isn't dead, it's mostly flavour though.

## Changelog
:cl:
add: Shepherd is now capable of lying
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
