### PR TITLE
Pscine Tweak

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/he/pisc_mermaid.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/pisc_mermaid.dm
@@ -176,15 +176,12 @@
 	..()
 	if(crown?.loved)
 		var/crown_mod = crown.success_mod
-		crown.loved.physiology.work_success_mod -= crown_mod //We take the mod off temporarily so we don't accidentally add or take off too much.
-		switch(amount)
-			if(1) //it shouldn't move more than 1 counter at a time apart from meltdowns so that should be fine right?
-				crown_mod += 5
-			if(-1)
-				crown_mod -= 5
-		crown_mod = clamp(crown_mod, 0, 15)
+		crown.loved.physiology.work_success_mod /= crown_mod //We take the mod off temporarily so we don't accidentally add or take off too much.
+		if(amount)
+			crown_mod += amount*0.05 // If it increases, amount should be positive, if it decreases it should be negative.
+		crown_mod = clamp(crown_mod, 1, 1.15)
 		crown.success_mod = crown_mod
-		crown.loved.physiology.work_success_mod += crown_mod
+		crown.loved.physiology.work_success_mod *= crown_mod
 
 //Gives a crown thing when you get good work on her. Anyone can wear the crown, even those that didn't work on her and there can only be one gift at a time.
 /mob/living/simple_animal/hostile/abnormality/pisc_mermaid/proc/GiveGift(mob/living/carbon/human/user)
@@ -255,7 +252,7 @@
 	icon_state = "unrequited_gift"
 	icon = 'icons/obj/clothing/ego_gear/head.dmi'
 	worn_icon = 'icons/mob/clothing/ego_gear/head.dmi'
-	var/success_mod = 15
+	var/success_mod = 1.15
 	var/love_cooldown
 	var/love_cooldown_time = 1 MINUTES //It takes around 3 minutes for mermaid to breach if left unchecked
 	var/mob/living/simple_animal/hostile/abnormality/pisc_mermaid/mermaid
@@ -273,7 +270,7 @@
 	if(ishuman(user))
 		START_PROCESSING(SSobj, src)
 		mermaid.datum_reference.qliphoth_change(3)
-		user.physiology.work_success_mod += success_mod
+		user.physiology.work_success_mod *= success_mod
 		loved = user //Because, you know? You know? I'm doing it for you after all~
 		love_cooldown = world.time + love_cooldown_time
 
@@ -286,7 +283,7 @@
 
 /obj/item/clothing/head/unrequited_crown/Destroy()
 	if(loved)
-		loved.physiology.work_success_mod -= success_mod
+		loved.physiology.work_success_mod /= success_mod
 	return ..()
 
 //Mermaid bath water


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Piscine Mermaid now uses *= and /= for their work chance modifications as opposed to += and -=. This change was made because I was debating deleting the Global Work Success Modifier altogether until I found out she used it.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Covers edge-cases.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
code: Changed Piscine from using += / -= work mod to *= / /= work mod.
code: changed Piscine from being able to go up/down by 1 qliphoth to covering larger increases/decreases.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
