### PR TITLE
Moves HandleStartingAbnormalities call to post_setup(), ...

### DIFF
--- a/code/controllers/subsystem/abnormality_queue.dm
+++ b/code/controllers/subsystem/abnormality_queue.dm
@@ -1,3 +1,5 @@
+#define ABNORMALITY_DELAY 180 SECONDS
+
 SUBSYSTEM_DEF(abnormality_queue)
 	name = "Abnormality Queue"
 	flags = SS_KEEP_TIMING | SS_BACKGROUND
@@ -30,7 +32,6 @@ SUBSYSTEM_DEF(abnormality_queue)
 			possible_abnormalities[initial(abno.threat_level)] += abno
 	if(LAZYLEN(possible_abnormalities))
 		pick_abno()
-	addtimer(CALLBACK(src, .proc/HandleStartingAbnormalities), 180 SECONDS)
 	rooms_start = GLOB.abnormality_room_spawners.len
 	next_abno_spawn_time -= min(30, rooms_start * 0.05) MINUTES // 20 rooms will decrease wait time by 1 minute
 	..()

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -118,6 +118,9 @@
 	if(report)
 		addtimer(CALLBACK(src, .proc/send_intercept, 0), rand(waittime_l, waittime_h))
 	generate_station_goals()
+
+	addtimer(CALLBACK(SSabnormality_queue, /datum/controller/subsystem/abnormality_queue/proc/HandleStartingAbnormalities), ABNORMALITY_DELAY)
+
 	gamemode_ready = TRUE
 	return TRUE
 


### PR DESCRIPTION
… moves magic number to define
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This ensures, no matter what, that it always happens 1800 ticks after game start or whatever the define is set to

<details>
<summary>Tested timing via debugger</summary>

![image](https://user-images.githubusercontent.com/5896309/205135805-ac7dd641-3223-47af-bdd8-12ed385f514b.png)

</details>

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This fixes #451 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Starting abnormalities now spawn exactly 190 seconds after round start.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
