### PR TITLE
Prevent Attack from Judgement, scorched, current, helper, and warden

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/_abnormality.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_abnormality.dm
@@ -103,6 +103,11 @@
 		return FALSE
 	return ..()
 
+/mob/living/simple_animal/hostile/abnormality/ClickOn( atom/A, params )
+	if(IsContained())
+		return
+	..()
+
 /mob/living/simple_animal/hostile/abnormality/Life()
 	. = ..()
 	if(!.) // Dead
@@ -349,6 +354,10 @@
 	var/obj/item/implant/radio/slime/imp = new(src)
 	imp.implant(src, src) //acts as if the abno is both the implanter and the one being implanted, which is technically true I guess?
 	datum_reference.abno_radio = TRUE
+
+/mob/living/simple_animal/hostile/abnormality/proc/IsContained() //Are you in a cell and currently contained?? If so stop.
+	if(status_flags & GODMODE)
+		return TRUE
 
 // Actions
 /datum/action/innate/abnormality_attack


### PR DESCRIPTION
## About The Pull Request
Adds a check for these abnormalities to see if they are currently in godmode.

## Why It's Good For The Game
Prevents skullduggery in sentient abnormality rounds

## Changelog
:cl:
add: Godmode check for Judgement Bird, Dreaming Current, Scorched Girl, All Around Helper, and Warden.
/:cl:
