### PR TITLE
allow admins to give every abnormality a radio implant

### DIFF
--- a/code/datums/abnormality/datum/abnormality.dm
+++ b/code/datums/abnormality/datum/abnormality.dm
@@ -52,6 +52,8 @@
 	var/working = FALSE
 	///a list of variable the abno wants to remember after death
 	var/list/transferable_var
+	///if the abno spawns with a slime radio or not
+	var/abno_radio = FALSE
 
 /datum/abnormality/New(obj/effect/landmark/abnormality_spawn/new_landmark, mob/living/simple_animal/hostile/abnormality/new_type = null)
 	if(!istype(new_landmark))
@@ -104,6 +106,8 @@
 	if (understanding == max_understanding && max_understanding > 0)
 		current.gift_chance *= 1.5
 	overload_chance_limit = overload_chance_amount * 10
+	if(abno_radio)
+		current.AbnoRadio()
 	current.PostSpawn()
 
 /datum/abnormality/proc/FillEgoList()

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -105,7 +105,8 @@ GLOBAL_LIST_INIT(admin_verbs_fun, list(
 	/client/proc/polymorph_all,
 	/client/proc/show_tip,
 	/client/proc/smite,
-	/client/proc/admin_away
+	/client/proc/admin_away,
+	/client/proc/AbnoRadio
 	))
 GLOBAL_PROTECT(admin_verbs_fun)
 GLOBAL_LIST_INIT(admin_verbs_spawn, list(/datum/admins/proc/spawn_atom, /datum/admins/proc/podspawn_atom, /datum/admins/proc/spawn_cargo, /datum/admins/proc/spawn_objasmob, /client/proc/respawn_character, /datum/admins/proc/beaker_panel))

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -1093,6 +1093,23 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	var/obj/item/food/bread/plain/bread = new(get_turf(target))
 	target.forceMove(bread)
 
+///Give EVERY current abnormality a radio for the round even after respawn, this needs to be used again if an abnormality arrives after you used this
+/client/proc/AbnoRadio()
+	set category = "Admin.Fun"
+	set name = "Abnormality radio"
+	if(!check_rights(R_ADMIN) || !check_rights(R_FUN))
+		return
+
+	if(!LAZYLEN(SSlobotomy_corp.all_abnormality_datums))
+		return
+	for(var/datum/abnormality/A in SSlobotomy_corp.all_abnormality_datums)
+		if(A.abno_radio)
+			continue
+		if(isnull(A.current))
+			A.abno_radio = TRUE
+			continue
+		A.current.AbnoRadio()
+
 /**
  * firing_squad is a proc for the :B:erforate smite to shoot each individual bullet at them, so that we can add actual delays without sleep() nonsense
  *

--- a/code/modules/mob/living/simple_animal/abnormality/_abnormality.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_abnormality.dm
@@ -316,6 +316,12 @@
 /mob/living/simple_animal/hostile/abnormality/proc/OnQliphothChange(mob/living/carbon/human/user)
 	return
 
+///implants the abno with a slime radio implant, only really relevant during admeme or sentient abno rounds
+/mob/living/simple_animal/hostile/abnormality/proc/AbnoRadio()
+	var/obj/item/implant/radio/slime/imp = new(src)
+	imp.implant(src, src) //acts as if the abno is both the implanter and the one being implanted, which is technically true I guess?
+	datum_reference.abno_radio = TRUE
+
 // Actions
 /datum/action/innate/abnormality_attack
 	name = "Megafauna Attack"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Admins now have a fun button that allows them to implant every abnormality currently in the facility to get a radio implant, if the abno dies and respawn they will also respawn with a radio implant

this does NOT apply to abnormality that spawn later, and the button will need to be used again later. This is mostly relevant during sentient abnormality rounds, but might have some edge case uses if someone wants to make an abnormality capable of talking over the radio. You can call the proc manually on a specific abnormality if you don't want it to affect every abno

## Why It's Good For The Game

sentient abnormality rounds are quite special, however it can be quite tedious to give a radio implant to each abno if you want them to feel more special in the round, especially if they die and respawn often.

## Changelog
:cl:
add: Admins can now give every abnormality a radio at the press of a button.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
