### PR TITLE
Regenerators now consider Training Dummy and contained abnormalities

### DIFF
--- a/code/game/machinery/regenerator.dm
+++ b/code/game/machinery/regenerator.dm
@@ -54,7 +54,7 @@
 	var/regen_amt = regeneration_amount
 	Threat = FALSE //Assume there is no enemies
 	for(var/mob/living/L in A)
-		if(!("neutral" in L.faction) && L.stat != DEAD) // Enemy spotted
+		if(!("neutral" in L.faction) && L.stat != DEAD && !(L.status_flags & GODMODE)) // Enemy spotted
 			regen_amt *= 0.5
 			if(!Threat)
 				icon_state = alert_icon


### PR DESCRIPTION
## About The Pull Request
The very presence of training dummy reduces the training regenerators output by 50%.
I now made it so if a creature has godmode then they are not considered

## Why It's Good For The Game
Restores training regenerator output from 50% to 100%

## Changelog
:cl:
fix: Regenerator freaking out about training dummy
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
