### PR TITLE
fix porccubus head explosion not accounting for directions

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/he/porccubus.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/porccubus.dm
@@ -309,8 +309,8 @@
 	expanding_head.layer = -BODY_FRONT_LAYER
 	expanding_head.plane = FLOAT_PLANE
 	expanding_head.mouse_opacity = 0
-	expanding_head.vis_flags = VIS_INHERIT_DIR|VIS_INHERIT_DIR //FOR SOME REASON THE DIRECTION OF THE HEAD WON'T UPDATE SO INSTEAD WE KEEP THIS CREEPY HEAD THAT ALWAYS LOOKS FORWARD
-	expanding_head.add_overlay(head.get_limb_icon(TRUE, TRUE))
+	expanding_head.vis_flags = VIS_INHERIT_DIR|VIS_INHERIT_DIR
+	expanding_head.add_overlay(head.get_limb_icon(TRUE, TRUE, TRUE))
 	addict.vis_contents += expanding_head
 	addict.managed_vis_overlays += expanding_head
 	animate(expanding_head, transform = matrix()*2, color = "#FF0000", pixel_y = expanding_head.pixel_y - 5, time = 2 SECONDS) //you can actually still somewhat see the head under it but the overlay should hide it well enough

--- a/code/modules/surgery/bodyparts/head.dm
+++ b/code/modules/surgery/bodyparts/head.dm
@@ -197,8 +197,9 @@
 		I.pixel_y = px_y
 	add_overlay(standing)
 
-//get_normal_head is used if you want to get a non messed up head that still looks as if it was on the original body
-/obj/item/bodypart/head/get_limb_icon(dropped, get_normal_head = FALSE)
+//get_normal_head is used if you want to get a non messed up head that still looks as if it was on the original body.
+//get_all_dir means you automatically get every direction of the head, otherwise just get the south facing version.
+/obj/item/bodypart/head/get_limb_icon(dropped, get_normal_head = FALSE, get_all_dir = FALSE)
 	cut_overlays()
 	. = ..()
 	if(dropped) //certain overlays only appear when the limb is being detached from its owner.
@@ -208,7 +209,9 @@
 			if(facial_hairstyle)
 				var/datum/sprite_accessory/S = GLOB.facial_hairstyles_list[facial_hairstyle]
 				if(S)
-					var/image/facial_overlay = image(S.icon, "[S.icon_state]", -HAIR_LAYER, SOUTH)
+					var/image/facial_overlay = image(S.icon, "[S.icon_state]", -HAIR_LAYER, dir = SOUTH)
+					if(get_all_dir)
+						facial_overlay = image(S.icon, "[S.icon_state]", -HAIR_LAYER)
 					facial_overlay.color = "#" + facial_hair_color
 					facial_overlay.alpha = hair_alpha
 					. += facial_overlay
@@ -216,6 +219,8 @@
 			//Applies the debrained overlay if there is no brain
 			if(!brain && !get_normal_head)
 				var/image/debrain_overlay = image(layer = -HAIR_LAYER, dir = SOUTH)
+				if(get_all_dir)
+					debrain_overlay = image(layer = -HAIR_LAYER)
 				if(animal_origin == ALIEN_BODYPART)
 					debrain_overlay.icon = 'icons/mob/animal_parts.dmi'
 					debrain_overlay.icon_state = "debrained_alien"
@@ -229,7 +234,9 @@
 			else
 				var/datum/sprite_accessory/S2 = GLOB.hairstyles_list[hairstyle]
 				if(S2)
-					var/image/hair_overlay = image(S2.icon, "[S2.icon_state]", -HAIR_LAYER, SOUTH)
+					var/image/hair_overlay = image(S2.icon, "[S2.icon_state]", -HAIR_LAYER, dir = SOUTH)
+					if(get_all_dir)
+						hair_overlay = image(S2.icon, "[S2.icon_state]", -HAIR_LAYER)
 					hair_overlay.color = "#" + hair_color
 					hair_overlay.alpha = hair_alpha
 					. += hair_overlay
@@ -237,14 +244,17 @@
 
 		// lipstick
 		if(lip_style)
-			var/image/lips_overlay = image('icons/mob/human_face.dmi', "lips_[lip_style]", -BODY_LAYER, SOUTH)
+			var/image/lips_overlay = image('icons/mob/human_face.dmi', "lips_[lip_style]", -BODY_LAYER, dir = SOUTH)
+			if(get_all_dir)
+				lips_overlay = image('icons/mob/human_face.dmi', "lips_[lip_style]", -BODY_LAYER)
 			lips_overlay.color = lip_color
 			. += lips_overlay
 
 		// eyes
-		var/image/eyes_overlay
+		var/image/eyes_overlay = image('icons/mob/human_face.dmi', "eyes_missing", -BODY_LAYER, dir = SOUTH)
 		if(!get_normal_head)
-			eyes_overlay = image('icons/mob/human_face.dmi', "eyes_missing", -BODY_LAYER, SOUTH)
+			if(get_all_dir)
+				eyes_overlay = image('icons/mob/human_face.dmi', "eyes_missing", -BODY_LAYER)
 			. += eyes_overlay
 		if(eyes)
 			eyes_overlay.icon_state = eyes.eye_icon_state


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

porccubus head overlay thing always faced south which looked weird
the fix is basically making an extra argument (again) that allows us to get every direction for the head overlay

this is believe it or not, the simpler solution as the alternative is copying the entirety of the get head code and changing 2 lines.

from what i've tested, this does not impact the regular decapitated head icon item at all

## Why It's Good For The Game

I hate visual contents I hate visual contents

## Changelog
:cl:
fix: Porccubus's head explosion now face the proper way
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
