### PR TITLE
Calming Cup of Tea Reagent update

### DIFF
--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -253,6 +253,9 @@
 	M.AdjustSleeping(-40)
 	//310.15 is the normal bodytemp.
 	M.adjust_bodytemperature(25 * TEMPERATURE_DAMAGE_COEFFICIENT, 0, M.get_body_temp_normal())
+	if(prob(5))
+		var/mob/living/carbon/human/H = M
+		H.adjustSanityLoss(1*REM) // That's healing
 	if(holder.has_reagent(/datum/reagent/consumable/frostoil))
 		holder.remove_reagent(/datum/reagent/consumable/frostoil, 5)
 	..()
@@ -273,6 +276,9 @@
 	M.drowsyness = max(0,M.drowsyness-1)
 	M.jitteriness = max(0,M.jitteriness-3)
 	M.AdjustSleeping(-20)
+	if(prob(5))
+		var/mob/living/carbon/human/H = M
+		H.adjustSanityLoss(0.02*H.maxSanity*REM) // That's healing 2% of max sanity.
 	if(M.getToxLoss() && prob(20))
 		M.adjustToxLoss(-1, 0)
 	M.adjust_bodytemperature(20 * TEMPERATURE_DAMAGE_COEFFICIENT, 0, M.get_body_temp_normal())
@@ -322,6 +328,9 @@
 	M.AdjustSleeping(-40)
 	M.adjust_bodytemperature(-5 * TEMPERATURE_DAMAGE_COEFFICIENT, M.get_body_temp_normal())
 	M.Jitter(5)
+	if(prob(5))
+		var/mob/living/carbon/human/H = M
+		H.adjustSanityLoss(0.02*H.maxSanity*REM) // That's healing 2% of max sanity.
 	..()
 	. = 1
 
@@ -359,6 +368,9 @@
 	M.dizziness = max(0,M.dizziness-2)
 	M.drowsyness = max(0,M.drowsyness-1)
 	M.AdjustSleeping(-40)
+	if(prob(5))
+		var/mob/living/carbon/human/H = M
+		H.adjustSanityLoss(0.02*H.maxSanity*REM) // That's healing 2% of max sanity.
 	if(M.getToxLoss() && prob(20))
 		M.adjustToxLoss(-1, 0)
 	M.adjust_bodytemperature(-5 * TEMPERATURE_DAMAGE_COEFFICIENT, M.get_body_temp_normal())
@@ -630,6 +642,9 @@
 	M.SetSleeping(0)
 	M.adjust_bodytemperature(5 * TEMPERATURE_DAMAGE_COEFFICIENT, 0, M.get_body_temp_normal())
 	M.Jitter(5)
+	if(prob(5))
+		var/mob/living/carbon/human/H = M
+		H.adjustSanityLoss(0.02*H.maxSanity*REM) // That's healing 2% of max sanity.
 	if(M.getBruteLoss() && prob(20))
 		M.heal_bodypart_damage(1,0, 0)
 	..()
@@ -651,6 +666,9 @@
 	M.SetSleeping(0)
 	M.adjust_bodytemperature(5 * TEMPERATURE_DAMAGE_COEFFICIENT, 0, M.get_body_temp_normal())
 	M.Jitter(5)
+	if(prob(5))
+		var/mob/living/carbon/human/H = M
+		H.adjustSanityLoss(0.02*H.maxSanity*REM) // That's healing 2% of max sanity.
 	if(M.getBruteLoss() && prob(20))
 		M.heal_bodypart_damage(1,0, 0)
 	..()

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -63,12 +63,18 @@
 	M.AdjustUnconscious(-5)
 	M.AdjustParalyzed(-5)
 	M.AdjustImmobilized(-5)
+	if(prob(1))
+		var/mob/living/carbon/human/H = M
+		H.adjustSanityLoss(3*REM) // That's healing
 	..()
 	. = 1
 
 /datum/reagent/drug/nicotine/overdose_process(mob/living/M)
 	M.adjustToxLoss(0.1*REM, 0)
 	M.adjustOxyLoss(1.1*REM, 0)
+	if(prob(10))
+		var/mob/living/carbon/human/H = M
+		H.adjustSanityLoss(-5*REM) // That's BAD
 	..()
 	. = 1
 

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -498,28 +498,6 @@
 	REMOVE_TRAIT(L, TRAIT_STUNRESISTANCE, type)
 	..()
 
