### PR TITLE
Robots Improved?

### DIFF
--- a/_maps/map_files/Alpha/alphacorp.dmm
+++ b/_maps/map_files/Alpha/alphacorp.dmm
@@ -30,11 +30,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/facility_hallway/south)
-"al" = (
-/mob/living/simple_animal/bot/cleanbot,
-/obj/effect/turf_decal/siding/brown,
-/turf/open/floor/plasteel,
-/area/facility_hallway/north)
 "am" = (
 /obj/effect/turf_decal/siding/yellow,
 /obj/structure/railing,
@@ -552,11 +547,6 @@
 	},
 /turf/open/floor/carpet/red,
 /area/department_main/control)
-"ek" = (
-/mob/living/simple_animal/bot/cleanbot,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/facility,
-/area/facility_hallway/central)
 "ep" = (
 /obj/effect/turf_decal/siding/green,
 /obj/structure/sign/poster/official/work_for_a_future{
@@ -3241,11 +3231,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/department_main/training)
-"yz" = (
-/mob/living/simple_animal/bot/cleanbot,
-/obj/effect/turf_decal/siding/green,
-/turf/open/floor/plasteel,
-/area/facility_hallway/north)
 "yG" = (
 /turf/open/floor/carpet/royalblue,
 /area/department_main/command)
@@ -4016,13 +4001,6 @@
 	},
 /turf/open/floor/plating,
 /area/department_main/training)
-"Fd" = (
-/mob/living/simple_animal/bot/cleanbot,
-/obj/effect/turf_decal/siding/purple{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/facility_hallway/south)
 "Ff" = (
 /obj/structure/chair,
 /turf/open/floor/plasteel/dark,
@@ -5041,9 +5019,9 @@
 /turf/open/floor/plasteel,
 /area/facility_hallway/north)
 "Nu" = (
-/mob/living/simple_animal/bot/cleanbot,
 /obj/effect/landmark/department_center,
 /obj/machinery/navbeacon/wayfinding/centralcommanddepartment,
+/mob/living/simple_animal/bot/cleanbot,
 /turf/open/floor/wood,
 /area/department_main/command)
 "ND" = (
@@ -5588,10 +5566,10 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/mob/living/simple_animal/bot/cleanbot,
 /obj/structure/sign/ordealmonitor{
 	pixel_x = -32
 	},
+/mob/living/simple_animal/bot/cleanbot,
 /turf/open/floor/carpet/purple,
 /area/department_main/information)
 "Ss" = (
@@ -35951,7 +35929,7 @@ vg
 vg
 vg
 Kn
-Fd
+Nn
 Kw
 DQ
 zm
@@ -37964,7 +37942,7 @@ Ir
 jD
 CL
 oA
-yz
+PR
 vs
 RF
 Ov
@@ -39533,7 +39511,7 @@ Jy
 Jy
 Jy
 Jy
-ek
+LZ
 LZ
 LZ
 Jy
@@ -41048,7 +41026,7 @@ Ir
 Wp
 Yu
 oA
-al
+Fy
 vs
 Ry
 vS
@@ -43147,7 +43125,7 @@ vg
 vg
 vg
 Kn
-Fd
+Nn
 Kw
 DQ
 zm

--- a/_maps/map_files/Beta/betacorp.dmm
+++ b/_maps/map_files/Beta/betacorp.dmm
@@ -821,6 +821,25 @@
 	},
 /turf/open/floor/carpet/black,
 /area/department_main/records)
+"dX" = (
+/obj/effect/turf_decal/tile/blue{
+	color = "#3234B9";
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#3234B9";
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#3234B9";
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#3234B9"
+	},
+/mob/living/simple_animal/bot/cleanbot,
+/turf/open/floor/plasteel/dark,
+/area/department_main/welfare)
 "ed" = (
 /obj/machinery/camera/autoname{
 	dir = 5
@@ -1754,10 +1773,6 @@
 	},
 /turf/open/floor/facility/dark,
 /area/department_main/discipline)
-"ji" = (
-/turf/open/space/basic,
-/turf/open/floor/plasteel,
-/area/facility_hallway/information)
 "jj" = (
 /obj/structure/chair/stool,
 /turf/open/floor/carpet/purple,
@@ -4354,6 +4369,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/department_main/information)
+"uT" = (
+/obj/effect/turf_decal/siding/blue{
+	color = "#3234B9";
+	dir = 8
+	},
+/mob/living/simple_animal/bot/cleanbot,
+/turf/open/floor/plasteel,
+/area/department_main/welfare)
 "uV" = (
 /obj/machinery/button/door{
 	id = "cellfour";
@@ -5320,10 +5343,6 @@
 	},
 /turf/open/floor/carpet/stellar,
 /area/department_main/command)
