### PR TITLE
reworks shepherd and buddy's fight

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/he/blue_shepherd.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/blue_shepherd.dm
@@ -58,7 +58,6 @@
 	var/datum/abnormality/buddy //the red buddy datum linked to this shepherd
 	var/mob/living/simple_animal/hostile/abnormality/red_buddy/awakened_buddy //the red buddy shepherd is currently fighting with
 	var/awakened = FALSE //if shepherd has seen red buddy or not
-	var/abuse = FALSE //if shepherd is attacking buddy
 	var/list/people_list = list() //list of people shepperd can mention
 	//lines said during combat
 	var/buddy_hit = FALSE
@@ -180,7 +179,7 @@
 		say(pick(combat_lines))
 		slashing = TRUE
 		slash()
-	if(awakened_buddy && !abuse)
+	if(awakened_buddy)
 		awakened_buddy.GiveTarget(target)
 	..()
 
@@ -194,7 +193,7 @@
 
 /mob/living/simple_animal/hostile/abnormality/blue_shepherd/Life()
 	. = ..()
-	if(status_flags & GODMODE || abuse)
+	if(status_flags & GODMODE)
 		return
 	var/mob/living/buddy_abno = buddy?.current
 	if(!buddy_abno)
@@ -215,17 +214,6 @@
 		update_health_hud() //I have to do this shit manually because adjustHealth is just fucked when changing max HP
 	if(!awakened_buddy)
 		return
-
-	if(health <= maxHealth * 0.5 && awakened_buddy.health <= awakened_buddy.maxHealth * 0.5) //if both shepherd and buddy are under half health, they fight each other
-		Infighting()
-
-/mob/living/simple_animal/hostile/abnormality/blue_shepherd/proc/Infighting()
-	abuse = TRUE
-	if(!awakened_buddy.rebel)
-		awakened_buddy.Infighting()
-	faction -= "blueshep"
-	GiveTarget(awakened_buddy)
-	say("a wolf, A WOLF. I WANT YOU TO BE A WOLF YOU USELESS THING!")
 
 /mob/living/simple_animal/hostile/abnormality/blue_shepherd/Move()
 	if(slashing)
@@ -267,9 +255,9 @@
 	for(var/mob/living/L in T)
 		if(L == src)
 			continue
-		if(L == awakened_buddy && !abuse && !buddy_hit)
+		if(L == awakened_buddy && !buddy_hit)
 			buddy_hit = TRUE //sometimes buddy get hit twice so we check if it got hit in this slash
-			awakened_buddy.adjustHealth(225) //it would take approximatively 12 slashes to take buddy to half health (accounting for the extra normal damage of slash)
+			awakened_buddy.adjustHealth(700) //it would take approximatively 9 slashes to take buddy down
 		L.apply_damage(slash_damage, BLACK_DAMAGE, null, L.run_armor_check(null, BLACK_DAMAGE), spread_damage = TRUE)
 		all_turfs -= T
 	if(slash_count >= range)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
near completely reworks the way red buddy and shepherd's fight work, this also fixes a lot of bugs related to the two in the process.

-----------------------------------------------------buddy and shepherd fight---------------------------------------------------
-when red buddy and shepherd meet, they will now gain 3 to 4 times as much max health instead of extra resistances
-they will no longer be healed to full health but instead lose health proportionally to what health they had before they met
-shepherd's slash and red buddy's howl will now hurt the other, red buddy's howl is now both triggered by a cooldown AND losing 10% of their max HP
-if shepherd dies first, buddy dies too, if buddy dies first, shepherd gets a lot of movement speed but their damage is immensely nerfed (even lower than his normal form)

-----------------------------------------------------random fixes---------------------------------------------------------------
the fixes were basically necessary to make this fight work, and a lot of those issues came from the use of sleep()
-both slash and red buddy's howl now use timer to avoid some fuckery where they would interrupt the other
-shepherd can no longer (sometimes?) strike you twice in one attack right after using its slash move
-fixes a lot more dragging jank, this time I'm *pretty* sure I've got them all
-shepherd now has an attack sound

## Why It's Good For The Game

shepherd and buddy's fight was basically impossible not just because of the insane resistances but speed and a huge part of dragging jank, even if you could deal with them it wasn't a really interactive fight.

in this the goal is to make you juggle different damage type and make the fight more of a proper gimmick fight. you need to get up close to trigger shepherd's slash which speeds up the fight by a lot, guns are safer but take a lot longer because of their very high health. 

this gives actual options on how to deal with them without making their fight extremely punishing if not near impossible

## Changelog
:cl:
tweak: shepherd and buddy's fight has been reworked
balance: shepherd now has less extra speed and damage when with buddy
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
