### PR TITLE
Abnormality Archive

### DIFF
--- a/code/game/machinery/computer/abnormality_archive.dm
+++ b/code/game/machinery/computer/abnormality_archive.dm
@@ -1,0 +1,89 @@
+/obj/machinery/computer/abnormality_archive
+	name = "abnormality archive"
+	desc = "A secure terminal connected to the Lobotomy Corp archive."
+	icon = 'icons/obj/computer.dmi'
+	icon_state = "computer"
+	icon_keyboard = "tech_key"
+	icon_screen = "forensic"
+	var/printfile
+	var/printing_status
+	var/notehtml
+	var/note
+	var/linecount
+	var/paper = 1 //You get one paper
+	var/papermax = 10 //Recycle more paper
+	var/list/note_list
+
+/obj/machinery/computer/abnormality_archive/ui_interact(mob/user, datum/tgui/ui)
+	ui = SStgui.try_update_ui(user, src, ui)
+	if(!ui)
+		ui = new(user, src, "LC13AbnormalityArchive", name) //apparently connected to .Js which is invisable to dreammaker but not to Visual Studio Code.
+		ui.open()
+
+/obj/machinery/computer/abnormality_archive/ui_static_data(mob/user) //list is created the moment a person boots up the UI and inherited by future iterations of this object
+	. = ..()
+	var/abnormality_info //if the abnormality info is already made do not make a new one.
+	if(!abnormality_info)
+		abnormality_info = list()
+		for(var/_record_detail in subtypesof(/obj/item/paper/fluff/info)) //consists of all threat levels and their branches
+			var/obj/item/paper/fluff/info/record_detail = _record_detail
+			var/list/record_data = list()
+			if(initial(record_detail.name) == "paper" || initial(record_detail.no_archive) == TRUE) //removes template papers and allows for secret files
+				continue
+			note_list = splittext(initial(record_detail.info), "<br>") //splits text into a list by making <br> into a break,
+			popleft(note_list) //Remove first line since it is the name
+			linecount = note_list.len //Doing it seperately results in only half of the lines being given a value. A single variable seems to keep it stable.
+			record_data["linecount"] = linecount //len is list length
+			record_data["type"] = record_detail //gives the typepath of the file we are reading
+			record_data["name"] = remove_paper_commands(initial(record_detail.name))
+			for(var/i=0,i <= linecount,i++) //loop until we reach the same length as the linecount
+				record_data["line[i]"] += remove_paper_commands(popleft(note_list))
+			abnormality_info += list(record_data)
+
+	.["abnormality_info"] = abnormality_info
+
+/obj/machinery/computer/abnormality_archive/ui_act(action, params) //Basically catches signals caused by the Javascript act('print_file', { ref: currentAbnormality.type })
+	. = ..()
+	if(.)
+		return
+	switch(action)
+		if("print_file")
+			if(paper <= 0)
+				return
+			printfile = params["ref"]
+			print_file(printfile)
+
+/obj/machinery/computer/abnormality_archive/attackby(obj/item/O, mob/user)
+	if(istype(O, /obj/item/paper) && paper <= papermax)
+		qdel(O)
+		paper = paper + 1
+	..()
+
+/obj/machinery/computer/abnormality_archive/proc/print_file(file)
+	paper = paper - 1
+	visible_message("<span class='notice'>[src] begins to print a file.</span>")
+	playsound(src, 'sound/machines/terminal_prompt_confirm.ogg', 30, TRUE)
+	new file(get_turf(src))
+
+//Sanitize code did not work.
+//Sanitize code uses both sanitize_simple and HTML_encode.
+/obj/machinery/computer/abnormality_archive/proc/remove_paper_commands(paper) //Removes all command code. WILL cause problems for abnormality documents later. I am sorry about this.
+	note = replacetext(paper, "<br>", "")
+	note = replacetext(note, "<li>", "")
+	note = replacetext(note, "'", "")
+	note = replacetext(note, "<ul>", "")
+	note = replacetext(note, "</ul>", "")
+	note = replacetext(note, "<center>", "")
+	note = replacetext(note, "</center>", "")
+	note = replacetext(note, "<strong>", "")
+	note = replacetext(note, "</strong>", "")
+	note = replacetext(note, "<h1>", "")
+	note = replacetext(note, "</h1>", "")
+	note = replacetext(note, "<h2>", "")
+	note = replacetext(note, "</h2>", "")
+	note = replacetext(note, "<h3>", "")
+	note = replacetext(note, "</h3>", "")
+	note = replacetext(note, "<h4>", "")
+	note = replacetext(note, "</h4>", "")
+	note = html_encode(note)
+	return note

