### PR TITLE
Remove Barriers from Clerk Spawns

### DIFF
--- a/code/modules/jobs/job_types/assistant.dm
+++ b/code/modules/jobs/job_types/assistant.dm
@@ -30,7 +30,6 @@ Assistant
 	backpack_contents = list(
 		/obj/item/storage/firstaid/revival=1,
 		/obj/item/flashlight/seclite = 1,
-		/obj/item/storage/box/barrier= 1,
 		/obj/item/healthanalyzer = 1,
 		/obj/item/gun/ego_gun/clerk = 1,
 		/obj/item/kitchen/knife/hunting = 1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Clerks no longer spawn with a barrier box.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Barriers can be abused pretty easily. This PR should help limit the use of barriers to the amount placed in maps and creates a purchasable option if desired for the eventual cargo update. Also helps free up precious clerk inventory.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: clerks no longer spawn with barrier box
:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
