### PR TITLE
Green Noon now has some spread on their gun

### DIFF
--- a/code/modules/projectiles/projectile/bullets/smg.dm
+++ b/code/modules/projectiles/projectile/bullets/smg.dm
@@ -41,4 +41,5 @@
 /obj/projectile/bullet/c9x19mm
 	name = "9x19mm bullet"
 	damage = 10
+	spread = 25
 	embedding = null

--- a/code/modules/projectiles/projectile/bullets/smg.dm
+++ b/code/modules/projectiles/projectile/bullets/smg.dm
@@ -41,5 +41,5 @@
 /obj/projectile/bullet/c9x19mm
 	name = "9x19mm bullet"
 	damage = 10
-	spread = 25
+	spread = 12
 	embedding = null


### PR DESCRIPTION
Update smg.dm

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds 25 degrees of spread on their gun

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
They used to be pinpoint accurate, now this makes them less so.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Green noon guns are no longer pinpoint accurate
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
