### PR TITLE
Adds Random Roll buttons for Queue Console

### DIFF
--- a/tgui/packages/tgui/interfaces/AbnormalityQueue.js
+++ b/tgui/packages/tgui/interfaces/AbnormalityQueue.js
@@ -15,9 +15,9 @@ export const AbnormalityQueue = (props, context) => {
     <Window
       title="Abnormality Queue Console"
       width={360}
-      height={240}>
+      height={400}>
       <Window.Content>
-        <Flex direction="column" height="35%">
+        <Flex direction="column" mb={1}>
           <Section
             title="Currently queued abnormality"
             bold
@@ -46,6 +46,46 @@ export const AbnormalityQueue = (props, context) => {
                 </Flex.Item>
               ))}
             </Flex>
+          </Flex>
+        </Section>
+        <Section
+          title="Dangerous Buttons"
+          scrollable>
+          <Flex direction="column" mr={7}>
+            <Flex.Item grow={1} mb={0.3}>
+              <Box
+                bold>
+                Lobotomy Corporation is not responsible for any lynching or
+                Manager death as a result of using of the below buttons.
+              </Box>
+            </Flex.Item>
+            <Flex.Item grow={1} mb={0.3}>
+              <Button
+                icon="bomb"
+                fluid
+                bold
+                content={"Lets Roll"}
+                color="green"
+                onClick={() => act("lets_roll")} />
+            </Flex.Item>
+            <Flex.Item grow={1} mb={0.3}>
+              <Button
+                icon="bomb"
+                fluid
+                bold
+                content={"Fuck It Lets Roll"}
+                color="yellow"
+                onClick={() => act("fuck_it_lets_roll")} />
+            </Flex.Item>
+            <Flex.Item grow={1} mb={0.3}>
+              <Button
+                icon="bomb"
+                fluid
+                bold
+                content={"Hardcore Fuck It Lets Roll"}
+                color="red"
+                onClick={() => act("hardcore_fuck_it_lets_roll")} />
+            </Flex.Item>
           </Flex>
         </Section>
       </Window.Content>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds "Let's Roll":
Picks randomly from the list of abnormalities in the possible abnormalities.
Adds "Fuck It Let's Roll":
Picks randomly from all abnormalities in the unlocked levels. Locks all queue consoles afterwards to prevent metagaming.
Adds "Hardcore Fuck It Let's Roll":
Picks randomly from all levels. Locks all queue consoles afterwards to prevent metagaming.
Refactors some code to their own procs, adds some helper procs to SSabnormality_queue
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
~~it isnt???~~
<details>
<summary>CHAOS CHAOS</summary>

https://www.youtube.com/watch?v=Z01Tsgwe2dQ

</details>
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: The Abnormality Queue console can now do the Manager's job for them by randomly choosing new abnormalities!
refactor: Cleaner queue console code, more SSabnormality_queue helper procs.
admin: Admins can now use admeme magic (MC -> SSabnormality_queue -> call proc "AnnounceLock") to lock all queue consoles for whatever possible reason they could fathom.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
