### PR TITLE
Fixes on_mob_death procs

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/aleph/mountain.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/mountain.dm
@@ -193,11 +193,13 @@
 
 /mob/living/simple_animal/hostile/abnormality/mountain/proc/on_mob_death(datum/source, mob/living/died, gibbed)
 	SIGNAL_HANDLER
-	if(!(status_flags & GODMODE)) // If it's breaching right now
+	if(!IsContained()) // If it's breaching right now
 		return FALSE
 	if(!ishuman(died))
 		return FALSE
-	if(!died.ckey)
+	if(died.z != z)
+		return FALSE
+	if(!died.mind)
 		return FALSE
 	death_counter += 1
 	if(death_counter >= 2)

--- a/code/modules/mob/living/simple_animal/abnormality/waw/big_bird.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/big_bird.dm
@@ -134,11 +134,13 @@
 
 /mob/living/simple_animal/hostile/abnormality/big_bird/proc/on_mob_death(datum/source, mob/living/died, gibbed)
 	SIGNAL_HANDLER
-	if(!(status_flags & GODMODE)) // If it's breaching right now
+	if(!IsContained()) // If it's breaching right now
 		return FALSE
 	if(!ishuman(died))
 		return FALSE
-	if(!died.ckey)
+	if(died.z != z)
+		return FALSE
+	if(!died.mind)
 		return FALSE
 	datum_reference.qliphoth_change(-1) // One death reduces it
 	return TRUE

--- a/code/modules/mob/living/simple_animal/abnormality/waw/hatred_queen.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/hatred_queen.dm
@@ -205,7 +205,9 @@
 	SIGNAL_HANDLER
 	if(!ishuman(died))
 		return FALSE
-	if(!died.ckey)
+	if(died.z != z)
+		return FALSE
+	if(!died.mind)
 		return FALSE
 	death_counter += 1
 	//if BREACHED, check if death_counter over the death limit


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- MoSB, Big Bird and QoH will now react to insane/afk/otherwise ghosted people dying, if they were previously player controlled.
- The abnormalities will ignore deaths that occured on another z-level.
- Uses IsContained() instead of directly checking for godmode.

## Why It's Good For The Game

- Previously insane people would be ignored as they technically do not have ckey. This fixes it by checking for mind instead.
- They will no longer get triggered by deaths in manager's office or centcom/thunderdome.
- Just code stuff.
