### PR TITLE
Scaredy cat now properly teleport to other Oz abnos and use types instead of names

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/he/scaredy_cat.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/scaredy_cat.dm
@@ -42,8 +42,8 @@
 	gift_type =  /datum/ego_gifts/courage_cat //the sprites for the EGO are shitty codersprites placeholders and are only here so that there's EGO to use
 	///The list of abnormality scaredy cat will automatically join when they breach, add any "Oz" abno to this list if possible
 	var/list/prefered_abno_list = list(
-										"Warm-Hearted Woodsman" ,
-										"Scarecrow searching for wisdom"
+										/mob/living/simple_animal/hostile/abnormality/woodsman ,
+										/mob/living/simple_animal/hostile/abnormality/scarecrow
 										)
 	///If scaredy cat is breaching but has no "friend" to follow, he'll wait for the next abno breach to follow them
 	var/wait_for_friend = FALSE
@@ -202,16 +202,16 @@
 
 /mob/living/simple_animal/hostile/abnormality/scaredy_cat/proc/OnAbnoBreach(datum/source, mob/living/simple_animal/hostile/abnormality/abno)
 	SIGNAL_HANDLER
-	if(abno.name == "Standard training-dummy rabbit" || z != abno.z)
+	if(istype(abno.type, /mob/living/simple_animal/hostile/abnormality/training_rabbit) || z != abno.z)
 		return
 	if(status_flags & GODMODE)
-		if(LAZYFIND(prefered_abno_list, abno.name))
+		if(LAZYFIND(prefered_abno_list, abno.type))
 			priority_friend = abno
 			datum_reference.qliphoth_change(-3) //for all intents and purposes he instantly breach
 		else
 			datum_reference.qliphoth_change(-1)
 		return
-	if(LAZYFIND(prefered_abno_list, abno.name) && !LAZYFIND(prefered_abno_list, friend.name))
+	if(LAZYFIND(prefered_abno_list, abno.type) && !LAZYFIND(prefered_abno_list, friend.type))
 		friend = abno //literally ditches his old friend if an oz abno gets out and he's not already friend with one
 	if(stat == DEAD || !wait_for_friend)
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

fixes shitcode where scaredy cat used abno names instead of types to detect oz abno breaching, which meant any typo fixing would fuck scaredy cat's ability to discern friends forever. so now scaredy cat should properly prioritize oz abnormalities

## Why It's Good For The Game
cat bug bad

## Changelog
:cl:
fix: scaredy cat will now properly teleport to scarecrow when it breaches
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