-"AE" = (
-/turf/open/space/basic,
-/turf/open/floor/plasteel,
-/area/facility_hallway/discipline)
 "AF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -8931,9 +8950,9 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/department_main/information)
 "Tz" = (
-/mob/living/simple_animal/bot/cleanbot,
 /obj/effect/landmark/department_center,
 /obj/machinery/navbeacon/wayfinding/safetydepartment,
+/mob/living/simple_animal/bot/cleanbot/medbay,
 /turf/open/floor/carpet/green,
 /area/department_main/safety)
 "TE" = (
@@ -9023,10 +9042,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/facility_hallway/welfare)
-"TV" = (
-/turf/open/space/basic,
-/turf/open/floor/facility,
-/area/facility_hallway/information)
 "Ub" = (
 /obj/effect/turf_decal/siding/yellow{
 	dir = 8
@@ -30785,7 +30800,7 @@ SR
 SR
 cQ
 So
-AE
+ot
 ph
 cQ
 JB
@@ -40318,7 +40333,7 @@ Xh
 Qv
 GV
 xc
-fw
+dX
 mU
 vN
 JB
@@ -40575,7 +40590,7 @@ TI
 bM
 GV
 RR
-fw
+dX
 tB
 vN
 JB
@@ -40832,7 +40847,7 @@ Xh
 Xr
 vN
 dr
-fw
+dX
 cP
 vN
 JB
@@ -41089,7 +41104,7 @@ Jp
 Xh
 YW
 eD
-eD
+uT
 Ch
 vN
 JB
@@ -50317,7 +50332,7 @@ Yr
 Yr
 ZQ
 Jo
-TV
+FK
 En
 ZQ
 Yr
@@ -51859,7 +51874,7 @@ Yr
 Yr
 ZQ
 Jo
-ji
+vK
 BE
 ZQ
 JB

--- a/_maps/map_files/Delta/deltacorp.dmm
+++ b/_maps/map_files/Delta/deltacorp.dmm
@@ -1616,19 +1616,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/department_main/discipline)
-"eI" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/siding/red{
-	dir = 4
-	},
-/obj/machinery/light/floor,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/space/basic,
-/turf/open/floor/plasteel/dark,
-/area/department_main/discipline)
 "eJ" = (
 /obj/structure/window/reinforced/spawner/east,
 /obj/structure/rack,
@@ -6262,7 +6249,9 @@
 "sj" = (
 /obj/structure/window/reinforced/spawner/west,
 /obj/effect/turf_decal/delivery/red,
-/mob/living/simple_animal/bot/cleanbot,
+/mob/living/simple_animal/bot/cleanbot/medbay{
+	auto_patrol = 0
+	},
 /turf/open/floor/noslip,
 /area/department_main/safety)
 "sl" = (
@@ -7720,13 +7709,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/facility_hallway/east)
-"wH" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 1
-	},
-/turf/open/space/basic,
-/turf/open/floor/plasteel,
-/area/facility_hallway/east)
 "wI" = (
 /obj/structure/sign/painting/library{
 	pixel_x = 32
@@ -8035,6 +8017,7 @@
 /obj/machinery/light/cold/no_nightlight{
 	dir = 8
 	},
+/mob/living/simple_animal/bot/cleanbot,
 /turf/open/floor/plasteel/dark,
 /area/department_main/welfare)
 "xF" = (
@@ -8056,6 +8039,7 @@
 	dir = 10
 	},
 /obj/structure/railing,
+/mob/living/simple_animal/bot/cleanbot,
 /turf/open/floor/plasteel/dark,
 /area/department_main/welfare)
 "xJ" = (
@@ -8115,11 +8099,6 @@
 	},
 /turf/open/floor/facility/dark,
 /area/facility_hallway/west)
