### PR TITLE
Meltdown Scaling

### DIFF
--- a/code/controllers/subsystem/lobotomy_corp.dm
+++ b/code/controllers/subsystem/lobotomy_corp.dm
@@ -136,7 +136,7 @@ SUBSYSTEM_DEF(lobotomy_corp)
 	InitiateMeltdown(qliphoth_meltdown_amount, FALSE)
 	if(abno_wait <= qliphoth_state)
 		SSabnormality_queue.fire() // Fired AFTER the meltdown occurs, so there's no situation where players are screwed because they were prepping for CENSORED and he arrives and instant meltdowns.
-		abno_wait_cooldown = round(clamp(1+(player_ratio*player_count), 1, INFINITY)) // Actively dynamic with the living players.
+		abno_wait_cooldown = round(max(1+(player_ratio*player_count), 1)) // Actively dynamic with the living players.
 		abno_wait = abno_wait_cooldown + qliphoth_state
 	qliphoth_meltdown_amount = max(1, round(abno_amount * 0.35))
 
@@ -182,7 +182,11 @@ SUBSYSTEM_DEF(lobotomy_corp)
 		return FALSE
 	next_ordeal = pick(available_ordeals)
 	all_ordeals[next_ordeal_level] -= next_ordeal
-	next_ordeal_time = qliphoth_state + (next_ordeal_level * 2) + rand(1,3)
+	var/active_players = 0
+	for(var/mob/player in GLOB.player_list)
+		if(isliving(player))
+			active_players += 1
+	next_ordeal_time = qliphoth_state + (next_ordeal_level * 2) + rand(1,3) + round(active_players*0.2)
 	next_ordeal_level += 1 // Increase difficulty!
 	for(var/obj/structure/sign/ordealmonitor/O in GLOB.ordeal_monitors)
 		O.update_icon()

--- a/code/controllers/subsystem/lobotomy_corp.dm
+++ b/code/controllers/subsystem/lobotomy_corp.dm
@@ -50,7 +50,7 @@ SUBSYSTEM_DEF(lobotomy_corp)
 	// How many meltdowns should occur before a new abno arrives
 	var/abno_wait_cooldown = 1
 	var/abno_wait = 0
-	var/player_ratio = 0.35
+	var/player_ratio = 0.2
 
 	var/current_box = 0
 	var/box_goal = INFINITY // Initialized later
@@ -119,7 +119,7 @@ SUBSYSTEM_DEF(lobotomy_corp)
 	for(var/mob/player in GLOB.player_list)
 		if(isliving(player))
 			player_count += 1
-	qliphoth_max = 4 + round(abno_amount * 0.25) + round(player_count * 0.3)
+	qliphoth_max = 4 + round(abno_amount * 0.20) + round(player_count * 0.1)
 	qliphoth_state += 1
 	for(var/datum/abnormality/A in all_abnormality_datums)
 		if(istype(A.current))
@@ -136,7 +136,7 @@ SUBSYSTEM_DEF(lobotomy_corp)
 	InitiateMeltdown(qliphoth_meltdown_amount, FALSE)
 	if(abno_wait <= qliphoth_state)
 		SSabnormality_queue.fire() // Fired AFTER the meltdown occurs, so there's no situation where players are screwed because they were prepping for CENSORED and he arrives and instant meltdowns.
-		abno_wait_cooldown = round(clamp(1+(player_ratio*player_count), 2, INFINITY)) // Actively dynamic with the living players.
+		abno_wait_cooldown = round(clamp(1+(player_ratio*player_count), 1, INFINITY)) // Actively dynamic with the living players.
 		abno_wait = abno_wait_cooldown + qliphoth_state
 	qliphoth_meltdown_amount = max(1, round(abno_amount * 0.35))
 
@@ -182,7 +182,7 @@ SUBSYSTEM_DEF(lobotomy_corp)
 		return FALSE
 	next_ordeal = pick(available_ordeals)
 	all_ordeals[next_ordeal_level] -= next_ordeal
-	next_ordeal_time = qliphoth_state + (next_ordeal_level * 2) + rand(1,3)
+	next_ordeal_time = qliphoth_state*1.5 + (next_ordeal_level * 2) + rand(1,3) // Increased
 	next_ordeal_level += 1 // Increase difficulty!
 	for(var/obj/structure/sign/ordealmonitor/O in GLOB.ordeal_monitors)
 		O.update_icon()

--- a/code/controllers/subsystem/lobotomy_corp.dm
+++ b/code/controllers/subsystem/lobotomy_corp.dm
@@ -182,7 +182,7 @@ SUBSYSTEM_DEF(lobotomy_corp)
 		return FALSE
 	next_ordeal = pick(available_ordeals)
 	all_ordeals[next_ordeal_level] -= next_ordeal
