### PR TITLE
Manager camera examination overhaul

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -385,6 +385,8 @@
 #define COMSIG_MOB_MIDDLECLICKON "mob_middleclickon"
 ///from base of mob/AltClickOn(): (atom/A)
 #define COMSIG_MOB_ALTCLICKON "mob_altclickon"
+///from base of mob/ShiftClickOn(): (atom/A)
+#define COMSIG_MOB_SHIFTCLICKON "mob_shiftclickon"
 	#define COMSIG_MOB_CANCEL_CLICKON (1<<0)
 
 ///from base of obj/allowed(mob/M): (/obj) returns bool, if TRUE the mob has id access to the obj
@@ -980,7 +982,7 @@
 #define COMSIG_ACTION_TRIGGER "action_trigger"
 	#define COMPONENT_ACTION_BLOCK_TRIGGER (1<<0)
 
-//Xenobio hotkeys
+//Xenobio and manager console hotkeys
 
 ///from slime CtrlClickOn(): (/mob)
 #define COMSIG_XENO_SLIME_CLICK_CTRL "xeno_slime_click_ctrl"
@@ -988,10 +990,10 @@
 #define COMSIG_XENO_SLIME_CLICK_ALT "xeno_slime_click_alt"
 ///from slime ShiftClickOn(): (/mob)
 #define COMSIG_XENO_SLIME_CLICK_SHIFT "xeno_slime_click_shift"
-///from turf ShiftClickOn(): (/mob)
+///from turf ShiftClick(): (/mob)
 #define COMSIG_XENO_TURF_CLICK_SHIFT "xeno_turf_click_shift"
-///from turf AltClickOn(): (/mob)
-#define COMSIG_XENO_TURF_CLICK_CTRL "xeno_turf_click_alt"
+///from turf AltClick(): (/mob)
+#define COMSIG_XENO_TURF_CLICK_ALT "xeno_turf_click_alt"
 ///from monkey CtrlClickOn(): (/mob)
 #define COMSIG_XENO_MONKEY_CLICK_CTRL "xeno_monkey_click_ctrl"
 

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -293,6 +293,9 @@
  * This is overridden in ai.dm
  */
 /mob/proc/ShiftClickOn(atom/A)
+	. = SEND_SIGNAL(src, COMSIG_MOB_SHIFTCLICKON, A)
+	if(. & COMSIG_MOB_CANCEL_CLICKON)
+		return
 	A.ShiftClick(src)
 	return
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The camera examination will now use shift click for convenience, and the hologram spawn will use alt click
The camera examination from the manager console will now :
Give the attributes and agent level if an agent is examined.
Give the resistances of a hostile simple animal (abnormality or ordeal) if it is examined

Also changes a couple of things with written signals that doesn't really affect gameplay directly.

## Why It's Good For The Game

The only thing the manager can bother examining right now is abnormality counters, this makes the manager more like the LC one in the information they have available.

## Changelog
:cl:
tweak: The camera examination now allows you to get more information from hostiles and agents
tweak: The camera examination and hologram spawn from the manager console have swapped hotkeys.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