--- a/code/modules/paperwork/records/info/_info.dm
+++ b/code/modules/paperwork/records/info/_info.dm
@@ -20,6 +20,7 @@ For Escape damage, I think I'll just honestly ball-park how fast it could reason
 /obj/item/paper/fluff/info
 	show_written_words = FALSE
 	slot_flags = null	//No books on head, sorry
+	var/no_archive = FALSE //will not show up in Lobotomy Corp Archive Computer if true
 
 
 /obj/item/paper/fluff/info/attackby(obj/item/P, mob/living/user, params)
@@ -40,3 +41,28 @@ For Escape damage, I think I'll just honestly ball-park how fast it could reason
 
 /obj/item/paper/fluff/info/aleph
 	icon_state = "aleph"
+
+/obj/item/paper/fluff/info/zayin/archive_guide
+	name = "Archive Guide"
+	info = {"<h1><center>Archive Guide</center></h1>	<br>
+	Welcome to Lobotomy Corps Digital Archive! <br>
+	In order to effeciently navigate the archives please learn what the classification code of a abnormality actually means.<br>
+	The first letter in a abnormalities classification code is their series or class.<br>
+	F is for abnormalities that take on the traits of fictional stories or urban legends.<br>
+	T is for abnormalities that formed from traumatic experiences or embody a certain phobia.<br>
+	O is for abnormalities that do not take on the traits of traumas or fairy tales. <br>
+	D is for abnormalities that were labeled as non essential for our overall goal. <br>
+	-<br>
+	The second letter of the classification code is their physical form, this is easier to find if you have seen the abnormality.<br>
+	01 is humanoids, <br>
+	02 is animals, <br>
+	03 is otherworldy creatures, <br>
+	04 is inanimate objects, <br>
+	05 is mechanical or inorganic creatures,<br>
+	06 is abstract or an amalgamation of entities, <br>
+	07 is enities who are usable items while inert but can transform {currently used for O-O7-103}, <br>
+	08 is currently unused,<br>
+	09 is devices that require interaction to express their effects.<br>
+	- <br>
+	The final numbers in the code are unique to each abnormality.<br>
+	Lobotomy Corp hopes you can meet their expectations.<br>"}

--- a/lobotomy-corp13.dme
+++ b/lobotomy-corp13.dme
@@ -923,6 +923,7 @@
 #include "code\game\machinery\camera\presets.dm"
 #include "code\game\machinery\camera\tracking.dm"
 #include "code\game\machinery\computer\_computer.dm"
+#include "code\game\machinery\computer\abnormality_archive.dm"
 #include "code\game\machinery\computer\abnormality_ego.dm"
 #include "code\game\machinery\computer\abnormality_logs.dm"
 #include "code\game\machinery\computer\abnormality_queue.dm"

--- a/tgui/packages/tgui/interfaces/LC13AbnormalityArchive.js
+++ b/tgui/packages/tgui/interfaces/LC13AbnormalityArchive.js
@@ -1,0 +1,132 @@
+import { sortBy } from 'common/collections';
+import { flow } from 'common/fp';
+import { useBackend, useLocalState } from '../backend';
+import { Box, Button, LabeledList, Section, Stack } from '../components';
+import { Window } from '../layouts';
+import { capitalize } from 'common/string';
+
+export const LC13AbnormalityArchive = (props, context) => {
+  const { act, data } = useBackend(context);
+
+  const {
+    abnormality_info,
+  } = data;
+
+  const abnormality_by_name = flow([
+    sortBy(abnormality_info => abnormality_info.name),
+  ])(data.abnormality_info || []);
+
+  const [
+    current_abnormality,
+    setcurrent_abnormality,
+  ] = useLocalState(context, 'current_abnormality', null);
+  return (
+    <Window
+      width={800}
+      height={600}>
+      <Window.Content>
+        <Stack fill>
+          <Stack.Item width="150px">
+            <Section fill scrollable>
+              {abnormality_by_name.map(f => (
+                <Button
+                  key={f.name}
+                  fluid
+                  color="transparent"
+                  selected={f === current_abnormality}
+                  onClick={() => { setcurrent_abnormality(f); }}>
+                  {f.name}
+                </Button>
+              ))}
+            </Section>
+          </Stack.Item>
+          <Stack.Item grow basis={0}>
+            <Section
+              fill
+              scrollable
+              title={current_abnormality
+                ? capitalize(current_abnormality.name)
+                : " Lobotomy Corporation Archive"}>
+              {current_abnormality && (
+                <LabeledList>
+                  <LabeledList.Item label="File Info">
+                    {current_abnormality.name}
+                  </LabeledList.Item>
+                  <LabeledList.Item>
+                    <Linesoftext subject={current_abnormality} />
+                  </LabeledList.Item>
+                  <LabeledList.Item>
+                    <Button.Confirm
+                      fluid
+                      icon="check"
+                      color="red"
+                      textAlign="center"
+                      content="Print File"
+                      onClick={() => act('print_file', { ref: current_abnormality.type })} />
+                  </LabeledList.Item>
+                </LabeledList>
+              )}
+            </Section>
+          </Stack.Item>
+        </Stack>
+      </Window.Content>
+    </Window>
+  );
+};
+
+// Theres a tower on this island.
+const Linesoftext = (props, context) => {
+  const { subject } = props;
+  const the_tower = []; // The bottom of the_tower
+  if (!subject) {
+    return (
+      <Section>
+        {"ERROR NO FILE subject"}
+      </Section>
+    );
+  }
+  if (!subject.linecount) {
+    return (
+      <Section>
+        {"ERROR NO READABLE FILE TEXT"}
+      </Section>
+    );
+  }
+  for (let index = 0; index <= subject.linecount; index++) {
+    const Tower_element = ( // Produce Tower_element
+      <Towergear 
+        tower_subject={subject} 
+        line_place={index} 
+      /> // Tower_Gear is on the Next Island. 
+      // It produces Tower_element based on the values put inside it.
+    );
+    the_tower.push(Tower_element); // Add Tower_element to the_tower
+  }
+  return ( // Return the_tower code.
+    [the_tower]
+  );
+};
+
+// Towergear does not work unless it has capitalization. 
+// Apparently all consts must be in pascaltext
+const Towergear = (props, context) => { 
+  const { tower_subject, line_place } = props;
+  let tower_gear_sound = "line" + [line_place]; 
+  // Coding this has the feeling of being lost 
+  // with only fickle candles to light the way.
+  if (!tower_subject[tower_gear_sound]) { 
+    // The value is empty even though the max size of the list counts it.
+    return (
+      <Box>
+        {" "}
+      </Box>
+    );
+  }
+  return ( // Return code below to the tower.
+    <Box>
+      {tower_subject[tower_gear_sound]}
+    </Box>
+  );
+};
+// It turns out in the end tower_subject[tower_gear_sound] 
+// is the same as tower_subject.tower_gear_sound.


### PR DESCRIPTION
## About The Pull Request
I was requested to make a abnormality archive that shows file using a UI similar to the fish catalog.
![image](https://user-images.githubusercontent.com/109536843/205192455-8c808a3f-351a-4ae3-aeb5-2eda2ec72224.png)
information is derived directly from subtypes of the info paper.
UI for me doesnt seem to show up unless i do the build.exe after every change.

Coding and subsequently testing this was a nightmare because it involved me opening and closing 3 different programs every time I made a change to the tgui code which required me to do build file before being integrated.
## Why It's Good For The Game
You can print files and browse files without having to pull the item out of the file cabinet. Printing however costs paper.
Im going to talk with kirie on how to make the printing of the paper be on a delay because do_after doesnt work.

## Changelog
:cl:
add: Abnormality Archive Computer
add: noArchive variable to _info
add: Archive guide document
add: LC13AbnormalityArchive.js
/:cl:
