### PR TITLE
Gun Complexity update and Ego fixes

### DIFF
--- a/code/game/objects/items/ego_weapons/aleph.dm
+++ b/code/game/objects/items/ego_weapons/aleph.dm
@@ -227,14 +227,14 @@
 	desc = "The weapon of someone who can swing their weight around like a truck"
 	special = "This weapon deals it's damage after a short windup."
 	icon_state = "gold_rush"
-	force = 150
+	force = 140
 	attribute_requirements = list(
 							FORTITUDE_ATTRIBUTE = 100,
 							PRUDENCE_ATTRIBUTE = 80,
 							TEMPERANCE_ATTRIBUTE = 80,
 							JUSTICE_ATTRIBUTE = 80
 							)
-	var/goldrush_damage = 150
+	var/goldrush_damage = 140
 	damtype = RED_DAMAGE
 	armortype = RED_DAMAGE
 
@@ -242,7 +242,7 @@
 /obj/item/ego_weapon/goldrush/attack(mob/living/target, mob/living/user)
 	if(!CanUseEgo(user))
 		return
-	if(do_after(user, 4, target))
+	if(do_after(user, 6, target))
 
 		target.visible_message("<span class='danger'>[user] rears up and slams into [target]!</span>", \
 						"<span class='userdanger'>[user] punches you with everything you got!!</span>", COMBAT_MESSAGE_RANGE, user)

--- a/code/game/objects/items/ego_weapons/he.dm
+++ b/code/game/objects/items/ego_weapons/he.dm
@@ -43,8 +43,11 @@
 							TEMPERANCE_ATTRIBUTE = 20		//It's 20 to keep clerks from using it
 							)
 	var/can_spin = TRUE
+	var/spinning = FALSE
 
 /obj/item/ego_weapon/harvest/attack(mob/living/target, mob/living/user)
+	if(spinning)
+		return FALSE
 	..()
 	can_spin = FALSE
 	addtimer(CALLBACK(src, .proc/spin_reset), 12)
@@ -59,13 +62,15 @@
 		to_chat(user,"<span class='warning'>You attacked too recently.</span>")
 		return
 	can_spin = FALSE
+	spinning = TRUE
 	if(do_after(user, 12))
+		can_spin = TRUE
 		addtimer(CALLBACK(src, .proc/spin_reset), 12)
 		playsound(src, 'sound/weapons/ego/harvest.ogg', 75, FALSE, 4)
 		for(var/turf/T in orange(1, user))
 			new /obj/effect/temp_visual/smash_effect(T)
 
-		for(var/mob/living/L in livinginrange(1, user))
+		for(var/mob/living/L in range(1, user))
 			var/aoe = 30
 			var/userjust = (get_attribute_level(user, JUSTICE_ATTRIBUTE))
 			var/justicemod = 1 + userjust/100
@@ -73,6 +78,8 @@
 			if(L == user || ishuman(L))
 				continue
 			L.apply_damage(aoe, BLACK_DAMAGE, null, L.run_armor_check(null, BLACK_DAMAGE), spread_damage = TRUE)
+	spinning = FALSE
+
 
 /obj/item/ego_weapon/fury
 	name = "blind fury"

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -90,7 +90,11 @@
 		if(!thrown_item.throwforce)
 			return
 		var/armor = run_armor_check(zone, MELEE, "Your armor has protected your [parse_zone(zone)].", "Your armor has softened hit to your [parse_zone(zone)].", thrown_item.armour_penetration)
-		apply_damage(thrown_item.throwforce, thrown_item.damtype, zone, armor, sharpness = thrown_item.get_sharpness(), wound_bonus = (nosell_hit * CANT_WOUND))
+		var/justice_mod = 1
+		if(ishuman(thrown_item.thrownby))
+			var/mob/living/carbon/human/H = thrown_item.thrownby
+			justice_mod += get_attribute_level(H, JUSTICE_ATTRIBUTE)/100
+		apply_damage(thrown_item.throwforce * justice_mod, thrown_item.damtype, zone, armor, sharpness = thrown_item.get_sharpness(), wound_bonus = (nosell_hit * CANT_WOUND))
 		if(QDELETED(src)) //Damage can delete the mob.
 			return
 		return ..()

