### PR TITLE
Abnorm Patrolling + Changes

### DIFF
--- a/code/controllers/subsystem/lobotomy_corp.dm
+++ b/code/controllers/subsystem/lobotomy_corp.dm
@@ -133,7 +133,7 @@ SUBSYSTEM_DEF(lobotomy_corp)
 			continue
 		if(!cmp.datum_reference || !cmp.datum_reference.current)
 			continue
-		if(!(cmp.datum_reference.current.status_flags & GODMODE))
+		if(!(cmp.datum_reference.current.status_flags & GODMODE) || (!cmp.datum_reference.qliphoth_meter && cmp.datum_reference.qliphoth_meter_max))
 			continue
 		if(!(cmp.datum_reference.threat_level in qliphoth_meltdown_affected) && !forced)
 			continue

--- a/code/modules/mob/living/simple_animal/abnormality/_abnormality.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_abnormality.dm
@@ -58,6 +58,12 @@
 	var/datum/ego_gifts/gift_type = null
 	var/gift_chance = null
 	var/gift_message = null
+	/// Patrol Code
+	var/can_patrol = TRUE
+	var/patrol_cooldown
+	var/patrol_cooldown_time = 30 SECONDS
+	var/list/patrol_path = list()
+	var/patrol_tries = 0 //max of 5
 
 /mob/living/simple_animal/hostile/abnormality/Initialize(mapload)
 	. = ..()
@@ -104,7 +110,75 @@
 	if(status_flags & GODMODE)
 		return FALSE
 	FearEffect()
-	return
+	if(!can_patrol || client)
+		return
+	if(target && patrol_path) //if AI has acquired a target while on patrol, stop patrol
+		patrol_reset()
+		return
+	if(AIStatus == AI_IDLE) //if AI is idle, begin checking for patrol
+		if(patrol_cooldown <= world.time)
+			if(!patrol_path || !patrol_path.len)
+				patrol_select()
+				if(patrol_path.len)
+					patrol_move(patrol_path[patrol_path.len])
+
+/mob/living/simple_animal/hostile/abnormality/proc/patrol_select()
+	var/turf/target_center
+	var/list/potential_centers = list()
+	for(var/pos_targ in GLOB.department_centers)
+		var/possible_center_distance = get_dist(src, pos_targ)
+		if(possible_center_distance > 4 && possible_center_distance < 46)
+			potential_centers += pos_targ
+	if(LAZYLEN(potential_centers))
+		target_center = pick(potential_centers)
+	else
+		target_center = pick(GLOB.department_centers)
+	patrol_path = get_path_to(src, target_center, /turf/proc/Distance_cardinal, 0, 200)
+
+/mob/living/simple_animal/hostile/abnormality/proc/patrol_reset()
+	patrol_path = null
+	patrol_tries = 0
+	stop_automated_movement = 0
+	patrol_cooldown = world.time + patrol_cooldown_time
+
+/mob/living/simple_animal/hostile/abnormality/proc/patrol_move(dest)
+	if(client || target || status_flags & GODMODE)
+		return FALSE
+	if(!dest || !patrol_path || !patrol_path.len) //A-star failed or a path/destination was not set.
+		return FALSE
+	stop_automated_movement = 1
+	dest = get_turf(dest) //We must always compare turfs, so get the turf of the dest var if dest was originally something else.
+	var/turf/last_node = get_turf(patrol_path[patrol_path.len]) //This is the turf at the end of the path, it should be equal to dest.
+	if(get_turf(src) == dest) //We have arrived, no need to move again.
+		return TRUE
+	else if(dest != last_node) //The path should lead us to our given destination. If this is not true, we must stop.
+		patrol_reset()
+		return FALSE
+	if(patrol_tries < 5)
+		patrol_step(dest)
+	else
+		patrol_reset()
+		return FALSE
+	addtimer(CALLBACK(src, .proc/patrol_move, dest), (move_to_delay+speed))
+	return TRUE
+
+/mob/living/simple_animal/hostile/abnormality/proc/patrol_step(dest)
+	if(client || target  || status_flags & GODMODE || !patrol_path || !patrol_path.len)
+		return FALSE
+	if(patrol_path.len > 1)
+		step_towards(src, patrol_path[1])
+		if(get_turf(src) == patrol_path[1]) //Successful move
+			if(!patrol_path || !patrol_path.len)
+				return
+			patrol_path.Cut(1, 2)
+			patrol_tries = 0
+		else
+			patrol_tries++
+			return FALSE
+	else if(patrol_path.len == 1)
+		step_to(src, dest)
+		patrol_reset()
+	return TRUE
 
 // Applies fear damage to everyone in range
 /mob/living/simple_animal/hostile/abnormality/proc/FearEffect()

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/blue_star.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/blue_star.dm
@@ -1,5 +1,5 @@
 /mob/living/simple_animal/hostile/abnormality/bluestar
