### PR TITLE
Clerks start with -50 stats

### DIFF
--- a/code/modules/jobs/job_types/assistant.dm
+++ b/code/modules/jobs/job_types/assistant.dm
@@ -20,6 +20,9 @@ Assistant
 	display_order = JOB_DISPLAY_ORDER_PRISONER
 
 
+//they start at -50 all, you max out at level 4
+/datum/job/assistant/after_spawn(mob/living/carbon/human/H, mob/M, latejoin = FALSE)
+	H.adjust_all_attribute_buffs(-50)
 
 /datum/outfit/job/assistant
 	name = "Clerk"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Clerks start with -50 in every stat to discourage working.
This does not actually bring them below 0 effective stats

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Clerks should not be working, and this is to heavily discourage them. They can now never use aleph gear, but can still work if they absolutely need to

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Clerks spawn with -50 stats
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
