### PR TITLE
working on a meltdown now gives pity attributes

### DIFF
--- a/code/datums/abnormality/datum/abnormality.dm
+++ b/code/datums/abnormality/datum/abnormality.dm
@@ -116,7 +116,7 @@
 	return TRUE
 
 
-/datum/abnormality/proc/work_complete(mob/living/carbon/human/user, work_type, pe, work_time)
+/datum/abnormality/proc/work_complete(mob/living/carbon/human/user, work_type, pe, work_time, was_melting)
 	current.work_complete(user, work_type, pe, work_time) // Cross-referencing gone wrong
 	var/user_job_title = "Unidentified Employee"
 	var/obj/item/card/id/W = user.get_idcard()
@@ -155,6 +155,8 @@
 	var/attribute_given = clamp(((maximum_attribute_level / (user_attribute_level * 0.25)) * (0.25 + (pe / max_boxes))), 0, 16)
 	if((user_attribute_level + attribute_given) >= maximum_attribute_level) // Already/Will be at maximum.
 		attribute_given = max(0, maximum_attribute_level - user_attribute_level)
+	if(attribute_given == 0 && was_melting)
+		attribute_given = 2 //pity stats on meltdowns
 	user.adjust_attribute_level(attribute_type, attribute_given)
 
 /datum/abnormality/proc/qliphoth_change(amount, user)

--- a/code/game/machinery/computer/abnormality_work.dm
+++ b/code/game/machinery/computer/abnormality_work.dm
@@ -133,6 +133,7 @@
 			to_chat(user, "<span class='danger'>Calm down... Calm down...</span>")
 		if(3 to INFINITY)
 			to_chat(user, "<span class='userdanger'>I'm not ready for this!</span>")
+	var/was_melting = meltdown //to remember if it was melting down before the work started
 	meltdown = FALSE // Reset meltdown
 	update_icon()
 	datum_reference.working = TRUE
@@ -168,7 +169,7 @@
 	REMOVE_TRAIT(user, TRAIT_PUSHIMMUNE, src)
 	user.density = TRUE
 	user.set_anchored(FALSE)
-	finish_work(user, work_type, success_boxes, work_speed, training)
+	finish_work(user, work_type, success_boxes, work_speed, training, was_melting)
 
 /obj/machinery/computer/abnormality/proc/CheckStatus(mob/living/carbon/human/user)
 	if(user.sanity_lost)
@@ -186,7 +187,7 @@
 	playsound(src, 'sound/machines/synth_no.ogg', 25, FALSE, -4)
 	return FALSE
 
-/obj/machinery/computer/abnormality/proc/finish_work(mob/living/carbon/human/user, work_type, pe = 0, work_speed = 2 SECONDS, training = FALSE)
+/obj/machinery/computer/abnormality/proc/finish_work(mob/living/carbon/human/user, work_type, pe = 0, work_speed = 2 SECONDS, training = FALSE, was_melting)
 	if(!training)
 		SEND_SIGNAL(user, COMSIG_WORK_COMPLETED, datum_reference, user, work_type)
 	if(!work_type)
@@ -201,7 +202,7 @@
 			visible_message("<span class='notice'>Work Result: Bad</span>")
 	if(istype(user))
 		if(!training)
-			datum_reference.work_complete(user, work_type, pe, work_speed*datum_reference.max_boxes)
+			datum_reference.work_complete(user, work_type, pe, work_speed*datum_reference.max_boxes, was_melting)
 			SSlobotomy_corp.WorkComplete(pe, (meltdown_time <= 0))
 		else
 			datum_reference.current.work_complete(user, work_type, pe, work_speed*datum_reference.max_boxes)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Working on an abnormality who is melting down will give you 2 of an attribute if your level is already too high to get anything from them.

## Why It's Good For The Game

meltdowns tend to get ignored by anyone of a high enough level because "they can just beat them up later" and while that can certainly work, taking care of meltdowns should be encouraged by everyone especially if we want meltdowns to take away total PE later on and the cargo system gets implemented.

this also allows people that are already maxed out with no abnormality of their level to work on an alternative to go slightly beyond what they normally can at the moment.

## Changelog
:cl:
tweak: Working on meltdowns now give "pity stats" if your level is too high
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
