### PR TITLE
SC's revive cooldown is now based on threat level

### DIFF
--- a/code/game/objects/effects/abnormality.dm
+++ b/code/game/objects/effects/abnormality.dm
@@ -118,8 +118,3 @@
 	base_pixel_x = -10
 	pixel_y = 25
 	base_pixel_y = 25
-
-/obj/effect/scaredy_stun/Initialize()
-	..()
-	animate(src, alpha = 0, time = 20 SECONDS)
-	QDEL_IN(src, 20 SECONDS)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

scaredy cat's regeneration cooldown is now based on the threat level of his friend, a WAW will mean 40 seconds to regenerate and an ALEPH 60 seconds to regenerate.  as a tradeoff he now revives twice as fast if his friend is a TETH, and 4 times as fast if his friend is (somehow?) a ZAYIN

this also fix buddy not properly breaching with scarecrow

## Why It's Good For The Game

scaredy cat should generally keep the same degree of power whenever he revives, the main issue is ALEPH (and to some degree WAW) are so tanky that SC ends up slowing down some fights to a crawl as they constantly have to take him outside and deal with it so he doesn't absorb ranged attacks and blocks line of sight

now he should still fill his role of "deal with me and my friend" without you spending most of your time on scaredy cat because NT keeps fucking regenerating while you're dealing with garfield

also him becoming more dangerous on TETH makes some early game threat slightly more relevant even later in the game.

## Changelog
:cl:
balance: scaredy cat's revive cooldown is now based on the threat level of his friend
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
