### PR TITLE
nerfs red buddy's rapid melee

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/he/red_buddy.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/red_buddy.dm
@@ -12,7 +12,7 @@
 	health = 2200
 	speed = 4
 	move_to_delay = 7
-	rapid_melee = 2
+	rapid_melee = 1
 	del_on_death = FALSE
 	move_resist = MOVE_FORCE_NORMAL + 1 //Can't be pulled by humans, but can be pulled by shepherd this might have other unforeseen consequences
 	threat_level = HE_LEVEL


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
nerfs red buddy's rapid melee from 2 to 1

## Why It's Good For The Game

red buddy was originally built like an amber dusk worm, slow but hits like a truck, the rapid melee was supposed to make up for the fact that he technically did less damage than an amber dusk despite being just as slow buuut
turns out this is a massive issue when fused with shepherd's awakening and the main point of the slower rapid melee is it gives more time for people to "dodge" their attacks. his damage will stay the same but now it might actually be possible to melee kite him or parry him if you're skilled enough

## Changelog
:cl:
balance: red buddy's attacks are now slower
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
