### PR TITLE
Minor Singing Machine buff

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/he/singing_machine.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/singing_machine.dm
@@ -39,6 +39,7 @@ Finally, an abnormality that DOESN'T have to do any fancy movement shit. It's a 
 	var/playLength = 60 SECONDS
 	var/playStatus = 0
 	var/playRange = 20
+	var/noiseFactor = 2
 	var/datum/looping_sound/singing_grinding/grindNoise
 	var/datum/looping_sound/singing_music/musicNoise
 	var/list/musicalAddicts = list()
@@ -48,9 +49,9 @@ Finally, an abnormality that DOESN'T have to do any fancy movement shit. It's a 
 		for(var/mob/living/carbon/human/H in livinginrange(playRange, src))
 			if(faction_check_mob(H))
 				continue
-			H.apply_damage(rand(playStatus * 1, playStatus * 2), WHITE_DAMAGE, null, H.run_armor_check(null, WHITE_DAMAGE), spread_damage = TRUE)
+			H.apply_damage(rand(playStatus * noiseFactor, playStatus * noiseFactor * 2), WHITE_DAMAGE, null, H.run_armor_check(null, WHITE_DAMAGE), spread_damage = TRUE)
 			if(H in musicalAddicts)
-				H.apply_damage(rand(playStatus * 1, playStatus * 2), WHITE_DAMAGE, null, H.run_armor_check(null, WHITE_DAMAGE), spread_damage = TRUE)
+				H.apply_damage(rand(playStatus * noiseFactor, playStatus * noiseFactor * 2), WHITE_DAMAGE, null, H.run_armor_check(null, WHITE_DAMAGE), spread_damage = TRUE)
 				to_chat(H, "<span class='warning'>You can hear it again... it needs more...</span>")
 			else
 				to_chat(H, "<span class='warning'>That terrible grinding noise...</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I heard a few people on the Discord say Singing Machine doesn't do quite enough damage when it's open and when it's playing. This doubles the damage of both (from 1-2 and 2-4 to 2-4 and 4-8), with a new variable that lets admins tune its damage if necessary.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Better balance.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: singing machine damage slightly increased
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
