### PR TITLE
fix even more shepherd dragging jank

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/he/blue_shepherd.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/blue_shepherd.dm
@@ -239,11 +239,15 @@
 		var/turf/orgin = get_turf(src)
 		var/list/all_turfs = RANGE_TURFS(1, orgin)
 		var/turf/open/Y = pick(all_turfs - orgin)
-		awakened_buddy.forceMove(Y) //the lazy solution that forces buddy to get pulled by shepherd
-		src.pulled(awakened_buddy)
+		awakened_buddy.forceMove(Y) //the lazy solution that forces buddy to get pulled by shepherd, ideally this should only happen once.
+		src.start_pulling(awakened_buddy)
 	if(slashing)
 		return FALSE
-	..()
+	if(awakened_buddy)
+		awakened_buddy.AIStatus = AI_OFF //we stop buddy from moving while being dragged to avoid jank, player controlled buddy will probably fuck this up but eeeh
+	. = ..()
+	if(awakened_buddy)
+		awakened_buddy.AIStatus = AI_ON //turning the AI status on and off isn't performance consuming as far as I can tell from mob code
 
 /mob/living/simple_animal/hostile/abnormality/blue_shepherd/stop_pulling()
 	if(pulling == awakened_buddy) //it's tempting to make player controlled shepherd pull you forever but I'll hold off on it

--- a/code/modules/mob/living/simple_animal/abnormality/he/red_buddy.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/red_buddy.dm
@@ -150,15 +150,16 @@
 		melee_damage_lower = 60
 		melee_damage_upper = 80
 		move_to_delay = 4 //this doesn't matter as much as you'd think because he can't move before shepherd
+		can_patrol = FALSE //just in case
 
 /mob/living/simple_animal/hostile/abnormality/red_buddy/Move(atom/newloc)
-	if(!awakened_master)
-		return ..()
+	if(!awakened_master || AIStatus == AI_OFF)
+		return . = ..()
 	var/turf/orgin = get_turf(awakened_master)
 	var/list/all_turfs = RANGE_TURFS(1, orgin)
-	if(!LAZYFIND(all_turfs,newloc))
+	if(!LAZYFIND(all_turfs, newloc))
 		return FALSE //he doesn't get to move outside of his master's range
-	..()
+	. = ..()
 
 /mob/living/simple_animal/hostile/abnormality/red_buddy/breach_effect()
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

shepherd had an issue with dragging buddy diagonally because the way it works is going left then right instead of a clean diagonal line. I changed a few things and now buddy should stop being abandonned and teleported around like a maniac, buddy's AI will also be turned off while being dragged around, this does not stop him from attacking while dragged and moving once shepherd stops moving.

## Why It's Good For The Game

I'm going to make this dog stop no clipping if it's the last thing I fucking do

## Changelog
:cl:
fix: red buddy will now teleport less than usual while being dragged by shepherd
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
