### PR TITLE
Wander and Justice Panic update

### DIFF
--- a/code/datums/ai/sanity/_sanityloss_controller.dm
+++ b/code/datums/ai/sanity/_sanityloss_controller.dm
@@ -215,6 +215,7 @@
 	var/suicide_enter = 0
 	var/list/locations_visited = list()
 	var/list/total_locations = list() // Primarily here so admins/maintainers can see where they can actually go.
+	var/list/current_path = list()
 
 /datum/ai_controller/insane/wander/PossessPawn(atom/new_pawn)
 	. = ..()
@@ -266,6 +267,7 @@
 /datum/ai_controller/insane/release
 	lines_type = /datum/ai_behavior/say_line/insanity_release
 	var/next_smash = 0
+	var/list/current_path = list()
 
 /datum/ai_controller/insane/release/PossessPawn(atom/new_pawn)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Wander Panic and Release Panic were not functioning as intended (or at all in some cases) as their pathing variables were stored in their behaviors, which are not unique and are shared between all panicking players of that type, resulting in them "taking turns." This is resolved by moving variables to the unique controllers. In the process, I've reduced the variables being used by utilizing the so far unused Pathing Attempts variable and Max_Pathing_Attempts definition. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes an entirely broken system.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Wander Panic
fix: Justice Panic
add: Justice Panic not dog-piling a single abno console.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