-"xS" = (
-/obj/effect/turf_decal/siding/white,
-/turf/open/space/basic,
-/turf/open/floor/plasteel,
-/area/facility_hallway/east)
 "xV" = (
 /obj/machinery/telecomms/bus/preset_one,
 /turf/open/floor/circuit/telecomms/mainframe,
@@ -13726,6 +13705,7 @@
 /obj/machinery/light/cold/no_nightlight{
 	dir = 4
 	},
+/mob/living/simple_animal/bot/cleanbot,
 /turf/open/floor/plasteel/dark,
 /area/department_main/welfare)
 "OD" = (
@@ -17540,6 +17520,7 @@
 	dir = 6
 	},
 /obj/structure/railing,
+/mob/living/simple_animal/bot/cleanbot,
 /turf/open/floor/plasteel/dark,
 /area/department_main/welfare)
 "Yr" = (
@@ -54940,7 +54921,7 @@ gt
 sQ
 sQ
 sQ
-eI
+mV
 sQ
 sQ
 sQ
@@ -67309,8 +67290,8 @@ rR
 qH
 uj
 ou
-wH
-xS
+wG
+xH
 ou
 Al
 Al
@@ -67318,8 +67299,8 @@ Al
 Al
 Al
 ou
-wH
-xS
+wG
+xH
 ou
 Ky
 LB

--- a/_maps/map_files/Psi/psicorp.dmm
+++ b/_maps/map_files/Psi/psicorp.dmm
@@ -656,6 +656,7 @@
 /obj/structure/mirror{
 	pixel_x = 27
 	},
+/mob/living/simple_animal/bot/cleanbot,
 /turf/open/floor/facility/white,
 /area/facility_hallway/west)
 "ej" = (
@@ -3418,6 +3419,7 @@
 /obj/structure/mirror{
 	pixel_x = -27
 	},
+/mob/living/simple_animal/bot/cleanbot,
 /turf/open/floor/facility/white,
 /area/facility_hallway/east)
 "sQ" = (
@@ -7727,6 +7729,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1
 	},
+/mob/living/simple_animal/bot/cleanbot,
 /turf/open/floor/plasteel/dark,
 /area/facility_hallway/west)
 "QA" = (
@@ -9003,6 +9006,7 @@
 	color = "#440000";
 	dir = 5
 	},
+/mob/living/simple_animal/bot/cleanbot,
 /turf/open/floor/carpet/red,
 /area/department_main/command)
 "Wk" = (

--- a/_maps/map_files/Theta/thetacorp.dmm
+++ b/_maps/map_files/Theta/thetacorp.dmm
@@ -1622,7 +1622,7 @@
 /obj/structure/railing{
 	dir = 4;
 	name = "invincible railing";
-	max_integrity = 10000000
+	max_integrity = 1e+007
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -7458,7 +7458,7 @@
 /obj/structure/railing{
 	dir = 6;
 	name = "invincible railing";
-	max_integrity = 10000000
+	max_integrity = 1e+007
 	},
 /turf/open/floor/facility/dark,
 /area/department_main/records)
@@ -12862,6 +12862,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/facility_hallway/information)
+"CP" = (
+/mob/living/simple_animal/bot/cleanbot,
+/turf/open/floor/wood,
+/area/facility_hallway/south)
 "CQ" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1;
@@ -15644,14 +15648,6 @@
 	},
 /turf/open/floor/carpet/green,
 /area/department_main/safety)
-"ID" = (
-/obj/structure/fluff/big_chain{
-	pixel_y = 10
-	},
-/obj/machinery/light/small,
-/turf/open/floor/grass/fakebasalt,
-/turf/open/floor/grass/fakebasalt,
-/area/facility_hallway/central)
 "IF" = (
 /obj/effect/turf_decal/siding/purple/corner{
 	dir = 1
@@ -16696,13 +16692,6 @@
 	},
 /turf/open/floor/plasteel/sepia,
 /area/facility_hallway/safety)
-"KG" = (
-/obj/structure/fluff/big_chain{
-	pixel_y = 10
-	},
-/turf/open/floor/grass/fakebasalt,
-/turf/open/floor/grass/fakebasalt,
-/area/facility_hallway/central)
 "KJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -18704,7 +18693,7 @@
 /obj/structure/railing{
 	dir = 4;
 	name = "invincible railing";
-	max_integrity = 10000000
+	max_integrity = 1e+007
 	},
 /turf/open/floor/facility/dark,
 /area/department_main/records)
@@ -20342,6 +20331,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/facility_hallway/records)
+"RR" = (
+/obj/structure/sign/poster/lobotomycorp/random{
+	pixel_x = 32
+	},
+/mob/living/simple_animal/bot/cleanbot,
+/turf/open/floor/wood,
+/area/facility_hallway/south)
 "RS" = (
 /obj/effect/landmark/latejoin,
 /turf/open/floor/wood,
@@ -48902,7 +48898,7 @@ ik
 jo
 mi
 bj
-eC
+CP
 zo
 VH
 sg
@@ -49159,7 +49155,7 @@ ik
 jo
 Gy
 EX
-eC
+CP
 ZC
 VH
 Ki
@@ -49386,7 +49382,7 @@ Yq
 JT
 zk
 zk
-ID
+hG
 Yu
 VA
 on
@@ -50187,7 +50183,7 @@ gx
 Sr
 tm
 EX
-eC
+CP
 OZ
 VH
 Ki
@@ -50444,7 +50440,7 @@ QR
 Te
 Pm
 EX
-sJ
+RR
 BN
 VH
 Dt
@@ -50928,7 +50924,7 @@ JZ
 wf
 zk
 zk
-ID
+hG
 Yu
 fv
 on
@@ -62736,7 +62732,7 @@ qI
 qS
 gw
 gw
-KG
+mN
 zk
 zk
 iQ
@@ -64278,7 +64274,7 @@ rt
 AT
 gw
 gw
-KG
+mN
 zk
 zk
 FQ

--- a/_maps/map_files/Xi/xicorp.dmm
+++ b/_maps/map_files/Xi/xicorp.dmm
@@ -4432,7 +4432,7 @@
 /obj/structure/railing{
 	dir = 8;
 	name = "invincible railing";
-	max_integrity = 10000000
+	max_integrity = 1e+007
 	},
 /turf/open/floor/plasteel/stairs,
 /area/department_main/command)
@@ -4874,6 +4874,7 @@
 	},
 /area/facility_hallway/information)
 "KB" = (
+/mob/living/simple_animal/bot/cleanbot,
 /turf/open/floor/plasteel/white,
 /area/facility_hallway/command)
 "KG" = (
@@ -6648,7 +6649,7 @@
 /obj/structure/railing{
 	dir = 4;
 	name = "invincible railing";
-	max_integrity = 10000000
+	max_integrity = 1e+007
 	},
 /turf/open/floor/plasteel/stairs,
 /area/department_main/command)

--- a/_maps/map_files/Zeta/zetacorp.dmm
+++ b/_maps/map_files/Zeta/zetacorp.dmm
@@ -34,7 +34,7 @@
 /obj/structure/railing{
 	dir = 8;
 	name = "invincible railing";
-	max_integrity = 10000000
+	max_integrity = 1e+007
 	},
 /obj/machinery/camera/autoname{
 	dir = 1
@@ -637,7 +637,7 @@
 /obj/structure/railing{
 	dir = 4;
 	name = "invincible railing";
-	max_integrity = 10000000
+	max_integrity = 1e+007
 	},
 /obj/effect/mermaid_water{
 	name = "Coastal Waters";
@@ -2175,7 +2175,7 @@
 /obj/structure/railing{
 	dir = 8;
 	name = "invincible railing";
-	max_integrity = 10000000
+	max_integrity = 1e+007
 	},
 /turf/open/floor/facility/white,
 /area/department_main/command)
@@ -3301,6 +3301,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow,
+/mob/living/simple_animal/bot/cleanbot,
 /turf/open/floor/plasteel/sepia,
 /area/facility_hallway/command)
 "vg" = (
@@ -4189,6 +4190,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/mob/living/simple_animal/bot/cleanbot,
 /turf/open/floor/plasteel/sepia,
 /area/facility_hallway/command)
 "zY" = (
@@ -5784,7 +5786,7 @@
 	},
 /obj/structure/railing{
 	dir = 9;
-	max_integrity = 10000000
+	max_integrity = 1e+007
 	},
 /turf/open/floor/facility/white,
 /area/department_main/command)
