### PR TITLE
increases red buddy's work rate

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/he/red_buddy.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/red_buddy.dm
@@ -17,10 +17,10 @@
 	move_resist = MOVE_FORCE_NORMAL + 1 //Can't be pulled by humans, but can be pulled by shepherd this might have other unforeseen consequences
 	threat_level = HE_LEVEL
 	work_chances = list(
-						ABNORMALITY_WORK_INSTINCT = list(0, 10, 30, 30, 30),
-						ABNORMALITY_WORK_INSIGHT = list(0, 20, 30, 40, 40),
-						ABNORMALITY_WORK_ATTACHMENT = list(20, 45, 55, 60, 60),
-						ABNORMALITY_WORK_REPRESSION = list(20, 45, 55, 60, 60)
+						ABNORMALITY_WORK_INSTINCT = list(0, 30, 35, 35, 35),
+						ABNORMALITY_WORK_INSIGHT = list(0, 20, 40, 40, 40),
+						ABNORMALITY_WORK_ATTACHMENT = list(20, 55, 60, 60, 60),
+						ABNORMALITY_WORK_REPRESSION = list(20, 55, 60, 60, 60)
 						)
 	damage_coeff = list(BRUTE = 1, RED_DAMAGE = 0.8, WHITE_DAMAGE = 0.5, BLACK_DAMAGE = 1.5, PALE_DAMAGE = 1.5)
 	melee_damage_lower = 50


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

this slightly increases buddy's work rate, but most importantly raises their level 2 work rate

## Why It's Good For The Game

people are generally used to level 2 and level 3 work to be very close chance wise and red buddy had a relatively big difference of 10% in work chances from those two levels, instinct also has a 20% difference in rates from level 2 to 3. and it's not really something you can immediately see from records, so I'd rather keep them pretty close with only a 5% chance difference especially on an abno where each work tick fail ends up biting you in the ass later

## Changelog
:cl:
tweak: red buddy's work rate slightly increase
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
