### PR TITLE
Artillery Nerf

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/waw/generalb.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/generalb.dm
@@ -114,6 +114,7 @@
 	icon_state = "soldier_bee"
 	icon_living = "soldier_bee"
 	base_pixel_x = -8
+	pixel_x = -8
 	health = 450
 	maxHealth = 450
 	melee_damage_type = RED_DAMAGE
@@ -187,12 +188,12 @@
 	pull_force = INFINITY
 	generic_canpass = FALSE
 	movement_type = PHASING | FLYING
-	var/boom_damage = 100 //Half Red, Half Black
+	var/boom_damage = 80 //Half Red, Half Black
 	layer = POINT_LAYER	//We want this HIGH. SUPER HIGH. We want it so that you can absolutely, guaranteed, see exactly what is about to hit you.
 
 /obj/effect/beeshell/Initialize()
 	..()
-	addtimer(CALLBACK(src, .proc/explode), 2 SECONDS)
+	addtimer(CALLBACK(src, .proc/explode), 3.5 SECONDS)
 
 //Smaller Scorched Girl bomb
 /obj/effect/beeshell/proc/explode()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Artillery Bee damage reduced from 200 to 160, and warning time increased from 2 to 3.5 seconds

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The artillery hit too hard and too fast. I've slightly tuned them down.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Artillery nerfed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
