### PR TITLE
Apocalypse Bird Enchant Changes

### DIFF
--- a/code/game/machinery/computer/abnormality_work.dm
+++ b/code/game/machinery/computer/abnormality_work.dm
@@ -147,6 +147,7 @@
 	ADD_TRAIT(user, TRAIT_PUSHIMMUNE, src)
 	user.density = FALSE // If they can be walked through they can't be switched! I didn't wanna add chairs because if there WAS it'd nullify the ability to DODGE issues that appear.
 	user.set_anchored(TRUE)
+	user.is_working = TRUE
 	while(total_boxes < work_time)
 		if(!CheckStatus(user))
 			break
@@ -178,6 +179,7 @@
 	REMOVE_TRAIT(user, TRAIT_PUSHIMMUNE, src)
 	user.density = TRUE
 	user.set_anchored(FALSE)
+	user.is_working = FALSE
 	finish_work(user, work_type, success_boxes, work_speed, training, was_melting, canceled)
 
 /obj/machinery/computer/abnormality/proc/CheckStatus(mob/living/carbon/human/user)

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -85,3 +85,6 @@
 
 	/// List of EGO Gifts
 	var/list/ego_gift_list = list()
+
+	/// Boolean for working status
+	var/is_working = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
- Adds a var to human_defines that is set TRUE during work. Enchant does not target these people, preventing them from getting enchanted.
- Enchant targets 10% of possible candidates and at least one person is enchanted.
- Enchant ends if you are within 3 tiles of apoca bird.
- Uses new insanity code when being moved by enchant

## Why It's Good For The Game
This prevents people who are addressing meltdowns from getting pulled by enchant. Hopefully will also make enchant less janky.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: apoca bird enchant
:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
