### PR TITLE
Auto-Apocalypse

### DIFF
--- a/code/_globalvars/lists/mobs.dm
+++ b/code/_globalvars/lists/mobs.dm
@@ -18,6 +18,7 @@ GLOBAL_LIST_INIT(dangerous_turfs, typecacheof(list(
 
 GLOBAL_LIST_EMPTY(player_list)				//all mobs **with clients attached**.
 GLOBAL_LIST_EMPTY(mob_list)					//all mobs, including clientless
+GLOBAL_LIST_EMPTY(abnormality_mob_list)		//all abnormality mobs
 GLOBAL_LIST_EMPTY(mob_directory)			//mob_id -> mob
 GLOBAL_LIST_EMPTY(alive_mob_list)			//all alive mobs, including clientless. Excludes /mob/dead/new_player
 GLOBAL_LIST_EMPTY(suicided_mob_list)		//contains a list of all mobs that suicided, including their associated ghosts.

--- a/code/controllers/subsystem/lobotomy_events.dm
+++ b/code/controllers/subsystem/lobotomy_events.dm
@@ -1,0 +1,96 @@
+#define APOCALYPSE 1
+SUBSYSTEM_DEF(lobotomy_events)
+	name = "Lobotomy Corp Events"
+	flags = SS_KEEP_TIMING | SS_BACKGROUND
+	wait = 10 SECONDS
+
+
+	//Apocalypse Bird
+	var/list/AB_types = list(
+		/mob/living/simple_animal/hostile/abnormality/punishing_bird,
+		/mob/living/simple_animal/hostile/abnormality/big_bird,
+		/mob/living/simple_animal/hostile/abnormality/judgement_bird)
+	var/list/AB_breached = list()
+
+/datum/controller/subsystem/lobotomy_events/Initialize(start_timeofday)
+	. = ..()
+	RegisterSignal(SSdcs, COMSIG_GLOB_ABNORMALITY_BREACH, .proc/OnAbnoBreach)
+
+/datum/controller/subsystem/lobotomy_events/fire(resumed)
+	if(PruneList(APOCALYPSE) && (AB_breached.len >= 2))
+		for(var/datum/abnormality/A in SSlobotomy_corp.all_abnormality_datums)
+			// This can technically allow for the event to trigger with a duplicate bird breaching, however I don't believe that to be significant.
+			if((A.current?.type in AB_types) && !(A.current in AB_breached))
+				AB_breached += A.current
+				break
+		if(AB_breached.len >= 3)
+			addtimer(CALLBACK(src, .proc/SpawnEvent, APOCALYPSE))
+
+
+/datum/controller/subsystem/lobotomy_events/proc/OnAbnoBreach(datum/source, mob/living/simple_animal/hostile/abnormality/abno)
+	SIGNAL_HANDLER
+	if(abno.type in AB_types)
+		AB_breached += abno
+	return
+	//Further checks for event abnos can go here.
+
+/**
+ * Cleans lists of dead/QDELETED abnormalities.
+ */
+/datum/controller/subsystem/lobotomy_events/proc/PruneList(event_type = 0)
+	if(event_type == 0)
+		return FALSE
+	var/prune_list = list()
+	switch(event_type)
+		if(APOCALYPSE)
+			for(var/mob/living/simple_animal/hostile/abnormality/a in AB_breached)
+				if(QDELETED(a) || !istype(a))
+					prune_list += a
+			AB_breached -= prune_list
+			return TRUE
+	return FALSE
+
+/datum/controller/subsystem/lobotomy_events/proc/SpawnEvent(event_type = 0)
+	if(event_type == 0)
+		return
+	switch(event_type)
+		if(APOCALYPSE)
+			var/mob/living/simple_animal/forest_portal/portal
+			for(var/turf/T in GLOB.department_centers)
+				if(istype(get_area(T),/area/department_main/command))
+					for(var/mob/living/simple_animal/forest_portal/FP in T.contents) // If we SOMEHOW have duplicates...
+						return
+					portal = new(T)
+					break
+			for(var/mob/living/simple_animal/hostile/abnormality/A in AB_breached)
+				if(A.IsContained())
+					A.datum_reference.qliphoth_change(-999) // Breach it!
+				if(istype(A, /mob/living/simple_animal/hostile/abnormality/punishing_bird))
+					var/mob/living/simple_animal/hostile/abnormality/punishing_bird/PB = A
+					deltimer(PB.death_timer)
+				A.patrol_to(get_turf(portal), TRUE)
+				A.density = FALSE // They ignore you and walk past you.
+				A.AIStatus = AI_OFF
+				A.can_patrol = FALSE
+				A.damage_coeff = list(BRUTE = 0, RED_DAMAGE = 0, WHITE_DAMAGE = 0, BLACK_DAMAGE = 0, PALE_DAMAGE = 0) // You can kill the portal but not them.
+			AB_breached = list()
+			AB_types = list() // So the event can't run again.
+			return
+	return
+
+/**
+ * Proc built primarily for testing but could be refined later?
+ */
+/datum/controller/subsystem/lobotomy_events/proc/SpawnEventAbnos(event_type = 0)
+	if(event_type == 0)
+		return
+	switch(event_type)
+		if(APOCALYPSE)
+			for(var/type in AB_types)
+				SSabnormality_queue.queued_abnormality = type
+				SSabnormality_queue.SpawnAbno()
+				sleep(1 SECONDS)
+			return
+	return
+
+

--- a/code/modules/mob/living/simple_animal/abnormality/_abnormality.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_abnormality.dm
@@ -93,6 +93,14 @@
 		addtimer(CALLBACK (datum_reference, .datum/abnormality/proc/RespawnAbno), 30 SECONDS)
 	..()
 
+/mob/living/simple_animal/hostile/abnormality/add_to_mob_list()
+	. = ..()
+	GLOB.abnormality_mob_list |= src
+
+/mob/living/simple_animal/hostile/abnormality/remove_from_mob_list()
+	. = ..()
+	GLOB.abnormality_mob_list -= src
+
 /mob/living/simple_animal/hostile/abnormality/Move()
 	if(status_flags & GODMODE) // STOP STEALING MY FREAKING ABNORMALITIES
 		return FALSE

--- a/code/modules/mob/living/simple_animal/abnormality/teth/punishing_bird.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/punishing_bird.dm
@@ -54,6 +54,8 @@
 	var/list/pecking_targets = list()
 	var/list/already_punished = list()
 
+	var/death_timer
+
 /mob/living/simple_animal/hostile/abnormality/punishing_bird/Initialize()
 	. = ..()
 	if(locate(/obj/structure/pbird_perch) in get_turf(src))
@@ -259,14 +261,14 @@
 	base_pixel_x = initial(base_pixel_x)
 	base_pixel_y = initial(base_pixel_y)
 	update_icon()
-	addtimer(CALLBACK(src, .proc/kill_bird), 180 SECONDS)
+	death_timer = addtimer(CALLBACK(src, .proc/kill_bird), 180 SECONDS, TIMER_STOPPABLE)
 	return
 
 /mob/living/simple_animal/hostile/abnormality/punishing_bird/proc/kill_bird()
 	if(!(status_flags & GODMODE) && !isliving(target) && icon_state != "pbird_red")
 		QDEL_NULL(src)
 	else
-		addtimer(CALLBACK(src, .proc/kill_bird), 60 SECONDS)
+		death_timer = addtimer(CALLBACK(src, .proc/kill_bird), 60 SECONDS, TIMER_STOPPABLE)
 
 // Modified patrolling
 /mob/living/simple_animal/hostile/abnormality/punishing_bird/patrol_select()

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -686,8 +686,16 @@
 			charge_state = FALSE
 			update_icons()
 
+////// Patrol Code ///////
 /mob/living/simple_animal/hostile/proc/CanStartPatrol()
 	return AIStatus == AI_IDLE //if AI is idle, begin checking for patrol
+
+/mob/living/simple_animal/hostile/proc/patrol_to(turf/target_location = null)
+	if(isnull(target_location)) // Sets a preset location for them to go to
+		return
+	patrol_reset() // Stop your current patrol for this one
+	patrol_path = get_path_to(src, target_location, /turf/proc/Distance_cardinal, 0, 200)
+	patrol_move(patrol_path[patrol_path.len])
 
 /mob/living/simple_animal/hostile/proc/patrol_select()
 	var/turf/target_center
@@ -714,6 +722,8 @@
 		return FALSE
 	if(!dest || !patrol_path || !patrol_path.len) //A-star failed or a path/destination was not set.
 		return FALSE
+	if(health <= 0) // No more moving corpses.
+		return FALSE
 	stop_automated_movement = 1
 	dest = get_turf(dest) //We must always compare turfs, so get the turf of the dest var if dest was originally something else.
 	var/turf/last_node = get_turf(patrol_path[patrol_path.len]) //This is the turf at the end of the path, it should be equal to dest.
@@ -732,6 +742,8 @@
 
 /mob/living/simple_animal/hostile/proc/patrol_step(dest)
 	if(client || target  || status_flags & GODMODE || !patrol_path || !patrol_path.len)
+		return FALSE
+	if(health <= 0) // No more moving corpses.
 		return FALSE
 	if(patrol_path.len > 1)
 		step_towards(src, patrol_path[1])

--- a/lobotomy-corp13.dme
+++ b/lobotomy-corp13.dme
@@ -311,6 +311,7 @@
 #include "code\controllers\subsystem\language.dm"
 #include "code\controllers\subsystem\lighting.dm"
 #include "code\controllers\subsystem\lobotomy_corp.dm"
+#include "code\controllers\subsystem\lobotomy_events.dm"
 #include "code\controllers\subsystem\machines.dm"
 #include "code\controllers\subsystem\mapping.dm"
 #include "code\controllers\subsystem\materials.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Automates Apocalypse Bird and limits it to once per round. This is done via the new "Lobotomy Events" subsystem which is designed to be able to handle future events as well. This also implements and utilizes the "patrol_to" proc, which accepts a single Turf as a location and sends the target walking to that location.  

While the Birds are walking, they lose density, become immune to damage, and will not target people. Furthermore, the Gate will receive the birds in bulk and output their text one at a time, both giving a buffer before the big bird himself shows up and allowing the text to fully render and not overlap with other instances.

The gate IS vulnerable but is still absurdly healthy and resistant but if it dies the event WILL stop. The event will also be able to occur again later, should the situation allow for it.

Finally this also implements and utilizes a Global list for Abnormality mobs
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
No longer will admins be forced to spawn the gate! Also, it's frankly fucking terrifying, as this can occur BEFORE people are ready.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Selectable Patrol
add: Lobotomy Events subsystem
add: Loot Drop to Apocalypse Bird
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
