### PR TITLE
Pink Midnight no longer calls hostile abnormalities to her

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/ordeal/misc.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/misc.dm
@@ -25,7 +25,11 @@
 
 	//Funny drags everything to it
 /mob/living/simple_animal/hostile/ordeal/pink_midnight/proc/Breach_All()
-	for(var/mob/living/simple_animal/hostile/abnormality/A)
+	for(var/mob/living/simple_animal/hostile/abnormality/A in GLOB.mob_list)
+		//These two abnormalities kill everything else no matter what faction we set them to
+		if(istype(A, /mob/living/simple_animal/hostile/abnormality/hatred_queen) || istype(A, /mob/living/simple_animal/hostile/abnormality/white_night))
+			return
+
 		if(A.can_breach && (A.status_flags & GODMODE))
 			A.breach_effect()
 			var/turf/orgin = get_turf(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Pink Midnight can never call QOH or WN.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
They ended up killing half of the abnormalities and it makes pink midnight much easier.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Pink Midnight cannot call QOH or WN to her
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
