### PR TITLE
Blood Bath no longer requires 2 stats

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/teth/blood_bath.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/blood_bath.dm
@@ -26,8 +26,8 @@
 	var/hands = 0
 
 /mob/living/simple_animal/hostile/abnormality/bloodbath/work_complete(mob/living/carbon/human/user, work_type, pe, work_time)
-// any work performed with level 1 Fort or Temperance makes you panic and die
-	if(get_attribute_level(user, TEMPERANCE_ATTRIBUTE) < 40 || get_attribute_level(user, FORTITUDE_ATTRIBUTE) < 40 || (hands == 3 && prob(50)))
+// any work performed with level 1 Fort and Temperance makes you panic and die
+	if(get_attribute_level(user, TEMPERANCE_ATTRIBUTE) < 40 && get_attribute_level(user, FORTITUDE_ATTRIBUTE) < 40 || (hands == 3 && prob(50)))
 		icon = 'ModularTegustation/Teguicons/48x64.dmi'
 		icon_state = "bloodbath_a[hands]"
 		user.Stun(30 SECONDS)

--- a/code/modules/paperwork/records/info/teth.dm
+++ b/code/modules/paperwork/records/info/teth.dm
@@ -202,7 +202,7 @@
 	Qliphoth Counter : X	<br>
 	Work Damage Type : White	<br>
 	Work Damage : Low	<br>
-	- When an Agent, who had Level 1 Fortitude, completed the work process, a hand stretched out of Bloodbath and dragged them into its depths. The same phenomenon occurred with an Agent who had Level 1 Temperance.	<br>
+	- When an Agent, who had Level 1 Fortitude and Level 1 Temperance, completed the work process, a hand stretched out of Bloodbath and dragged them into its depths.	<br>
 	- A pale hand surfaced from Bloodbath after it had absorbed an employee. As the number of hands increased, the number of PE-Boxes produced with it also increased.	<br>
 	- WARNING: When Bloodbath has three hands, the safety of the next worker cannot be guaranteed. It seems Bloodbath will absorb employees regardless of the work result or virtue levels.	<br>
 	<h4>Instinct:</h4> Common<br>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Bloodbath now requires Level 2 for OR temp, and not both.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This is a teth that is literally never worked on.
Our limit for teths is 60 stats and you need 40 in 2 of them to even start working on them
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: bloodbath no longer requires 2 stats.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
