### PR TITLE
Update status_display.dm

### DIFF
--- a/code/game/machinery/status_display.dm
+++ b/code/game/machinery/status_display.dm
@@ -353,6 +353,32 @@
 	set_picture(emotion_map[emotion])
 	return PROCESS_KILL
 
+//LC13 Energy Production Monitor
+/obj/machinery/status_display/ebox_counter
+	name = "facility energy counter"
+	desc = "A screen that shows how close the facility is to achiving the energy quota."
+	index1 = 1
+	index2 = 1
+
+/obj/machinery/status_display/ebox_counter/process()
+	check_lobotomySubsystem()
+	. = ..()
+
+/obj/machinery/status_display/ebox_counter/proc/check_lobotomySubsystem()
+	var/calculate_percent = round(SSlobotomy_corp.current_box / SSlobotomy_corp.box_goal)
+	index1 = 1
+	index2 = 1
+	if(!SSlobotomy_corp)
+		message1 = "ERROR"
+		message2 = "ERROR"
+	else if(SSlobotomy_corp.box_goal <= SSlobotomy_corp.current_box)
+		message1 = "Energy Quota Met!"
+		message2 = "Good Job :)c"
+	else
+		index2 = 0
+		message1 = "[SSlobotomy_corp.current_box]/[SSlobotomy_corp.box_goal]"
+		message2 = "[calculate_percent]%"
+
 #undef CHARS_PER_LINE
 #undef FONT_SIZE
 #undef FONT_COLOR


### PR DESCRIPTION
## About The Pull Request
We had a request for a screen that showed our current amount of Eboxes.
![image](https://user-images.githubusercontent.com/109536843/206881715-98028348-cafc-49e6-bf02-a474d437d91c.png)
## Why It's Good For The Game
It can show a % of energy collected and display a smile when you meet the goal.

## Changelog
:cl:
add: Ebox Display
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
