### PR TITLE
Allows the manager camera to examine things

### DIFF
--- a/code/game/machinery/computer/manager_camera.dm
+++ b/code/game/machinery/computer/manager_camera.dm
@@ -69,6 +69,8 @@
 	RegisterSignal(user, COMSIG_MOB_CTRL_CLICKED, .proc/on_hotkey_click) //wanted to use shift click but shift click only allowed applying the effects to my player.
 	RegisterSignal(user, COMSIG_XENO_TURF_CLICK_SHIFT, .proc/on_shift_click)
 	RegisterSignal(user, COMSIG_MOB_MIDDLECLICKON, .proc/managerbolt)
+	RegisterSignal(user, COMSIG_MOB_ALTCLICKON, .proc/ManagerExaminate)
+	to_chat(user, "<span class='notice'>You can examine things with alt-click.</span>")
 
 /obj/machinery/computer/camera_advanced/manager/attackby(obj/item/O, mob/user, params)
 	if(istype(O, /obj/item/managerbullet) && ammo <= maxAmmo)
@@ -83,6 +85,7 @@
 	UnregisterSignal(user, COMSIG_MOB_CTRL_CLICKED)
 	UnregisterSignal(user, COMSIG_XENO_TURF_CLICK_SHIFT)
 	UnregisterSignal(user, COMSIG_MOB_MIDDLECLICKON)
+	UnregisterSignal(user, COMSIG_MOB_ALTCLICKON)
 	..()
 
 /obj/machinery/computer/camera_advanced/manager/proc/on_hotkey_click(datum/source, atom/clicked_atom) //system control for hotkeys
@@ -152,6 +155,9 @@
 	else
 		to_chat(owner, "<span class='warning'>NO TARGET.</span>")
 		return
+
+/obj/machinery/computer/camera_advanced/manager/proc/ManagerExaminate(mob/living/user, atom/clicked_atom)
+	user.examinate(clicked_atom) //maybe put more info on the agent/abno they examine if we want to be fancy later
 
 /obj/machinery/computer/camera_advanced/manager/proc/on_shift_click(mob/living/user, turf/open/T)
 	var/mob/living/C = user


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

You can now examine things with the manager camera using alt-click. You have no idea how long those two lines of code took me to figure out. But either way, here's a long-awaited feature.

## Why It's Good For The Game
The manager can now examine Qliphoth Counter and other things if we want it to. Which is a feature we should've gotten long ago.

## Changelog
:cl:
tweak: the manager camera console can now examine things using alt-click
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
