### PR TITLE
Worktick procs!

### DIFF
--- a/code/game/machinery/computer/abnormality_work.dm
+++ b/code/game/machinery/computer/abnormality_work.dm
@@ -154,9 +154,11 @@
 				break
 			if(do_work(work_chance))
 				success_boxes++
+				datum_reference.current.worktick_success(user)
 			else
 				datum_reference.current.worktick_failure(user)
 			total_boxes++
+			datum_reference.current.worktick(user)
 		else
 			if(!CheckStatus(user)) // No punishment if the thing is already breached or any other issue is prevelant.
 				break

--- a/code/modules/mob/living/simple_animal/abnormality/_abnormality.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_abnormality.dm
@@ -282,6 +282,14 @@
 /mob/living/simple_animal/hostile/abnormality/proc/failure_effect(mob/living/carbon/human/user, work_type, pe)
 	return
 
+// Additional effect on each work tick, whether successful or not
+/mob/living/simple_animal/hostile/abnormality/proc/worktick(mob/living/carbon/human/user)
+	return
+
+// Additional effect on each individual work tick success
+/mob/living/simple_animal/hostile/abnormality/proc/worktick_success(mob/living/carbon/human/user)
+	return
+
 // Additional effect on each individual work tick failure
 /mob/living/simple_animal/hostile/abnormality/proc/worktick_failure(mob/living/carbon/human/user)
 	user.apply_damage(work_damage_amount, work_damage_type, null, user.run_armor_check(null, work_damage_type), spread_damage = TRUE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds worktick_success and worktick procs to match with worktick_failure. They do as their names imply; whereas worktick_failure only fires when the user fails a work, worktick occurs every time any work is completed, and worktick_success is run on each successful work tick.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

For completeness's sake, if nothing else. It also helps with my coding of Singing Machine, and will likely make some other future abnormality concepts easier to code as well.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: A few code tweaks.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
