### PR TITLE
Remove recursion on Magic Bullet movement

### DIFF
--- a/code/game/objects/effects/abnormality.dm
+++ b/code/game/objects/effects/abnormality.dm
@@ -52,32 +52,31 @@
 	..()
 	playsound(get_turf(src), 'sound/abnormalities/freischutz/shoot.ogg', 100, 1)
 
-/obj/effect/magic_bullet/Moved() // Shamelessly stolen code from immovable rod and paradise lost, GO!
+/obj/effect/magic_bullet/proc/moveBullet() // Shamelessly stolen code from immovable rod and paradise lost, GO!
 	var/list/nearmiss = list()
-	if(dir in list(EAST, WEST))
-		nearmiss |= get_step(src, SOUTH).contents
-		nearmiss |= get_step(src, NORTH).contents
-	else
-		nearmiss |= get_step(src, EAST).contents
-		nearmiss |= get_step(src, WEST).contents
-	var/turf/T = get_turf(src)
-	for(var/mob/living/L in T.contents)
-		if(L in nearmiss)
-			continue
-		L.apply_damage(160, BLACK_DAMAGE, null, L.run_armor_check(null, BLACK_DAMAGE), spread_damage = TRUE)
-		visible_message("<span class='boldwarning'>[src] pierces through [L]!</span>")
-		to_chat(L, "<span class='userdanger'>[src] slams through you!</span>")
-	for(var/mob/living/L in nearmiss)
-		L.apply_damage(80, BLACK_DAMAGE, null, L.run_armor_check(null, BLACK_DAMAGE), spread_damage = TRUE)
-		visible_message("<span class='warning'>[src] just barely brushes past [L]!</span>")
-		to_chat(L, "<span class='danger'>[src] grazes your side!</span>")
-	if((src.x > 245) || (src.x < 10) || (src.y > 245) || (src.y < 10))
-		qdel(src)
-		return
-	var/obj/effect/frei_trail/trayl = new(T)
-	trayl.dir = dir
-	forceMove(get_step(src, dir))
-	return ..()
+	while(src.x < 245 && src.x > 10 && src.y < 245 && src.y > 10)
+		if(dir in list(EAST, WEST))
+			nearmiss |= get_step(src, SOUTH).contents
+			nearmiss |= get_step(src, NORTH).contents
+		else
+			nearmiss |= get_step(src, EAST).contents
+			nearmiss |= get_step(src, WEST).contents
+		var/turf/T = get_turf(src)
+		for(var/mob/living/L in T.contents)
+			if(L in nearmiss)
+				continue
+			L.apply_damage(160, BLACK_DAMAGE, null, L.run_armor_check(null, BLACK_DAMAGE), spread_damage = TRUE)
+			visible_message("<span class='boldwarning'>[src] pierces through [L]!</span>")
+			to_chat(L, "<span class='userdanger'>[src] slams through you!</span>")
+		for(var/mob/living/L in nearmiss)
+			L.apply_damage(80, BLACK_DAMAGE, null, L.run_armor_check(null, BLACK_DAMAGE), spread_damage = TRUE)
+			visible_message("<span class='warning'>[src] just barely brushes past [L]!</span>")
+			to_chat(L, "<span class='danger'>[src] grazes your side!</span>")
+		var/obj/effect/frei_trail/trayl = new(T)
+		trayl.dir = dir
+		forceMove(get_step(src, dir))
+	qdel(src)
+	return
 
 /obj/effect/frei_magic
 	name = "magic circle"

--- a/code/modules/mob/living/simple_animal/abnormality/he/der_freischutz.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/der_freischutz.dm
@@ -125,7 +125,7 @@
 			var/obj/effect/magic_bullet/B = new(T)
 			playsound(get_turf(src), 'sound/abnormalities/freischutz/shoot.ogg', 100, 0, 20)
 			B.dir = freidir
-			walk(B,freidir,0,0)
+			addtimer(CALLBACK(B, .obj/effect/magic_bullet/proc/moveBullet), 0.1)
 			src.icon = 'ModularTegustation/Teguicons/32x64.dmi'
 			src.update_icon()
 			for(var/obj/effect/frei_magic/Port in portals)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Very small PR at KawaiiPotato's request. Old Magic Bullet behavior was capable of reaching BYOND's maximum recursion level, thus triggering a runtime. This code no longer relies on recursion.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Moderately better code with less odds of a runtime. Effectively the same from a gameplay perspective.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: magic bullet movement is no longer based on recursion
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