-	name = "Blue star"
+	name = "Blue Star"
 	desc = "Floating heart-shaped object. It's alive, and soon you will become one with it."
 	health = 4000
 	maxHealth = 4000
@@ -25,6 +25,7 @@
 						)
 	work_damage_amount = 16
 	work_damage_type = WHITE_DAMAGE
+	can_patrol = FALSE
 
 	wander = FALSE
 	light_color = COLOR_BLUE_LIGHT

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/censored.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/censored.dm
@@ -70,7 +70,7 @@
 				break
 
 /mob/living/simple_animal/hostile/abnormality/censored/CanAttack(atom/the_target)
-	if(isliving(target) && !ishuman(target))
+	if(isliving(the_target) && !ishuman(the_target))
 		var/mob/living/L = target
 		if(L.stat == DEAD)
 			return FALSE

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/mountain.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/mountain.dm
@@ -56,6 +56,7 @@
 	var/spit_cooldown_time = 18 SECONDS
 	/// Actually it fires this amount thrice, so, multiply it by 3 to get actual amount
 	var/spit_amount = 32
+	patrol_cooldown_time = 10 SECONDS //stage 1 - 10s, stage 2 - 20s, stage 3 - 30s
 
 /mob/living/simple_animal/hostile/abnormality/mountain/Initialize()		//1 in 100 chance for amogus MOSB
 	. = ..()
@@ -183,10 +184,12 @@
 				icon_living = "mosb_breach2"
 				speed = 4
 				move_to_delay = 5
+				patrol_cooldown_time = 30 SECONDS
 			if(phase == 2)
 				icon_living = "mosb_breach"
 				speed = 3
 				move_to_delay = 4
+				patrol_cooldown_time = 20 SECONDS
 			icon_state = icon_living
 		return
 	// Decrease stage
@@ -203,12 +206,14 @@
 		base_pixel_x = -16
 		speed = 2
 		move_to_delay = 2
+		patrol_cooldown_time = 10 SECONDS
 	if(phase == 2)
 		icon = 'ModularTegustation/Teguicons/96x96.dmi'
 		pixel_x = -32
 		base_pixel_x = -32
 		speed = 3
 		move_to_delay = 4
+		patrol_cooldown_time = 20 SECONDS
 	icon_state = icon_living
 	return TRUE
 

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/silent_orchestra.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/silent_orchestra.dm
@@ -1,5 +1,5 @@
 /mob/living/simple_animal/hostile/abnormality/silentorchestra
-	name = "Silent orchestra"
+	name = "Silent Orchestra"
 	desc = "From break and ruin, the most beautiful performance begins."
 	health = 4000
 	maxHealth = 4000
@@ -18,6 +18,7 @@
 						)
 	work_damage_amount = 16
 	work_damage_type = WHITE_DAMAGE
+	can_patrol = FALSE
 
 	wander = FALSE
 	light_system = MOVABLE_LIGHT

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/white_night.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/white_night.dm
@@ -1,7 +1,7 @@
 GLOBAL_LIST_EMPTY(apostles)
 
 /mob/living/simple_animal/hostile/abnormality/white_night
-	name = "White night"
+	name = "WhiteNight"
 	desc = "The heavens' wrath. Say your prayers, heretic, the day has come."
 	health = 15000
 	maxHealth = 15000
@@ -34,6 +34,7 @@ GLOBAL_LIST_EMPTY(apostles)
 						)
 	work_damage_amount = 14
 	work_damage_type = PALE_DAMAGE
+	can_patrol = FALSE
 
 	light_system = MOVABLE_LIGHT
 	light_color = COLOR_VERY_SOFT_YELLOW

--- a/code/modules/mob/living/simple_animal/abnormality/he/helper.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/helper.dm
@@ -1,5 +1,5 @@
 /mob/living/simple_animal/hostile/abnormality/helper
-	name = "All around helper"
+	name = "All-Around Helper"
 	desc = "A tiny robot with helpful intentions."
 	icon = 'ModularTegustation/Teguicons/tegumobs.dmi'
 	icon_state = "helper"