-	next_ordeal_time = qliphoth_state*1.5 + (next_ordeal_level * 2) + rand(1,3) // Increased
+	next_ordeal_time = qliphoth_state + (next_ordeal_level * 2) + rand(1,3)
 	next_ordeal_level += 1 // Increase difficulty!
 	for(var/obj/structure/sign/ordealmonitor/O in GLOB.ordeal_monitors)
 		O.update_icon()

--- a/code/game/machinery/computer/abnormality_queue.dm
+++ b/code/game/machinery/computer/abnormality_queue.dm
@@ -26,6 +26,7 @@
 		for(var/type in SSabnormality_queue.picking_abnormalities)
 			var/mob/living/simple_animal/hostile/abnormality/abno = type
 			dat += " <A href='byond://?src=[REF(src)];queue=[abno]'>\[[THREAT_TO_NAME[initial(abno.threat_level)]]\] [initial(abno.name)]</A><br>"
+	dat += " <A href='byond://?src=[REF(src)];call_abno'>Request Abno</A><br>"
 	var/datum/browser/popup = new(user, "abno_queue", "Abnormality Queue Console", 360, 240)
 	popup.set_content(dat)
 	popup.open()
@@ -54,3 +55,17 @@
 			playsound(get_turf(src), 'sound/machines/terminal_prompt_confirm.ogg', 50, TRUE)
 			updateUsrDialog()
 			return TRUE
+		else
+			if(SSlobotomy_corp.abno_wait > 0)
+				SSlobotomy_corp.abno_wait = 0
+				to_chat(usr, "<span class='notice'>Abnormality will arrive after next meltdown!</span>")
+				playsound(get_turf(src), 'sound/machines/terminal_prompt_confirm.ogg', 50, TRUE)
+				updateUsrDialog()
+				return TRUE
+			else
+				to_chat(usr, "<span class='warning'>Abnormality already requested!</span>")
+				playsound(get_turf(src), 'sound/machines/terminal_prompt_deny.ogg', 50, TRUE)
+				updateUsrDialog() // Forcibly update it, in case someone doesn't understand why it won't work
+				return FALSE
+
+

--- a/code/modules/jobs/job_types/agent.dm
+++ b/code/modules/jobs/job_types/agent.dm
@@ -75,7 +75,7 @@
 
 	var/set_attribute = normal_attribute_level
 	var/interval = SSabnormality_queue.spawned_abnos
-	var/max = GLOB.abnormality_room_spawners.len
+	var/max = SSabnormality_queue.rooms_start
 	if(interval >= round(max * (5/6))) // Full facility expected
 		set_attribute *= 4
 	else if(interval >= round(max * (2/3))) // More than one ALEPH

--- a/code/modules/jobs/job_types/agent.dm
+++ b/code/modules/jobs/job_types/agent.dm
@@ -74,15 +74,17 @@
 		to_chat(M, "<b>You have not been assigned to any department.</b>")
 
 	var/set_attribute = normal_attribute_level
-	if(world.time >= 75 MINUTES) // Full facility expected
+	var/interval = SSabnormality_queue.spawned_abnos
+	var/max = GLOB.abnormality_room_spawners.len
+	if(interval >= round(max * (5/6))) // Full facility expected
 		set_attribute *= 4
-	else if(world.time >= 60 MINUTES) // More than one ALEPH
+	else if(interval >= round(max * (2/3))) // More than one ALEPH
 		set_attribute *= 3
-	else if(world.time >= 45 MINUTES) // Wowzer, an ALEPH?
+	else if(interval >= round(max * (1/2))) // Wowzer, an ALEPH?
 		set_attribute *= 2.5
-	else if(world.time >= 30 MINUTES) // Expecting WAW
+	else if(interval >= round(max * (1/3))) // Expecting WAW
 		set_attribute *= 2
-	else if(world.time >= 15 MINUTES) // Usual time for HEs
+	else if(interval >= round(max * (1/6))) // Usual time for HEs
 		set_attribute *= 1.5
 
 	for(var/A in roundstart_attributes)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes various facets from scaling based on time to scale off meltdowns and abnormality quantity. Affected are Abnormality Arrivals (Scaling with Players, Min 2), Agent spawn stats (Every 1/6th of the facility filled is buffed), and Zayin and Teth removal from the queue. Also added is a randomized Pizza reward for hitting Energy Goal, because it's nice. Alongside these changes, at least 1 abno is now forced to spawn at the round start after the usual 3 minutes of the world being up, but this excludes the 3 stat-check Teths and We Can Change anything. A second abno follows the moment the first meltdown occurs.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It's been requested by quite a few people and I think it would help smooth the game out overall, especially on rounds that get "abandoned" in the middle of the night (Full facility but no ego). I know you (Egor) want the Ordeals to still be able to disadvantage people, I think, so I would still be down for making Ordeals turn the auto-fire timer back on for the duration of an ordeal if you wanted. That way Ordeals actively speed up the game if not handled properly (or timely).
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Pizza Time
tweak: Changed Abno Arrival to be based on Meltdowns.
balance: Changed Agent late-join stats to be based off how full the facility is, instead of time.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
