### PR TITLE
Blue Star & Queen Bee buff

### DIFF
--- a/code/datums/diseases/bee_spawn.dm
+++ b/code/datums/diseases/bee_spawn.dm
@@ -22,7 +22,7 @@
 		return
 
 	var/mob/living/carbon/human/H = affected_mob
-	H.apply_damage(stage, RED_DAMAGE, null, H.run_armor_check(null, RED_DAMAGE), spread_damage = TRUE)
+	H.apply_damage(stage*2, RED_DAMAGE, null, H.run_armor_check(null, RED_DAMAGE), spread_damage = TRUE)
 
 	if(H.health <= 0)
 		var/turf/T = get_turf(H)

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/blue_star.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/blue_star.dm
@@ -40,8 +40,8 @@
 	gift_type =  /datum/ego_gifts/star
 
 	var/pulse_cooldown
-	var/pulse_cooldown_time = 9 SECONDS
-	var/pulse_damage = 40 // Scales with distance
+	var/pulse_cooldown_time = 12 SECONDS
+	var/pulse_damage = 80 // Scales with distance
 
 	var/datum/looping_sound/bluestar/soundloop
 
@@ -80,7 +80,7 @@
 	for(var/mob/living/L in livinginrange(48, src))
 		if(faction_check_mob(L))
 			continue
-		L.apply_damage((pulse_damage - round(get_dist(src, L) * 0.75)), WHITE_DAMAGE, null, L.run_armor_check(null, WHITE_DAMAGE), spread_damage = TRUE)
+		L.apply_damage((pulse_damage - round(get_dist(src, L) * 1.5)), WHITE_DAMAGE, null, L.run_armor_check(null, WHITE_DAMAGE), spread_damage = TRUE)
 		flash_color(L, flash_color = COLOR_BLUE_LIGHT, flash_time = 70)
 		if(!ishuman(L))
 			continue


### PR DESCRIPTION
Update bee_spawn.dm

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Doubles Queen Bee Damage
Blue star has double damage but hits 1.5x speed

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
So, Queen Bee and Blue Star were at the time motherfuckers to deal with, but now they're kinda mid. 
Honestly, it's entirely because their numbers are too small for Queen bee, everyone can heal it without any need for armor.
Now we have armor and a better way of healing in L&H.

Blue Star just simply does not do enough damage.
It should be as scary, if not scarier than other alephs, but as it stands now it's a joke

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Beesease does more damage.
balance: Blue Star does more damage.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