-/datum/reagent/medicine/mental_stabilizator
-	name = "Mental Stabilizator"
-	description = "Heals any potential issues with mental state of the patient."
-	reagent_state = LIQUID
-	color = "#CCFFFF"
-	metabolization_rate = 0.5 * REAGENTS_METABOLISM
-	overdose_threshold = 25
-
-/datum/reagent/medicine/mental_stabilizator/on_mob_life(mob/living/M)
-	if(!ishuman(M))
-		return
-	var/mob/living/carbon/human/H = M
-	H.adjustSanityLoss(5*REM) // That's healing
-	..()
-	. = 1
-
-/datum/reagent/medicine/sal_acid/overdose_process(mob/living/M)
-	if(M.getBruteLoss()) //It only makes existing bruises worse
-		M.adjustBruteLoss(4.5*REM, FALSE, FALSE, BODYPART_ORGANIC) // it's going to be healing either 4 or 0.5
-		. = 1
-	..()
-
 /datum/reagent/medicine/ephedrine/on_mob_life(mob/living/M)
 	if(prob(20) && iscarbon(M))
 		var/obj/item/I = M.get_active_held_item()
@@ -547,6 +525,38 @@
 		M.losebreath++
 		. = 1
 	return TRUE
+
+/datum/reagent/medicine/mental_stabilizator //Classic sanity restoration medicine.
+	name = "Mental Stabilizator"
+	description = "Heals any potential issues with mental state of the patient."
+	reagent_state = LIQUID
+	color = "#CCFFFF"
+	metabolization_rate = 0.5 * REAGENTS_METABOLISM
+	overdose_threshold = 25
+
+/datum/reagent/medicine/mental_stabilizator/on_mob_life(mob/living/M)
+	if(!ishuman(M))
+		return
+	var/mob/living/carbon/human/H = M
+	H.adjustSanityLoss(5*REM) // That's healing 5 units.
+	..()
+	. = 1
+
+/datum/reagent/medicine/mental_stabilizator/overdose_process(mob/living/M)
+	if(prob(5))
+		if(current_cycle >= 50)
+			var/mob/living/carbon/human/H = M
+			to_chat(M, "<span class='notice'>[pick("Your blood starts to move.", "Your memories are fading.", "'Do not fear for we are with you now.'", "The sound of knocking is deafening.")]</span>")
+			H.adjustSanityLoss(-0.30*H.maxSanity*REM) // That's hurting 10% of sanity
+		else
+			var/mob/living/carbon/human/H = M
+			to_chat(M, "<span class='notice'>[pick("Your head pounds.", "Your thoughts are not your own.", "'You are in danger you have to run NOW!'")]</span>")
+			H.adjustSanityLoss(-0.10*H.maxSanity*REM) // That's hurting 5% of sanity
+	else if(prob(50))
+		var/mob/living/carbon/human/H = M
+		H.adjustSanityLoss(-10*REM) // That's hurting 10 units.
+		. = 1
+	..()
 
 /datum/reagent/medicine/diphenhydramine
 	name = "Diphenhydramine"
@@ -1193,9 +1203,9 @@
 	if(iscarbon(M))
 		var/mob/living/carbon/C = M
 		C.disgust = max(0, C.disgust-6)
-	var/datum/component/mood/mood = M.GetComponent(/datum/component/mood)
-	if(mood != null && mood.sanity <= SANITY_NEUTRAL) // only take effect if in negative sanity and then...
-		mood.setSanity(min(mood.sanity+5, SANITY_NEUTRAL)) // set minimum to prevent unwanted spiking over neutral
+	if(prob(10))
+		var/mob/living/carbon/human/H = M
+		H.adjustSanityLoss(1*REM) // That's healing
 	..()
 	. = 1
 


### PR DESCRIPTION
## About The Pull Request
Adds mental effects to Psicodine, Tea, Coffee, and Nicotine. Also worsens the overdose of Mental Stabalizers.
After a few tests they seem to work if not very inefficently. The mental stabalizer overdose is wacky but still punishing.

I just noticed in my notes there is some typos. Sanity harm from mental stabalizor overdose is 30% if 50 metabolism cycles have passed.

## Why It's Good For The Game
Drinking tea for a 5% chance to heal 2% of your mental health is fine if your stuck outside of combat. If you drink it during combat i wouldnt expect it to save you from blue star or any other white damage creature since 0.02*H.maxSanity usually equals 1 or 2 respectively. You could game it if you have a absurdly high prudence but at that point your facing things that take bites bigger than 2% out of your brain.

Mental stabaliztor overdose prevents the abuse of mental stabaliztors.

## Changelog
add: Mental Stabaliztor Overdose Effects
add: Chance to restore sanity when metabolizing Tea, Coffee, Nicotine, and Psicodine.

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
