### PR TITLE
fix buddy no longer dying with shepherd

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/he/red_buddy.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/red_buddy.dm
@@ -158,6 +158,7 @@
 		var/turf/open/Y = pick(all_turfs - orgin)
 		forceMove(Y) //the lazy solution that forces buddy to get pulled by shepherd, ideally this should only happen once.
 		awakened_master.start_pulling(src)
+		awakened_master.awakened_buddy = src
 		med_hud_set_health()
 		med_hud_set_status()
 		update_health_hud()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

A one line fix I should've done long ago.

When buddy died and respawned and met shepherd AGAIN, it wouldn't properly set up shepherd as his master, so when shepherd died it was unable to move and just kind of stood there because he can only move within range of his master. Now he properly dies with his master every time.

## Why It's Good For The Game

The buggiest abnos in the west are back at it again

## Changelog
:cl:
fix: Buddy will now always die with shepherd
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
