### PR TITLE
Download Tablet apps for FREE

### DIFF
--- a/code/modules/modular_computers/file_system/programs/airestorer.dm
+++ b/code/modules/modular_computers/file_system/programs/airestorer.dm
@@ -6,7 +6,7 @@
 	size = 12
 	requires_ntnet = FALSE
 	usage_flags = PROGRAM_CONSOLE | PROGRAM_LAPTOP
-	transfer_access = ACCESS_COMMAND
+	//transfer_access = ACCESS_COMMAND //nullified due to LC13
 	available_on_ntnet = TRUE
 	tgui_id = "NtosAiRestorer"
 	program_icon = "laptop-code"

--- a/code/modules/modular_computers/file_system/programs/budgetordering.dm
+++ b/code/modules/modular_computers/file_system/programs/budgetordering.dm
@@ -4,7 +4,7 @@
 	program_icon_state = "request"
 	extended_desc = "A request network that utilizes the Nanotrasen Ordering network to purchase supplies using a department budget account."
 	requires_ntnet = TRUE
-	transfer_access = ACCESS_COMMAND
+	//transfer_access = ACCESS_COMMAND //nullified due to LC13
 	usage_flags = PROGRAM_LAPTOP | PROGRAM_TABLET
 	size = 20
 	tgui_id = "NtosCargo"

--- a/code/modules/modular_computers/file_system/programs/card.dm
+++ b/code/modules/modular_computers/file_system/programs/card.dm
@@ -11,7 +11,7 @@
 	filedesc = "Plexagon Access Management"
 	program_icon_state = "id"
 	extended_desc = "Program for programming employee ID cards to access parts of the station."
-	transfer_access = ACCESS_COMMAND
+	// transfer_access = ACCESS_COMMAND //nullified due to LC13
 	requires_ntnet = 0
 	size = 8
 	tgui_id = "NtosCard"

--- a/code/modules/modular_computers/file_system/programs/crewmanifest.dm
+++ b/code/modules/modular_computers/file_system/programs/crewmanifest.dm
@@ -3,7 +3,7 @@
 	filedesc = "Plexagon Crew List"
 	program_icon_state = "id"
 	extended_desc = "Program for viewing and printing the current crew manifest"
-	transfer_access = ACCESS_COMMAND
+	//transfer_access = ACCESS_COMMAND //nullified due to LC13
 	requires_ntnet = TRUE
 	size = 4
 	tgui_id = "NtosCrewManifest"

--- a/code/modules/modular_computers/file_system/programs/jobmanagement.dm
+++ b/code/modules/modular_computers/file_system/programs/jobmanagement.dm
@@ -3,7 +3,7 @@
 	filedesc = "Plexagon HR Core"
 	program_icon_state = "id"
 	extended_desc = "Program for viewing and changing job slot avalibility."
-	transfer_access = ACCESS_COMMAND
+	//transfer_access = ACCESS_COMMAND //nullified due to LC13
 	requires_ntnet = TRUE
 	size = 4
 	tgui_id = "NtosJobManager"

--- a/code/modules/modular_computers/file_system/programs/powermonitor.dm
+++ b/code/modules/modular_computers/file_system/programs/powermonitor.dm
@@ -6,7 +6,7 @@
 	program_icon_state = "power_monitor"
 	extended_desc = "This program connects to sensors around the station to provide information about electrical systems"
 	ui_header = "power_norm.gif"
-	transfer_access = ACCESS_ENGINE
+	//transfer_access = ACCESS_ENGINE //nullified due to LC13
 	usage_flags = PROGRAM_CONSOLE
 	requires_ntnet = 0
 	size = 9

--- a/code/modules/modular_computers/file_system/programs/secureye.dm
+++ b/code/modules/modular_computers/file_system/programs/secureye.dm
@@ -7,7 +7,7 @@
 	program_icon_state = "generic"
 	extended_desc = "This program allows access to standard security camera networks."
 	requires_ntnet = TRUE
-	transfer_access = ACCESS_SECURITY
+	//transfer_access = ACCESS_SECURITY //nullified due to LC13
 	usage_flags = PROGRAM_CONSOLE | PROGRAM_LAPTOP | PROGRAM_TABLET
 	size = 5
 	tgui_id = "NtosSecurEye"


### PR DESCRIPTION
## About The Pull Request
Now anyone can download secureye and other listed programs, Crew access modifcation still requires the needed credentials but you can download it and see that it refuses you.

## Why It's Good For The Game
A blessing for the few people who use tablets. Also gives clerks more power.

## Changelog
:cl:
tweak: Airstorer, Budgetordering, Access Management, Crewmanifest Job Management, Powermonitor, and Secureeye now dont require access.
/:cl:
