### PR TITLE
Ego gear nerf

### DIFF
--- a/code/game/objects/items/ego_weapons/_ego_weapon.dm
+++ b/code/game/objects/items/ego_weapons/_ego_weapon.dm
@@ -7,6 +7,7 @@
 	righthand_file = 'icons/mob/inhands/weapons/ego_righthand.dmi'
 	w_class = WEIGHT_CLASS_BULKY			//No more stupid 10 egos in bag
 	slot_flags = ITEM_SLOT_BELT
+	drag_slowdown = 1
 	var/list/attribute_requirements = list()
 	var/attack_speed
 	var/special

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -14,7 +14,7 @@
 	close_sound = 'sound/machines/crate_close.ogg'
 	open_sound_volume = 35
 	close_sound_volume = 50
-	drag_slowdown = 0
+	drag_slowdown = 0.5
 	var/crate_climb_time = 20
 	var/obj/item/paper/fluff/jobs/cargo/manifest/manifest
 

--- a/code/modules/clothing/suits/ego_gear/_ego_gear.dm
+++ b/code/modules/clothing/suits/ego_gear/_ego_gear.dm
@@ -9,6 +9,8 @@
 	heat_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS|HEAD
 	w_class = WEIGHT_CLASS_BULKY								//No more stupid 10 egos in bag
 	allowed = list(/obj/item/gun, /obj/item/ego_weapon, /obj/item/melee)
+	drag_slowdown = 1
+	var/equip_slowdown = 3 SECONDS
 
 	var/list/attribute_requirements = list()
 
@@ -19,7 +21,11 @@
 	if(slot_flags & slot) // Equipped to right slot, not just in hands
 		if(!CanUseEgo(H))
 			return FALSE
+		if(equip_slowdown > 0)
+			if(!do_after(H, equip_slowdown, target = H))
+				return FALSE
 	return ..()
+
 
 /obj/item/clothing/suit/armor/ego_gear/proc/CanUseEgo(mob/living/carbon/human/user)
 	if(!ishuman(user))

--- a/code/modules/clothing/suits/ego_gear/special.dm
+++ b/code/modules/clothing/suits/ego_gear/special.dm
@@ -5,6 +5,7 @@
 	desc = "An armored combat suit worn by R-Corporation mercenaries in the field, interestingly"
 	icon_state = "rabbit"
 	armor = list(RED_DAMAGE = 50, WHITE_DAMAGE = 50, BLACK_DAMAGE = 50, PALE_DAMAGE = 50)
+	equip_slowdown = 0
 
 /obj/item/clothing/suit/armor/ego_gear/rabbit/grunts
 	name = "\improper rabbit team suit"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds Doafter before equipping Ego.
It takes 5 seconds.

Dragging crates now slows you down 0.5
Dragging armor and weapons slows you down 1.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Players should have to go to extraction to requip ego, not drag everything around with them
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: carrying multiple ego weapons and armor is now more unwieldy.
balance: equipping armor now takes a second.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
