### PR TITLE
Remove Barriers, and Revival Pens

### DIFF
--- a/code/modules/jobs/job_types/agent.dm
+++ b/code/modules/jobs/job_types/agent.dm
@@ -16,6 +16,8 @@
 	access = list() // LC13:To-Do
 	minimal_access = list()
 
+	allow_bureaucratic_error = FALSE
+
 	roundstart_attributes = list(
 								FORTITUDE_ATTRIBUTE = 20,
 								PRUDENCE_ATTRIBUTE = 20,

--- a/code/modules/jobs/job_types/assistant.dm
+++ b/code/modules/jobs/job_types/assistant.dm
@@ -11,13 +11,13 @@ Assistant
 	access = list()			//See /datum/job/assistant/get_access()
 	minimal_access = list()	//See /datum/job/assistant/get_access()
 	outfit = /datum/outfit/job/assistant
-	antag_rep = 7
-	paycheck = PAYCHECK_ASSISTANT
+	antag_rep = 7 //persistant currency but currently unusable
+
 
 	liver_traits = list(TRAIT_GREYTIDE_METABOLISM)
 
-	paycheck_department = ACCOUNT_CIV
 	display_order = JOB_DISPLAY_ORDER_PRISONER
+	allow_bureaucratic_error = FALSE
 
 
 //they start at -50 all, you max out at level 4
@@ -31,9 +31,8 @@ Assistant
 	l_pocket = /obj/item/sensor_device
 	r_pocket = /obj/item/modular_computer/tablet/preset/advanced/medical
 	backpack_contents = list(
-		/obj/item/storage/firstaid/revival=1,
+		/obj/item/clothing/gloves/color/latex/nitrile = 1,
 		/obj/item/flashlight/seclite = 1,
-		/obj/item/storage/box/barrier= 1,
 		/obj/item/healthanalyzer = 1,
 		/obj/item/gun/ego_gun/clerk = 1,
 		/obj/item/kitchen/knife/hunting = 1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Pens are a remnant of Lobotomy Corp Alpha, a form of healing that is more effective than it is worth.
RP Reason: Lobotomy corp HQ is requesting more branches and that means funding is spread thin.

## Why It's Good For The Game
No one cares about clerks. Also makes things that counter pale damage more rare and valuable.

## Changelog
:cl:
tweak: remove barriers and revival pens from clerks.
tweak: gives clerks nitrile guns
/:cl:
