### PR TITLE
Nest Fixes

### DIFF
--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -968,3 +968,26 @@
 /datum/status_effect/cloudstruck/Destroy()
 	. = ..()
 	QDEL_NULL(mob_overlay)
+
+
+//~~~LC13 General Debuffs~~~
+
+/datum/status_effect/sunder_red
+	id = "sunder red armor"
+	status_type = STATUS_EFFECT_UNIQUE
+	duration = 60 //3 seconds
+	alert_type = null
+
+/datum/status_effect/sunder_red/on_apply()
+	. = ..()
+	if(isanimal(owner))
+		var/mob/living/simple_animal/M = owner
+		if(M.damage_coeff[RED_DAMAGE] >= 0)
+			M.damage_coeff[RED_DAMAGE] += 0.2 //20% damage increase
+
+/datum/status_effect/sunder_red/on_remove()
+	. = ..()
+	if(isanimal(owner))
+		var/mob/living/simple_animal/M = owner
+		if(M.damage_coeff[RED_DAMAGE] >= 0)
+			M.damage_coeff[RED_DAMAGE] -= 0.2

--- a/code/modules/mob/living/simple_animal/abnormality/waw/naked_nest.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/naked_nest.dm
@@ -76,20 +76,34 @@
 		serpentsnested = serpentsnested + 1
 	return
 
+/mob/living/simple_animal/hostile/abnormality/naked_nest/death(gibbed)
+	for(var/atom/movable/AM in src)
+		AM.forceMove(get_turf(src))
+	if(serpentsnested > 0)
+		var/mob/living/simple_animal/hostile/naked_nest_serpent/S = new(get_turf(src))
+		S.hide()
+	..()
+
 /mob/living/simple_animal/hostile/abnormality/naked_nest/Move()
 	return FALSE
 
 /mob/living/simple_animal/hostile/abnormality/naked_nest/AttackingTarget(atom/attacked_target)
 	return OpenFire()
 
-/mob/living/simple_animal/hostile/naked_nest_serpent/PickTarget(list/Targets)
+/mob/living/simple_animal/hostile/abnormality/naked_nest/Found(mob/living/H)
+	if(!H.has_status_effect(/datum/status_effect/serpents_host))
+		return TRUE
+	return FALSE
+
+/mob/living/simple_animal/hostile/abnormality/naked_nest/PickTarget(list/Targets)
 	var/list/highest_priority = list()
 	var/list/lower_priority = list()
 	for(var/mob/living/L in Targets)
 		if(!CanAttack(L))
 			continue
 		if(ishuman(L))
-			highest_priority += L
+			if(!L.has_status_effect(/datum/status_effect/serpents_host))
+				highest_priority += L
 		else
 			lower_priority += L
 	if(LAZYLEN(highest_priority))
@@ -166,7 +180,7 @@
 
 /mob/living/simple_animal/hostile/naked_nest_serpent/Initialize()
 	. = ..()
-	for(var/mob/living/simple_animal/hostile/abnormality/naked_nest/N in range(0, src))
+	for(var/mob/living/simple_animal/hostile/abnormality/naked_nest/N in loc)
 		origin_nest = N.tag
 	AddComponent(/datum/component/swarming)
 
@@ -188,7 +202,8 @@
 		if(!CanAttack(L))
 			continue
 		if(ishuman(L))
-			highest_priority += L
+			if(!L.has_status_effect(/datum/status_effect/serpents_host))
+				highest_priority += L
 		else
 			lower_priority += L
 	if(LAZYLEN(highest_priority))
@@ -210,7 +225,7 @@
 		to_chat(host, "<span class='notice'>You feel something cold touch the back of your leg.</span>")
 	to_chat(src, "<span class='nicegreen'>You've found a new nest!</span>")
 	host.apply_status_effect(/datum/status_effect/serpents_host)
-	qdel(src)
+	QDEL_IN(src, 5)
 
 /mob/living/simple_animal/hostile/naked_nest_serpent/proc/nest(mob/living/simple_animal/hostile/abnormality/naked_nest/nest)
 	for(var/mob/living/simple_animal/hostile/abnormality/naked_nest/N in range(1, src))
@@ -218,9 +233,8 @@
 			nest.recover_serpent(src)
 
 /mob/living/simple_animal/hostile/naked_nest_serpent/proc/hide()
-	for(var/obj/structure/table/S in oview(get_turf(src), 9))
-		Goto(S, move_to_delay, 0)
-		break
+	Goto((locate(/obj/structure/table) in oview(get_turf(src), 9)), move_to_delay, 0)
+	wander = FALSE
 
 /mob/living/simple_animal/hostile/naked_nested
 	name = "naked nested"
@@ -243,10 +257,15 @@
 	minbodytemp = INHOSPITABLE_FOR_NESTING
 	guaranteed_butcher_results = list(/obj/item/food/meatball/human = 1) //considered having it spawn a single worm on butcher but that seemed cruel.
 	var/nestingtimer
+	var/fortitude
+	var/prudence
+	var/temperance
+	var/justice
 
 /mob/living/simple_animal/hostile/naked_nested/Initialize()
 	. = ..()
 	nestingtimer = world.time + (40 SECONDS)
+	updateArmor() //in order to fix damage coefficents
 
 /mob/living/simple_animal/hostile/naked_nested/Life()
 	. = ..()
@@ -254,9 +273,42 @@
 		buffed = 1
 		nestingtimer = nestingtimer + (120 SECONDS)
 	if(nestingtimer <= world.time && !target)
-		new /mob/living/simple_animal/hostile/abnormality/naked_nest(get_turf(src))
-		playsound(get_turf(src), 'sound/misc/moist_impact.ogg', 10, 1)
-		qdel(src)
+		Nest()
+
+/mob/living/simple_animal/hostile/naked_nested/gib()
+	for(var/atom/movable/AM in src) //morph code
+		AM.forceMove(loc)
+	..()
+
+/mob/living/simple_animal/hostile/naked_nested/proc/Nest()
+	var/mob/living/simple_animal/hostile/abnormality/naked_nest/N = new(get_turf(src))
+	for(var/atom/movable/AM in src) //morph code
+		AM.forceMove(N)
+	N.damage_coeff = damage_coeff
+	playsound(get_turf(src), 'sound/misc/moist_impact.ogg', 30, 1)
+	qdel(src)
+
+/mob/living/simple_animal/hostile/naked_nested/proc/updateArmor()
+	damage_coeff = list(BRUTE = 1, RED_DAMAGE = 0.6, WHITE_DAMAGE = 0.8, BLACK_DAMAGE = 1.2, PALE_DAMAGE = 1.5)
+	var/obj/item/clothing/suit/armor/host_armor = locate(/obj/item/clothing/suit/armor) in contents
+	if(host_armor)
+		if(host_armor.armor[RED_DAMAGE])
+			fortitude = 1 - (host_armor.armor[RED_DAMAGE] / 100) // 100 armor / 100 = 1
+			if(fortitude <= damage_coeff[RED_DAMAGE] && fortitude > 0) //if armor is less than current red armor and is more than 0 since anything 0 or below is healing or immune to damage
+				damage_coeff[RED_DAMAGE] = fortitude
+		if(host_armor.armor[WHITE_DAMAGE])
+			prudence = 1 - (host_armor.armor[WHITE_DAMAGE] / 100)
+			if(prudence <= damage_coeff[WHITE_DAMAGE] && prudence > 0)
+				damage_coeff[WHITE_DAMAGE] = prudence
+		if(host_armor.armor[BLACK_DAMAGE])
+			temperance = 1 - (host_armor.armor[BLACK_DAMAGE] / 100)
+			if(temperance > 0)
+				damage_coeff[BLACK_DAMAGE] = temperance
+		if(host_armor.armor[PALE_DAMAGE])
+			justice = 1 - (host_armor.armor[PALE_DAMAGE] / 100)
+			if(justice > 0)
+				damage_coeff[PALE_DAMAGE] = justice
+		return TRUE
 
 	//Status Effect
 /datum/status_effect/serpents_host // its final destination is your frontal lobe
@@ -266,7 +318,7 @@
 	alert_type = null
 	var/cured = 0
 	var/physical_symptoms
-	var/presented_symptoms
+	var/presented_symptoms = 0
 	var/originalskintone
 	var/extra_time = 0.8 SECONDS //doubles remaining time
 
@@ -275,10 +327,10 @@
 	if(ishuman(owner))
 		owner.add_movespeed_mod_immunities(type, /datum/movespeed_modifier/damage_slowdown)
 		owner.add_movespeed_mod_immunities(type, /datum/movespeed_modifier/justice_attribute) //will test to see if can be cured.
-		owner.faction += "Naked_Nest"
 		var/mob/living/carbon/human/H = owner
 		originalskintone = H.skin_tone
 	physical_symptoms = world.time + (180 SECONDS)
+	owner.faction += "Naked_Nest"
 
 /datum/status_effect/serpents_host/tick()
 	. = ..()
@@ -316,33 +368,28 @@
 			host.skin_tone = originalskintone
 			host.regenerate_icons()
 		if(B && cured != 1)
-			var/mob/living/simple_animal/hostile/naked_nested/N = new(get_turf(owner))
-			convert(host, N)
-			playsound(get_turf(N), 'sound/misc/soggy.ogg', 20, 1)
+			var/mob/living/simple_animal/hostile/naked_nested/N = new(owner.loc) //there was a issue with several converted naked nests getting the same damage coeffs so convert proc had to be moved here.
+			nested_items(N, host.get_item_by_slot(ITEM_SLOT_SUITSTORE))
+			nested_items(N, host.get_item_by_slot(ITEM_SLOT_BELT))
+			nested_items(N, host.get_item_by_slot(ITEM_SLOT_BACK))
+			if(host.get_item_by_slot(ITEM_SLOT_OCLOTHING))
+				nested_items(N, host.get_item_by_slot(ITEM_SLOT_OCLOTHING))
+				N.updateArmor() //moved to creature proc since changing armor values in the status effect resulted in all naked nested having their armor values changed. Even admin spawned ones.
+			playsound(get_turf(owner), 'sound/misc/soggy.ogg', 20, 1)
 			qdel(owner)
-		owner.faction -= "Naked_Nest"
+	owner.faction -= "Naked_Nest"
 	. = ..()
 
-/datum/status_effect/serpents_host/proc/convert(mob/living/carbon/human/host, mob/living/simple_animal/hostile/naked_nested/N) //armor intigration code.
-	var/fortitude = 1 - (host.getarmor(null, RED_DAMAGE) / 100)
-	var/prudence = 1 - (host.getarmor(null, WHITE_DAMAGE) / 100)
-	var/temperance = 1 - (host.getarmor(null, BLACK_DAMAGE) / 100)
-	var/justice = 1 - (host.getarmor(null, PALE_DAMAGE) / 100)
-	if(fortitude <= 0.6 || fortitude > 0)
-		N.damage_coeff[RED_DAMAGE] = fortitude
-	if(prudence <= 0.8 || prudence > 0) //The nest will cover weaknesses with its own flesh.
-		N.damage_coeff[WHITE_DAMAGE] = prudence
-	if(temperance > 0)
-		N.damage_coeff[BLACK_DAMAGE] = temperance
-	if(justice > 0)
-		N.damage_coeff[PALE_DAMAGE] = justice
+/datum/status_effect/serpents_host/proc/nested_items(mob/living/simple_animal/hostile/naked_nested/nest, obj/item/nested_item)
+	if(nested_item)
+		nested_item.forceMove(nest)
 
 #undef INHOSPITABLE_FOR_NESTING
 
 //Offical Cure
 /obj/item/serpentspoision
 	name = "serpents cure"
-	desc = "A formula that prevents O-02-74-1 infestation."
+	desc = "A formula that removes O-02-74-1 infestation."
 	icon = 'icons/obj/chromosomes.dmi'
 	icon_state = ""
 	color = "gold"

--- a/code/modules/projectiles/guns/ego_gun/waw.dm
+++ b/code/modules/projectiles/guns/ego_gun/waw.dm
@@ -285,7 +285,7 @@
 				Upon hit the targets RED vulnerability is increased by 0.2."
 	damtype = RED_DAMAGE
 	armortype = RED_DAMAGE
-	fire_delay = 50
+	fire_delay = 55 //5 less than the Rend Armor status effect
 	fire_sound = 'sound/misc/moist_impact.ogg'
 	attribute_requirements = list(
 							FORTITUDE_ATTRIBUTE = 80,

--- a/code/modules/projectiles/projectile/ego_bullets/waw.dm
+++ b/code/modules/projectiles/projectile/ego_bullets/waw.dm
@@ -198,27 +198,6 @@
 	. = ..()
 	if(isliving(target))
 		var/mob/living/simple_animal/M = target
-		if(!ishuman(M) && !M.has_status_effect(/datum/status_effect/rendRedArmor))
+		if(!ishuman(M) && !M.has_status_effect(/datum/status_effect/sunder_red))
 			new /obj/effect/temp_visual/cult/sparks(get_turf(M))
-			M.apply_status_effect(/datum/status_effect/rendRedArmor)
-
-/datum/status_effect/rendRedArmor
-	id = "rend red armor"
-	status_type = STATUS_EFFECT_UNIQUE
-	duration = 30 //3 seconds
-	alert_type = null
-	var/original_armor
-
-/datum/status_effect/rendRedArmor/on_apply()
-	. = ..()
-	var/mob/living/simple_animal/M = owner
-	original_armor = M.damage_coeff[RED_DAMAGE]
-	if(original_armor > 0)
-		M.damage_coeff[RED_DAMAGE] = original_armor + 0.2
-
-/datum/status_effect/rendRedArmor/on_remove()
-	. = ..()
-	var/mob/living/simple_animal/M = owner
-	if(M.damage_coeff[RED_DAMAGE] == original_armor + 0.2)
-		M.damage_coeff[RED_DAMAGE] = original_armor
-
+			M.apply_status_effect(/datum/status_effect/sunder_red)


### PR DESCRIPTION
## Changelog
:cl:
add: naked nests that have remaining nested serpents when they die will drop a single serpent and command it to hide.
fix: naked nested inheriting damage coefficents if there is no armor to read.
tweak: status effect Rend Armor duration to 6 seconds
tweak: naked nest now drops the hosts armor when it dies.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
