### PR TITLE
fix mermaid's gift keeping buff after destruction

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/he/pisc_mermaid.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/pisc_mermaid.dm
@@ -267,9 +267,7 @@
 		if(loved)
 			STOP_PROCESSING(SSobj, src)
 			mermaid.datum_reference.qliphoth_change(-3)
-			loved.physiology.work_success_mod -= success_mod
 			mermaid.breach_effect()
-			loved = user
 			qdel(src)
 		return
 	if(ishuman(user))
@@ -286,6 +284,10 @@
 		to_chat(loved, "<span class='warning'>You feel as though you're forgetting someone...</span>")
 		love_cooldown = world.time + love_cooldown_time
 
+/obj/item/clothing/head/unrequited_crown/Destroy()
+	if(loved)
+		loved.physiology.work_success_mod -= success_mod
+	return ..()
 
 //Mermaid bath water
 /obj/effect/mermaid_water


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

If mermaid breached by herself it sometimes caused the gifted to keep the buff if they survived mermaid. Fixes this by simply removing the stats on the gift's destruction, so it's more reliable.

## Why It's Good For The Game

bug bad

## Changelog
:cl:
fix: mermaid's gift will no longer sometimes keep its buff after being destroyed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
