### PR TITLE
scaredy cat loses courage when his friend is deleted instead of dying

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/he/scaredy_cat.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/scaredy_cat.dm
@@ -89,6 +89,9 @@
 	. = ..()
 	if(!friend || status_flags & GODMODE || stat == DEAD) //for some reason life() works on death ain't that something
 		return
+	if(QDELETED(friend)) //if the friend is deleted instead of dying first somehow (looking at you pbird)
+		Courage(FALSE)
+		return
 	if(protect_cooldown < world.time)
 		protect_cooldown = world.time + protect_cooldown_time
 		if(!can_see(src, friend, vision_range))
@@ -165,6 +168,9 @@
 		icon_living = "cat_courage"
 		icon_dead = "dead_courage"
 	else
+		friend = null //just to make sure it's actually empty
+		if(stat != DEAD)
+			wait_for_friend = TRUE //kill him fast before he finds another friend
 		faction = list("neutral")
 		melee_damage_lower = initial(melee_damage_lower)
 		melee_damage_upper = initial(melee_damage_upper) //it shouldn't attack in that form in the first place but...
@@ -191,8 +197,6 @@
 	if(died == friend)
 		friend = null
 		Courage(FALSE)
-		if(stat != DEAD)
-			wait_for_friend = TRUE //kill him fast before he finds another friend
 		return TRUE
 	return FALSE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

when an abnormality is deleted they are not considered "null" and scaredy cat still considered them a friend, this now takes into account the rare eventuality of a friend abnormality being deleted which apparently caused quite a lot of problems.

## Why It's Good For The Game

that damn cat is back at it again

## Changelog
:cl:
fix: scaredy cat will no longer go on without a friend
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
