### PR TITLE
Void Dream nerf

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/teth/void_dream.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/void_dream.dm
@@ -47,7 +47,7 @@
 /mob/living/simple_animal/hostile/abnormality/voiddream/OpenFire()
 	if(!punched)
 		SleepyDart()
-		addtimer(CALLBACK (src, .proc/OpenFire), 6 SECONDS)
+		addtimer(CALLBACK (src, .proc/OpenFire), 12 SECONDS)
 	else
 		Crow()
 		addtimer(CALLBACK (src, .proc/OpenFire), 8 SECONDS)
@@ -61,13 +61,12 @@
 	if(!LAZYLEN(possibletargets))
 		return
 	playsound(get_turf(src), 'sound/magic/staff_change.ogg', 100, 0, 12)
-	for(var/i = 1 to 4)
-		var/obj/projectile/P = new /obj/projectile/sleepdart(get_turf(src))
-		P.firer = src
-		target = pick(possibletargets)
-		P.original = target
-		P.fire(Get_Angle(src, target))
-		target = null
+	var/obj/projectile/P = new /obj/projectile/sleepdart(get_turf(src))
+	P.firer = src
+	target = pick(possibletargets)
+	P.original = target
+	P.fire(Get_Angle(src, target))
+	target = null
 
 /mob/living/simple_animal/hostile/abnormality/voiddream/proc/Crow()
 	playsound(get_turf(src), 'sound/magic/staff_change.ogg', 100, 0, 12)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Void Dream now shoots 1 projectile instead of 4, every 12 seconds instead of 6.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Changelog
:cl:
balance: void dream sleep projectile fires less often and less.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
