### PR TITLE
Scaredy Cat loses its target when teleporting

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/he/scaredy_cat.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/scaredy_cat.dm
@@ -156,6 +156,7 @@
 			continue
 		playsound(src, 'sound/abnormalities/scaredycat/cateleport.ogg', 50, FALSE, 4)
 		forceMove(T)
+		LoseTarget()
 		for(var/mob/living/carbon/human/enemy in oview(src, vision_range))
 			if(enemy.stat != DEAD)
 				GiveTarget(enemy) //the moment he teleports he's already on the offensive


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

A very simple fix that makes Scaredy cat loses its target when teleporting

## Why It's Good For The Game

Scaredy cat instantly leaving his friend after teleporting looked weird, especially when that target was way too far for him to reach.  so we reset his aggro whenever he comes back to his friend.

## Changelog
:cl:
fix: Scaredy Cat will now lose aggro when he teleports back to his friend
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