--- a/code/modules/projectiles/ammunition/ego_ammunition/aleph.dm
+++ b/code/modules/projectiles/ammunition/ego_ammunition/aleph.dm
@@ -14,3 +14,19 @@
 	name = "adoration slug"
 	desc = "A adoration slug."
 	projectile_type = /obj/projectile/ego_bullet/melting_blob
+	pellets = 3
+	variance = 20
+
+/obj/item/ammo_casing/caseless/ego_adoration/dot
+	name = "adoration slug"
+	desc = "A adoration slug."
+	projectile_type = /obj/projectile/ego_bullet/melting_blob/dot
+	pellets = 1
+	variance = 0
+
+/obj/item/ammo_casing/caseless/ego_adoration/aoe
+	name = "adoration slug"
+	desc = "A adoration slug."
+	projectile_type = /obj/projectile/ego_bullet/melting_blob/aoe
+	pellets = 1
+	variance = 0

--- a/code/modules/projectiles/ammunition/ego_ammunition/waw.dm
+++ b/code/modules/projectiles/ammunition/ego_ammunition/waw.dm
@@ -29,6 +29,11 @@
 	projectile_type = /obj/projectile/ego_bullet/ego_solemnvow
 
 /obj/item/ammo_casing/caseless/ego_loyalty
+	name = "loyalty IFF casing"
+	desc = "A loyalty IFF casing."
+	projectile_type = /obj/projectile/ego_bullet/ego_loyalty/iff
+
+/obj/item/ammo_casing/caseless/ego_loyaltynoiff
 	name = "loyalty casing"
 	desc = "A loyalty casing."
 	projectile_type = /obj/projectile/ego_bullet/ego_loyalty
@@ -37,6 +42,14 @@
 	name = "executive casing"
 	desc = "An executive casing."
 	projectile_type = /obj/projectile/ego_bullet/ego_executive
+
+//The only justice scaling gun is a shitty 10 pale pistol
+/obj/item/ammo_casing/caseless/ego_executive/ready_proj(atom/target, mob/living/user, quiet, zone_override = "", atom/fired_from)
+	..()
+	if(isgun(fired_from) && ishuman(user))
+		var/userjust = (get_attribute_level(user, JUSTICE_ATTRIBUTE))
+		var/justicemod = 1 + userjust/100
+		BB.damage *= justicemod
 
 /obj/item/ammo_casing/caseless/ego_crimson
 	name = "crimson casing"

--- a/code/modules/projectiles/guns/ego_gun/aleph.dm
+++ b/code/modules/projectiles/guns/ego_gun/aleph.dm
@@ -1,3 +1,7 @@
+#define SHOT_MODE 0
+#define DOT_MODE 1
+#define AOE_MODE 2
+
 /obj/item/gun/ego_gun/star
 	name = "sound of a star"
 	desc = "The star shines brighter as our despair gathers. The weapon's small, evocative sphere fires a warm ray."
@@ -26,13 +30,12 @@
 	It’s the byproduct of some horrid experiment in a certain laboratory that eventually failed."
 	icon_state = "adoration"
 	inhand_icon_state = "adoration"
-	special = "This weapon does black damage over time on direct hit. \
-				This weapon has an AOE attack dealing 30 damage."
+	special = "Use in hand to swap between AOE, DOT and shotgun modes."
 	ammo_type = /obj/item/ammo_casing/caseless/ego_adoration
 	weapon_weight = WEAPON_HEAVY
 	fire_sound = 'sound/effects/attackblob.ogg'
 	fire_sound_volume = 50
-	fire_delay = 2.4 SECONDS
+	fire_delay = 18
 
 	attribute_requirements = list(
 							FORTITUDE_ATTRIBUTE = 80,
@@ -40,3 +43,27 @@
 							TEMPERANCE_ATTRIBUTE = 100,
 							JUSTICE_ATTRIBUTE = 80
 							)
