### PR TITLE
Increase items that LC vending machines start with

### DIFF
--- a/code/modules/vending/lobotomyarmband.dm
+++ b/code/modules/vending/lobotomyarmband.dm
@@ -5,16 +5,15 @@
 	icon_deny = null
 	req_access = null //Shouldn't need access on lc13, can be changed
 	vend_reply = "Armband vended."
-	products = list(/obj/item/clothing/accessory/armband/lobotomy = 4,
-					/obj/item/clothing/accessory/armband/lobotomy/command = 4,
-					/obj/item/clothing/accessory/armband/lobotomy/training = 4,
-					/obj/item/clothing/accessory/armband/lobotomy/info = 4,
-					/obj/item/clothing/accessory/armband/lobotomy/safety = 4,
-					/obj/item/clothing/accessory/armband/lobotomy/discipline = 4,
-					/obj/item/clothing/accessory/armband/lobotomy/welfare = 4,
-					/obj/item/clothing/accessory/armband/lobotomy/records = 4,
-					/obj/item/clothing/accessory/armband/lobotomy/extraction = 4,
-					/obj/item/clothing/accessory/armband/lobotomy/architecture = 4)
+	products = list(/obj/item/clothing/accessory/armband/lobotomy = 20,
+					/obj/item/clothing/accessory/armband/lobotomy/command = 20,
+					/obj/item/clothing/accessory/armband/lobotomy/training = 20,
+					/obj/item/clothing/accessory/armband/lobotomy/info = 20,
+					/obj/item/clothing/accessory/armband/lobotomy/safety = 20,
+					/obj/item/clothing/accessory/armband/lobotomy/discipline = 20,
+					/obj/item/clothing/accessory/armband/lobotomy/welfare = 20,
+					/obj/item/clothing/accessory/armband/lobotomy/records = 20,
+					/obj/item/clothing/accessory/armband/lobotomy/extraction = 20)
 
 	refill_canister = null //Refill it with the clothing of the dead.
 	default_price = PAYCHECK_RESOURCE //Makes vended items cost 0 ahn.

--- a/code/modules/vending/lobotomyheadset.dm
+++ b/code/modules/vending/lobotomyheadset.dm
@@ -1,17 +1,17 @@
 /obj/machinery/vending/lobotomyheadset
 	name = "\improper Communications Vendor"
-	desc = "A vending machine for facility headsets, and encryption keys."
+	desc = "A vending machine for facility headsets and encryption keys."
 	icon_state = "generic" //Placeholder
 	icon_deny = null
 	req_access = null //Shouldn't need access on lc13, can be changed
-	vend_reply = "Uniform vended."
-	products = list(/obj/item/encryptionkey/headset_control = 4,
-					/obj/item/encryptionkey/headset_information = 4,
-					/obj/item/encryptionkey/headset_safety = 4,
-					/obj/item/encryptionkey/headset_training = 4,
-					/obj/item/encryptionkey/headset_command = 4,
-					/obj/item/encryptionkey/headset_welfare = 4,
-					/obj/item/encryptionkey/headset_discipline = 4)
+	vend_reply = "Encryption key vended."
+	products = list(/obj/item/encryptionkey/headset_control = 20,
+					/obj/item/encryptionkey/headset_information = 20,
+					/obj/item/encryptionkey/headset_safety = 20,
+					/obj/item/encryptionkey/headset_training = 20,
+					/obj/item/encryptionkey/headset_command = 20,
+					/obj/item/encryptionkey/headset_welfare = 20,
+					/obj/item/encryptionkey/headset_discipline = 20)
 					// /obj/item/encryptionkey/headset_extraction = 4, //Placeholder for when they're added.
 					// /obj/item/encryptionkey/headset_records = 4) //Same as above.
 

--- a/code/modules/vending/lobotomyuniform.dm
+++ b/code/modules/vending/lobotomyuniform.dm
@@ -5,17 +5,16 @@
 	icon_deny = null
 	req_access = null //Shouldn't need access on lc13, can be changed
 	vend_reply = "Uniform vended."
-	products = list(/obj/item/clothing/under/suit/lobotomy = 4,
-					/obj/item/clothing/under/suit/lobotomy/control = 4,
-					/obj/item/clothing/under/suit/lobotomy/information = 4,
-					/obj/item/clothing/under/suit/lobotomy/training = 4,
-					/obj/item/clothing/under/suit/lobotomy/safety = 4,
-					/obj/item/clothing/under/suit/lobotomy/welfare = 4,
-					/obj/item/clothing/under/suit/lobotomy/discipline = 4,
-					/obj/item/clothing/under/suit/lobotomy/command = 4,
-					/obj/item/clothing/under/suit/lobotomy/extraction = 4,
-					/obj/item/clothing/under/suit/lobotomy/records = 4,
-					/obj/item/clothing/under/suit/lobotomy/architecture = 4)
+	products = list(/obj/item/clothing/under/suit/lobotomy = 20,
+					/obj/item/clothing/under/suit/lobotomy/control = 20,
+					/obj/item/clothing/under/suit/lobotomy/information = 20,
+					/obj/item/clothing/under/suit/lobotomy/training = 20,
+					/obj/item/clothing/under/suit/lobotomy/safety = 20,
+					/obj/item/clothing/under/suit/lobotomy/welfare = 20,
+					/obj/item/clothing/under/suit/lobotomy/discipline = 20,
+					/obj/item/clothing/under/suit/lobotomy/command = 20,
+					/obj/item/clothing/under/suit/lobotomy/extraction = 20,
+					/obj/item/clothing/under/suit/lobotomy/records = 20)
 
 	refill_canister = null //Refill it with the clothing of the dead.
 	default_price = PAYCHECK_RESOURCE //Makes vended items cost 0 ahn.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Increases the number of items that LobCorp vending machines have at roundstart.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This allows us to avoid clunking up the maps with department armbands and encryption keys. Instead, people can get them all from these vending machines.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: vending machine
:cl: