### PR TITLE
MoSB Upgrade

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/_abnormality.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_abnormality.dm
@@ -115,12 +115,15 @@
 	if(target && patrol_path) //if AI has acquired a target while on patrol, stop patrol
 		patrol_reset()
 		return
-	if(AIStatus == AI_IDLE) //if AI is idle, begin checking for patrol
+	if(CanStartPatrol())
 		if(patrol_cooldown <= world.time)
 			if(!patrol_path || !patrol_path.len)
 				patrol_select()
 				if(patrol_path.len)
 					patrol_move(patrol_path[patrol_path.len])
+
+/mob/living/simple_animal/hostile/abnormality/proc/CanStartPatrol()
+	return AIStatus == AI_IDLE //if AI is idle, begin checking for patrol
 
 /mob/living/simple_animal/hostile/abnormality/proc/patrol_select()
 	var/turf/target_center

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/mountain.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/mountain.dm
@@ -5,13 +5,13 @@
 	icon_state = "mosb"
 	icon_living = "mosb"
 	icon_dead = "mosb_dead"
-	maxHealth = 1000
-	health = 1000
+	maxHealth = 1500
+	health = 1500
 	pixel_x = -16
 	base_pixel_x = -16
 	damage_coeff = list(BRUTE = 1, RED_DAMAGE = 1.2, WHITE_DAMAGE = 0.8, BLACK_DAMAGE = 0.8, PALE_DAMAGE = 0.5)
-	melee_damage_lower = 20
-	melee_damage_upper = 30
+	melee_damage_lower = 25
+	melee_damage_upper = 35
 	melee_damage_type = RED_DAMAGE
 	armortype = RED_DAMAGE
 	rapid_melee = 2
@@ -19,6 +19,7 @@
 	ranged = TRUE
 	speed = 2
 	move_to_delay = 2
+	generic_canpass = FALSE
 	attack_sound = 'sound/abnormalities/mountain/bite.ogg'
 	attack_verb_continuous = "bites"
 	attack_verb_simple = "bite"
@@ -47,15 +48,15 @@
 	var/belly = 0
 	var/phase = 1
 	var/scream_cooldown
-	var/scream_cooldown_time = 7 SECONDS
+	var/scream_cooldown_time = 6 SECONDS
 	var/scream_damage = 40
 	var/slam_cooldown
-	var/slam_cooldown_time = 4 SECONDS
+	var/slam_cooldown_time = 2 SECONDS
 	var/slam_damage = 30
 	var/spit_cooldown
-	var/spit_cooldown_time = 18 SECONDS
+	var/spit_cooldown_time = 8 SECONDS
 	/// Actually it fires this amount thrice, so, multiply it by 3 to get actual amount
-	var/spit_amount = 32
+	var/spit_amount = 16
 	patrol_cooldown_time = 10 SECONDS //stage 1 - 10s, stage 2 - 20s, stage 3 - 30s
 
 /mob/living/simple_animal/hostile/abnormality/mountain/Initialize()		//1 in 100 chance for amogus MOSB
@@ -69,46 +70,28 @@
 	UnregisterSignal(SSdcs, COMSIG_GLOB_MOB_DEATH)
 	return ..()
 
-/mob/living/simple_animal/hostile/abnormality/mountain/CanAttack(atom/the_target)
-	if(finishing)
-		return FALSE
-	return ..()
+/* Movement */
 
 /mob/living/simple_animal/hostile/abnormality/mountain/Move()
 	if(finishing)
 		return FALSE
 	return ..()
 
-//Nabbed from Big Bird
-/mob/living/simple_animal/hostile/abnormality/mountain/proc/on_mob_death(datum/source, mob/living/died, gibbed)
-	SIGNAL_HANDLER
-	if(!(status_flags & GODMODE)) // If it's breaching right now
-		return FALSE
-	if(!ishuman(died))
-		return FALSE
-	if(!died.ckey)
-		return FALSE
-	death_counter += 1
-	if(death_counter >= 3)
-		death_counter = 0
-		datum_reference.qliphoth_change(-1)
-	return TRUE
-
-/mob/living/simple_animal/hostile/abnormality/mountain/death()
-	//Make sure we didn't get cheesed
-	if(health > 0)
+/mob/living/simple_animal/hostile/abnormality/mountain/Goto(target, delay, minimum_distance)
+	if(LAZYLEN(patrol_path)) // This is here so projectiles won't cause it to go off track
 		return
-	if(StageChange(FALSE)) // We go down by one stage
-		return
-	animate(src, alpha = 0, time = 10 SECONDS)
-	QDEL_IN(src, 10 SECONDS)
 	return ..()
 
