### PR TITLE
EGO gifts fix, change to abnormality proc cases

### DIFF
--- a/code/datums/abnormality/datum/abnormality.dm
+++ b/code/datums/abnormality/datum/abnormality.dm
@@ -132,7 +132,7 @@
 
 
 /datum/abnormality/proc/work_complete(mob/living/carbon/human/user, work_type, pe, work_time, was_melting, canceled)
-	current.work_complete(user, work_type, pe, work_time, canceled) // Cross-referencing gone wrong
+	current.WorkComplete(user, work_type, pe, work_time, canceled) // Cross-referencing gone wrong
 	var/user_job_title = "Unidentified Employee"
 	var/obj/item/card/id/W = user.get_idcard()
 	if(istype(W))
@@ -178,7 +178,7 @@
 	var/pre_qlip = qliphoth_meter
 	qliphoth_meter = clamp(qliphoth_meter + amount, 0, qliphoth_meter_max)
 	if((qliphoth_meter_max > 0) && (qliphoth_meter <= 0) && (pre_qlip > 0))
-		current?.zero_qliphoth(user)
+		current?.ZeroQliphoth(user)
 		current?.visible_message("<span class='danger'>Warning! Qliphoth level reduced to 0!")
 		playsound(get_turf(current), 'sound/effects/alertbeep.ogg', 50, FALSE)
 		return
@@ -199,7 +199,7 @@
 		var/work_level = clamp(round(get_attribute_level(user, WORK_TO_ATTRIBUTE[workType])/20), 1, 5)
 		acquired_chance = acquired_chance[work_level]
 	if(current)
-		acquired_chance = current.work_chance(user, acquired_chance)
+		acquired_chance = current.WorkChance(user, acquired_chance, workType)
 	switch (workType)
 		if (ABNORMALITY_WORK_INSTINCT)
 			acquired_chance += user.physiology.instinct_success_mod

--- a/code/game/machinery/computer/abnormality_work.dm
+++ b/code/game/machinery/computer/abnormality_work.dm
@@ -90,7 +90,7 @@
 			if(!(datum_reference.current.status_flags & GODMODE))
 				to_chat(usr, "<span class='warning'>Abnormality has escaped containment!</span>")
 				return
-			var/work_attempt = datum_reference.current.attempt_work(usr, href_list["do_work"])
+			var/work_attempt = datum_reference.current.AttemptWork(usr, href_list["do_work"])
 			if(!work_attempt)
 				if(work_attempt == FALSE)
 					to_chat(usr, "<span class='warning'>This operation is currently unavailable.</span>")
@@ -160,16 +160,16 @@
 			user.remove_status_effect(/datum/status_effect/interventionshield/pale)
 			if(do_work(work_chance))
 				success_boxes++
-				datum_reference.current.worktick_success(user)
+				datum_reference.current.WorktickSuccess(user)
 			else
-				datum_reference.current.worktick_failure(user)
+				datum_reference.current.WorktickFailure(user)
 			total_boxes++
-			datum_reference.current.worktick(user)
+			datum_reference.current.Worktick(user)
 		else
 			if(!CheckStatus(user)) // No punishment if the thing is already breached or any other issue is prevelant.
 				break
 			for(var/i = 0 to round((work_time - total_boxes)*(1-((work_chance*0.5)/100)), 1)) // Take double of what you'd fail on average as NE box damage.
-				datum_reference.current.worktick_failure(user)
+				datum_reference.current.WorktickFailure(user)
 			playsound(src, 'sound/machines/synth_no.ogg', 75, FALSE, -4)
 			to_chat(user, "<span class='warning'>The Abnormality grows frustrated as you cut your work short!")
 			success_boxes = 0
@@ -217,7 +217,7 @@
 			datum_reference.work_complete(user, work_type, pe, work_speed*datum_reference.max_boxes, was_melting, canceled)
 			SSlobotomy_corp.WorkComplete(pe, (meltdown_time <= 0))
 		else
-			datum_reference.current.work_complete(user, work_type, pe, work_speed*datum_reference.max_boxes)
+			datum_reference.current.WorkComplete(user, work_type, pe, work_speed*datum_reference.max_boxes)
 	meltdown_time = 0
 	datum_reference.working = FALSE
 	return TRUE
@@ -232,7 +232,7 @@
 /obj/machinery/computer/abnormality/proc/start_meltdown()
 	meltdown_time = rand(60, 90)
 	meltdown = TRUE
-	datum_reference.current.meltdown_start()
+	datum_reference.current.MeltdownStart()
 	update_icon()
 	playsound(src, 'sound/machines/warning-buzzer.ogg', 75, FALSE, 3)
 	return TRUE

--- a/code/modules/mob/living/simple_animal/abnormality/!tutorial/bill.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/!tutorial/bill.dm
@@ -25,11 +25,11 @@
 	start_qliphoth = 1
 	can_spawn = FALSE // Normally doesn't appear
 
