### PR TITLE
Paradise Lost and It's Consequences Have Been Disastrous for Lobotomy Corp 13 endgame.

### DIFF
--- a/code/datums/abnormality/_ego_datum/aleph.dm
+++ b/code/datums/abnormality/_ego_datum/aleph.dm
@@ -1,7 +1,7 @@
 // White night - Paradise lost
 /datum/ego_datum/armor/paradise
 	item_path = /obj/item/clothing/suit/armor/ego_gear/paradise
-	cost = 250
+	cost = 200
 
 // Judgement bird - Justitia
 /datum/ego_datum/weapon/justitia

--- a/code/modules/clothing/suits/ego_gear/aleph.dm
+++ b/code/modules/clothing/suits/ego_gear/aleph.dm
@@ -1,12 +1,11 @@
-// ALEPH armor, go wild, but attempt to keep total armor at ~245 total.
-// Paradise lost and Twilight are the only exceptions.
+// ALEPH armor, go wild, but attempt to keep total armor at ~240 total.
 
 /obj/item/clothing/suit/armor/ego_gear/paradise
 	name = "paradise lost"
 	desc = "\"My loved ones, do not worry; I have heard your prayers. \
 	Have you not yet realized that pain is but a speck to a determined mind?\""
 	icon_state = "paradise"
-	armor = list(RED_DAMAGE = 80, WHITE_DAMAGE = 80, BLACK_DAMAGE = 80, PALE_DAMAGE = 80) // 320
+	armor = list(RED_DAMAGE = 70, WHITE_DAMAGE = 70, BLACK_DAMAGE = 70, PALE_DAMAGE = 70) // 280
 	attribute_requirements = list(
 							FORTITUDE_ATTRIBUTE = 100,
 							PRUDENCE_ATTRIBUTE = 100,

--- a/code/modules/clothing/suits/ego_gear/realized.dm
+++ b/code/modules/clothing/suits/ego_gear/realized.dm
@@ -4,10 +4,10 @@
 	icon = 'icons/obj/clothing/ego_gear/realization.dmi'
 	worn_icon = 'icons/mob/clothing/ego_gear/realized.dmi'
 	attribute_requirements = list(
-							FORTITUDE_ATTRIBUTE = 130,
-							PRUDENCE_ATTRIBUTE = 130,
-							TEMPERANCE_ATTRIBUTE = 130,
-							JUSTICE_ATTRIBUTE = 130
+							FORTITUDE_ATTRIBUTE = 100,
+							PRUDENCE_ATTRIBUTE = 100,
+							TEMPERANCE_ATTRIBUTE = 100,
+							JUSTICE_ATTRIBUTE = 100
 							)
 
 /obj/item/clothing/suit/armor/ego_gear/realization/item_action_slot_check(slot)
@@ -135,4 +135,11 @@
 	desc = "In the face of pain there are no heroes."
 	icon_state = "cruelty"
 	armor = list(RED_DAMAGE = 80, WHITE_DAMAGE = 50, BLACK_DAMAGE = 70, PALE_DAMAGE = 60)
+	flags_inv = HIDEJUMPSUIT|HIDEGLOVES|HIDESHOES
+
+/obj/item/clothing/suit/armor/ego_gear/realization/prophet
+	name = "prophet"
+	desc = "And they have conquered him by the blood of the Lamb and by the word of their testimony, for they loved not their lives even unto death."
+	icon_state = "prophet"
+	armor = list(RED_DAMAGE = 80, WHITE_DAMAGE = 80, BLACK_DAMAGE = 80, PALE_DAMAGE = 80)
 	flags_inv = HIDEJUMPSUIT|HIDEGLOVES|HIDESHOES


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
### -------THIS IS A SPITE PR.-------
Paradise Lost nerfed to 7/7/7/7
Realization can be worn at 100s, still requires 130 stats to realize, and still subtracts 30 from all stats.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It's an abno that's easy in containment that is a bitch when it breaches and it gives you armor that invalidates EVERY SINGLE ALEPH ARMOR Except for 3.
It's not even significantly harder than most alephs either, just slightly more annoying when it breaches, and super tame in containment.
There is NO reason that it should make every armor entirely useless except for Smile, Mimicry and Da Capo. 

Honestly, IMO, the very existence of PL makes endgame significantly easier. This will make endgame a lot harder because you don't get 80% armor in everything, and now have to grind and choose armor for the circumstances.

Realized armor can now be worn at all 100s. You no longer have to hold on to armor for a million years while you grind it up.
You are still weaker though, and it still requires all 130s, technically.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: rebalanced endgame armor.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
