### PR TITLE
Possessing Ghosts now always allows Ghosts to possess.

### DIFF
--- a/code/controllers/subsystem/lobotomy_corp.dm
+++ b/code/controllers/subsystem/lobotomy_corp.dm
@@ -53,6 +53,8 @@ SUBSYSTEM_DEF(lobotomy_corp)
 	var/current_box = 0
 	var/box_goal = INFINITY // Initialized later
 	var/goal_reached = FALSE
+	//possession conditions
+	var/enable_possession = FALSE
 
 /datum/controller/subsystem/lobotomy_corp/Initialize(timeofday)
 	. = ..()

--- a/code/modules/events/wizard/ghost.dm
+++ b/code/modules/events/wizard/ghost.dm
@@ -20,6 +20,8 @@
 	earliest_start = 0 MINUTES
 
 /datum/round_event/wizard/possession/start()
+	if(!SSlobotomy_corp.enable_possession)
+		SSlobotomy_corp.enable_possession = TRUE
 	for(var/mob/dead/observer/G in GLOB.player_list)
 		add_verb(G, /mob/dead/observer/verb/boo)
 		add_verb(G, /mob/dead/observer/verb/possess)


### PR DESCRIPTION
## About The Pull Request
Ghosts now always get possession but cannot possess unless a subsystem variable is enabled by the event. There is now a 10 seconds delay on possession whenever a ghost is initialized.
There is also now a banned abnormality list within the Lobotomy Corp subsystem that will not show up on the possession list.
Yes i did test this.
## Why It's Good For The Game
I'm tired of being on spamming the event button duty for Possessing G-G-ghosts.

## Changelog
:cl:
tweak: possession
/:cl: