### PR TITLE
Adds a bit denoting the change to Dingle-Dangle's success rate at higher levels

### DIFF
--- a/code/modules/paperwork/records/info/teth.dm
+++ b/code/modules/paperwork/records/info/teth.dm
@@ -125,8 +125,8 @@
 	Work Damage : Moderate	<br>
 	- An employee with Level 3 or higher Prudence was consumed after completing their work.	<br>
 	- When the work result was Bad, the employee was consumed with a normal probability	<br><br>
-	<h4>Instinct:</h4> High<br>
-	<h4>Insight:</h4> Low<br>
+	<h4>Instinct:</h4> High/Low<br>
+	<h4>Insight:</h4> Low/High<br>
 	<h4>Attachment:</h4> Common<br>
 	<h4>Repression:</h4> Common<br>"}
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Literally changes the record to say High/Low for Instinct, and Low/High on Insight. As it is.

## Why It's Good For The Game

While agents should not need exact percentages, it would be best if an agent did not end up getting gotted by Dangle because they just reached level 3 through 55 in every stat, then had to handle a meltdown or something without knowing of the success rate difference. 
Such writing can also be seen on Silent Girl's record, so I figured it wouldn't hurt to have here, too.

## Changelog
:cl:
tweak: Adjusted Dingle-Dangle's record to mention the change in success rate on higher ranks.
:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
