### PR TITLE
Mermaid gift nerf

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/he/pisc_mermaid.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/pisc_mermaid.dm
@@ -257,7 +257,7 @@
 	worn_icon = 'icons/mob/clothing/ego_gear/head.dmi'
 	var/success_mod = 15
 	var/love_cooldown
-	var/love_cooldown_time = 2.5 MINUTES //It takes around 7.5 minutes for mermaid to breach if left unchecked
+	var/love_cooldown_time = 1 MINUTES //It takes around 3 minutes for mermaid to breach if left unchecked
 	var/mob/living/simple_animal/hostile/abnormality/pisc_mermaid/mermaid
 	var/mob/living/carbon/human/loved //What's wrong anon? Unconditional love is what you wanted right?
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Nerfs the mermaid gift to lower her counter every 1 minute instead. This also indirectly nerfs its success rate as the counter is directly tied to its success rate

## Why It's Good For The Game
Admittedly, 15% was a _little_ over tuned, while there is only one gift, and there is the very high chance of you getting fucked over. The success rate is the equivalent of 75 temperance and just requires you to check up on her every 7 or so minutes.

Now you'll have 3 minute max before she gets pissed off. So she will need constant attention and will feel a lot more needy during ordeals and other long fights.

## Changelog
:cl:
balance: Mermaid's gift now lowers mermaid's counter every minute
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
