### PR TITLE
Snow White deletes vines on death

### DIFF
--- a/code/game/objects/items/ego_weapons/waw.dm
+++ b/code/game/objects/items/ego_weapons/waw.dm
@@ -371,14 +371,14 @@
 		return
 	if(vine_cooldown <= world.time)
 		user.visible_message("<span class='notice'>[user] stabs [src] into the ground.</span>", "<span class='nicegreen'>You stab your [src] into the ground.</span>")
-		for(var/obj/structure/alien/weeds/F0442/F in range(0, get_turf(user)))
+		for(var/obj/structure/alien/weeds/apple_vine/F in range(0, get_turf(user)))
 			if(F)
 				playsound(src, 'sound/creatures/venus_trap_hurt.ogg', 10, FALSE, 5)
 				qdel(F)
 				return
 		var/mob/living/carbon/human/L = user
 		L.visible_message("<span class='notice'>Wilted stems grow from [src].</span>")
-		new /obj/structure/alien/weeds/F0442(get_turf(user))
+		new /obj/structure/alien/weeds/apple_vine(get_turf(user))
 		L.adjust_nutrition(-10)
 		vine_cooldown = world.time + vine_delay
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Snow-white will now make every vine fade out on death. All the vines will fade out at different interval from 4 to 10 seconds.
The vines will also stop replicating on snow's death.

## Why It's Good For The Game

I'm tired of nature healing, I want nature hurting.

## Changelog
:cl:
tweak: Snow White's vine will now destroy themselves on the abnormality's death

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
