### PR TITLE
Agent spawn updates

### DIFF
--- a/code/modules/jobs/job_types/agent.dm
+++ b/code/modules/jobs/job_types/agent.dm
@@ -7,6 +7,8 @@
 	supervisors = "the manager"
 	selection_color = "#ccaaaa"
 	exp_requirements = 60
+	exp_type = EXP_TYPE_CREW
+	exp_type_department = EXP_TYPE_SECURITY
 
 	outfit = /datum/outfit/job/agent
 	display_order = JOB_DISPLAY_ORDER_WARDEN
@@ -99,7 +101,6 @@
 	ears = /obj/item/radio/headset/alt
 	glasses = /obj/item/clothing/glasses/sunglasses
 	uniform = /obj/item/clothing/under/suit/lobotomy
-	suit = /obj/item/clothing/suit/armor/vest/alt
 	backpack_contents = list(/obj/item/melee/classic_baton=1)
 	shoes = /obj/item/clothing/shoes/laceup
 	gloves = /obj/item/clothing/gloves/color/black
@@ -125,6 +126,8 @@
 	jobtype = /datum/job/agent/captain
 	head = /obj/item/clothing/head/hos/beret
 	ears = /obj/item/radio/headset/heads/agent_captain/alt
+	l_pocket = /obj/item/commandprojector
+	suit = /obj/item/clothing/suit/armor/vest/alt
 
 // Trainee, for new players
 /datum/job/agent/intern
@@ -135,6 +138,7 @@
 	outfit = /datum/outfit/job/agent/intern
 	display_order = JOB_DISPLAY_ORDER_SECURITY_OFFICER
 	normal_attribute_level = 20
+	exp_requirements = 0
 
 /datum/outfit/job/agent/intern
 	name = "Agent Intern"


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Agent Timelock should be fixed.
Agent and Intern lose their armor vest, they now have to wait for ego to hold two weapons or find one around.
Captains gain a command projector to relay orders.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Agents should have had a one hr timelock to pidgeonhole new players into intern.
Also, It's been heavily requested to remove their armor vest, now if they want one they can find one around the map.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added timelock to agent.
del: Removed agent and intern armor vests
balance: Captains now get command projectors.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
