### PR TITLE
Zayin EGO support abilities

### DIFF
--- a/code/game/objects/items/ego_weapons/zayin.dm
+++ b/code/game/objects/items/ego_weapons/zayin.dm
@@ -11,7 +11,7 @@
 	var/pulse_cooldown_time = 1 SECONDS
 	var/pulse_damage = -0.5
 
-/obj/item/ego_weapon/penitence/equipped(mob/user, slot, initial = FALSE)
+/obj/item/ego_weapon/penitence/equipped(mob/user, slot = ITEM_SLOT_HANDS, initial = FALSE)
 	. = ..()
 	if(!ishuman(user))
 		return

--- a/code/game/objects/items/ego_weapons/zayin.dm
+++ b/code/game/objects/items/ego_weapons/zayin.dm
@@ -7,6 +7,23 @@
 	armortype = WHITE_DAMAGE
 	attack_verb_continuous = list("smacks", "strikes", "beats")
 	attack_verb_simple = list("smack", "strike", "beat")
+	var/pulse_cooldown
+	var/pulse_cooldown_time = 1 SECONDS
+	var/pulse_damage = -0.5
+
+/obj/item/ego_weapon/penitence/equipped(mob/user, slot, initial = FALSE)
+	. = ..()
+	if(!ishuman(user))
+		return
+	var/mob/living/carbon/human/H = user
+	var/obj/item/clothing/suit/armor/ego_gear/penitence/P = H.get_item_by_slot(ITEM_SLOT_OCLOTHING)
+	if(istype(P))
+		Healpulse()
+
+/obj/item/ego_weapon/penitence/proc/Healpulse()
+	pulse_cooldown = world.time + pulse_cooldown_time
+	for(var/mob/living/L in livinginview(8, src))
+		L.apply_damage(pulse_damage, WHITE_DAMAGE, null, L.run_armor_check(null, WHITE_DAMAGE), spread_damage = TRUE)
 
 /obj/item/ego_weapon/little_alice
 	name = "little alice"


### PR DESCRIPTION
## About The Pull Request

So, this gives ZAYIN EGO some abilities that act as support, this is though so ZAYIN EGO gets actually used by clerks instead of getting left forgotten in the dark, never to be seen again.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

For now, only one sin has an ability, im planning to add an ability for all ZAYINs

Also side note: For the ability to trigger the player has to wear the weapon in its hand AND wear the armor.

## Why It's Good For The Game

Currently, ZAYIN gear is useless and straight up just TETH gear but worse.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

If ZAYIN gear has no use at all, why even have it? having it have minor support abilities would make them more usefull

## Changelog
:cl:
add: One sin EGO ability
/:cl:
