### PR TITLE
Big Bird tweaks

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/waw/big_bird.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/big_bird.dm
@@ -54,14 +54,12 @@
 	var/bite_cooldown_time = 8 SECONDS
 	var/hypnosis_cooldown
 	var/hypnosis_cooldown_time = 16 SECONDS
-	/// How many people died at the moment? When it hits 3 - reduce qliphoth and reset counter to 0.
-	var/death_counter = 0
 
 /datum/action/innate/abnormality_attack/hypnosis
 	name = "Hypnosis"
 	icon_icon = 'icons/obj/wizard.dmi'
 	button_icon_state = "magicm"
-	chosen_message = "<span class='colossus'>You will now put random human near you to sleep.</span>"
+	chosen_message = "<span class='colossus'>You will now stun random humans near you.</span>"
 	chosen_attack_num = 1
 
 /mob/living/simple_animal/hostile/abnormality/big_bird/OpenFire()
@@ -120,15 +118,19 @@
 		return
 	hypnosis_cooldown = world.time + hypnosis_cooldown_time
 	playsound(get_turf(src), 'sound/abnormalities/bigbird/hypnosis.ogg', 50, 1, 2)
-	for(var/mob/living/carbon/C in view(7, src))
+	for(var/mob/living/carbon/C in view(8, src))
 		if(faction_check_mob(C, FALSE))
 			continue
 		if(!CanAttack(C))
 			continue
 		if(prob(66))
-			to_chat(C, "<span class='warning'>You feel sleepy...</span>")
-			C.drowsyness += 4
-			addtimer(CALLBACK (C, .mob/living/proc/AdjustSleeping, 2 SECONDS), 4 SECONDS)
+			to_chat(C, "<span class='warning'>You feel tired...</span>")
+			C.blur_eyes(5)
+			addtimer(CALLBACK (C, .mob/proc/blind_eyes, 2), 2 SECONDS)
+			addtimer(CALLBACK (C, .mob/living/proc/Stun, 2 SECONDS), 2 SECONDS)
+			var/new_overlay = mutable_appearance('ModularTegustation/Teguicons/tegu_effects.dmi', "enchanted", -HALO_LAYER)
+			C.add_overlay(new_overlay)
+			addtimer(CALLBACK (C, .atom/proc/cut_overlay, new_overlay), 4 SECONDS)
 
 /mob/living/simple_animal/hostile/abnormality/big_bird/proc/on_mob_death(datum/source, mob/living/died, gibbed)
 	SIGNAL_HANDLER
@@ -138,10 +140,7 @@
 		return FALSE
 	if(!died.ckey)
 		return FALSE
-	death_counter += 1
-	if(death_counter >= 2)
-		death_counter = 0
-		datum_reference.qliphoth_change(-1)
+	datum_reference.qliphoth_change(-1) // One death reduces it
 	return TRUE
 
 /mob/living/simple_animal/hostile/abnormality/big_bird/success_effect(mob/living/carbon/human/user, work_type, pe)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Big Bird doesn't put you to sleep anymore: Instead it will blind(4s) and stun(2s) you.
- Affected people will have a visible overlay over them to warn others about your impending doom, so that they may try to save you.
- One death will reduce BB's qliphoth counter. This reduces total requirement from 10 to 5, given its counter is at 5.

## Why It's Good For The Game

- Sleep was rather annoying and boring, as it didn't let you scream for help :)
- Just what it says: Allows others to save you from death.
- 10 deaths with our normal pop was TOO much, especially since you can increase its qliphoth counter easily.
