### PR TITLE
Judgement Bird range increase

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/waw/judgement_bird.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/judgement_bird.dm
@@ -43,7 +43,7 @@
 	var/judgement_cooldown = 10 SECONDS
 	var/judgement_cooldown_base = 10 SECONDS
 	var/judgement_damage = 65
-	var/judgement_range = 8
+	var/judgement_range = 10
 
 /datum/action/innate/abnormality_attack/judgement
 	name = "Judgement"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Changes Judgement Bird's ability range from 8 to 10(one tile off-screen).

## Why It's Good For The Game

- Players were able to kite JBird way too easily. This should change it so running away from JBird after attacking it in melee is a bit harder.
