### PR TITLE
Porccubus nerf & dash fix

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/he/porccubus.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/porccubus.dm
@@ -16,8 +16,9 @@
 		ABNORMALITY_WORK_REPRESSION = 30
 			) //for some reason all its work rates are uniform through attribute levels in LC
 	damage_coeff = list(BRUTE = 1, RED_DAMAGE = 1, WHITE_DAMAGE = 0.5, BLACK_DAMAGE = 1, PALE_DAMAGE = 1.5)
-	melee_damage_lower = 30
-	melee_damage_upper = 35
+	ranged = TRUE
+	melee_damage_lower = 15
+	melee_damage_upper = 20
 	rapid_melee = 3 //you can withdraw out of its range very easily so it needs to be a little harder to melee it
 	work_damage_amount = 12
 	can_patrol = FALSE //it can't move anyway but why not
@@ -127,6 +128,11 @@
 		forceMove(T)
 		damage_taken = FALSE
 
+/mob/living/simple_animal/hostile/abnormality/porccubus/OpenFire()
+	if(!target)
+		return
+	PorcDash(target)
+
 /mob/living/simple_animal/hostile/abnormality/porccubus/adjustHealth(amount)
 	..()
 	if(amount > 0)
@@ -136,6 +142,14 @@
 //additionally, it can dash to its target every 15 seconds if it's out of range, the dash itself doesn't hurt them but it does bring porccubus into melee range
 /mob/living/simple_animal/hostile/abnormality/porccubus/CheckAndAttack()
 	if(!target)
+		return
+
+	if(targets_from && isturf(targets_from.loc) && get_dist(target, src) <= 2 && !incapacitated()) //a slightly modified check that includes people on a 2 tile radius
+		AttackingTarget()
+		return
+
+/mob/living/simple_animal/hostile/abnormality/porccubus/proc/PorcDash(mob/living/target)
+	if(!istype(target))
 		return
 	var/dist = get_dist(target, src)
 	if(dist > 2 && dash_cooldown < world.time)
@@ -147,10 +161,6 @@
 			SLEEP_CHECK_DEATH(0.8)
 		playsound(src, 'sound/abnormalities/porccubus/head_explode_laugh.ogg', 50, FALSE, 4)
 		dash_cooldown = world.time + dash_cooldown_time
-
-	if(targets_from && isturf(targets_from.loc) && dist <= 2 && !incapacitated()) //a slightly modified check that includes people on a 2 tile radius
-		AttackingTarget()
-		return
 
 /mob/living/simple_animal/hostile/abnormality/porccubus/AttackingTarget()
 	var/mob/living/carbon/human/H

--- a/code/modules/paperwork/records/info/he.dm
+++ b/code/modules/paperwork/records/info/he.dm
@@ -345,7 +345,7 @@
 	Risk Class : HE    <br>
 	Max PE Boxes : 16    <br>
 	Qliphoth Counter : 2    <br>
-	Work Damage Type : White	<br>
+	Work Damage Type : Black	<br>
 	Work Damage : High	<br>
 	- When the work result was Bad, the Qliphoth counter lowered.   <br>
 	- When the work result was good, the Qliphoth counter increased.    <br>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Severely nerfs porccubus damage but make his dash work as intended
his dash only really worked when people kind of hovered around it, now it works at the original vision range it was intended. Which does mean more porccubus jumpscares more often now.

also fix a mistake in records that said he did white work damage when it does black

## Why It's Good For The Game

Porccubus is meant to be an absolute menace in close range because of its relatively static nature, but it shouldn't be literally ALEPH tier level of damage capable of even shredding WAW armor in seconds.

## Changelog
:cl:
balance: nerf Porccubus damage
fix: Porccubus dash now happens more consistently and records are more accurate

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
