### PR TITLE
Adds parry to lutemia

### DIFF
--- a/code/datums/abnormality/_ego_datum/teth.dm
+++ b/code/datums/abnormality/_ego_datum/teth.dm
@@ -51,7 +51,7 @@
 
 // Dingle-Dangle - Dear Lutemia
 /datum/ego_datum/weapon/lutemia
-	item_path = /obj/item/ego_weapon/lutemia
+	item_path = /obj/item/ego_weapon/shield/lutemia
 	cost = 20
 
 /datum/ego_datum/armor/lutemia

--- a/code/game/objects/items/ego_weapons/teth.dm
+++ b/code/game/objects/items/ego_weapons/teth.dm
@@ -39,7 +39,7 @@
 	attack_verb_simple = list("poke", "jab", "tear", "lacerate", "gore")
 	hitsound = 'sound/weapons/ego/spear1.ogg'
 
-/obj/item/ego_weapon/lutemia
+/obj/item/ego_weapon/shield/lutemia
 	name = "dear lutemia"
 	desc = "Don't you want your cares to go away?"
 	icon_state = "lutemia"
@@ -49,6 +49,17 @@
 	attack_verb_continuous = list("pokes", "jabs", "tears", "lacerates", "gores")
 	attack_verb_simple = list("poke", "jab", "tear", "lacerate", "gore")
 	hitsound = 'sound/weapons/ego/spear1.ogg'
+	reductions = list(20, 20, 20, 0, 1)
+	recovery_time = 0 SECONDS //No ranged parry
+	block_time = 0.5 SECONDS
+	block_recovery = 3 SECONDS
+	block_sound = 'sound/weapons/parry.ogg'
+	block_message = "You attempt to parry the attack!"
+	hit_message = "parries the attack!"
+	reposition_message = "You rearm your blade."
+
+/obj/item/ego_weapon/shield/lutemia/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
+	return 0 //Prevents ranged  parry
 
 /obj/item/ego_weapon/eyes
 	name = "red eyes"


### PR DESCRIPTION
Refractors lutemia into a shield subtype and gives it a parry

Do not merge until #555 is merged or there will be issues.

![image](https://user-images.githubusercontent.com/35991533/212561586-8a50d7ad-64f2-483a-bd00-d59d5cce52a0.png)

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a parry to Lutemia
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The parry is actually quite weak, and will only be of use to skilled players. It's more content, and while it is a buff to  the weapon misuse of the parry punishes the player. It also lacks the ranged deflect that all shields have by default.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added a parry to Lutemia
refactor: Changed Lutemia into a shield subtype
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
