### PR TITLE
Silent Girl Refactor

### DIFF
--- a/code/datums/status_effects/panic.dm
+++ b/code/datums/status_effects/panic.dm
@@ -109,7 +109,7 @@
 
 /datum/status_effect/panicked_type
 	id = "panic_state_base"
-	status_type = STATUS_EFFECT_UNIQUE
+	status_type = STATUS_EFFECT_REPLACE
 	alert_type = null
 	var/icon = "berserk"
 
@@ -118,6 +118,10 @@
 	owner.add_overlay(mutable_appearance('icons/effects/effects.dmi', icon, -ABOVE_MOB_LAYER))
 
 /datum/status_effect/panicked_type/on_remove()
+	. = ..()
+	owner.cut_overlay(mutable_appearance('icons/effects/effects.dmi', icon, -ABOVE_MOB_LAYER))
+
+/datum/status_effect/panicked_type/be_replaced()
 	. = ..()
 	owner.cut_overlay(mutable_appearance('icons/effects/effects.dmi', icon, -ABOVE_MOB_LAYER))
 

--- a/code/modules/paperwork/records/info/he.dm
+++ b/code/modules/paperwork/records/info/he.dm
@@ -115,12 +115,12 @@
 	- When an Agent with less a Prudence level 3 worked on Silent Girl, regardless of the work result the Qliphoth counter lowered.    <br>
 	- When the Work Result was poor, the Qliphoth counter lowered.	<br>
 	- When the Qliphoth counter lowered, the working Agent NAME felt a heavy weight upon their shoulders, we have dubbed this effect 'Guilt'    <br>
-	- When NAME who was under the 'Guilt' attempted to work with Silent Girl, they immediately panicked and began attempting to breach the nearest Abnormality.	<br>
+	- When NAME who was under the 'Guilt' attempted to work with Silent Girl, they briefed reported a splitting headache before only murmuring could be heard before contact was lost. We have dubbed this state 'Atonement.'	<br>
 	- Agents under the effect of 'Guilt' have reported significantly decreased work success rate.	<br>
-	- When an Agent under the 'Guilt' effect performed Attachment Work on another Abnormality, they felt the weight lift from their shoulders.	<br>
-	- When the 'Guilt' effect is removed from an Agent, the Qliphoth counter increased. This did not recognize the death of the Agent as a removal for the effect. <br>
-	- When Silent Girl's Qliphoth counter hit 0, all Agents under the effects of 'Guilt' proceeded to panic and attempt to breach the nearest Abnormality. After successfully breaching an Abnormality, the Agent was then found dead from self-inflicted injuries.	<br>
-	- When Silent Girl melted down, and no Agents had were under the 'Guilt' effect, one random employee was sent into a panic as if they had gone insane from 'Guilt'.	<br><br>
+	- When an Agent under the 'Guilt' or 'Atonement' effects completed Attachment Work on another Abnormality, they felt the weight lift from their shoulders.	<br>
+	- When the 'Guilt' or 'Atonement' effect is removed from an Agent, the Qliphoth counter increased. This did not recognize the death of the Agent as a removal for the effect. <br>
+	- When Silent Girl's Qliphoth counter hit 0, all Agents under the effects of 'Guilt' fell into the 'Atonement' state. Afterwards, the Agent was found dead from self-inflicted injuries.	<br>
+	- When Silent Girl melted down, and no Agents had were under the 'Guilt' effect, one random employee was sent into the 'Atonement' state.	<br><br>
 	<h4>Instinct:</h4> Low<br>
 	<h4>Insight:</h4> Very Low/High<br>
 	<h4>Attachment:</h4> Very Low<br>


### PR DESCRIPTION
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Silent Girl's debuffs now use Status Effects as opposed to a gross conglomeration of timers.
Silent Girl's lethal debuff should now revert to non-lethal once someone becomes sane. They still need to work it off.
Silent Girl's lethal debuff is no longer an instant kill, but instead puts you into Suicide Panic after a set duration.
Silent Girl's secret sound condition now plays to the Z level as opposed to simply in a small local area.
Silent Girl's code is, overall, better.
*Moved Piscine to new PR
Panic status's are now "replaceable" so should another be applied, instead of overlapping, the newest one will replace the old one.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It's so much cleaner and less buggy.
No more "random" deaths.
Fits a lot better.
I like it.
I have unspaghetti'd the code. Mostly. Right?
Self explanatory.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->


<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