+	var/mode = 0
+
+/obj/item/gun/ego_gun/adoration/attack_self(mob/user)
+	..()
+	switch(mode)
+		if(SHOT_MODE)
+			to_chat(user,"<span class='warning'>You focus, changing for a DOT blast</span>")
+			ammo_type = /obj/item/ammo_casing/caseless/ego_adoration/dot
+			mode = DOT_MODE
+			return
+		if(DOT_MODE)
+			to_chat(user,"<span class='warning'>You focus, changing for an AOE blast</span>")
+			ammo_type = /obj/item/ammo_casing/caseless/ego_adoration/aoe
+			mode = AOE_MODE
+			return
+		if(AOE_MODE)
+			to_chat(user,"<span class='warning'>You focus, changing for a shotgun blast</span>")
+			ammo_type = /obj/item/ammo_casing/caseless/ego_adoration
+			mode = SHOT_MODE
+			return
+
+#undef SHOT_MODE
+#undef DOT_MODE
+#undef AOE_MODE

--- a/code/modules/projectiles/guns/ego_gun/waw.dm
+++ b/code/modules/projectiles/guns/ego_gun/waw.dm
@@ -73,7 +73,7 @@
 							)
 
 /obj/item/gun/ego_gun/magicbullet/before_firing(atom/target, mob/user)
-	fire_delay = 24
+	fire_delay = initial(fire_delay)
 	var/mob/living/carbon/human/myman = user
 	var/obj/item/clothing/suit/armor/ego_gear/magicbullet/Y = myman.get_item_by_slot(ITEM_SLOT_OCLOTHING)
 	if(istype(Y))
@@ -89,15 +89,21 @@
 	Can feathers gain their own wings?"
 	icon_state = "solemnlament"
 	inhand_icon_state = "solemnlament"
+	special = "Firing both solemn lament and solemn vow at the same time will increase damage by 1.5x"
 	ammo_type = /obj/item/ammo_casing/caseless/ego_solemnlament
 	burst_size = 1
 	fire_delay = 0
 	fire_sound = 'sound/abnormalities/funeral/spiritgunwhite.ogg'
 	fire_sound_volume = 30
+	attribute_requirements = list(JUSTICE_ATTRIBUTE = 60)
 
-	attribute_requirements = list(
-							JUSTICE_ATTRIBUTE = 60
-	)
+/obj/item/gun/ego_gun/pistol/solemnlament/process_fire(atom/target, mob/living/user)
+	for(var/obj/item/gun/ego_gun/pistol/solemnvow/Vow in user.held_items)
+		projectile_damage_multiplier = 1.5
+		break
+	..()
+	projectile_damage_multiplier = 1
+
 
 /obj/item/gun/ego_gun/pistol/solemnvow
 	name = "solemn vow"
@@ -105,15 +111,22 @@
 	Even with wings, no feather can leave this place."
 	icon_state = "solemnvow"
 	inhand_icon_state = "solemnvow"
+	special = "Firing both solemn lament and solemn vow at the same time will increase damage by 1.5x"
 	ammo_type = /obj/item/ammo_casing/caseless/ego_solemnvow
 	burst_size = 1
 	fire_delay = 0
 	fire_sound = 'sound/abnormalities/funeral/spiritgunblack.ogg'
 	fire_sound_volume = 30
 
-	attribute_requirements = list(
-							JUSTICE_ATTRIBUTE = 60
-	)
+	attribute_requirements = list(JUSTICE_ATTRIBUTE = 60)
+
+/obj/item/gun/ego_gun/pistol/solemnvov/process_fire(atom/target, mob/living/user)
+	for(var/obj/item/gun/ego_gun/pistol/solemnlament/Lament in user.held_items)
+		projectile_damage_multiplier = 1.5
+		break
+	..()
+	projectile_damage_multiplier = 1
+
 
 /obj/item/gun/ego_gun/loyalty
 	name = "loyalty"
@@ -122,14 +135,26 @@
 	inhand_icon_state = "loyalty"
 	ammo_type = /obj/item/ammo_casing/caseless/ego_loyalty
 	weapon_weight = WEAPON_HEAVY
-	spread = 8
+	spread = 20
 	special = "This weapon fires 750 rounds per minute. \
-		This weapon has IFF capabilities."
+		This weapon has IFF capabilities.\
+		Use in hand to turn off IFF."
 	fire_sound = 'sound/weapons/gun/smg/vp70.ogg'
 	autofire = 0.08 SECONDS
 	attribute_requirements = list(
 							FORTITUDE_ATTRIBUTE = 60
 	)
