### PR TITLE
Red Queen now does less damage

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/he/red_queen.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/red_queen.dm
@@ -9,12 +9,12 @@
 	health = 650
 	threat_level = HE_LEVEL
 	work_chances = list(
-		ABNORMALITY_WORK_INSTINCT = 60,
-		ABNORMALITY_WORK_INSIGHT = 60,
-		ABNORMALITY_WORK_ATTACHMENT = 60,
-		ABNORMALITY_WORK_REPRESSION = 60
+		ABNORMALITY_WORK_INSTINCT = 65,
+		ABNORMALITY_WORK_INSIGHT = 65,
+		ABNORMALITY_WORK_ATTACHMENT = 65,
+		ABNORMALITY_WORK_REPRESSION = 65
 		)
-	work_damage_amount = 30			//Unlikely to hurt you but if she ever does she'll fuck you
+	work_damage_amount = 20			//Unlikely to hurt you but if she ever does she'll fuck you
 	work_damage_type = RED_DAMAGE
 
 	ego_list = list(


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Red Queen work failure now does 20 damage instead of 30, and it's work changes has been increased
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Red Queen is no longer utter dogshit to work with
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Red Queen has been enweakened
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
