### PR TITLE
Silent Girl Null Removal

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/he/silent_girl.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/silent_girl.dm
@@ -91,7 +91,7 @@
 /mob/living/simple_animal/hostile/abnormality/silent_girl/zero_qliphoth(mob/living/carbon/human/user)
 	var/dead_list = guilty_people
 	for(var/mob/living/carbon/human/dead_body in dead_list)
-		if(dead_body.stat == DEAD)
+		if(dead_body.stat == DEAD || isnull(dead_body))
 			guilty_people -= dead_body
 	if (!LAZYLEN(guilty_people)) // No Guilty on 0 counter? Find a random person and take them <3
 		var/list/potential_guilt = list()
@@ -103,7 +103,7 @@
 			Guilt_Effect(pick(potential_guilt))
 		else
 			manual_emote("giggles.")
-			playsound(get_turf(src), 'sound/voice/human/womanlaugh.ogg', 50, 0, 6, ignore_walls = TRUE)
+			playsound(get_turf(src), 'sound/voice/human/womanlaugh.ogg', 50, 0, 20, ignore_walls = TRUE)
 	for(var/mob/living/carbon/human/i in guilty_people) // Drive all Guilty people insane on Qliphoth 0
 		to_chat(i, "<span class='userdanger'>You feel your head begin to split!</span>")
 		addtimer(CALLBACK(src, .proc/DriveInsane, i), 10 SECONDS)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
If someone's dead for enough time, their body is deleted (or cremated), or they are gibbed, then they can be set to "null" in the list. I did NOT account for this previously so she would be stuck being... well, harmless. This has remedied that and she WILL kill. I've also reduced her panic warning time from 10 seconds to 5.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes a broken abno.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Null-check for Silent Girl's list
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
