### PR TITLE
Changes Hub message and Death Message

### DIFF
--- a/ModularTegustation/tegu_world.dm
+++ b/ModularTegustation/tegu_world.dm
@@ -28,9 +28,7 @@
 
 	// Tegu Description
 	s += "<br>Map: <b>\[[SSmapping.config?.map_name || "Loading..."]</b>\]"
-	s += "<br>Roleplay: \[<b>Medium</b>\]"
-	if(GLOB.master_mode)
-		s += "<br>Mode: \[<b>" + (GLOB.master_mode == "secret_extended" ? "secret" : GLOB.master_mode) + "</b>"//\]"
+	s += "<br>Roleplay: \[<b>Medium</b>\]"//\]"
 		// NOTE: If this is the LAST THING to be added to the description, then it'll end with a ] anyway. So don't include it here
 
 	var/players = GLOB.clients.len

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -41,7 +41,7 @@ GLOBAL_LIST_EMPTY(dead_players_during_shift)
 		log_message("has died (BRUTE: [src.getBruteLoss()], BURN: [src.getFireLoss()], TOX: [src.getToxLoss()], OXY: [src.getOxyLoss()], CLONE: [src.getCloneLoss()])", LOG_ATTACK)
 
 	med_hud_set_sanity() // Change it to death state
-	to_chat(src, "<span class='warning'>You have died. Barring complete bodyloss, you can in most cases be revived by other players. If you do not wish to be brought back, use the \"Do Not Resuscitate\" verb in the ghost tab.</span>")
+	to_chat(src, "<span class='warning'>You have died. To continue playing, use the \"Respawn\" verb in the OOC tab.</span>")
 
 /mob/living/carbon/human/proc/makeSkeleton()
 	ADD_TRAIT(src, TRAIT_DISFIGURED, TRAIT_GENERIC)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes "Gamemode" from the hub info, and changes the death message
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
We don't really have gamemodes here so having this is not really needed, and may turn off people who notice that we're 
"On a greenshift" (lol)
We don't have defibrillators, so I've changed the death message to reflect that.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: changes death message and hub info
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
