### PR TITLE
Sal acid & mental stabilizator tweaks; Changes examine message for damage.

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -187,27 +187,27 @@
 		else
 			temp = getBruteLoss()
 		if(temp)
-			if(temp < 25)
+			if(temp < (maxHealth*0.25))
 				msg += "[t_He] [t_has] minor bruising.\n"
-			else if(temp < 50)
+			else if(temp < (maxHealth*0.5))
 				msg += "[t_He] [t_has] <b>moderate</b> bruising!\n"
 			else
 				msg += "<B>[t_He] [t_has] severe bruising!</B>\n"
 
 		temp = getFireLoss()
 		if(temp)
-			if(temp < 25)
+			if(temp < (maxHealth*0.25))
 				msg += "[t_He] [t_has] minor burns.\n"
-			else if (temp < 50)
+			else if(temp < (maxHealth*0.5))
 				msg += "[t_He] [t_has] <b>moderate</b> burns!\n"
 			else
 				msg += "<B>[t_He] [t_has] severe burns!</B>\n"
 
 		temp = getCloneLoss()
 		if(temp)
-			if(temp < 25)
+			if(temp < (maxHealth*0.25))
 				msg += "[t_He] [t_has] minor cellular damage.\n"
-			else if(temp < 50)
+			else if(temp < (maxHealth*0.5))
 				msg += "[t_He] [t_has] <b>moderate</b> cellular damage!\n"
 			else
 				msg += "<b>[t_He] [t_has] severe cellular damage!</b>\n"

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -452,18 +452,14 @@
 	overdose_threshold = 25
 
 /datum/reagent/medicine/sal_acid/on_mob_life(mob/living/M)
-	if(M.getBruteLoss() > 25)
+	if(overdosed)
+		return
+	if(M.getBruteLoss() > (M.maxHealth*0.25))
 		M.adjustBruteLoss(-4*REM, 0)
 	else
-		M.adjustBruteLoss(-0.5*REM, 0)
+		M.adjustBruteLoss(-1*REM, 0)
 	..()
 	. = 1
-
-/datum/reagent/medicine/sal_acid/overdose_process(mob/living/M)
-	if(M.getBruteLoss()) //It only makes existing bruises worse
-		M.adjustBruteLoss(4.5*REM, FALSE, FALSE, BODYPART_ORGANIC) // it's going to be healing either 4 or 0.5
-		. = 1
-	..()
 
 /datum/reagent/medicine/salbutamol
 	name = "Salbutamol"
@@ -537,26 +533,12 @@
 /datum/reagent/medicine/mental_stabilizator/on_mob_life(mob/living/M)
 	if(!ishuman(M))
 		return
+	if(overdosed)
+		return
 	var/mob/living/carbon/human/H = M
 	H.adjustSanityLoss(5*REM) // That's healing 5 units.
 	..()
 	. = 1
-
-/datum/reagent/medicine/mental_stabilizator/overdose_process(mob/living/M)
-	if(prob(5))
-		if(current_cycle >= 50)
-			var/mob/living/carbon/human/H = M
-			to_chat(M, "<span class='notice'>[pick("Your blood starts to move.", "Your memories are fading.", "'Do not fear for we are with you now.'", "The sound of knocking is deafening.")]</span>")
-			H.adjustSanityLoss(-0.30*H.maxSanity*REM) // That's hurting 10% of sanity
-		else
-			var/mob/living/carbon/human/H = M
-			to_chat(M, "<span class='notice'>[pick("Your head pounds.", "Your thoughts are not your own.", "'You are in danger you have to run NOW!'")]</span>")
-			H.adjustSanityLoss(-0.10*H.maxSanity*REM) // That's hurting 5% of sanity
-	else if(prob(50))
-		var/mob/living/carbon/human/H = M
-		H.adjustSanityLoss(-10*REM) // That's hurting 10 units.
-		. = 1
-	..()
 
 /datum/reagent/medicine/diphenhydramine
 	name = "Diphenhydramine"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Both mental stabilizator and salicylic acid will simply stop healing on overdose, instead of damaging the user/victim. High speed healing of sal. acid will apply when brute damage is above 25%, instead of flat 25.
- Examine messages for damage(severe bruising, etc) will use percentages of max health instead of flat values.

## Why It's Good For The Game

- Sometimes clueless clerks would overdose people on either of these chems, usually resulting in a death of agent. This keeps overdose something you'd like to avoid while not being outright destructive.
- 25 brute damage is moderate in normal SS13 where max health is 100, sure, but here people go up to 230(or more) max health, so it should stay consistent, instead of showing "They have severe bruising!" when it's not even quarter of their max health.