-/mob/living/simple_animal/hostile/abnormality/mountain/gib()
-	if(phase > 1)
-		if(health < maxHealth * 0.2) // MoSB hammer, usually
-			return StageChange(FALSE)
-		return
+/mob/living/simple_animal/hostile/abnormality/mountain/CanPassThrough(atom/blocker, turf/target, blocker_opinion)
+	if(phase <= 1 && isliving(blocker)) // Phase 1 MoSB cannot be blocked by mobs when it's moving towards corpses
+		return TRUE
+	return ..()
+
+/* Attacking */
+
+/mob/living/simple_animal/hostile/abnormality/mountain/CanAttack(atom/the_target)
+	if(finishing)
+		return FALSE
 	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/mountain/OpenFire()
@@ -154,8 +137,40 @@
 				belly += 1
 				StageChange(TRUE)
 
+/mob/living/simple_animal/hostile/abnormality/mountain/attacked_by(obj/item/I, mob/living/user)
+	if(LAZYLEN(patrol_path) && CanAttack(user)) // Basically, it will retaliate while patrolling without stopping or chasing after them
+		user.attack_animal(src)
+	return ..()
+
+/* Death and "Death" */
+
+/mob/living/simple_animal/hostile/abnormality/mountain/death()
+	//Make sure we didn't get cheesed
+	if(health > 0)
+		return
+	if(StageChange(FALSE)) // We go down by one stage
+		return
+	animate(src, alpha = 0, time = 10 SECONDS)
+	QDEL_IN(src, 10 SECONDS)
+	return ..()
+
+/mob/living/simple_animal/hostile/abnormality/mountain/gib()
+	if(phase > 1)
+		if(health < maxHealth * 0.2) // MoSB hammer, usually
+			return StageChange(FALSE)
+		return
+	return ..()
+
+/* Targeting */
+
+/mob/living/simple_animal/hostile/abnormality/mountain/GiveTarget(new_target)
+	if(LAZYLEN(patrol_path))
+		if(locate(/mob/living/carbon/human) in patrol_path[patrol_path.len]) // FOOD
+			return // IGNORE EVERYTHING, CHARGE!!!!
+	return ..()
+
 /mob/living/simple_animal/hostile/abnormality/mountain/PickTarget(list/Targets) // We attack corpses first if there are any
-	if(phase == 1)
+	if((phase <= 1) || (health <= maxHealth * 0.5))
 		var/list/highest_priority = list()
 		var/list/lower_priority = list()
 		for(var/mob/living/L in Targets)
@@ -174,14 +189,30 @@
 			return pick(lower_priority)
 	return ..()
 
+/* Own procs */
+
+/mob/living/simple_animal/hostile/abnormality/mountain/proc/on_mob_death(datum/source, mob/living/died, gibbed)
+	SIGNAL_HANDLER
+	if(!(status_flags & GODMODE)) // If it's breaching right now
+		return FALSE
+	if(!ishuman(died))
+		return FALSE
+	if(!died.ckey)
+		return FALSE
+	death_counter += 1
+	if(death_counter >= 2)
+		death_counter = 0
+		datum_reference.qliphoth_change(-1)
+	return TRUE
+
 /mob/living/simple_animal/hostile/abnormality/mountain/proc/StageChange(increase = TRUE)
 	// Increase stage
 	if(increase)
-		if(belly >= 3)
+		if(belly >= 2)
 			if(phase < 3)
 				playsound(get_turf(src), 'sound/abnormalities/mountain/level_up.ogg', 75, 1)
 				adjustHealth(-5000)
-				maxHealth += 500
+				maxHealth += 1000
 				phase += 1
 				belly = 0
 			icon = 'ModularTegustation/Teguicons/96x96.dmi'
@@ -204,7 +235,7 @@
 		return FALSE
 	playsound(get_turf(src), 'sound/abnormalities/mountain/level_down.ogg', 75, 1)
 	adjustHealth(-5000)
-	maxHealth -= 500
+	maxHealth -= 1000
 	phase -= 1
 	icon_living = "mosb_breach"
 	if(phase == 1)
@@ -223,6 +254,8 @@
 		patrol_cooldown_time = 20 SECONDS
 	icon_state = icon_living
 	return TRUE
+
+/* Special attacks */
 
 /mob/living/simple_animal/hostile/abnormality/mountain/proc/Scream()
 	if(scream_cooldown > world.time)
@@ -274,7 +307,17 @@
 		SLEEP_CHECK_DEATH(2)
 	finishing = FALSE
 
-// Modified patrolling
+/* Modified patrolling */
+
+/mob/living/simple_animal/hostile/abnormality/mountain/CanStartPatrol()
+	if(phase <= 1) // Still phase one, we need corpses and can't really fight
+		return TRUE
+	return ..()
+
+/mob/living/simple_animal/hostile/abnormality/mountain/patrol_reset()
+	. = ..()
+	FindTarget() // Start eating corpses IMMEDIATELLY
+
 /mob/living/simple_animal/hostile/abnormality/mountain/patrol_select()
 	if(phase >= 3) // Ignore dead stuff from now on
 		return ..()
@@ -312,6 +355,8 @@
 		return
 	return ..()
 
+/* Abnormality work */
+
 /mob/living/simple_animal/hostile/abnormality/mountain/failure_effect(mob/living/carbon/human/user, work_type, pe)
 	datum_reference.qliphoth_change(-1)
 	return
@@ -328,6 +373,8 @@
 	if(user.health != user.maxHealth)
 		agent_hurt = TRUE
 	return TRUE
+
+/* Abnormality breach */
 
 /mob/living/simple_animal/hostile/abnormality/mountain/breach_effect(mob/living/carbon/human/user)
 	..()

--- a/code/modules/paperwork/records/info/aleph.dm
+++ b/code/modules/paperwork/records/info/aleph.dm
@@ -113,10 +113,10 @@
 	Qliphoth Counter : 2	<br>
 	Work Damage Type : Black	<br>
 	Work Damage : Extreme	<br>
-	- When NAME died or was critically injured while working with Mountain of Smiling Bodies, the Qliphoth Counter lowered. <br>
-	- When a wounded employee began work on The Mountain of Smiling Bodies, the Qliphoth Counter lowered.	<br>
+	- When NAME died or was critically injured while working with Mountain of Smiling Bodies, the Qliphoth Counter decreased. <br>
+	- When a wounded employee began work on The Mountain of Smiling Bodies, the Qliphoth Counter decreased.	<br>
 	- When the work result was Bad, the Qliphoth Counter decreased.	<br>
-	- When 3 employees die inside the facility, the Qliphoth Counter will lower.	<br>
+	- When an employee died within the facility, the Qliphoth Counter decreased.	<br>
 	- While Mountain of Smiling Bodies is escaping, it will show sensitive reactions to corpses. During suppression, ensure that no one dies due to the Abnormality; if casualties do happen, try to keep Mountain of Smiling Bodies away from the dead.	<br>
 	- If Mountain of Smiling Bodies’s suppression could not be completed on the previous level, you must be very careful to prevent any death inside the section where Mountain of Smiling Bodies is located.	<br>
 	- After other entities spawned from Mountain of Smiling Bodies’s main body while escaping, reducing its HP to 0 did not fully suppress it. Mountain of Smiling Bodies will only be quelled by attacking the main body after continuously reducing its HP and defeating the other spawned entities	<br>

--- a/code/modules/projectiles/projectile/magic/abnormality.dm
+++ b/code/modules/projectiles/projectile/magic/abnormality.dm
@@ -78,7 +78,7 @@
 	icon_state = "mountain"
 	damage_type = BLACK_DAMAGE
 	flag = BLACK_DAMAGE
-	damage = 10 // Launches 32(96) of those, for a whooping 320(960) black damage
+	damage = 15 // Launches 16(48) of those, for a whooping 240(720) black damage
 	spread = 60
 	slur = 3
 	eyeblur = 3
@@ -86,4 +86,10 @@
 /obj/projectile/mountain_spit/Initialize()
 	. = ..()
 	speed += pick(0, 0.1, 0.2, 0.3) // Randomized speed
+	animate(src, transform = src.transform*pick(1.8, 2.4, 2.8, 3.2), time = rand(1,4))
 
+/obj/projectile/mountain_spit/Range()
+	for(var/mob/living/L in range(1, get_turf(src)))
+		if(L.stat != DEAD && L != firer && !L.faction_check_mob(firer, FALSE))
+			return Bump(L)
+	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Improves MoSB pathfinding to ignore being attacked if it is currently moving towards a corpse.
- While being attacked in melee during patrol, MoSB will retaliate(RIP fast attacking weapons).
- Stage 1 MoSB will now pass through people blocking its path.
- MoSB will prioritize corpses and wounded people not only at stage 1, but also when on low HP.
- Only 2 deaths are required for qliphoth counter to go down, instead of 3.
- Only 2 kills are required for MoSB to grow.
- Melee damage is slightly increased by 5.
- Starting health increased from 1000 to 1500.
- Health increase when growing increased from 500 to 1000; This means stage 3 MoSB will have 3500 HP.
- Most cooldowns are reduced.
- The spit attack deals more damage and hits in range, but fires less projectiles in total.

## Why It's Good For The Game

- No longer can you just punch MoSB to stop its path towards a corpse. Now abnormalities will kite YOU.
- See above.
- You can't cheese MoSB by standing still at a door frame with corpses behind you now.
- It should prioritize healing itself when in a fight.
- 6 deaths for an ALEPH to breach was too much.
- Same as above.
- Fighting tier 1 MoSB, in case it does not find any corpses, shouldn't be *too* easy.
- Killing MoSB is a tiny bit harder now.
- Same as above. Most ALEPHs have 3000 or 4000 HP.
- Old cooldowns were slightly too long, this fixes it.
- This is mostly done to reduce the lag.