@@ -6876,6 +6878,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow,
+/mob/living/simple_animal/bot/cleanbot,
 /turf/open/floor/plasteel/sepia,
 /area/facility_hallway/command)
 "Qp" = (

--- a/code/game/objects/items/ego_weapons/_ego_weapon.dm
+++ b/code/game/objects/items/ego_weapons/_ego_weapon.dm
@@ -12,7 +12,7 @@
 	var/attack_speed
 	var/special
 
-/obj/item/ego_weapon/attack(mob/living/target, mob/living/carbon/human/user)
+/obj/item/ego_weapon/attack(mob/living/target, mob/living/user)
 	if(!CanUseEgo(user))
 		return FALSE
 	. = ..()
@@ -61,7 +61,12 @@
 		display_text += SpecialGearRequirements()
 		to_chat(usr, display_text)
 
-/obj/item/ego_weapon/proc/CanUseEgo(mob/living/carbon/human/user)
+/obj/item/ego_weapon/proc/CanUseEgo(mob/living/user)
+	if(istype(user, /mob/living/simple_animal/bot/cleanbot))
+		for(var/atr in attribute_requirements)
+			if(attribute_requirements[atr] > 40)
+				return FALSE
+		return TRUE
 	if(!ishuman(user))
 		return FALSE
 

--- a/code/modules/jobs/job_types/assistant.dm
+++ b/code/modules/jobs/job_types/assistant.dm
@@ -8,8 +8,9 @@ Assistant
 	spawn_positions = -1
 	supervisors = "absolutely everyone"
 	selection_color = "#dddddd"
-	access = list()			//See /datum/job/assistant/get_access()
-	minimal_access = list()	//See /datum/job/assistant/get_access()
+	access = list(ACCESS_ROBOTICS)			//See /datum/job/assistant/get_access()
+	minimal_access = list(ACCESS_ROBOTICS)	//See /datum/job/assistant/get_access()
+	// Let their be bot maintenance!
 	outfit = /datum/outfit/job/assistant
 	antag_rep = 7 //persistant currency but currently unusable
 	display_order = JOB_DISPLAY_ORDER_CLERK

--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -229,6 +229,9 @@
 	if((H == oldpatient) && (world.time < last_found + 200))
 		return
 
+	if(H.is_working)
+		return
+
 	if(assess_patient(H))
 		last_found = world.time
 		if((last_newpatient_speak + 300) < world.time) //Don't spam these messages!


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Bots now use Abnormality containment cells, Xeno Spawns, and Main Rooms as viable locations to roam to, should they find no nav beacons. Cleaning Bots are untargettable and otherwise invincible. Clerks now have access to Behaviour panels on Bots, allowing them to do the classic "turn it off and back on again" or simply make them stop patrolling. EGO weapons can now be strapped to Cleaning bots, given they possess no requirement higher than 40. Doing so will make them vulnerable but attack Hostile creatures. They are NOT very tanky but could serve as a brief distraction or even finish off a very wounded Teth. Any weapon with a requirement above 40 will simply fall off upon attempting to attach it to the Cleaning bot. Medbots will now IGNORE someone working on an abnormality console. Armed Cleaning bots can now steal the Lobotomy Corporation job titles of people they trip, where they previously could not.

Unarmed Cleaning Bots are given GODMODE by default. I know this is a very delicate toggle but it does serve a few very specific purposes. The first is that enemies will ignore the bot and vice versa; They won't be infinitely hitting it or just stuck focusing one with lots of health. This one makes sense because from what I recall, Abnormalities target people in particular, as this also generates Enkaphalin, though they won't discriminate against anything going after them. The second is that it protects the bot from any AoE that may come after it. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Cleaning bots can't patrol as is and, while beloved, typically end up as buckets roughly 20 minutes into the game. They also have a violently untapped potential that was equipping them with weapons to be shit-mobs (and tripping hazards). The equipable weapons are almost always Zayin and TETH unless someone has made a weapon that specifically lacks requirements. Guns are also excluded so that shouldn't be an issue.

Medbots were also being exploited a bit and it seemed a good idea to at least reduce that.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
code: Changed the CanUseEgo code for `ego_weapon` to check for if it's a bot and if so, check if the weapon has any requirements. 
code: Changed Deputize to allow for bots to equip more than just a kitchen knife.
code/add: Added lines to check for an in-use abnormality console within a tile of potential patients for the Medbot.
code/add: Added godmode checking for potential mobs to be chosen by the Bot as a target.
code/add: Gave bots the ability to repeatedly hit a target based on the `strike` cooldown, modified by the individual weapons attack speed, should it be an EGO Weapon.
add: Gave assistants/clerks Robotics access, so they can operate bots.
mapping: Adds and Removes cleanbots so there's ~4 cleanbots on every map. Also fixes some double turfs on Beta and Delta (they had Space as well as a basic floor turf, so I removed the space)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
