### PR TITLE
Abnormality queue, qliphoth and ordeal timing changes

### DIFF
--- a/code/controllers/subsystem/lobotomy_corp.dm
+++ b/code/controllers/subsystem/lobotomy_corp.dm
@@ -58,8 +58,8 @@ SUBSYSTEM_DEF(lobotomy_corp)
 	addtimer(CALLBACK(src, .proc/InitializeOrdeals), 60 SECONDS)
 
 /datum/controller/subsystem/lobotomy_corp/proc/SetGoal()
-	var/player_mod = GLOB.clients.len * 0.1
-	box_goal = clamp(round(4000 * player_mod), 3000, 24000)
+	var/player_mod = GLOB.clients.len * 0.15
+	box_goal = clamp(round(5000 * player_mod), 3000, 36000)
 	return TRUE
 
 /datum/controller/subsystem/lobotomy_corp/proc/InitializeOrdeals()
@@ -117,12 +117,15 @@ SUBSYSTEM_DEF(lobotomy_corp)
 	for(var/mob/player in GLOB.player_list)
 		if(isliving(player))
 			player_count += 1
-	qliphoth_max = 4 + round(abno_amount * 0.25) + round(player_count * 0.3)
+	qliphoth_max = 4 + round(player_count * 0.5)
 	qliphoth_state += 1
 	for(var/datum/abnormality/A in all_abnormality_datums)
 		if(istype(A.current))
 			A.current.OnQliphothEvent()
 	var/ran_ordeal = FALSE
+	if(qliphoth_state + 1 >= next_ordeal_time) // If ordeal is supposed to happen on the meltdown after that one
+		if(istype(next_ordeal) && ordeal_timelock[next_ordeal.level] > world.time) // And it's on timelock
+			next_ordeal_time += 1 // So it does not appear on the ordeal monitors until timelock is off
 	if(qliphoth_state >= next_ordeal_time)
 		if(OrdealEvent())
 			ran_ordeal = TRUE
@@ -186,8 +189,7 @@ SUBSYSTEM_DEF(lobotomy_corp)
 /datum/controller/subsystem/lobotomy_corp/proc/OrdealEvent()
 	if(!next_ordeal)
 		return FALSE
-	if(ordeal_timelock[next_ordeal_level - 1] && (ordeal_timelock[next_ordeal_level - 1] > world.time))
-		next_ordeal_time += 1
+	if(ordeal_timelock[next_ordeal.level] > world.time)
 		return FALSE // Time lock
 	next_ordeal.Run()
 	next_ordeal = null

--- a/code/datums/abnormality/datum/abnormality.dm
+++ b/code/datums/abnormality/datum/abnormality.dm
@@ -67,6 +67,17 @@
 	RespawnAbno()
 	FillEgoList()
 
+/datum/abnormality/Destroy()
+	SSlobotomy_corp.all_abnormality_datums -= src
+	for(var/datum/ego_datum/ED in ego_datums)
+		qdel(ED)
+	QDEL_NULL(landmark)
+	QDEL_NULL(current)
+	ego_datums = null
+	landmark = null
+	current = null
+	..()
+
 /datum/abnormality/proc/RespawnAbno()
 	if(!ispath(abno_path))
 		CRASH("Abnormality tried to respawn a mob, but abnormality path wasn't valid.")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Refactored the way abnormality queue works to allow dynamically changing the time for next abno spawn.
- Additionally, the queue will only fire when round has started(?). This provides a 3 minute window of peace and calm just like in the past, for people to have a roll call and anything the manager/captains might have to say.
- Amount of players has no role in the speed of abnormality spawns, instead it will now slow down the further you are into the game(when you begin getting WAW and ALEPH abnormalities) and speed up at the beginning(to get all the ZAYIN, TETH and HE).
- Qliphoth counter was changed in the opposite direction: It now only cares for the amount of players, instead of a combination of players and amount of abnormalities.
- Ordeals will not show up on the monitor if they are still timelocked(they are simply getting pushed further away).
- Added some cleanup code for when abnormality datum gets destroyed so admins don't have to do it manually in case they want to replace it with something else.

## Why It's Good For The Game

- The game was too slow at the beginning and too fast at the end. This should solve the problem and slightly update the code in the better direction.
- Something that was requested by a lot of players. You don't have to speedrun the nearest abnormality cell 0.001 seconds into the round to keep up with the others. Take it slow, talk to people, *relax*.
- See above. Game will slightly slow down while you are adjusting for the higher level abnormalities.
- I see no reason to keep abnormality count as a factor for qliphoth counter required for meltdown/ordeal since most people will be working on the maximum threat abnormality, instead of working on all of them. The amount of players, on the other hand, is very important.
- ";VIOLET NOON NEXT MELTDOWN!!", and then it doesn't happen. Sounds familiar? Not anymore.
- It's just a QOL change for admins(and me).