### PR TITLE
Ordeal size difference update

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/ordeal/_ordeal.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/_ordeal.dm
@@ -1,4 +1,5 @@
 /mob/living/simple_animal/hostile/ordeal
+	mob_size = MOB_SIZE_HUGE
 	robust_searching = TRUE
 	stat_attack = HARD_CRIT
 	a_intent = INTENT_HARM


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a size to most ordeals.

## Why It's Good For The Game
You cant put an ordeal in a bodybag anymore unless its a clown.
edit: All things are now huge. 

## Changelog
:cl:
add: mob_size to most ordeals
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