-/mob/living/simple_animal/hostile/abnormality/bill/failure_effect(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/bill/FailureEffect(mob/living/carbon/human/user, work_type, pe)
 	datum_reference.qliphoth_change(-1)
 	return
 
-/mob/living/simple_animal/hostile/abnormality/bill/breach_effect(mob/living/carbon/human/user)
+/mob/living/simple_animal/hostile/abnormality/bill/BreachEffect(mob/living/carbon/human/user)
 	..()
 	GiveTarget(user)
 	addtimer(CALLBACK(src, .proc/die), 60 SECONDS)

--- a/code/modules/mob/living/simple_animal/abnormality/!tutorial/cube.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/!tutorial/cube.dm
@@ -25,13 +25,12 @@
 	var/pulse_cooldown_time = 3 SECONDS
 	var/pulse_damage = 6
 
-/mob/living/simple_animal/hostile/abnormality/cube/breach_effect(mob/living/carbon/human/user)
+/mob/living/simple_animal/hostile/abnormality/cube/BreachEffect(mob/living/carbon/human/user)
 	..()
 	GiveTarget(user)
 	addtimer(CALLBACK(src, .proc/die), 60 SECONDS)
 
-/mob/living/simple_animal/hostile/abnormality/cube/work_complete(mob/living/carbon/human/user, work_type, pe)
-	..()
+/mob/living/simple_animal/hostile/abnormality/cube/PostWorkEffect(mob/living/carbon/human/user, work_type, pe)
 	if(work_type == ABNORMALITY_WORK_REPRESSION)
 		datum_reference.qliphoth_change(-1)
 	return

--- a/code/modules/mob/living/simple_animal/abnormality/!tutorial/fairies.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/!tutorial/fairies.dm
@@ -27,12 +27,12 @@
 	start_qliphoth = 1
 	can_spawn = FALSE // Normally doesn't appear
 
-/mob/living/simple_animal/hostile/abnormality/fairy_swarm/breach_effect(mob/living/carbon/human/user)
+/mob/living/simple_animal/hostile/abnormality/fairy_swarm/BreachEffect(mob/living/carbon/human/user)
 	..()
 	GiveTarget(user)
 	addtimer(CALLBACK(src, .proc/die), 60 SECONDS)
 
-/mob/living/simple_animal/hostile/abnormality/fairy_swarm/failure_effect(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/fairy_swarm/FailureEffect(mob/living/carbon/human/user, work_type, pe)
 	datum_reference.qliphoth_change(-1)
 	return
 

--- a/code/modules/mob/living/simple_animal/abnormality/!tutorial/shadow.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/!tutorial/shadow.dm
@@ -26,12 +26,12 @@
 	start_qliphoth = 1
 	can_spawn = FALSE // Normally doesn't appear
 
-/mob/living/simple_animal/hostile/abnormality/shadow/breach_effect(mob/living/carbon/human/user)
+/mob/living/simple_animal/hostile/abnormality/shadow/BreachEffect(mob/living/carbon/human/user)
 	..()
 	GiveTarget(user)
 	addtimer(CALLBACK(src, .proc/die), 60 SECONDS)
 
-/mob/living/simple_animal/hostile/abnormality/shadow/failure_effect(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/shadow/FailureEffect(mob/living/carbon/human/user, work_type, pe)
 	datum_reference.qliphoth_change(-1)
 	return
 

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/blue_star.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/blue_star.dm
@@ -93,7 +93,7 @@
 	SLEEP_CHECK_DEATH(3)
 	animate(src, transform = init_transform, time = 5)
 
-/mob/living/simple_animal/hostile/abnormality/bluestar/attempt_work(mob/living/carbon/human/user, work_type)
+/mob/living/simple_animal/hostile/abnormality/bluestar/AttemptWork(mob/living/carbon/human/user, work_type)
 	if(get_attribute_level(user, TEMPERANCE_ATTRIBUTE) < 80)
 		datum_reference.qliphoth_change(-1)
 		playsound(src, 'sound/abnormalities/bluestar/pulse.ogg', 25, FALSE, 28)
@@ -103,8 +103,7 @@
 		return FALSE
 	return TRUE
 
-/mob/living/simple_animal/hostile/abnormality/bluestar/work_complete(mob/living/carbon/human/user, work_type, pe, work_time)
-	..()
+/mob/living/simple_animal/hostile/abnormality/bluestar/PostWorkEffect(mob/living/carbon/human/user, work_type, pe, work_time)
 	if(get_attribute_level(user, PRUDENCE_ATTRIBUTE) < 100)
 		datum_reference.qliphoth_change(-1)
 	if(user.sanity_lost)
@@ -117,7 +116,7 @@
 		QDEL_IN(user, 5)
 	return
 
-/mob/living/simple_animal/hostile/abnormality/bluestar/breach_effect(mob/living/carbon/human/user)
+/mob/living/simple_animal/hostile/abnormality/bluestar/BreachEffect(mob/living/carbon/human/user)
 	..()
 	var/turf/T = pick(GLOB.department_centers)
 	soundloop.start()

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/censored.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/censored.dm
@@ -110,7 +110,7 @@
 	can_act = TRUE
 
 /* Work */
-/mob/living/simple_animal/hostile/abnormality/censored/attempt_work(mob/living/carbon/human/user, work_type)
+/mob/living/simple_animal/hostile/abnormality/censored/AttemptWork(mob/living/carbon/human/user, work_type)
 	if(work_type == "Sacrifice")
 		to_chat(user, "<span class='warning'>You hesitate for a moment...</span>")
 		datum_reference.working = TRUE
@@ -138,17 +138,16 @@
 		return null
 	return TRUE
 
-/mob/living/simple_animal/hostile/abnormality/censored/work_complete(mob/living/carbon/human/user, work_type, pe, work_time)
-	..()
+/mob/living/simple_animal/hostile/abnormality/censored/PostWorkEffect(mob/living/carbon/human/user, work_type, pe, work_time)
 	if(user.sanity_lost)
 		datum_reference.qliphoth_change(-1)
 	return
 
-/mob/living/simple_animal/hostile/abnormality/censored/failure_effect(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/censored/FailureEffect(mob/living/carbon/human/user, work_type, pe)
 	datum_reference.qliphoth_change(-1)
 	return
 
-/mob/living/simple_animal/hostile/abnormality/censored/breach_effect(mob/living/carbon/human/user)
+/mob/living/simple_animal/hostile/abnormality/censored/BreachEffect(mob/living/carbon/human/user)
 	..()
 	icon_living = "censored_breach"
 	icon_state = icon_living

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/melting_love.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/melting_love.dm
@@ -54,7 +54,7 @@
 	if(gifted_human)
 		sanityheal()
 
-/mob/living/simple_animal/hostile/abnormality/melting_love/breach_effect(mob/living/carbon/human/user)
+/mob/living/simple_animal/hostile/abnormality/melting_love/BreachEffect(mob/living/carbon/human/user)
 	..()
 	icon = 'ModularTegustation/Teguicons/96x96.dmi'
 	icon_living = "melting_breach"
@@ -107,23 +107,23 @@
 	return TRUE
 
 /* Qliphoth things */
-/mob/living/simple_animal/hostile/abnormality/melting_love/neutral_effect(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/melting_love/NeutralEffect(mob/living/carbon/human/user, work_type, pe)
 	if(prob(50))
 		datum_reference.qliphoth_change(-1)
 	return
 
-/mob/living/simple_animal/hostile/abnormality/melting_love/failure_effect(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/melting_love/FailureEffect(mob/living/carbon/human/user, work_type, pe)
 	datum_reference.qliphoth_change(-1)
 	return
 
-/mob/living/simple_animal/hostile/abnormality/melting_love/zero_qliphoth(mob/living/carbon/human/user)
+/mob/living/simple_animal/hostile/abnormality/melting_love/ZeroQliphoth(mob/living/carbon/human/user)
 	if(gifted_human)
 		to_chat(gifted_human, "<span class='userdanger'>You feel like you are about to burst !</span>")
 		gifted_human.emote("scream")
 		gifted_human.gib()
 	UnregisterSignal(gifted_human, COMSIG_LIVING_DEATH)
 	UnregisterSignal(gifted_human, COMSIG_WORK_COMPLETED)
-	breach_effect()
+	BreachEffect()
 	return
 
 /* Gift */
@@ -133,8 +133,7 @@
 	datum_reference.qliphoth_change(-9)
 	return TRUE
 
-/mob/living/simple_animal/hostile/abnormality/melting_love/work_complete(mob/living/carbon/human/user, work_type, pe)
-	..()
+/mob/living/simple_animal/hostile/abnormality/melting_love/PostWorkEffect(mob/living/carbon/human/user, work_type, pe)
 	if (GODMODE in user.status_flags)
 		return
 	if(!gifted_human && istype(user) && work_type != ABNORMALITY_WORK_REPRESSION && user.stat != DEAD)
@@ -162,7 +161,7 @@
 		gifted_human.adjustSanityLoss(30)
 		sanityheal_cooldown = (world.time + sanityheal_cooldown_base)
 
-/mob/living/simple_animal/hostile/abnormality/melting_love/work_chance(mob/living/carbon/human/user, chance)
+/mob/living/simple_animal/hostile/abnormality/melting_love/WorkChance(mob/living/carbon/human/user, chance)
 	if(user == gifted_human)
 		return chance + 10
 	return chance

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/mountain.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/mountain.dm
@@ -357,26 +357,26 @@
 
 /* Abnormality work */
 
-/mob/living/simple_animal/hostile/abnormality/mountain/failure_effect(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/mountain/FailureEffect(mob/living/carbon/human/user, work_type, pe)
 	datum_reference.qliphoth_change(-1)
 	return
 
-/mob/living/simple_animal/hostile/abnormality/mountain/work_complete(mob/living/carbon/human/user, work_type, pe, work_time)
+/mob/living/simple_animal/hostile/abnormality/mountain/PostWorkEffect(mob/living/carbon/human/user, work_type, pe, work_time)
 	if(user.health < 0)
 		datum_reference.qliphoth_change(-1)
 	if(agent_hurt)
 		datum_reference.qliphoth_change(-1)
 		agent_hurt = FALSE
-	return ..()
+	return
 
-/mob/living/simple_animal/hostile/abnormality/mountain/attempt_work(mob/living/carbon/human/user, work_type)
+/mob/living/simple_animal/hostile/abnormality/mountain/AttemptWork(mob/living/carbon/human/user, work_type)
 	if(user.health != user.maxHealth)
 		agent_hurt = TRUE
 	return TRUE
 
 /* Abnormality breach */
 
-/mob/living/simple_animal/hostile/abnormality/mountain/breach_effect(mob/living/carbon/human/user)
+/mob/living/simple_animal/hostile/abnormality/mountain/BreachEffect(mob/living/carbon/human/user)
 	..()
 	GiveTarget(user)
 	icon_living = "mosb_breach"

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/nothing_there.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/nothing_there.dm
@@ -197,7 +197,7 @@
 	appearance = M.appearance
 	M.death()
 	M.forceMove(src) // Hide them for examine message to work
-	addtimer(CALLBACK(src, .proc/zero_qliphoth), rand(20 SECONDS, 50 SECONDS))
+	addtimer(CALLBACK(src, .proc/ZeroQliphoth), rand(20 SECONDS, 50 SECONDS))
 
 /mob/living/simple_animal/hostile/abnormality/nothing_there/proc/drop_disguise()
 	if(!istype(disguise))
@@ -295,7 +295,7 @@
 	icon_state = icon_living
 	can_act = TRUE
 
-/mob/living/simple_animal/hostile/abnormality/nothing_there/attempt_work(mob/living/carbon/human/user, work_type)
+/mob/living/simple_animal/hostile/abnormality/nothing_there/AttemptWork(mob/living/carbon/human/user, work_type)
 	if(istype(disguise))
 		return FALSE
 	worker = user
@@ -304,28 +304,27 @@
 		playsound(get_turf(src), 'sound/abnormalities/nothingthere/growl.ogg', 25, 0)
 	return TRUE
 
-/mob/living/simple_animal/hostile/abnormality/nothing_there/work_chance(mob/living/carbon/human/user, chance)
+/mob/living/simple_animal/hostile/abnormality/nothing_there/WorkChance(mob/living/carbon/human/user, chance)
 	var/adjusted_chance = chance
 	var/fort = get_attribute_level(user, FORTITUDE_ATTRIBUTE)
 	if(fort < 100)
 		adjusted_chance -= (100 - fort) * 0.5
 	return adjusted_chance
 
-/mob/living/simple_animal/hostile/abnormality/nothing_there/work_complete(mob/living/carbon/human/user, work_type, pe, work_time)
-	. = ..()
+/mob/living/simple_animal/hostile/abnormality/nothing_there/PostWorkEffect(mob/living/carbon/human/user, work_type, pe, work_time)
 	worker = null
 	if(get_attribute_level(user, JUSTICE_ATTRIBUTE) < 80)
 		if(!istype(disguise)) // Not work failure
 			datum_reference.qliphoth_change(-1)
 	return
 
-/mob/living/simple_animal/hostile/abnormality/nothing_there/failure_effect(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/nothing_there/FailureEffect(mob/living/carbon/human/user, work_type, pe)
 	if(GODMODE in user.status_flags)
 		return
 	disguise_as(user)
 	return
 
-/mob/living/simple_animal/hostile/abnormality/nothing_there/breach_effect(mob/living/carbon/human/user)
+/mob/living/simple_animal/hostile/abnormality/nothing_there/BreachEffect(mob/living/carbon/human/user)
 	if(!(status_flags & GODMODE)) // Already breaching
 		return
 	..()

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/silent_orchestra.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/silent_orchestra.dm
@@ -127,15 +127,15 @@
 	performers += O
 	return
 
-/mob/living/simple_animal/hostile/abnormality/silentorchestra/success_effect(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/silentorchestra/SuccessEffect(mob/living/carbon/human/user, work_type, pe)
 	datum_reference.qliphoth_change(-1)
 	return
 
-/mob/living/simple_animal/hostile/abnormality/silentorchestra/failure_effect(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/silentorchestra/FailureEffect(mob/living/carbon/human/user, work_type, pe)
 	datum_reference.qliphoth_change(-1)
 	return
 
-/mob/living/simple_animal/hostile/abnormality/silentorchestra/breach_effect(mob/living/carbon/human/user)
+/mob/living/simple_animal/hostile/abnormality/silentorchestra/BreachEffect(mob/living/carbon/human/user)
 	..()
 	var/turf/T = pick(GLOB.department_centers)
 	forceMove(T)

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/staining_rose.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/staining_rose.dm
@@ -44,8 +44,7 @@
 	..()
 	meltdown_cooldown = world.time + meltdown_cooldown_time
 
-/mob/living/simple_animal/hostile/abnormality/staining_rose/work_complete(mob/living/carbon/human/user, work_type, pe)
-	..()
+/mob/living/simple_animal/hostile/abnormality/staining_rose/PostWorkEffect(mob/living/carbon/human/user, work_type, pe)
 	safe = TRUE
 	if (chosen == null)
 		chosen = user
@@ -91,7 +90,7 @@
 	icon_state = "rose_activated"
 
 //Death and Meltdown
-/mob/living/simple_animal/hostile/abnormality/staining_rose/zero_qliphoth(mob/living/carbon/human/user)
+/mob/living/simple_animal/hostile/abnormality/staining_rose/ZeroQliphoth(mob/living/carbon/human/user)
 	SSweather.run_weather(/datum/weather/petals)
 	chosen = null 	//You breached, now pick a new person to work on you
 	icon_state = "rose"

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/white_night.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/white_night.dm
@@ -182,18 +182,18 @@ GLOBAL_LIST_EMPTY(apostles)
 	sound_to_playing_players('sound/abnormalities/whitenight/apostle_bell.ogg', (25 * (3 - datum_reference.qliphoth_meter)))
 	return
 
-/mob/living/simple_animal/hostile/abnormality/white_night/success_effect(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/white_night/SuccessEffect(mob/living/carbon/human/user, work_type, pe)
 	if(prob(66))
 		datum_reference.qliphoth_change(1)
 		if(prob(66)) // Rare effect, mmmm
 			revive_humans(48, "neutral") // Big heal
 	return
 
-/mob/living/simple_animal/hostile/abnormality/white_night/failure_effect(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/white_night/FailureEffect(mob/living/carbon/human/user, work_type, pe)
 	datum_reference.qliphoth_change(-1)
 	return
 
-/mob/living/simple_animal/hostile/abnormality/white_night/breach_effect(mob/living/carbon/human/user)
+/mob/living/simple_animal/hostile/abnormality/white_night/BreachEffect(mob/living/carbon/human/user)
 	holy_revival_cooldown = world.time + holy_revival_cooldown_base
 	..()
 	for(var/mob/M in GLOB.player_list)

--- a/code/modules/mob/living/simple_animal/abnormality/he/blue_shepherd.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/blue_shepherd.dm
@@ -130,17 +130,17 @@
 	LAZYCLEARLIST(people_list)
 	return ..()
 
-/mob/living/simple_animal/hostile/abnormality/blue_shepherd/work_chance(mob/living/carbon/human/user, chance)
+/mob/living/simple_animal/hostile/abnormality/blue_shepherd/WorkChance(mob/living/carbon/human/user, chance)
 	var/mob/living/simple_animal/hostile/abnormality/red_buddy/buddy_abno = buddy?.current
 	if(buddy_abno)
 		chance += (buddy_abno.suffering * 0.5) //the more red buddy suffers, the higher your work chance on shepherd is
 	return chance
 
-/mob/living/simple_animal/hostile/abnormality/blue_shepherd/failure_effect(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/blue_shepherd/FailureEffect(mob/living/carbon/human/user, work_type, pe)
 	datum_reference.qliphoth_change(-1)
 	return
 
-/mob/living/simple_animal/hostile/abnormality/blue_shepherd/work_complete(mob/living/carbon/human/user, work_type, pe, work_time)
+/mob/living/simple_animal/hostile/abnormality/blue_shepherd/PostWorkEffect(mob/living/carbon/human/user, work_type, pe, work_time)
 	var/mob/living/simple_animal/hostile/abnormality/red_buddy/buddy_abno = buddy?.current
 	if(buddy_abno?.suffering >= 40)
 		user.Apply_Gift(new gift_type) //you get a free gift if you somehow made the dog suffer that much
@@ -156,9 +156,9 @@
 		SLEEP_CHECK_DEATH(10)
 	if(status_flags & GODMODE)
 		Lying(buddy_abno, user)
-	return ..()
+	return
 
-/mob/living/simple_animal/hostile/abnormality/blue_shepherd/breach_effect(mob/living/carbon/human/user)
+/mob/living/simple_animal/hostile/abnormality/blue_shepherd/BreachEffect(mob/living/carbon/human/user)
 	var/sighted = FALSE
 	for(var/mob/living/carbon/human/L in view(4, src))
 		sighted = TRUE

--- a/code/modules/mob/living/simple_animal/abnormality/he/der_freischutz.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/der_freischutz.dm
@@ -21,20 +21,20 @@
 		)
 	gift_type =  /datum/ego_gifts/magicbullet
 
-/mob/living/simple_animal/hostile/abnormality/der_freischutz/work_complete(mob/living/carbon/human/user, work_type, pe, work_time)
+/mob/living/simple_animal/hostile/abnormality/der_freischutz/PostWorkEffect(mob/living/carbon/human/user, work_type, pe, work_time)
 	if(get_attribute_level(user, JUSTICE_ATTRIBUTE) < 60)
 		datum_reference.qliphoth_change(-1)
-	return ..()
+	return
 
-/mob/living/simple_animal/hostile/abnormality/der_freischutz/failure_effect(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/der_freischutz/FailureEffect(mob/living/carbon/human/user, work_type, pe)
 	datum_reference.qliphoth_change(-(prob(75)))
 	return ..()
 
-/mob/living/simple_animal/hostile/abnormality/der_freischutz/neutral_effect(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/der_freischutz/NeutralEffect(mob/living/carbon/human/user, work_type, pe)
 	datum_reference.qliphoth_change(-(prob(50)))
 	return ..()
 
-/mob/living/simple_animal/hostile/abnormality/der_freischutz/zero_qliphoth(mob/living/carbon/human/user)
+/mob/living/simple_animal/hostile/abnormality/der_freischutz/ZeroQliphoth(mob/living/carbon/human/user)
 	var/list/targets = list()
 	var/turf/targetturf
 	var/targetx

--- a/code/modules/mob/living/simple_animal/abnormality/he/funeral.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/funeral.dm
@@ -228,22 +228,20 @@
 	..()
 
 //he die
-/mob/living/simple_animal/hostile/abnormality/funeral/failure_effect(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/funeral/FailureEffect(mob/living/carbon/human/user, work_type, pe)
 	if(prob(70))
 		datum_reference.qliphoth_change(-1)
 	return
 
-/mob/living/simple_animal/hostile/abnormality/funeral/work_complete(mob/living/carbon/human/user, work_type, pe, work_time)
+/mob/living/simple_animal/hostile/abnormality/funeral/PostWorkEffect(mob/living/carbon/human/user, work_type, pe, work_time)
 	if(get_attribute_level(user, FORTITUDE_ATTRIBUTE) >= 80)
 		datum_reference.qliphoth_change(-1)
-	return ..()
-
-/mob/living/simple_animal/hostile/abnormality/funeral/work_complete(mob/living/carbon/human/user, work_type, pe, work_time)
 	if(get_attribute_level(user, JUSTICE_ATTRIBUTE) < 60)
 		datum_reference.qliphoth_change(-1)
-	return ..()
+	return
+
 //But most importantly
-/mob/living/simple_animal/hostile/abnormality/funeral/breach_effect(mob/living/carbon/human/user)
+/mob/living/simple_animal/hostile/abnormality/funeral/BreachEffect(mob/living/carbon/human/user)
 	..()
 	GiveTarget(user)
 //He breach

--- a/code/modules/mob/living/simple_animal/abnormality/he/galaxy_child.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/galaxy_child.dm
@@ -38,9 +38,8 @@
 		heal_cooldown = world.time + heal_cooldown_time
 		heal()
 
-/mob/living/simple_animal/hostile/abnormality/galaxy_child/work_complete(mob/living/carbon/human/user, work_type, pe)
-	..()
-	icon_state = "galaxy"	//I'd run an if statement but It's actually more optimal processor wise to not.
+/mob/living/simple_animal/hostile/abnormality/galaxy_child/PostWorkEffect(mob/living/carbon/human/user, work_type, pe)
+	icon_state = "galaxy" //I'd run an if statement but It's actually more optimal processor wise to not.
 
 	if(user in galaxy_friend)
 		datum_reference.qliphoth_change(1)
@@ -54,7 +53,7 @@
 		RegisterSignal(user, COMSIG_LIVING_DEATH, .proc/FriendDeath)
 		user.add_overlay(mutable_appearance('ModularTegustation/Teguicons/tegu_effects32x48.dmi', "galaxy", -MUTATIONS_LAYER))
 
-/mob/living/simple_animal/hostile/abnormality/galaxy_child/zero_qliphoth(mob/living/carbon/human/user)
+/mob/living/simple_animal/hostile/abnormality/galaxy_child/ZeroQliphoth(mob/living/carbon/human/user)
 	if(LAZYLEN(galaxy_friend))
 		for (var/mob/living/carbon/human/L in galaxy_friend)
 			L.apply_damage(damage_amount, BLACK_DAMAGE, null, L.run_armor_check(null, BLACK_DAMAGE), spread_damage = TRUE)

--- a/code/modules/mob/living/simple_animal/abnormality/he/happy_teddy_bear.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/happy_teddy_bear.dm
@@ -69,7 +69,7 @@
 	if(buckled_mob.stat == DEAD)
 		. = ..()
 
-/mob/living/simple_animal/hostile/abnormality/happyteddybear/attempt_work(mob/living/carbon/human/user, work_type)
+/mob/living/simple_animal/hostile/abnormality/happyteddybear/AttemptWork(mob/living/carbon/human/user, work_type)
 	if(user == src.last_worker)
 		Strangle(user)
 		return FALSE

--- a/code/modules/mob/living/simple_animal/abnormality/he/helper.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/helper.dm
@@ -163,17 +163,17 @@
 	addtimer(CALLBACK(src, .proc/do_dash, move_dir, (times_ran + 1)), 1)
 
 /* Work effects */
-/mob/living/simple_animal/hostile/abnormality/helper/neutral_effect(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/helper/NeutralEffect(mob/living/carbon/human/user, work_type, pe)
 	if(prob(40))
 		datum_reference.qliphoth_change(-1)
 	return
 
-/mob/living/simple_animal/hostile/abnormality/helper/failure_effect(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/helper/FailureEffect(mob/living/carbon/human/user, work_type, pe)
 	if(prob(80))
 		datum_reference.qliphoth_change(-1)
 	return
 
-/mob/living/simple_animal/hostile/abnormality/helper/breach_effect(mob/living/carbon/human/user)
+/mob/living/simple_animal/hostile/abnormality/helper/BreachEffect(mob/living/carbon/human/user)
 	..()
 	update_icon()
 	GiveTarget(user)

--- a/code/modules/mob/living/simple_animal/abnormality/he/laetitia.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/laetitia.dm
@@ -24,7 +24,7 @@
 	gift_type = /datum/ego_gifts/prank
 	gift_message = "I hope you're pleased with this!"
 
-/mob/living/simple_animal/hostile/abnormality/laetitia/neutral_effect(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/laetitia/NeutralEffect(mob/living/carbon/human/user, work_type, pe)
 	var/datum/status_effect/pranked/P = user.has_status_effect(STATUS_EFFECT_PRANKED)
 	if(P)
 		if(prob(15)) //15% chance to remove prank
@@ -37,13 +37,13 @@
 			SE.laetitia_datum_reference = datum_reference
 	return
 
-/mob/living/simple_animal/hostile/abnormality/laetitia/success_effect(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/laetitia/SuccessEffect(mob/living/carbon/human/user, work_type, pe)
 	var/datum/status_effect/pranked/P = user.has_status_effect(STATUS_EFFECT_PRANKED)
 	if(P && prob(30)) //30% to remove prank
 		user.remove_status_effect(STATUS_EFFECT_PRANKED)
 	return
 
-/mob/living/simple_animal/hostile/abnormality/laetitia/failure_effect(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/laetitia/FailureEffect(mob/living/carbon/human/user, work_type, pe)
 	var/datum/status_effect/pranked/P = user.has_status_effect(STATUS_EFFECT_PRANKED)
 	if(P && prob(70)) //70% to trigger explosion
 		P.triggerprank()

--- a/code/modules/mob/living/simple_animal/abnormality/he/pisc_mermaid.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/pisc_mermaid.dm
@@ -53,14 +53,14 @@
 	var/obj/item/clothing/head/unrequited_crown/crown
 	var/mob/living/carbon/human/love_target
 
-/mob/living/simple_animal/hostile/abnormality/pisc_mermaid/failure_effect(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/pisc_mermaid/FailureEffect(mob/living/carbon/human/user, work_type, pe)
 	datum_reference.qliphoth_change(-1)
 
-/mob/living/simple_animal/hostile/abnormality/pisc_mermaid/neutral_effect(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/pisc_mermaid/NeutralEffect(mob/living/carbon/human/user, work_type, pe)
 	datum_reference.qliphoth_change(-1)
 	return
 
-/mob/living/simple_animal/hostile/abnormality/pisc_mermaid/success_effect(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/pisc_mermaid/SuccessEffect(mob/living/carbon/human/user, work_type, pe)
 	if(!crown)
 		GiveGift(user)
 		return
@@ -69,21 +69,21 @@
 			datum_reference.qliphoth_change(1)
 		return
 
-/mob/living/simple_animal/hostile/abnormality/pisc_mermaid/attempt_work(mob/living/carbon/human/user, work_type)
+/mob/living/simple_animal/hostile/abnormality/pisc_mermaid/AttemptWork(mob/living/carbon/human/user, work_type)
 	if(status_flags & GODMODE)
 		icon_living = "pmermaid_laying"
 		icon_state = "pmermaid_laying"
 	return TRUE
 
-/mob/living/simple_animal/hostile/abnormality/pisc_mermaid/work_complete(mob/living/carbon/human/user, work_type, pe, work_time)
+/mob/living/simple_animal/hostile/abnormality/pisc_mermaid/PostWorkEffect(mob/living/carbon/human/user, work_type, pe, work_time)
 	if(status_flags & GODMODE)
 		icon_living = "pmermaid_standing"
 		icon_state = "pmermaid_standing"
-	..()
+	return
 
 //mermaid will immensely slow down their lover and slowly kill them by cutting off their oxygen supply
 //dying by oxydeath actually takes a while, but it puts them on a clear timer to actually get shit done instead of just hoping someone else takes care of it.
-/mob/living/simple_animal/hostile/abnormality/pisc_mermaid/breach_effect()
+/mob/living/simple_animal/hostile/abnormality/pisc_mermaid/BreachEffect()
 	..()
 	icon = 'ModularTegustation/Teguicons/64x64.dmi'
 	icon_living = "pmermaid_breach"
@@ -264,7 +264,7 @@
 		if(loved)
 			STOP_PROCESSING(SSobj, src)
 			mermaid.datum_reference.qliphoth_change(-3)
-			mermaid.breach_effect()
+			mermaid.BreachEffect()
 			qdel(src)
 		return
 	if(ishuman(user))

--- a/code/modules/mob/living/simple_animal/abnormality/he/porccubus.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/porccubus.dm
@@ -49,7 +49,7 @@
 	var/damage_taken = FALSE
 
 
-/mob/living/simple_animal/hostile/abnormality/porccubus/success_effect(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/porccubus/SuccessEffect(mob/living/carbon/human/user, work_type, pe)
 	datum_reference.qliphoth_change(1)
 	var/datum/status_effect/porccubus_addiction/PA = user.has_status_effect(STATUS_EFFECT_ADDICTION)
 
@@ -62,8 +62,7 @@
 		user.apply_status_effect(STATUS_EFFECT_ADDICTION) //psst, you want some happiness?
 	..()
 
-/mob/living/simple_animal/hostile/abnormality/porccubus/work_complete(mob/living/carbon/human/user, work_type, pe, work_time)
-	..()
+/mob/living/simple_animal/hostile/abnormality/porccubus/PostWorkEffect(mob/living/carbon/human/user, work_type, pe, work_time)
 	if(user.sanity_lost) //if the person is driven insane mid work
 		DrugOverdose(user, agent_ckey)
 	agent_ckey = null
@@ -91,18 +90,18 @@
 	if(nirvana)
 		PA.sanity_gain = 60 //this basically instantly snaps them out of insanity and they get to play god for like 2 minute
 
-/mob/living/simple_animal/hostile/abnormality/porccubus/failure_effect(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/porccubus/FailureEffect(mob/living/carbon/human/user, work_type, pe)
 	datum_reference.qliphoth_change(-1)
 	return
 
-/mob/living/simple_animal/hostile/abnormality/porccubus/attempt_work(mob/living/carbon/human/user, work_type)
+/mob/living/simple_animal/hostile/abnormality/porccubus/AttemptWork(mob/living/carbon/human/user, work_type)
 	. = ..()
 	if(.)
 		agent_ckey = user //just in case the agent goes insane midwork
 
 //Porccubus can't actually move so it's more of a "bring your friend to beat it to death it isn't going anywhere" type of thing.
 //it does have a dash that makes it able to jump around, but it can't properly "roam" per say.
-/mob/living/simple_animal/hostile/abnormality/porccubus/breach_effect(mob/living/carbon/human/user)
+/mob/living/simple_animal/hostile/abnormality/porccubus/BreachEffect(mob/living/carbon/human/user)
 	..()
 	playsound(src, 'sound/abnormalities/porccubus/head_explode_laugh.ogg', 50, FALSE, 4)
 	icon_living = "porrcubus"

--- a/code/modules/mob/living/simple_animal/abnormality/he/red_buddy.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/red_buddy.dm
@@ -82,26 +82,26 @@
 		master = abno
 		UnregisterSignal(SSdcs, COMSIG_GLOB_ABNORMALITY_SPAWN)
 
-/mob/living/simple_animal/hostile/abnormality/red_buddy/neutral_effect(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/red_buddy/NeutralEffect(mob/living/carbon/human/user, work_type, pe)
 	if(work_type == ABNORMALITY_WORK_INSTINCT)
 		return
 	AdjustSuffering(3)
 	return
 
-/mob/living/simple_animal/hostile/abnormality/red_buddy/failure_effect(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/red_buddy/FailureEffect(mob/living/carbon/human/user, work_type, pe)
 	if(work_type == ABNORMALITY_WORK_INSTINCT)
 		return
 	datum_reference.qliphoth_change(-1)
 	AdjustSuffering(10)
 	return
 
-/mob/living/simple_animal/hostile/abnormality/red_buddy/worktick_failure(mob/living/carbon/human/user)
+/mob/living/simple_animal/hostile/abnormality/red_buddy/WorktickFailure(mob/living/carbon/human/user)
 	AdjustSuffering(1)
 	work_damage_amount = suffering
 	UpdateScars()
 	return ..()
 
-/mob/living/simple_animal/hostile/abnormality/red_buddy/work_complete(mob/living/carbon/human/user, work_type, pe, work_time)
+/mob/living/simple_animal/hostile/abnormality/red_buddy/PostWorkEffect(mob/living/carbon/human/user, work_type, pe, work_time)
 	switch(work_type)
 		if(ABNORMALITY_WORK_INSTINCT)
 			suffering = 0
@@ -114,14 +114,14 @@
 	if(lying)
 		user.Apply_Gift(new gift_type)
 		lying = FALSE
-	return ..()
+	return
 
-/mob/living/simple_animal/hostile/abnormality/red_buddy/work_chance(mob/living/carbon/human/user, chance)
+/mob/living/simple_animal/hostile/abnormality/red_buddy/WorkChance(mob/living/carbon/human/user, chance)
 	if(lying)
 		chance += 15 //you get extra success chance for calling out a shepherd lie
 	return chance
 
-/mob/living/simple_animal/hostile/abnormality/red_buddy/attempt_work(mob/living/carbon/human/user, work_type)
+/mob/living/simple_animal/hostile/abnormality/red_buddy/AttemptWork(mob/living/carbon/human/user, work_type)
 	if(lying_timer)
 		datum_reference.qliphoth_change(1)
 		deltimer(lying_timer)
@@ -180,7 +180,7 @@
 		return FALSE
 	. = ..()
 
-/mob/living/simple_animal/hostile/abnormality/red_buddy/breach_effect()
+/mob/living/simple_animal/hostile/abnormality/red_buddy/BreachEffect()
 	..()
 	deltimer(lying_timer)
 	icon_state = "redbuddy_active"

--- a/code/modules/mob/living/simple_animal/abnormality/he/red_queen.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/red_queen.dm
@@ -31,8 +31,7 @@
 	//Pick it once so people can find out
 	liked = pick(ABNORMALITY_WORK_INSTINCT, ABNORMALITY_WORK_INSIGHT, ABNORMALITY_WORK_ATTACHMENT, ABNORMALITY_WORK_REPRESSION)
 
-/mob/living/simple_animal/hostile/abnormality/red_queen/work_complete(mob/living/carbon/human/user, work_type, pe)
-	..()
+/mob/living/simple_animal/hostile/abnormality/red_queen/PostWorkEffect(mob/living/carbon/human/user, work_type, pe)
 	if(work_type != liked)
 		if(prob(20))
 			//The Red Queen is fickle, if you're unlucky, fuck you.

--- a/code/modules/mob/living/simple_animal/abnormality/he/rudolta.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/rudolta.dm
@@ -37,12 +37,12 @@
 	var/pulse_cooldown_time = 1.8 SECONDS
 	var/pulse_damage = 20
 
-/mob/living/simple_animal/hostile/abnormality/rudolta/neutral_effect(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/rudolta/NeutralEffect(mob/living/carbon/human/user, work_type, pe)
 	if(prob(40))
 		datum_reference.qliphoth_change(-1)
 	return
 
-/mob/living/simple_animal/hostile/abnormality/rudolta/failure_effect(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/rudolta/FailureEffect(mob/living/carbon/human/user, work_type, pe)
 	if(prob(80))
 		datum_reference.qliphoth_change(-1)
 	return

--- a/code/modules/mob/living/simple_animal/abnormality/he/scarecrow.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/scarecrow.dm
@@ -84,16 +84,16 @@
 				QDEL_NULL(O)
 			finishing = FALSE
 
-/mob/living/simple_animal/hostile/abnormality/scarecrow/failure_effect(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/scarecrow/FailureEffect(mob/living/carbon/human/user, work_type, pe)
 	datum_reference.qliphoth_change(-1)
 	return
 
-/mob/living/simple_animal/hostile/abnormality/scarecrow/work_complete(mob/living/carbon/human/user, work_type, pe, work_time)
+/mob/living/simple_animal/hostile/abnormality/scarecrow/PostWorkEffect(mob/living/carbon/human/user, work_type, pe, work_time)
 	if(get_attribute_level(user, PRUDENCE_ATTRIBUTE) >= 60)
 		datum_reference.qliphoth_change(-1)
-	return ..()
+	return
 
-/mob/living/simple_animal/hostile/abnormality/scarecrow/breach_effect(mob/living/carbon/human/user)
+/mob/living/simple_animal/hostile/abnormality/scarecrow/BreachEffect(mob/living/carbon/human/user)
 	..()
 	icon_living = "scarecrow_breach"
 	icon_state = icon_living

--- a/code/modules/mob/living/simple_animal/abnormality/he/scaredy_cat.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/scaredy_cat.dm
@@ -65,12 +65,12 @@
 	RegisterSignal(SSdcs, COMSIG_GLOB_MOB_DEATH, .proc/OnMobDeath)
 	RegisterSignal(SSdcs, COMSIG_GLOB_ABNORMALITY_BREACH, .proc/OnAbnoBreach)
 
-/mob/living/simple_animal/hostile/abnormality/scaredy_cat/work_complete(mob/living/carbon/human/user, work_type, pe, work_time)
+/mob/living/simple_animal/hostile/abnormality/scaredy_cat/PostWorkEffect(mob/living/carbon/human/user, work_type, pe, work_time)
 	if(get_attribute_level(user, FORTITUDE_ATTRIBUTE) >= 60)
 		datum_reference.qliphoth_change(-1)
-	return ..()
+	return
 
-/mob/living/simple_animal/hostile/abnormality/scaredy_cat/breach_effect(mob/living/carbon/human/user)
+/mob/living/simple_animal/hostile/abnormality/scaredy_cat/BreachEffect(mob/living/carbon/human/user)
 	protect_cooldown = world.time + protect_cooldown_time //to avoid him teleporting twice for no reason on breach
 	if(priority_friend) //if an oz abno escape they take absolute priority
 		ProtectFriend(priority_friend)

--- a/code/modules/mob/living/simple_animal/abnormality/he/silent_girl.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/silent_girl.dm
@@ -53,22 +53,22 @@
 	user.apply_status_effect(STATUS_EFFECT_SG_GUILTY, datum_reference)
 	return
 
-/mob/living/simple_animal/hostile/abnormality/silent_girl/work_complete(mob/living/carbon/human/user, work_type, pe, work_time)
+/mob/living/simple_animal/hostile/abnormality/silent_girl/PostWorkEffect(mob/living/carbon/human/user, work_type, pe, work_time)
 	if(get_attribute_level(user, PRUDENCE_ATTRIBUTE) < 60 && !user.has_status_effect(STATUS_EFFECT_SG_GUILTY))
 		Guilt_Effect(user)
-	return ..()
+	return
 
-/mob/living/simple_animal/hostile/abnormality/silent_girl/attempt_work(mob/living/carbon/human/user, work_type)
+/mob/living/simple_animal/hostile/abnormality/silent_girl/AttemptWork(mob/living/carbon/human/user, work_type)
 	if (user.has_status_effect(STATUS_EFFECT_SG_GUILTY) || user.has_status_effect(STATUS_EFFECT_SG_ATTONEMENT))
 		user.apply_status_effect(STATUS_EFFECT_SG_ATTONEMENT, datum_reference) //If a guilty person works on her, they panic.
 		return FALSE
 	return ..()
 
-/mob/living/simple_animal/hostile/abnormality/silent_girl/failure_effect(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/silent_girl/FailureEffect(mob/living/carbon/human/user, work_type, pe)
 	Guilt_Effect(user)
 	return
 
-/mob/living/simple_animal/hostile/abnormality/silent_girl/zero_qliphoth(mob/living/carbon/human/user)
+/mob/living/simple_animal/hostile/abnormality/silent_girl/ZeroQliphoth(mob/living/carbon/human/user)
 	var/list/guilty_people = list()
 	for(var/mob/living/carbon/human/H in GLOB.player_list)
 		if(H.has_status_effect(STATUS_EFFECT_SG_GUILTY))

--- a/code/modules/mob/living/simple_animal/abnormality/he/singing_machine.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/singing_machine.dm
@@ -57,7 +57,7 @@ Finally, an abnormality that DOESN'T have to do any fancy movement shit. It's a 
 				to_chat(H, "<span class='warning'>That terrible grinding noise...</span>")
 	return ..()
 
-/mob/living/simple_animal/hostile/abnormality/singing_machine/attempt_work(mob/living/carbon/human/user, work_type)
+/mob/living/simple_animal/hostile/abnormality/singing_machine/AttemptWork(mob/living/carbon/human/user, work_type)
 	if(work_type == ABNORMALITY_WORK_INSTINCT)
 		if(datum_reference.qliphoth_meter > 0) // Sets bonus damage on instinct work.
 			bonusRed = grindRed // Should be weaker, for less lethal grinding.
@@ -71,11 +71,11 @@ Finally, an abnormality that DOESN'T have to do any fancy movement shit. It's a 
 		statChecked = 1 // I see you've failed one of the stat checks, but have also chosen not to feed yourself to the machine.
 	return ..()
 
-/mob/living/simple_animal/hostile/abnormality/singing_machine/work_chance(mob/living/carbon/human/user, chance)
+/mob/living/simple_animal/hostile/abnormality/singing_machine/WorkChance(mob/living/carbon/human/user, chance)
 	chance -= statChecked * 15 // Perish.
 	return ..()
 
-/mob/living/simple_animal/hostile/abnormality/singing_machine/worktick(mob/living/carbon/human/user)
+/mob/living/simple_animal/hostile/abnormality/singing_machine/Worktick(mob/living/carbon/human/user)
 	if(bonusRed) // If you have bonus red damage to apply...
 		user.apply_damage(bonusRed, RED_DAMAGE, null, user.run_armor_check(null, RED_DAMAGE), spread_damage = TRUE)
 		if(bonusRed < 6 && playStatus == 0)	// Should only happen when the machine isn't dealing damage.
@@ -87,7 +87,7 @@ Finally, an abnormality that DOESN'T have to do any fancy movement shit. It's a 
 				H.adjustSanityLoss(rand(1,2))
 	return ..()
 
-/mob/living/simple_animal/hostile/abnormality/singing_machine/work_complete(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/singing_machine/PostWorkEffect(mob/living/carbon/human/user, work_type, pe)
 	bonusRed = 0 // Reset bonus red damage and the stat check.
 	statChecked = 0
 	if(user.sanity_lost || user.health < 0) // Did they die? Time to force a bad result.
@@ -98,9 +98,9 @@ Finally, an abnormality that DOESN'T have to do any fancy movement shit. It's a 
 		user.apply_status_effect(STATUS_EFFECT_MUSIC) // Time to addict them.
 		SEND_SOUND(user, 'sound/abnormalities/singingmachine/addiction.ogg')
 		addtimer(CALLBACK(src, .proc/removeAddict, user), 5 MINUTES)
-	return ..()
+	return
 
-/mob/living/simple_animal/hostile/abnormality/singing_machine/success_effect(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/singing_machine/SuccessEffect(mob/living/carbon/human/user, work_type, pe)
 	if(datum_reference.qliphoth_meter == 0) // You did it! You survived a work at 0 qliphoth!
 		manual_emote("rests silent once more...") // The machine is now dormant.
 		playsound(src, 'sound/abnormalities/singingmachine/creak.ogg', 50, 0, 1)
@@ -110,21 +110,21 @@ Finally, an abnormality that DOESN'T have to do any fancy movement shit. It's a 
 		stopPlaying()
 		update_icon()
 
-/mob/living/simple_animal/hostile/abnormality/singing_machine/neutral_effect(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/singing_machine/NeutralEffect(mob/living/carbon/human/user, work_type, pe)
 	if(datum_reference.qliphoth_meter > 0)
 		datum_reference.qliphoth_change(-(prob(40)))// If it's not already mad, it has a chance to get a little more mad.
 	else
 		eatBody(user) // If it is mad, you die.
 	return ..()
 
-/mob/living/simple_animal/hostile/abnormality/singing_machine/failure_effect(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/singing_machine/FailureEffect(mob/living/carbon/human/user, work_type, pe)
 	if(datum_reference.qliphoth_meter > 0)
 		datum_reference.qliphoth_change(-1) // If it's not already completely mad, it gets madder.
 	else
 		eatBody(user) // If it is, you die.
 	return ..()
 
-/mob/living/simple_animal/hostile/abnormality/singing_machine/zero_qliphoth(mob/living/carbon/human/user) // WARNING: Don't call this on its own. Several zero-qliphoth behaviors rely on its qliphoth actually being 0.
+/mob/living/simple_animal/hostile/abnormality/singing_machine/ZeroQliphoth(mob/living/carbon/human/user) // WARNING: Don't call this on its own. Several zero-qliphoth behaviors rely on its qliphoth actually being 0.
 	icon_state = "singingmachine_open_[cleanliness]" // Machine opens and starts making horrible empty grinding noises.
 	icon_living = icon_state
 	update_icon()

--- a/code/modules/mob/living/simple_animal/abnormality/he/white_lake.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/white_lake.dm
@@ -32,24 +32,24 @@
 	gift_chance = 0
 
 
-/mob/living/simple_animal/hostile/abnormality/whitelake/work_chance(mob/living/carbon/human/user, chance)
+/mob/living/simple_animal/hostile/abnormality/whitelake/WorkChance(mob/living/carbon/human/user, chance)
 	if(get_attribute_level(user, FORTITUDE_ATTRIBUTE) >= 60)
 		var/newchance = chance - 20 //You suck, die. I hate you
 		return newchance
 	return chance
 
-/mob/living/simple_animal/hostile/abnormality/whitelake/success_effect(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/whitelake/SuccessEffect(mob/living/carbon/human/user, work_type, pe)
 	if(get_attribute_level(user, FORTITUDE_ATTRIBUTE) < 60)		//Doesn't like these people
 		champion = user
 
-/mob/living/simple_animal/hostile/abnormality/whitelake/failure_effect(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/whitelake/FailureEffect(mob/living/carbon/human/user, work_type, pe)
 	datum_reference.qliphoth_change(-1)
 
 	if(get_attribute_level(user, FORTITUDE_ATTRIBUTE) >= 60)	//Lower it again.
 		datum_reference.qliphoth_change(-1)
 	return
 
-/mob/living/simple_animal/hostile/abnormality/whitelake/zero_qliphoth(mob/living/carbon/human/user)
+/mob/living/simple_animal/hostile/abnormality/whitelake/ZeroQliphoth(mob/living/carbon/human/user)
 	datum_reference.qliphoth_change(3)
 	if(!champion)	//no champion? Fuck you.
 		for(var/mob/living/L in GLOB.player_list)

--- a/code/modules/mob/living/simple_animal/abnormality/he/woodsman.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/woodsman.dm
@@ -235,13 +235,12 @@
 	icon_state = icon_living
 	can_act = TRUE
 
-/mob/living/simple_animal/hostile/abnormality/woodsman/work_complete(mob/living/carbon/human/user, work_type, pe, work_time)
-	. = ..()
+/mob/living/simple_animal/hostile/abnormality/woodsman/PostWorkEffect(mob/living/carbon/human/user, work_type, pe, work_time)
 	if (get_attribute_level(user, TEMPERANCE_ATTRIBUTE) >= 60)
 		datum_reference.qliphoth_change(-1)
 	return
 
-/mob/living/simple_animal/hostile/abnormality/woodsman/failure_effect(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/woodsman/FailureEffect(mob/living/carbon/human/user, work_type, pe)
 	datum_reference.qliphoth_change(-1)
 	return
 
@@ -254,7 +253,7 @@
 		if(2)
 			icon_state = "woodsman"
 
-/mob/living/simple_animal/hostile/abnormality/woodsman/attempt_work(mob/living/carbon/human/user, work_type)
+/mob/living/simple_animal/hostile/abnormality/woodsman/AttemptWork(mob/living/carbon/human/user, work_type)
 	. = ..()
 	if (GODMODE in user.status_flags)
 		return
@@ -283,7 +282,7 @@
 		to_chat(user, "<span class='userdanger'>Stands up!</span>")
 		datum_reference.qliphoth_change(-2)
 
-/mob/living/simple_animal/hostile/abnormality/woodsman/breach_effect(mob/living/carbon/human/user)
+/mob/living/simple_animal/hostile/abnormality/woodsman/BreachEffect(mob/living/carbon/human/user)
 	.=..()
 	layer = LARGE_MOB_LAYER
 	icon_state = icon_living

--- a/code/modules/mob/living/simple_animal/abnormality/teth/beauty_beast.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/beauty_beast.dm
@@ -49,8 +49,7 @@
 	QDEL_IN(src, 10 SECONDS)
 	..()
 
-/mob/living/simple_animal/hostile/abnormality/beauty/work_complete(mob/living/carbon/human/user, work_type, pe)
-	..()
+/mob/living/simple_animal/hostile/abnormality/beauty/PostWorkEffect(mob/living/carbon/human/user, work_type, pe)
 	if(work_type == ABNORMALITY_WORK_REPRESSION)
 		if(!injured)
 			injured = TRUE

--- a/code/modules/mob/living/simple_animal/abnormality/teth/blood_bath.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/blood_bath.dm
@@ -25,7 +25,7 @@
 
 	var/hands = 0
 
-/mob/living/simple_animal/hostile/abnormality/bloodbath/work_complete(mob/living/carbon/human/user, work_type, pe, work_time)
+/mob/living/simple_animal/hostile/abnormality/bloodbath/PostWorkEffect(mob/living/carbon/human/user, work_type, pe, work_time)
 // any work performed with level 1 Fort and Temperance makes you panic and die
 	if(get_attribute_level(user, TEMPERANCE_ATTRIBUTE) < 40 && get_attribute_level(user, FORTITUDE_ATTRIBUTE) < 40 || (hands == 3 && prob(50)))
 		icon = 'ModularTegustation/Teguicons/48x64.dmi'

--- a/code/modules/mob/living/simple_animal/abnormality/teth/cherry_blossoms.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/cherry_blossoms.dm
@@ -29,17 +29,17 @@
 	var/numbermarked = 5
 
 
-/mob/living/simple_animal/hostile/abnormality/cherry_blossoms/work_complete(mob/living/carbon/human/user, work_type, pe, work_time)
+/mob/living/simple_animal/hostile/abnormality/cherry_blossoms/PostWorkEffect(mob/living/carbon/human/user, work_type, pe, work_time)
 	if(user.sanity_lost)
 		datum_reference.qliphoth_change(-1)
-	return ..()
+	return
 
-/mob/living/simple_animal/hostile/abnormality/cherry_blossoms/success_effect(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/cherry_blossoms/SuccessEffect(mob/living/carbon/human/user, work_type, pe)
 	datum_reference.qliphoth_change(-1)
 	if(datum_reference.qliphoth_meter !=3)
 		icon_state = "graveofcherryblossoms_[datum_reference.qliphoth_meter]"
 
-/mob/living/simple_animal/hostile/abnormality/cherry_blossoms/zero_qliphoth(mob/living/carbon/human/user)
+/mob/living/simple_animal/hostile/abnormality/cherry_blossoms/ZeroQliphoth(mob/living/carbon/human/user)
 	mark_for_death()
 	icon_state = "graveofcherryblossoms_0"
 	datum_reference.qliphoth_change(3)

--- a/code/modules/mob/living/simple_animal/abnormality/teth/crumbling_armor.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/crumbling_armor.dm
@@ -48,8 +48,7 @@
 	UnregisterSignal(user, COMSIG_WORK_STARTED)
 	return FALSE
 
-/mob/living/simple_animal/hostile/abnormality/crumbling_armor/work_complete(mob/living/carbon/human/user, work_type, pe)
-	..()
+/mob/living/simple_animal/hostile/abnormality/crumbling_armor/PostWorkEffect(mob/living/carbon/human/user, work_type, pe)
 	if (get_attribute_level(user, FORTITUDE_ATTRIBUTE) < 40)
 		var/obj/item/bodypart/head/head = user.get_bodypart("head")
 		//Thanks Red Queen

--- a/code/modules/mob/living/simple_animal/abnormality/teth/dingle_dangle.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/dingle_dangle.dm
@@ -27,8 +27,7 @@
 	var/dead = FALSE
 
 
-/mob/living/simple_animal/hostile/abnormality/dingledangle/work_complete(mob/living/carbon/human/user, work_type, pe)
-	..()
+/mob/living/simple_animal/hostile/abnormality/dingledangle/PostWorkEffect(mob/living/carbon/human/user, work_type, pe)
 	if(get_attribute_level(user, PRUDENCE_ATTRIBUTE) >= 60)
 		//I mean it does this in wonderlabs
 		user.dust()
@@ -37,7 +36,7 @@
 		var/location = get_turf(user)
 		new /obj/item/clothing/suit/armor/ego_gear/lutemis(location)
 
-/mob/living/simple_animal/hostile/abnormality/dingledangle/failure_effect(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/dingledangle/FailureEffect(mob/living/carbon/human/user, work_type, pe)
 	if(prob(50))
 		//Yeah dust them too. No ego this time tho
 		user.dust()

--- a/code/modules/mob/living/simple_animal/abnormality/teth/forsaken_murderer.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/forsaken_murderer.dm
@@ -52,7 +52,7 @@
 		) //ego_list is the things you can buy with its unique type of PE
 	gift_type =  /datum/ego_gifts/regret //special thing you get from interacting with the abnormality
 
-/mob/living/simple_animal/hostile/abnormality/forsaken_murderer/failure_effect(mob/living/carbon/human/user, work_type, pe) //when work type is bad the qliphoth counter lowers with no chance.
+/mob/living/simple_animal/hostile/abnormality/forsaken_murderer/FailureEffect(mob/living/carbon/human/user, work_type, pe) //when work type is bad the qliphoth counter lowers with no chance.
 	datum_reference.qliphoth_change(-1)
 	return
 
@@ -62,7 +62,7 @@
 	QDEL_IN(src, 10 SECONDS)
 	..()
 
-/mob/living/simple_animal/hostile/abnormality/forsaken_murderer/breach_effect(mob/living/carbon/human/user) //causes breach?
+/mob/living/simple_animal/hostile/abnormality/forsaken_murderer/BreachEffect(mob/living/carbon/human/user) //causes breach?
 	..()
 	update_icon()
 	AddElement(/datum/element/waddling) //This made forsaken murderer waddle. Im supprised it was this easy to do this.

--- a/code/modules/mob/living/simple_animal/abnormality/teth/fragment.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/fragment.dm
@@ -84,22 +84,22 @@
 	can_act = TRUE
 	song_cooldown = world.time + song_cooldown_time
 
-/mob/living/simple_animal/hostile/abnormality/fragment/neutral_effect(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/fragment/NeutralEffect(mob/living/carbon/human/user, work_type, pe)
 	if(prob(40))
 		datum_reference.qliphoth_change(-1)
 	return
 
-/mob/living/simple_animal/hostile/abnormality/fragment/failure_effect(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/fragment/FailureEffect(mob/living/carbon/human/user, work_type, pe)
 	if(prob(80))
 		datum_reference.qliphoth_change(-1)
 	return
 
-/mob/living/simple_animal/hostile/abnormality/fragment/work_complete(mob/living/carbon/human/user, work_type, pe, work_time)
+/mob/living/simple_animal/hostile/abnormality/fragment/PostWorkEffect(mob/living/carbon/human/user, work_type, pe, work_time)
 	if(user.sanity_lost)
 		datum_reference.qliphoth_change(-1)
-	return ..()
+	return
 
-/mob/living/simple_animal/hostile/abnormality/fragment/breach_effect(mob/living/carbon/human/user)
+/mob/living/simple_animal/hostile/abnormality/fragment/BreachEffect(mob/living/carbon/human/user)
 	..()
 	update_icon()
 	GiveTarget(user)

--- a/code/modules/mob/living/simple_animal/abnormality/teth/old_lady.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/old_lady.dm
@@ -38,18 +38,18 @@
 			if(prob(70))
 				new /obj/effect/solitude (T)
 
-/mob/living/simple_animal/hostile/abnormality/old_lady/attempt_work(mob/living/carbon/human/user, work_type)
+/mob/living/simple_animal/hostile/abnormality/old_lady/AttemptWork(mob/living/carbon/human/user, work_type)
 	if(work_type == "Clear Solitude" && datum_reference.qliphoth_meter == 0)
 		return TRUE
 	else if(datum_reference.qliphoth_meter == 0 || work_type == "Clear Solitude")
 		return FALSE
 	return TRUE
 
-/mob/living/simple_animal/hostile/abnormality/old_lady/work_complete(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/old_lady/PostWorkEffect(mob/living/carbon/human/user, work_type, pe)
 	if(work_type == "Clear Solitude")
 		datum_reference.qliphoth_change(4)
 		icon_state = "old_lady"
-	return ..()
+	return
 
 //The Effect
 /obj/effect/solitude

--- a/code/modules/mob/living/simple_animal/abnormality/teth/ppodae.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/ppodae.dm
@@ -163,17 +163,16 @@
 	SLEEP_CHECK_DEATH(0.5 SECONDS)
 	can_act = TRUE
 
-/mob/living/simple_animal/hostile/abnormality/ppodae/work_complete(mob/living/carbon/human/user, work_type, pe)
-	..()
+/mob/living/simple_animal/hostile/abnormality/ppodae/PostWorkEffect(mob/living/carbon/human/user, work_type, pe)
 	if(work_type != ABNORMALITY_WORK_INSTINCT && prob(50))
 		datum_reference.qliphoth_change(-1)
 	return
 
-/mob/living/simple_animal/hostile/abnormality/ppodae/failure_effect(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/ppodae/FailureEffect(mob/living/carbon/human/user, work_type, pe)
 	datum_reference.qliphoth_change(-1)
 	return
 
-/mob/living/simple_animal/hostile/abnormality/ppodae/breach_effect(mob/living/carbon/human/user)
+/mob/living/simple_animal/hostile/abnormality/ppodae/BreachEffect(mob/living/carbon/human/user)
 	..()
 	icon_state = "ppodae_active"
 	GiveTarget(user)

--- a/code/modules/mob/living/simple_animal/abnormality/teth/punishing_bird.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/punishing_bird.dm
@@ -228,7 +228,7 @@
 	..()
 	Retaliate(user)
 
-/mob/living/simple_animal/hostile/abnormality/punishing_bird/breach_effect(mob/living/carbon/human/user)
+/mob/living/simple_animal/hostile/abnormality/punishing_bird/BreachEffect(mob/living/carbon/human/user)
 	..()
 	addtimer(CALLBACK(src, .proc/kill_bird), 180 SECONDS)
 	return
@@ -264,18 +264,17 @@
 	return ..()
 
 /* Work effects */
-/mob/living/simple_animal/hostile/abnormality/punishing_bird/work_complete(mob/living/carbon/human/user, work_type, pe)
-	..()
+/mob/living/simple_animal/hostile/abnormality/punishing_bird/PostWorkEffect(mob/living/carbon/human/user, work_type, pe)
 	if(work_type == ABNORMALITY_WORK_REPRESSION)
 		datum_reference.qliphoth_change(-1)
 	return
 
-/mob/living/simple_animal/hostile/abnormality/punishing_bird/success_effect(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/punishing_bird/SuccessEffect(mob/living/carbon/human/user, work_type, pe)
 	datum_reference.qliphoth_change(1)
 	manual_emote("chirps!")
 	return
 
-/mob/living/simple_animal/hostile/abnormality/punishing_bird/failure_effect(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/punishing_bird/FailureEffect(mob/living/carbon/human/user, work_type, pe)
 	datum_reference.qliphoth_change(-1)
 	return
 

--- a/code/modules/mob/living/simple_animal/abnormality/teth/scorched_girl.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/scorched_girl.dm
@@ -107,17 +107,17 @@
 	S.start()
 	qdel(src)
 
-/mob/living/simple_animal/hostile/abnormality/scorched_girl/neutral_effect(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/scorched_girl/NeutralEffect(mob/living/carbon/human/user, work_type, pe)
 	if(prob(40))
 		datum_reference.qliphoth_change(-1)
 	return
 
-/mob/living/simple_animal/hostile/abnormality/scorched_girl/failure_effect(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/scorched_girl/FailureEffect(mob/living/carbon/human/user, work_type, pe)
 	if(prob(80))
 		datum_reference.qliphoth_change(-1)
 	return
 
-/mob/living/simple_animal/hostile/abnormality/scorched_girl/breach_effect(mob/living/carbon/human/user)
+/mob/living/simple_animal/hostile/abnormality/scorched_girl/BreachEffect(mob/living/carbon/human/user)
 	..()
 	boom_cooldown = world.time + 5 SECONDS // So it doesn't instantly explode
 	update_icon()

--- a/code/modules/mob/living/simple_animal/abnormality/teth/shy_look.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/shy_look.dm
@@ -30,9 +30,9 @@
 	var/chance_modifier = 1
 	var/previous_mood
 	var/next_mood
-	var/mood_cooldown 
+	var/mood_cooldown
 
-/mob/living/simple_animal/hostile/abnormality/shy_look/work_chance(mob/living/carbon/human/user, chance)
+/mob/living/simple_animal/hostile/abnormality/shy_look/WorkChance(mob/living/carbon/human/user, chance)
 	return chance * chance_modifier
 
 /mob/living/simple_animal/hostile/abnormality/shy_look/Life()
@@ -89,11 +89,11 @@
 	var/mood_cooldown_time = rand(2, 5) SECONDS
 	mood_cooldown = world.time + mood_cooldown_time
 
-/mob/living/simple_animal/hostile/abnormality/shy_look/work_complete(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/shy_look/PostWorkEffect(mob/living/carbon/human/user, work_type, pe)
 	if(previous_mood == 1 && pe > 0) // heals 20% hp&sp
 		user.adjustSanityLoss(0.2*user.maxSanity)
 		user.adjustBruteLoss(-0.2*user.maxHealth)
 	if(previous_mood == 2 && pe > 0)
 		user.adjustSanityLoss(0.2*user.maxSanity)
 	ChangeMood() //Prevents spamming work on the same mood
-	return ..()
+	return

--- a/code/modules/mob/living/simple_animal/abnormality/teth/simple_smile.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/simple_smile.dm
@@ -69,16 +69,16 @@
 
 	src.pulled(pick(pullable))
 
-/mob/living/simple_animal/hostile/abnormality/smile/work_complete(mob/living/carbon/human/user, work_type, pe, work_time)
+/mob/living/simple_animal/hostile/abnormality/smile/PostWorkEffect(mob/living/carbon/human/user, work_type, pe, work_time)
 	if(lucky_counter > 3)
 		datum_reference.qliphoth_change(-1)
-	return ..()
+	return
 
-/mob/living/simple_animal/hostile/abnormality/smile/failure_effect(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/smile/FailureEffect(mob/living/carbon/human/user, work_type, pe)
 	datum_reference.qliphoth_change(-1)
 	return
 
-/mob/living/simple_animal/hostile/abnormality/smile/work_chance(mob/living/carbon/human/user, chance)
+/mob/living/simple_animal/hostile/abnormality/smile/WorkChance(mob/living/carbon/human/user, chance)
 	var/chance_modifier = 1
 	lucky_counter = 0	//Counts how many stats are above 40
 

--- a/code/modules/mob/living/simple_animal/abnormality/teth/spider_bud.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/spider_bud.dm
@@ -23,7 +23,7 @@
 		)
 	gift_type =  /datum/ego_gifts/redeyes
 
-/mob/living/simple_animal/hostile/abnormality/spider/work_complete(mob/living/carbon/human/user, work_type, pe, work_time)
+/mob/living/simple_animal/hostile/abnormality/spider/PostWorkEffect(mob/living/carbon/human/user, work_type, pe, work_time)
 	// If you do insight or have low prudence, fuck you and die for stepping on a spider
 	if((get_attribute_level(user, PRUDENCE_ATTRIBUTE) < 40 || work_type == ABNORMALITY_WORK_INSIGHT) && !(GODMODE in user.status_flags))
 		icon_state = "spider_open"
@@ -35,4 +35,4 @@
 		casing.density = FALSE
 		SLEEP_CHECK_DEATH(50)
 		icon_state = "spider_closed"
-		return
+	return

--- a/code/modules/mob/living/simple_animal/abnormality/teth/training_rabbit.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/training_rabbit.dm
@@ -25,13 +25,12 @@
 	gift_type =  /datum/ego_gifts/standard
 	can_patrol = FALSE
 
-/mob/living/simple_animal/hostile/abnormality/training_rabbit/breach_effect(mob/living/carbon/human/user)
+/mob/living/simple_animal/hostile/abnormality/training_rabbit/BreachEffect(mob/living/carbon/human/user)
 	..()
 	GiveTarget(user)
 	addtimer(CALLBACK(src, .proc/kill_dummy), 30 SECONDS)
 
-/mob/living/simple_animal/hostile/abnormality/training_rabbit/work_complete(mob/living/carbon/human/user, work_type, pe)
-	..()
+/mob/living/simple_animal/hostile/abnormality/training_rabbit/PostWorkEffect(mob/living/carbon/human/user, work_type, pe)
 	if(work_type == ABNORMALITY_WORK_REPRESSION)
 		datum_reference.qliphoth_change(-1)
 	return

--- a/code/modules/mob/living/simple_animal/abnormality/waw/alriune.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/alriune.dm
@@ -118,17 +118,17 @@
 
 /* Work stuff */
 
-/mob/living/simple_animal/hostile/abnormality/alriune/success_effect(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/alriune/SuccessEffect(mob/living/carbon/human/user, work_type, pe)
 	if(prob(50))
 		datum_reference.qliphoth_change(-1)
 	return
 
-/mob/living/simple_animal/hostile/abnormality/alriune/failure_effect(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/alriune/FailureEffect(mob/living/carbon/human/user, work_type, pe)
 	datum_reference.qliphoth_change(-1)
 	return
 
 /* Qliphoth/Breach effects */
-/mob/living/simple_animal/hostile/abnormality/alriune/breach_effect(mob/living/carbon/human/user)
+/mob/living/simple_animal/hostile/abnormality/alriune/BreachEffect(mob/living/carbon/human/user)
 	..()
 	petals_next = world.time + petals_next_time + 30
 	TeleportAway()

--- a/code/modules/mob/living/simple_animal/abnormality/waw/big_bird.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/big_bird.dm
@@ -143,10 +143,10 @@
 	datum_reference.qliphoth_change(-1) // One death reduces it
 	return TRUE
 
-/mob/living/simple_animal/hostile/abnormality/big_bird/success_effect(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/big_bird/SuccessEffect(mob/living/carbon/human/user, work_type, pe)
 	datum_reference.qliphoth_change(1)
 	return
 
-/mob/living/simple_animal/hostile/abnormality/big_bird/failure_effect(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/big_bird/FailureEffect(mob/living/carbon/human/user, work_type, pe)
 	datum_reference.qliphoth_change(-1)
 	return

--- a/code/modules/mob/living/simple_animal/abnormality/waw/despair_knight.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/despair_knight.dm
@@ -93,7 +93,7 @@
 	blessed_human.physiology.black_mod /= 0.5
 	blessed_human.physiology.pale_mod /= 2
 	blessed_human = null
-	breach_effect()
+	BreachEffect()
 	return TRUE
 
 /mob/living/simple_animal/hostile/abnormality/despair_knight/proc/TryTeleport()
@@ -126,7 +126,7 @@
 	new /obj/effect/temp_visual/guardian/phase/out(teleport_target)
 	forceMove(teleport_target)
 
-/mob/living/simple_animal/hostile/abnormality/despair_knight/success_effect(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/despair_knight/SuccessEffect(mob/living/carbon/human/user, work_type, pe)
 	if(user.stat != DEAD && !blessed_human && istype(user))
 		blessed_human = user
 		RegisterSignal(user, COMSIG_LIVING_DEATH, .proc/BlessedDeath)
@@ -140,7 +140,7 @@
 		playsound(get_turf(user), 'sound/abnormalities/despairknight/gift.ogg', 50, 0, 2)
 	return
 
-/mob/living/simple_animal/hostile/abnormality/despair_knight/breach_effect(mob/living/carbon/human/user)
+/mob/living/simple_animal/hostile/abnormality/despair_knight/BreachEffect(mob/living/carbon/human/user)
 	..()
 	icon_living = "despair_breach"
 	icon_state = icon_living

--- a/code/modules/mob/living/simple_animal/abnormality/waw/dreaming_current.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/dreaming_current.dm
@@ -153,17 +153,16 @@
 				if(!QDELETED(L))
 					been_hit += L
 
-/mob/living/simple_animal/hostile/abnormality/dreaming_current/work_complete(mob/living/carbon/human/user, work_type, pe, work_time)
-	..()
+/mob/living/simple_animal/hostile/abnormality/dreaming_current/PostWorkEffect(mob/living/carbon/human/user, work_type, pe, work_time)
 	if(user.sanity_lost)
 		datum_reference.qliphoth_change(-1)
 	return
 
-/mob/living/simple_animal/hostile/abnormality/dreaming_current/failure_effect(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/dreaming_current/FailureEffect(mob/living/carbon/human/user, work_type, pe)
 	datum_reference.qliphoth_change(-1)
 	return
 
-/mob/living/simple_animal/hostile/abnormality/dreaming_current/breach_effect(mob/living/carbon/human/user)
+/mob/living/simple_animal/hostile/abnormality/dreaming_current/BreachEffect(mob/living/carbon/human/user)
 	..()
 	ADD_TRAIT(src, TRAIT_MOVE_FLYING, ROUNDSTART_TRAIT) // Floating
 	icon_living = "current_breach"

--- a/code/modules/mob/living/simple_animal/abnormality/waw/express_train.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/express_train.dm
@@ -53,7 +53,7 @@
 			update_icon_state()
 	return ..()
 
-/mob/living/simple_animal/hostile/abnormality/express_train/attempt_work(mob/living/carbon/human/user, work_type)
+/mob/living/simple_animal/hostile/abnormality/express_train/AttemptWork(mob/living/carbon/human/user, work_type)
 	meltdown_timer += 100 SECONDS
 	switch(datum_reference.qliphoth_meter)
 		if(0)
@@ -78,16 +78,16 @@
 			say("No tickets available. Thank you for your interest.")
 	return ..()
 
-/mob/living/simple_animal/hostile/abnormality/express_train/work_chance(mob/living/carbon/human/user, chance)
+/mob/living/simple_animal/hostile/abnormality/express_train/WorkChance(mob/living/carbon/human/user, chance)
 	chance += lightscount * 10
 	return chance
 
-/mob/living/simple_animal/hostile/abnormality/express_train/work_complete(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/express_train/PostWorkEffect(mob/living/carbon/human/user, work_type, pe)
 	datum_reference.qliphoth_change(4)
 	meltdown_timer = world.time + meltdown_tick
 	lightscount = 0
 	update_icon_state()
-	return ..()
+	return
 
 /mob/living/simple_animal/hostile/abnormality/express_train/update_icon_state()
 	icon_state = "express_booth[lightscount]"

--- a/code/modules/mob/living/simple_animal/abnormality/waw/generalb.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/generalb.dm
@@ -39,17 +39,17 @@
 	var/fireball_range = 30
 	var/volley_count
 
-/mob/living/simple_animal/hostile/abnormality/general_b/neutral_effect(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/general_b/NeutralEffect(mob/living/carbon/human/user, work_type, pe)
 	if(prob(40))
 		datum_reference.qliphoth_change(-1)
 	return
 
-/mob/living/simple_animal/hostile/abnormality/general_b/failure_effect(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/general_b/FailureEffect(mob/living/carbon/human/user, work_type, pe)
 	if(prob(80))
 		datum_reference.qliphoth_change(-1)
 	return
 
-/mob/living/simple_animal/hostile/abnormality/general_b/zero_qliphoth(mob/living/carbon/human/user)
+/mob/living/simple_animal/hostile/abnormality/general_b/ZeroQliphoth(mob/living/carbon/human/user)
 	if(!(status_flags & GODMODE)) // If it's breaching right now
 		return	//Yeah don't increase Qliphoth
 	var/artillerbee_count = 0
@@ -82,7 +82,7 @@
 		volley_count=0
 		fire_cooldown = world.time + fire_cooldown_time*3	//Triple cooldown every 4 shells
 
-/mob/living/simple_animal/hostile/abnormality/general_b/breach_effect()
+/mob/living/simple_animal/hostile/abnormality/general_b/BreachEffect()
 	icon_state = "generalbee_breach"
 	addtimer(CALLBACK(GLOBAL_PROC, .proc/show_global_blurb, 5 SECONDS, "My queen? I hear your cries...", 25))
 	SLEEP_CHECK_DEATH(80)

--- a/code/modules/mob/living/simple_animal/abnormality/waw/hatred_queen.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/hatred_queen.dm
@@ -213,7 +213,7 @@
 		GoHysteric()
 	//if CONTAINED and not crazy
 	else if((status_flags & GODMODE) && (datum_reference?.qliphoth_meter == 2) && (death_counter > 3)) // Omagah a lot of dead people!
-		breach_effect() // We must help them!
+		BreachEffect() // We must help them!
 	return TRUE
 
 /mob/living/simple_animal/hostile/abnormality/hatred_queen/proc/ArcanaBeats(target)
@@ -454,7 +454,7 @@
 				continue
 			L.apply_damage(explode_damage, BLACK_DAMAGE, null, L.run_armor_check(null, BLACK_DAMAGE), spread_damage = TRUE)
 
-/mob/living/simple_animal/hostile/abnormality/hatred_queen/work_chance(mob/living/carbon/human/user, chance)
+/mob/living/simple_animal/hostile/abnormality/hatred_queen/WorkChance(mob/living/carbon/human/user, chance)
 	return chance * chance_modifier
 
 /mob/living/simple_animal/hostile/abnormality/hatred_queen/OnQliphothEvent()
@@ -499,20 +499,20 @@
 	addtimer(CALLBACK(src, .atom/movable/proc/say, "I wasn’t able to protect anyone like she did…"))
 	addtimer(CALLBACK(datum_reference, .datum/abnormality/proc/qliphoth_change, -1), 10 SECONDS)
 
-/mob/living/simple_animal/hostile/abnormality/hatred_queen/success_effect(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/hatred_queen/SuccessEffect(mob/living/carbon/human/user, work_type, pe)
 	datum_reference.qliphoth_change(1)
 	return
 
-/mob/living/simple_animal/hostile/abnormality/hatred_queen/neutral_effect(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/hatred_queen/NeutralEffect(mob/living/carbon/human/user, work_type, pe)
 	if(datum_reference?.qliphoth_meter == 1)
 		datum_reference.qliphoth_change(-1)
 	return
 
-/mob/living/simple_animal/hostile/abnormality/hatred_queen/failure_effect(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/hatred_queen/FailureEffect(mob/living/carbon/human/user, work_type, pe)
 	datum_reference.qliphoth_change(-1)
 	return
 
-/mob/living/simple_animal/hostile/abnormality/hatred_queen/breach_effect(mob/living/carbon/human/user)
+/mob/living/simple_animal/hostile/abnormality/hatred_queen/BreachEffect(mob/living/carbon/human/user)
 	death_counter = 0
 	if(datum_reference?.qliphoth_meter == 2) // Helpful/Passive breach
 		fear_level = TETH_LEVEL

--- a/code/modules/mob/living/simple_animal/abnormality/waw/judgement_bird.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/judgement_bird.dm
@@ -82,13 +82,13 @@
 		L.apply_damage(judgement_damage, PALE_DAMAGE, null, L.run_armor_check(null, PALE_DAMAGE), spread_damage = TRUE)
 	icon_state = icon_living
 
-/mob/living/simple_animal/hostile/abnormality/judgement_bird/neutral_effect(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/judgement_bird/NeutralEffect(mob/living/carbon/human/user, work_type, pe)
 	if(prob(40))
 		datum_reference.qliphoth_change(-1)
 	return
 
 // Additional effects on work failure
-/mob/living/simple_animal/hostile/abnormality/judgement_bird/failure_effect(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/judgement_bird/FailureEffect(mob/living/carbon/human/user, work_type, pe)
 	if(prob(80))
 		datum_reference.qliphoth_change(-1)
 	return

--- a/code/modules/mob/living/simple_animal/abnormality/waw/queen_bee.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/queen_bee.dm
@@ -51,20 +51,20 @@
 				H.ForceContractDisease(D, FALSE, TRUE)
 		for(var/mob/living/simple_animal/hostile/abnormality/general_b/Y in T.contents)
 			if(breached_others == FALSE)
-				Y.breach_effect()
+				Y.BreachEffect()
 				breached_others = TRUE
 
-/mob/living/simple_animal/hostile/abnormality/queen_bee/neutral_effect(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/queen_bee/NeutralEffect(mob/living/carbon/human/user, work_type, pe)
 	if(prob(40))
 		datum_reference.qliphoth_change(-1)
 	return
 
-/mob/living/simple_animal/hostile/abnormality/queen_bee/failure_effect(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/queen_bee/FailureEffect(mob/living/carbon/human/user, work_type, pe)
 	if(prob(80))
 		datum_reference.qliphoth_change(-1)
 	return
 
-/mob/living/simple_animal/hostile/abnormality/queen_bee/zero_qliphoth(mob/living/carbon/human/user)
+/mob/living/simple_animal/hostile/abnormality/queen_bee/ZeroQliphoth(mob/living/carbon/human/user)
 	emit_spores()
 	datum_reference.qliphoth_change(1)
 	return

--- a/code/modules/mob/living/simple_animal/abnormality/waw/shrimp.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/shrimp.dm
@@ -55,36 +55,35 @@
 				/obj/item/reagent_containers/food/drinks/soda_cans/wellcheers_white
 				)
 
-/mob/living/simple_animal/hostile/abnormality/shrimp_exec/work_chance(mob/living/carbon/human/user, chance)
+/mob/living/simple_animal/hostile/abnormality/shrimp_exec/WorkChance(mob/living/carbon/human/user, chance)
 	if(happy)
 		chance+=30
 	return chance
 
-/mob/living/simple_animal/hostile/abnormality/shrimp_exec/success_effect(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/shrimp_exec/SuccessEffect(mob/living/carbon/human/user, work_type, pe)
 	var/turf/dispense_turf = get_step(src, pick(1,2,4,5,6,8,9,10))
 	var/gift = pick(dispenseitem)
 	new gift(dispense_turf)
 	say("Here you are, my dear friend. High-quality firepower courtesy of shrimpcorp.")
 	return
 
-/mob/living/simple_animal/hostile/abnormality/shrimp_exec/failure_effect(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/shrimp_exec/FailureEffect(mob/living/carbon/human/user, work_type, pe)
 	datum_reference.qliphoth_change(-1)
 	return
 
-/mob/living/simple_animal/hostile/abnormality/shrimp_exec/zero_qliphoth(mob/living/carbon/human/user)
+/mob/living/simple_animal/hostile/abnormality/shrimp_exec/ZeroQliphoth(mob/living/carbon/human/user)
 	pissed()
 	datum_reference.qliphoth_change(1)
 	return
 
-/mob/living/simple_animal/hostile/abnormality/shrimp_exec/attempt_work(mob/living/carbon/human/user, work_type)
+/mob/living/simple_animal/hostile/abnormality/shrimp_exec/AttemptWork(mob/living/carbon/human/user, work_type)
 	if(work_type == liked || !liked)
 		happy = TRUE
 	else
 		happy = FALSE
 	return TRUE
 
-/mob/living/simple_animal/hostile/abnormality/shrimp_exec/work_complete(mob/living/carbon/human/user, work_type, pe, work_time)
-	..()
+/mob/living/simple_animal/hostile/abnormality/shrimp_exec/PostWorkEffect(mob/living/carbon/human/user, work_type, pe, work_time)
 	liked = pick(ABNORMALITY_WORK_INSTINCT, ABNORMALITY_WORK_INSIGHT, ABNORMALITY_WORK_ATTACHMENT)
 	switch(liked)
 		if(ABNORMALITY_WORK_INSTINCT)

--- a/code/modules/mob/living/simple_animal/abnormality/waw/silence.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/silence.dm
@@ -37,7 +37,7 @@
 	QDEL_NULL(soundloop)
 	..()
 
-/mob/living/simple_animal/hostile/abnormality/silence/success_effect(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/silence/SuccessEffect(mob/living/carbon/human/user, work_type, pe)
 	safe = TRUE
 	to_chat(user, "<span class='nicegreen'>The bells do not toll for thee. Not yet.</span>")
 	return
@@ -53,7 +53,7 @@
 	return
 
 //Meltdown
-/mob/living/simple_animal/hostile/abnormality/silence/zero_qliphoth(mob/living/carbon/human/user)
+/mob/living/simple_animal/hostile/abnormality/silence/ZeroQliphoth(mob/living/carbon/human/user)
 	// You have mere seconds to live
 	SLEEP_CHECK_DEATH(5 SECONDS)
 	sound_to_playing_players_on_level('sound/abnormalities/silence/price.ogg', 50, zlevel = z)

--- a/code/modules/mob/living/simple_animal/abnormality/waw/snow_whites_apple.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/snow_whites_apple.dm
@@ -50,15 +50,15 @@ GLOBAL_LIST_EMPTY(vine_list)
 	)
 	gift_type =  /datum/ego_gifts/stem
 
-/mob/living/simple_animal/hostile/abnormality/snow_whites_apple/neutral_effect(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/snow_whites_apple/NeutralEffect(mob/living/carbon/human/user, work_type, pe)
 	datum_reference.qliphoth_change(-1)
 	return
 
-/mob/living/simple_animal/hostile/abnormality/snow_whites_apple/failure_effect(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/snow_whites_apple/FailureEffect(mob/living/carbon/human/user, work_type, pe)
 	datum_reference.qliphoth_change(-1)
 	return
 
-/mob/living/simple_animal/hostile/abnormality/snow_whites_apple/breach_effect(mob/living/carbon/human/user)
+/mob/living/simple_animal/hostile/abnormality/snow_whites_apple/BreachEffect(mob/living/carbon/human/user)
 	..()
 	update_icon()
 	GiveTarget(user)

--- a/code/modules/mob/living/simple_animal/abnormality/waw/warden.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/warden.dm
@@ -74,16 +74,16 @@
 			finishing = FALSE
 			icon_state = "warden"
 
-/mob/living/simple_animal/hostile/abnormality/warden/failure_effect(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/warden/FailureEffect(mob/living/carbon/human/user, work_type, pe)
 	datum_reference.qliphoth_change(-1)
 	return
 
-/mob/living/simple_animal/hostile/abnormality/warden/work_complete(mob/living/carbon/human/user, work_type, pe, work_time)
+/mob/living/simple_animal/hostile/abnormality/warden/PostWorkEffect(mob/living/carbon/human/user, work_type, pe, work_time)
 	if(get_attribute_level(user, JUSTICE_ATTRIBUTE) < 80 && get_attribute_level(user, FORTITUDE_ATTRIBUTE) < 80)
 		datum_reference.qliphoth_change(-1)
-	return ..()
+	return
 
-/mob/living/simple_animal/hostile/abnormality/warden/breach_effect(mob/living/carbon/human/user)
+/mob/living/simple_animal/hostile/abnormality/warden/BreachEffect(mob/living/carbon/human/user)
 	..()
 	GiveTarget(user)
 

--- a/code/modules/mob/living/simple_animal/abnormality/waw/yang.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/yang.dm
@@ -137,16 +137,16 @@
 	icon_state = "impact_white"
 
 
-/mob/living/simple_animal/hostile/abnormality/yang/failure_effect(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/yang/FailureEffect(mob/living/carbon/human/user, work_type, pe)
 	datum_reference.qliphoth_change(-1)
 	return
 
-/mob/living/simple_animal/hostile/abnormality/yang/breach_effect(mob/living/carbon/human/user)
+/mob/living/simple_animal/hostile/abnormality/yang/BreachEffect(mob/living/carbon/human/user)
 	..()
 	icon_state = "yang_breach"
 	//So they can breach yin later
 
-/mob/living/simple_animal/hostile/abnormality/yang/work_complete(mob/living/carbon/human/user, work_type, pe, work_time)
+/mob/living/simple_animal/hostile/abnormality/yang/PostWorkEffect(mob/living/carbon/human/user, work_type, pe, work_time)
 	if(work_type == "Release")
 		datum_reference.qliphoth_change(-2)
-
+	return

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/bald.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/bald.dm
@@ -30,13 +30,12 @@
 							)
 	var/bald_users = list()
 
-/mob/living/simple_animal/hostile/abnormality/bald/work_chance(mob/living/carbon/human/user, chance)
+/mob/living/simple_animal/hostile/abnormality/bald/WorkChance(mob/living/carbon/human/user, chance)
 	if(user.hairstyle in balding_list)
 		return 95
 	return chance
 
-/mob/living/simple_animal/hostile/abnormality/bald/work_complete(mob/living/carbon/human/user, work_type, pe)
-	..()
+/mob/living/simple_animal/hostile/abnormality/bald/PostWorkEffect(mob/living/carbon/human/user, work_type, pe)
 	if(!do_bald(user)) // Already bald
 		return
 	bald_users |= user.ckey

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/bottle.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/bottle.dm
@@ -29,7 +29,7 @@
 	max_boxes = 10
 	var/cake = 5	//How many cake charges are there (4)
 
-/mob/living/simple_animal/hostile/abnormality/bottle/attempt_work(mob/living/carbon/human/user, work_type)
+/mob/living/simple_animal/hostile/abnormality/bottle/AttemptWork(mob/living/carbon/human/user, work_type)
 	if(cake)
 		if(work_type == "Drink")
 			return FALSE
@@ -51,7 +51,7 @@
 			return null
 	return TRUE
 
-/mob/living/simple_animal/hostile/abnormality/bottle/work_complete(mob/living/carbon/human/user, work_type, pe, work_time, canceled)
+/mob/living/simple_animal/hostile/abnormality/bottle/PostWorkEffect(mob/living/carbon/human/user, work_type, pe, work_time, canceled)
 	if(work_type == "Dining" && !canceled)
 		cake -= 1		//Eat some cake
 		if(cake > 0)
@@ -72,7 +72,7 @@
 			user.AdjustSleeping(10 SECONDS)
 			animate(user, alpha = 0, time = 2 SECONDS)
 			QDEL_IN(user, 3.5 SECONDS)
-	return ..()
+	return
 
 /datum/status_effect/tears
 	id = "tears"

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/fairy_festival.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/fairy_festival.dm
@@ -40,7 +40,7 @@
 	heal_cooldown = (world.time + heal_cooldown_base)
 	return
 
-/mob/living/simple_animal/hostile/abnormality/fairy_festival/success_effect(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/fairy_festival/SuccessEffect(mob/living/carbon/human/user, work_type, pe)
 	if(user.stat != DEAD && istype(user))
 		if(user in protected_people)
 			return
@@ -52,8 +52,8 @@
 		addtimer(CALLBACK(src, .proc/FairyEnd, user), heal_duration)
 	return
 
-/mob/living/simple_animal/hostile/abnormality/fairy_festival/neutral_effect(mob/living/carbon/human/user, work_type, pe)
-	success_effect(user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/fairy_festival/NeutralEffect(mob/living/carbon/human/user, work_type, pe)
+	SuccessEffect(user, work_type, pe)
 	return
 
 /mob/living/simple_animal/hostile/abnormality/fairy_festival/Life()

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/one_sin.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/one_sin.dm
@@ -26,12 +26,12 @@
 	gift_type =  /datum/ego_gifts/penitence
 	gift_message = "From this day forth, you shall never forget his words."
 
-/mob/living/simple_animal/hostile/abnormality/onesin/work_chance(mob/living/carbon/human/user, chance)
+/mob/living/simple_animal/hostile/abnormality/onesin/WorkChance(mob/living/carbon/human/user, chance)
 	. = ..()
 	if (istype(user.ego_gift_list[HAT], /datum/ego_gifts/penitence))
 		return chance + 10
 
-/mob/living/simple_animal/hostile/abnormality/onesin/attempt_work(mob/living/carbon/human/user, work_type)
+/mob/living/simple_animal/hostile/abnormality/onesin/AttemptWork(mob/living/carbon/human/user, work_type)
 	if(work_type == "Confess")
 		if(isapostle(user))
 			for(var/mob/living/simple_animal/hostile/abnormality/white_night/WN in GLOB.mob_living_list)
@@ -47,7 +47,7 @@
 		return FALSE
 	return TRUE
 
-/mob/living/simple_animal/hostile/abnormality/onesin/work_complete(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/onesin/PostWorkEffect(mob/living/carbon/human/user, work_type, pe)
 	if(work_type == "Confess")
 		for(var/mob/living/simple_animal/hostile/abnormality/white_night/WN in GLOB.mob_living_list)
 			if(WN.status_flags & GODMODE)
@@ -68,9 +68,9 @@
 		return
 	if (prob(5)) // Will be 5%
 		user.Apply_Gift(new /datum/ego_gifts/penitence)
-	return ..()
+	return
 
-/mob/living/simple_animal/hostile/abnormality/onesin/success_effect(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/onesin/SuccessEffect(mob/living/carbon/human/user, work_type, pe)
 	user.adjustSanityLoss(30) // It's healing
 	if(pe >= datum_reference.max_boxes)
 		for(var/mob/living/carbon/human/H in GLOB.player_list)

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/we_can_change_anything.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/we_can_change_anything.dm
@@ -26,12 +26,12 @@
 	gift_message = "Your heart beats with new vigor."
 
 
-/mob/living/simple_animal/hostile/abnormality/we_can_change_anything/worktick(mob/living/carbon/human/user)
+/mob/living/simple_animal/hostile/abnormality/we_can_change_anything/Worktick(mob/living/carbon/human/user)
 	user.apply_damage(4, RED_DAMAGE, null, user.run_armor_check(null, RED_DAMAGE)) // say goodbye to your kneecaps chucklenuts!
 
-/mob/living/simple_animal/hostile/abnormality/we_can_change_anything/work_complete(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/we_can_change_anything/PostWorkEffect(mob/living/carbon/human/user, work_type, pe)
 	user.apply_status_effect(STATUS_EFFECT_CHANGE)
-	..()
+	return
 
 /datum/status_effect/we_can_change_anything
 	id = "change"

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/wellcheers.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/wellcheers.dm
@@ -24,7 +24,7 @@
 	gift_type = /datum/ego_gifts/soda
 	gift_message = "You feel like you've been doing this your whole life."
 
-/mob/living/simple_animal/hostile/abnormality/wellcheers/success_effect(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/wellcheers/SuccessEffect(mob/living/carbon/human/user, work_type, pe)
 	var/obj/item/dropped_can
 	switch(work_type)
 		if(ABNORMALITY_WORK_INSTINCT)
@@ -42,7 +42,7 @@
 	return
 
 // Death!
-/mob/living/simple_animal/hostile/abnormality/wellcheers/failure_effect(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/wellcheers/FailureEffect(mob/living/carbon/human/user, work_type, pe)
 	for(var/turf/open/T in view(7, src))
 		new /obj/effect/temp_visual/water_waves(T)
 	playsound(get_turf(src), 'sound/abnormalities/wellcheers/ability.ogg', 75, 0)

--- a/code/modules/mob/living/simple_animal/hostile/ordeal/misc.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/misc.dm
@@ -31,7 +31,7 @@
 			return
 
 		if(A.can_breach && (A.status_flags & GODMODE))
-			A.breach_effect()
+			A.BreachEffect()
 			var/turf/orgin = get_turf(src)
 			var/list/all_turfs = RANGE_TURFS(4, orgin)
 			var/turf/open/Y = pick(all_turfs - orgin)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- EGO gifts will be applied after all work effects are done.
- Changes most of abnormality procs from under_line to CamelCase.

## Why It's Good For The Game

- Some gifts might shove into the insta-kill territory by giving/removing some attributes. This should fix it.
- All procs should be written in CamelCase, that's how it is.
