### PR TITLE
Fragment + Grant Us Love Nerf

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/teth/fragment.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/fragment.dm
@@ -1,5 +1,5 @@
 /mob/living/simple_animal/hostile/abnormality/fragment
-	name = "Fragment of the universe"
+	name = "Fragment of the Universe"
 	desc = "An abnormality taking form of a black ball covered by 'hearts' of different colors."
 	icon = 'ModularTegustation/Teguicons/32x48.dmi'
 	icon_state = "fragment"
@@ -40,6 +40,7 @@
 	var/song_cooldown
 	var/song_cooldown_time = 10 SECONDS
 	var/song_damage = 4 // Dealt 8 times
+	var/can_act = TRUE
 
 /datum/action/innate/abnormality_attack/fragment_song
 	name = "An Echo From Beyond"
@@ -48,7 +49,15 @@
 	chosen_message = "<span class='colossus'>You will now deal white damage to all enemies around you.</span>"
 	chosen_attack_num = 1
 
+/mob/living/simple_animal/hostile/abnormality/fragment/Move()
+	if(!can_act)
+		return FALSE
+	return ..()
+
 /mob/living/simple_animal/hostile/abnormality/fragment/OpenFire()
+	if(!can_act)
+		return
+
 	if(client)
 		switch(chosen_attack)
 			if(1)
@@ -61,17 +70,19 @@
 /mob/living/simple_animal/hostile/abnormality/fragment/proc/song()
 	if(song_cooldown > world.time)
 		return
-	song_cooldown = world.time + song_cooldown_time
+	can_act = FALSE
 	playsound(get_turf(src), 'sound/abnormalities/fragment/sing.ogg', 50, 0, 4)
 	for(var/i = 1 to 8)
 		new /obj/effect/temp_visual/fragment_song(get_turf(src))
-		for(var/mob/living/L in view(7, src))
+		for(var/mob/living/L in view(8, src))
 			if(faction_check_mob(L, FALSE))
 				continue
 			if(L.stat == DEAD)
 				continue
 			L.apply_damage(song_damage, WHITE_DAMAGE, null, L.run_armor_check(null, WHITE_DAMAGE), spread_damage = TRUE)
 		SLEEP_CHECK_DEATH(3)
+	can_act = TRUE
+	song_cooldown = world.time + song_cooldown_time
 
 /mob/living/simple_animal/hostile/abnormality/fragment/neutral_effect(mob/living/carbon/human/user, work_type, pe)
 	if(prob(40))
@@ -99,4 +110,3 @@
 	else // Breaching
 		icon_state = "fragment_breach"
 	icon_living = icon_state
-

--- a/code/modules/mob/living/simple_animal/hostile/ordeal/violet.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/violet.dm
@@ -71,7 +71,7 @@
 
 /mob/living/simple_animal/hostile/ordeal/violet_monolith/Initialize()
 	..()
-	next_pulse = world.time + 20 SECONDS
+	next_pulse = world.time + 30 SECONDS
 	addtimer(CALLBACK(src, .proc/FallDown))
 
 /mob/living/simple_animal/hostile/ordeal/violet_monolith/CanAttack(atom/the_target)
@@ -135,5 +135,5 @@
 			potential_computers += A
 	if(LAZYLEN(potential_computers))
 		CA = pick(potential_computers)
-		CA.datum_reference.qliphoth_change(pick(-1, -2))
+		CA.datum_reference.qliphoth_change(-1)
 	icon_state = "violet_noon_attack"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fragment posed way too much danger for a TETH. It now stands still when singing. 
Grant us love takes just a little bit longer to start pulsing, and it doesn't drop counters by 2 anymore.

## Why It's Good For The Game
Fragment is a goddamn menace, and it's all because it can sing while still chasing after you. Grant us love should hopefully not shred the entire facility with WL as quickly.

## Changelog
:cl:
balance: fragment and grant us love nerf
:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