--- a/code/modules/mob/living/simple_animal/abnormality/he/scarecrow.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/scarecrow.dm
@@ -1,5 +1,5 @@
 /mob/living/simple_animal/hostile/abnormality/scarecrow
-	name = "Scarecrow searching for wisdom"
+	name = "Scarecrow Searching for Wisdom"
 	desc = "An abnormality taking form of a scarecrow with metal rake in place of its hand."
 	icon = 'ModularTegustation/Teguicons/32x48.dmi'
 	icon_state = "scarecrow"

--- a/code/modules/mob/living/simple_animal/abnormality/he/scaredy_cat.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/scaredy_cat.dm
@@ -1,5 +1,5 @@
 /mob/living/simple_animal/hostile/abnormality/scaredy_cat
-	name = "Scaredy cat"
+	name = "Scaredy Cat"
 	desc = "An abnormality ressembling a small defenseless kitten."
 	icon = 'ModularTegustation/Teguicons/32x32.dmi'
 	icon_state = "scaredy_cat"
@@ -33,6 +33,7 @@
 						) //higher work chance than the rest of oz because he can breach so easily
 	work_damage_amount = 7 //Shit damage because it's a small cat
 	work_damage_type = RED_DAMAGE
+	can_patrol = FALSE
 	deathsound = 'sound/abnormalities/scaredycat/catgrunt.ogg'
 	ego_list = list(
 		/datum/ego_datum/weapon/courage,

--- a/code/modules/mob/living/simple_animal/abnormality/teth/blood_bath.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/blood_bath.dm
@@ -1,5 +1,5 @@
 /mob/living/simple_animal/hostile/abnormality/bloodbath
-	name = "bloodbath"
+	name = "Bloodbath"
 	desc = "A constantly dripping bath of blood"
 	icon = 'ModularTegustation/Teguicons/48x64.dmi'
 	icon_state = "bloodbath"

--- a/code/modules/mob/living/simple_animal/abnormality/teth/punishing_bird.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/punishing_bird.dm
@@ -1,5 +1,5 @@
 /mob/living/simple_animal/hostile/abnormality/punishing_bird
-	name = "Punishing bird"
+	name = "Punishing Bird"
 	desc = "A white bird with tiny beak. Looks harmless."
 	icon = 'icons/mob/punishing_bird.dmi'
 	icon_state = "pbird"
@@ -199,7 +199,7 @@
 	return
 
 /mob/living/simple_animal/hostile/abnormality/punishing_bird/proc/kill_bird()
-	if(!target && icon_state != "pbird_red")
+	if(!(status_flags & GODMODE) && !target && icon_state != "pbird_red")
 		QDEL_NULL(src)
 	else
 		addtimer(CALLBACK(src, .proc/kill_bird), 120 SECONDS)

--- a/code/modules/mob/living/simple_animal/abnormality/teth/scorched_girl.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/scorched_girl.dm
@@ -1,5 +1,5 @@
 /mob/living/simple_animal/hostile/abnormality/scorched_girl
-	name = "Scorched girl"
+	name = "Scorched Girl"
 	desc = "An abnormality resembling a girl burnt to ashes. \
 	Even though there's nothing left to burn, the fire still doesn't extinguish."
 	icon = 'ModularTegustation/Teguicons/tegumobs.dmi'
@@ -37,6 +37,23 @@
 	var/boom_cooldown
 	/// Amount of RED damage done on explosion
 	var/boom_damage = 250
+	patrol_cooldown_time = 10 SECONDS //Scorched be zooming
+
+/mob/living/simple_animal/hostile/abnormality/scorched_girl/patrol_select()
+	var/turf/target_center
+	var/highestcount = 0
+	for(var/turf/T in GLOB.department_centers)
+		var/targets_at_tile = 0
+		for(var/mob/living/L in view(10, T))
+			if(!faction_check_mob(L) && L.stat != DEAD)
+				targets_at_tile++
+		if(targets_at_tile > highestcount)
+			target_center = T
+			highestcount = targets_at_tile
+	if(!target_center)
+		..()
+	else
+		patrol_path = get_path_to(src, target_center, /turf/proc/Distance_cardinal, 0, 200)
 
 /mob/living/simple_animal/hostile/abnormality/scorched_girl/OpenFire()
 	if(client)
@@ -45,7 +62,8 @@
 
 	var/amount_inview = 0
 	for(var/mob/living/carbon/human/H in view(7, src))
-		amount_inview += 1
+		if(!faction_check_mob(H) && H.stat != DEAD)
+			amount_inview += 1
 	if(prob(amount_inview*20))
 		explode()
 
@@ -55,8 +73,9 @@
 	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/scorched_girl/CanAttack(atom/the_target)
-	if(ishuman(the_target))
-		return TRUE
+	if(..())
+		if(ishuman(the_target))
+			return TRUE
 	return FALSE
 
 /mob/living/simple_animal/hostile/abnormality/scorched_girl/AttackingTarget(atom/attacked_target)

--- a/code/modules/mob/living/simple_animal/abnormality/teth/training_rabbit.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/training_rabbit.dm
@@ -1,5 +1,5 @@
 /mob/living/simple_animal/hostile/abnormality/training_rabbit
-	name = "Standard training-dummy rabbit"
+	name = "Standard Training-Dummy Rabbit"
 	desc = "A rabbit-like training dummy. Should be completely harmless."
 	icon = 'ModularTegustation/Teguicons/tegumobs.dmi'
 	icon_state = "training_rabbit"
@@ -23,6 +23,7 @@
 	can_spawn = FALSE // Normally doesn't appear
 	//ego_list = list(datum/ego_datum/weapon/training, datum/ego_datum/armor/training)
 	gift_type =  /datum/ego_gifts/standard
+	can_patrol = FALSE
 
 /mob/living/simple_animal/hostile/abnormality/training_rabbit/breach_effect(mob/living/carbon/human/user)
 	..()

--- a/code/modules/mob/living/simple_animal/abnormality/waw/big_bird.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/big_bird.dm
@@ -1,7 +1,7 @@
 /mob/living/simple_animal/hostile/abnormality/big_bird
-	name = "Big bird"
+	name = "Big Bird"
 	desc = "A large, many-eyed bird that patrols the dark forest with an everlasting lamp. \
-	Unlike regular birds, it lacks wings and has long arms instead with which it can pick things up."
+	Unlike regular birds, it lacks wings and instead has long arms with which it can pick things up."
 	icon = 'ModularTegustation/Teguicons/64x64.dmi'
 	icon_state = "big_bird"
 	icon_living = "big_bird"

--- a/code/modules/mob/living/simple_animal/abnormality/waw/despair_knight.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/despair_knight.dm
@@ -1,5 +1,5 @@
 /mob/living/simple_animal/hostile/abnormality/despair_knight
-	name = "Knight of despair"
+	name = "Knight of Despair"
 	desc = "A tall humanoid abnormality in a blue dress. \
 	Half of her head is black with sharp horn segments protruding out of it."
 	icon = 'ModularTegustation/Teguicons/48x48.dmi'
@@ -25,6 +25,7 @@
 	speed = 3
 	move_to_delay = 4
 	threat_level = WAW_LEVEL
+	can_patrol = FALSE
 
 	work_chances = list(
 						ABNORMALITY_WORK_INSTINCT = 0,

--- a/code/modules/mob/living/simple_animal/abnormality/waw/dreaming_current.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/dreaming_current.dm
@@ -1,5 +1,5 @@
 /mob/living/simple_animal/hostile/abnormality/dreaming_current
-	name = "Dreaming current"
+	name = "\proper The Dreaming Current"
 	desc = "An abnormality resembling a cobalt blue shark with legs. \
 	There's a syringe embedded in a side of its body, and there are multiple injection holes on its lower body."
 	icon = 'ModularTegustation/Teguicons/64x48.dmi'
@@ -28,6 +28,7 @@
 
 	can_breach = TRUE
 	start_qliphoth = 2
+	can_patrol = FALSE
 
 	var/list/movement_path = list()
 	var/list/been_hit = list()

--- a/code/modules/mob/living/simple_animal/abnormality/waw/hatred_queen.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/hatred_queen.dm
@@ -1,6 +1,6 @@
 /mob/living/simple_animal/hostile/abnormality/hatred_queen
-	name = "Queen of hatred"
-	desc = "A an abnormality resembling pale-skinned girl in a rather bizzare outfit. \
+	name = "Queen of Hatred"
+	desc = "An abnormality resembling pale-skinned girl in a rather bizzare outfit. \
 	Right behind her is what you presume to be a magic wand."
 	icon = 'ModularTegustation/Teguicons/32x48.dmi'
 	icon_state = "hatred"
@@ -27,6 +27,7 @@
 	speed = 2
 	move_to_delay = 4
 	threat_level = WAW_LEVEL
+	can_patrol = FALSE
 
 	work_chances = list(
 						ABNORMALITY_WORK_INSTINCT = list(30, 40, 40, 50, 50),
@@ -542,6 +543,7 @@
 	beam_cooldown_time = 10 SECONDS //it's her only move while hostile
 	teleport_cooldown_time = 10 SECONDS
 	breach_max_death = 0 //who cares about humans anymore?
+	retreat_distance = null //this is annoying
 	addtimer(CALLBACK(src, .proc/TryTeleport, TRUE), 5)
 	return
 

--- a/code/modules/mob/living/simple_animal/abnormality/waw/judgement_bird.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/judgement_bird.dm
@@ -1,5 +1,5 @@
 /mob/living/simple_animal/hostile/abnormality/judgement_bird
-	name = "Judgement bird"
+	name = "Judgement Bird"
 	desc = "A bird that used to judge the living in the dark forest, carrying around an unbalanced scale."
 	icon = 'ModularTegustation/Teguicons/48x64.dmi'
 	icon_state = "judgement_bird"

--- a/code/modules/mob/living/simple_animal/abnormality/waw/queen_bee.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/queen_bee.dm
@@ -1,5 +1,5 @@
 /mob/living/simple_animal/hostile/abnormality/queen_bee
-	name = "Queen bee"
+	name = "Queen Bee"
 	desc = "A disfigured creature resembling a bee queen."
 	icon = 'ModularTegustation/Teguicons/48x64.dmi'
 	icon_state = "queen_bee"

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/bald.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/bald.dm
@@ -1,5 +1,5 @@
 /mob/living/simple_animal/hostile/abnormality/bald
-	name = "You are bald"
+	name = "You are Bald"
 	desc = "A helpful sphere, you think."
 	icon = 'ModularTegustation/Teguicons/tegumobs.dmi'
 	icon_state = "bald1"

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/fairy_festival.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/fairy_festival.dm
@@ -1,5 +1,5 @@
 /mob/living/simple_animal/hostile/abnormality/fairy_festival
-	name = "Fairy festival"
+	name = "Fairy Festival"
 	desc = "The abnormality is similar to a fairy, having two pairs of wings and a small body. The small fairies around it act as a cluster."
 	icon = 'ModularTegustation/Teguicons/tegumobs.dmi'
 	icon_state = "fairy"

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/one_sin.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/one_sin.dm
@@ -1,5 +1,5 @@
 /mob/living/simple_animal/hostile/abnormality/onesin
-	name = "One sin and hundreds of good deeds"
+	name = "One Sin and Hundreds of Good Deeds"
 	desc = "A giant skull that is attached to a cross, it wears a crown of thorns."
 	icon = 'ModularTegustation/Teguicons/tegumobs.dmi'
 	icon_state = "onesin"

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/we_can_change_anything.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/we_can_change_anything.dm
@@ -1,6 +1,6 @@
 #define STATUS_EFFECT_CHANGE /datum/status_effect/we_can_change_anything
 /mob/living/simple_animal/hostile/abnormality/we_can_change_anything
-	name = "We can change anything"
+	name = "We Can Change Anything"
 	desc = "A human sized container with spikes inside it, you shouldn't enter it"
 	icon = 'ModularTegustation/Teguicons/tegumobs.dmi'
 	icon_state = "wecanchange"

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/wellcheers.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/wellcheers.dm
@@ -1,6 +1,6 @@
 // A vending machine that is a mob type. My descent into madness continues.
 /mob/living/simple_animal/hostile/abnormality/wellcheers
-	name = "Wellcheers vending machine"
+	name = "Wellcheers Vending Machine"
 	desc = "A vending machine selling cans of \"Wellcheers\"."
 	icon = 'ModularTegustation/Teguicons/tegumobs.dmi'
 	icon_state = "wellcheers_vendor"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
~~Every 30 seconds, if the abnormality doesn't have a target, it will pick a random department center and navigate towards it. The patrol speed should be close to its normal chase speed. That's about it.~~
~~Abnormalities now just navigate to the closest department. So it's more like guarding rather than patrolling.~~
Abnormalities will now pick department centers within a certain distance to navigate to. This can hopefully cut down on server burden.
Teleporting and stationary abnorms shouldn't patrol.
Scorched Girl has a lower patrol cooldown and picks the department with the most people. Officers beware.
MoSB has a lower patrol cooldown which increases with each stage. Will hopefully help it find bodies easier.

Also capitalizes the names of abnormalities for consistency.


## Why It's Good For The Game
Abnorms will finally leave their cells.

## Changelog
:cl:
add: abnormality patrol
fix: scorched no longer targets dead bodies
spellcheck: capitalized abnorm names
:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