+
+/obj/item/gun/ego_gun/loyalty/attack_self(mob/user)
+	..()
+	if(ammo_type == /obj/item/ammo_casing/caseless/ego_loyaltynoiff)
+		to_chat(user,"<span class='warning'>You hit the switch, enabling IFF and decreasing damage.</span>")
+		ammo_type = /obj/item/ammo_casing/caseless/ego_loyalty
+		return
+	if(ammo_type == /obj/item/ammo_casing/caseless/ego_loyalty)
+		to_chat(user,"<span class='warning'>You hit the fire selector, disabling IFF and increasing damage.</span>")
+		ammo_type = /obj/item/ammo_casing/caseless/ego_loyaltynoiff
+		return
 
 //Just a funny gold soda pistol. It was originally meant to just be a golden meme weapon, now it is the only pale gun, lol
 /obj/item/gun/ego_gun/pistol/soda/executive
@@ -178,8 +203,8 @@
 	inhand_icon_state = "executive"
 	special = "This weapon fires IFF bullets."
 	ammo_type = /obj/item/ammo_casing/caseless/ego_praetorian
-	weapon_weight = WEAPON_HEAVY
 	fire_sound = 'sound/weapons/gun/pistol/tp17.ogg'
+	autofire = 0.12 SECONDS
 	fire_sound_volume = 30
 	attribute_requirements = list(
 							FORTITUDE_ATTRIBUTE = 60
@@ -193,7 +218,6 @@
 	special = "This weapon fires extremely slowly. \
 		This weapon pierces all targets."
 	ammo_type = /obj/item/ammo_casing/caseless/ego_magicpistol
-	weapon_weight = WEAPON_HEAVY
 	fire_delay = 24
 	fire_sound = 'sound/abnormalities/freischutz/shoot.ogg'
 	attribute_requirements = list(

--- a/code/modules/projectiles/projectile/ego_bullets/aleph.dm
+++ b/code/modules/projectiles/projectile/ego_bullets/aleph.dm
@@ -9,19 +9,30 @@
 	name = "slime projectile"
 	icon_state = "slime"
 	desc = "A glob of infectious slime. It's going for your heart."
-	damage = 40
+	damage = 40	//Fires 3
+	speed = 0.8
 	damage_type = BLACK_DAMAGE
 	flag = BLACK_DAMAGE
 	hitsound = "sound/effects/footstep/slime1.ogg"
 
-/obj/projectile/ego_bullet/melting_blob/on_hit(target)
+/obj/projectile/ego_bullet/melting_blob/dot
+	color = "#111111"
+
+/obj/projectile/ego_bullet/melting_blob/dot/on_hit(target)
 	. = ..()
 	var/mob/living/H = target
 	if(!isbot(H) && isliving(H))
 		H.visible_message("<span class='warning'>[target] is hit by [src], they seem to wither away!</span>")
-		for(var/i = 1 to 10)
+		for(var/i = 1 to 14)
 			addtimer(CALLBACK(H, /mob/living/proc/apply_damage, rand(6,8), BLACK_DAMAGE, null, H.run_armor_check(null, BLACK_DAMAGE)), 2 SECONDS * i)
-	for(var/mob/living/L in view(1, target))
+
+/obj/projectile/ego_bullet/melting_blob/aoe
+	color = "#6666BB"
+
+/obj/projectile/ego_bullet/melting_blob/aoe/on_hit(target)
+	. = ..()
+	for(var/mob/living/L in view(2, target))
 		new /obj/effect/temp_visual/revenant/cracks(get_turf(L))
-		L.apply_damage(30, BLACK_DAMAGE, null, L.run_armor_check(null, RED_DAMAGE), spread_damage = TRUE)
-		return BULLET_ACT_HIT
+		L.apply_damage(50, BLACK_DAMAGE, null, L.run_armor_check(null, RED_DAMAGE), spread_damage = TRUE)
+	return BULLET_ACT_HIT
+

--- a/code/modules/projectiles/projectile/ego_bullets/he.dm
+++ b/code/modules/projectiles/projectile/ego_bullets/he.dm
@@ -38,7 +38,7 @@
 /obj/projectile/ego_bullet/ego_galaxy/homing/proc/fireback()
 	icon_state = "magich"
 	var/list/targetslist = list()
-	for(var/mob/living/L in livinginrange(homing_range, src))
+	for(var/mob/living/L in range(homing_range, src))
 		if(ishuman(L) || isbot(L))
 			continue
 		if(L.stat == DEAD)

--- a/code/modules/projectiles/projectile/ego_bullets/waw.dm
+++ b/code/modules/projectiles/projectile/ego_bullets/waw.dm
@@ -69,14 +69,18 @@
 /obj/projectile/ego_bullet/ego_loyalty
 	name = "loyalty"
 	icon_state = "loyalty"
-	damage = 5
+	damage = 7
 	speed = 0.2
-	nodamage = TRUE	//Damage is calculated later
 	damage_type = RED_DAMAGE
 	flag = RED_DAMAGE
+
+/obj/projectile/ego_bullet/ego_loyalty/iff
+	name = "loyalty IFF"
+	damage = 5
+	nodamage = TRUE	//Damage is calculated later
 	projectile_piercing = PASSMOB
 
-/obj/projectile/ego_bullet/ego_loyalty/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/ego_bullet/ego_loyalty/iff/on_hit(atom/target, blocked = FALSE)
 	if(!ishuman(target))
 		nodamage = FALSE
 	else
@@ -89,6 +93,7 @@
 	name = "executive"
 	damage = 10
 	damage_type = PALE_DAMAGE	//hehe
+
 
 /obj/projectile/ego_bullet/ego_crimson
 	name = "crimson"
@@ -112,11 +117,14 @@
 /obj/projectile/ego_bullet/ego_praetorian
 	name = "praetorian"
 	icon_state = "loyalty"
-	damage = 21
+	damage = 5
 	nodamage = TRUE	//Damage is calculated later
 	damage_type = RED_DAMAGE
 	flag = RED_DAMAGE
 	projectile_piercing = PASSMOB
+	homing = TRUE
+	homing_turn_speed = 30		//Angle per tick.
+	var/homing_range = 9
 
 /obj/projectile/ego_bullet/ego_praetorian/on_hit(atom/target, blocked = FALSE)
 	if(!ishuman(target))
@@ -127,10 +135,28 @@
 	if(!ishuman(target))
 		qdel(src)
 
+/obj/projectile/ego_bullet/ego_praetorian/Initialize()
+	..()
+	addtimer(CALLBACK(src, .proc/fireback), 3)
+
+/obj/projectile/ego_bullet/ego_praetorian/proc/fireback()
+	var/list/targetslist = list()
+	for(var/mob/living/L in range(homing_range, src))
+		if(ishuman(L) || isbot(L))
+			continue
+		if(L.stat == DEAD)
+			continue
+		if(L.status_flags & GODMODE)
+			continue
+		targetslist+=L
+	if(!LAZYLEN(targetslist))
+		return
+	homing_target = pick(targetslist)
+
 /obj/projectile/ego_bullet/ego_magicpistol
 	name = "magic pistol"
 	icon_state = "magic_bullet"
-	damage = 62
+	damage = 40
 	speed = 0.1
 	damage_type = BLACK_DAMAGE
 	flag = BLACK_DAMAGE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Reworks:
Adoration now has 3 attack modes.
DOT, AOE and Shotgun.
Maybe it will finally be used.

Loyalty can turn off it's IFF for bonus damage

Solemn Vow & Solemn Lament get 1.5x damage when used together.

Throwing EVERYTHING scales with justice

Fixes:
Fixed Executive not justice scaling properly
Fixed Jank regarding Harvest's AOE attack

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Throwing weapons are a little underpowered, so this will buff those *just* a little.
Loyalty was a Point and click gun, this should make it so that it now has more than just point and click.
Adoration STILL sucks after my buff. Let's do it again.
Solemns are actually more often used as 2 sets of one. I want people to use one of each.

And some Ego fixes

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Ego guns get alternate firing modes.
tweak: Solemns now encourage dual wielding
tweak: throwing weapons get justice scaling
fix: Executive and Harvest now work as intended
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
