### PR TITLE
Silent Girl Lowpop Compensation

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/he/silent_girl.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/silent_girl.dm
@@ -28,6 +28,9 @@
 
 	var/mob/living/carbon/human/guilty_people = list()
 	var/mutable_appearance/guilt_icon  // Icon for the effect
+	var/insanity_long = 30 SECONDS
+	var/insanity_short = 10 SECONDS
+	var/population_threshold = 5
 
 /mob/living/simple_animal/hostile/abnormality/silent_girl/Initialize(mapload)
 	. = ..()
@@ -89,24 +92,29 @@
 	return
 
 /mob/living/simple_animal/hostile/abnormality/silent_girl/zero_qliphoth(mob/living/carbon/human/user)
+	var/insanity_timer = insanity_short
 	var/dead_list = guilty_people
+	var/list/potential_guilt = list()
 	for(var/mob/living/carbon/human/dead_body in dead_list)
 		if(dead_body.stat == DEAD || isnull(dead_body))
 			guilty_people -= dead_body
 	if (!LAZYLEN(guilty_people)) // No Guilty on 0 counter? Find a random person and take them <3
-		var/list/potential_guilt = list()
 		for(var/mob/living/carbon/human/H in GLOB.mob_living_list)
 			if(H.stat >= HARD_CRIT || H.sanity_lost || z != H.z) // Dead or in hard crit, insane, or on a different Z level.
 				continue
 			potential_guilt += H
 		if(LAZYLEN(potential_guilt))
+			if(LAZYLEN(potential_guilt) < population_threshold)
+				insanity_timer = insanity_long
+			else
+				insanity_timer = insanity_short
 			Guilt_Effect(pick(potential_guilt))
 		else
 			manual_emote("giggles.")
 			playsound(get_turf(src), 'sound/voice/human/womanlaugh.ogg', 50, 0, 20, ignore_walls = TRUE)
 	for(var/mob/living/carbon/human/i in guilty_people) // Drive all Guilty people insane on Qliphoth 0
 		to_chat(i, "<span class='userdanger'>You feel your head begin to split!</span>")
-		addtimer(CALLBACK(src, .proc/DriveInsane, i), 10 SECONDS)
+		addtimer(CALLBACK(src, .proc/DriveInsane, i), insanity_timer)
 	datum_reference.qliphoth_change(3)
 	return
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

What it says on the tin. If Silent Girl has 5 or more candidates for her guilt effect, she operates exactly as before, but if she has 4 or less, she'll give them an extra-long grace period between melting down and driving them insane.

The length of the lowpop grace period, the length of the highpop grace period, and the threshold of what she considers low enough population for a grace period at all, are all variables, for your administrative convenience.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

On any map but Alphacorp, ten seconds is too little of a delay for small groups to respond to and coordinate saving someone from Silent Girl's guilt effect.  While you could argue that competent players won't let her melt down, the fact is that when you have low population, you can't handle every meltdown to begin with, and players spreading out to handle as much as possible makes a potential Silent Girl meltdown even more of a death sentence. This should mitigate that.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: silent girl insanity has a longer grace period on lowpop
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
