### PR TITLE
Manager can now trigger core suppression

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -356,7 +356,6 @@
 /turf/open/floor/plasteel/dark,
 /area/department_main/manager)
 "cL" = (
-/obj/structure/table/wood,
 /obj/machinery/computer/security/telescreen{
 	network = list("ss13");
 	pixel_y = 39
@@ -385,12 +384,7 @@
 	pixel_x = -20;
 	pixel_y = 27
 	},
-/obj/item/storage/photo_album/captain,
-/obj/item/documents,
-/obj/item/clothing/glasses/regular,
-/obj/item/stamp/denied,
-/obj/item/stamp,
-/obj/item/stamp/captain,
+/obj/machinery/computer/abnormality_auxiliary,
 /turf/open/floor/carpet/royalblack,
 /area/department_main/manager)
 "cS" = (

--- a/code/_globalvars/lists/objects.dm
+++ b/code/_globalvars/lists/objects.dm
@@ -8,6 +8,7 @@ GLOBAL_LIST_EMPTY(machines)					        //NOTE: this is a list of ALL machines n
 GLOBAL_LIST_EMPTY(navigation_computers)				//list of all /obj/machinery/computer/camera_advanced/shuttle_docker
 GLOBAL_LIST_EMPTY(abnormality_consoles)				//list of all abnormality work consoles
 GLOBAL_LIST_EMPTY(abnormality_queue_consoles)		//list of all abnormality queue consoles
+GLOBAL_LIST_EMPTY(abnormality_auxiliary_consoles)	//list of all auxiliary managerial consoles
 GLOBAL_LIST_EMPTY(ordeal_monitors)					//list of all ordeal monitors
 GLOBAL_LIST_EMPTY(regenerators)						//list of all regenerator machines
 GLOBAL_LIST_EMPTY(sleepers)							//list of all sleepers

--- a/code/controllers/subsystem/lobotomy_corp.dm
+++ b/code/controllers/subsystem/lobotomy_corp.dm
@@ -45,6 +45,8 @@ SUBSYSTEM_DEF(lobotomy_corp)
 	var/datum/ordeal/next_ordeal = null
 	// Currently running core suppression
 	var/datum/suppression/core_suppression = null
+	// List of available core suppressions for manager to choose
+	var/list/available_core_suppressions = list()
 	// State of the core suppression
 	var/core_suppression_state = 0
 	// Work logs from all abnormalities
@@ -74,6 +76,22 @@ SUBSYSTEM_DEF(lobotomy_corp)
 		all_ordeals[O.level] += O
 	RollOrdeal()
 	return TRUE
+
+// Called when any normal midnight ends
+/datum/controller/subsystem/lobotomy_corp/proc/PickPotentialSuppressions()
+	if(istype(core_suppression))
+		return
+	var/list/cores = subtypesof(/datum/suppression)
+	for(var/i = 1 to 2)
+		var/core_type = pick(cores)
+		available_core_suppressions += core_type
+		cores -= core_type
+	if(!LAZYLEN(available_core_suppressions))
+		return
+	for(var/obj/machinery/computer/abnormality_auxiliary/A in GLOB.abnormality_auxiliary_consoles)
+		A.audible_message("<span class='notice'>Core Suppressions are now available!</span>")
+		playsound(get_turf(A), 'sound/machines/dun_don_alert.ogg', 50, TRUE)
+		A.updateUsrDialog()
 
 /datum/controller/subsystem/lobotomy_corp/proc/NewAbnormality(datum/abnormality/new_abno)
 	if(!istype(new_abno))

--- a/code/game/machinery/computer/abnormality_auxilary.dm
+++ b/code/game/machinery/computer/abnormality_auxilary.dm
@@ -1,0 +1,66 @@
+// Console for all the random managerial stuff like calling rabbits or starting core suppressions
+/obj/machinery/computer/abnormality_auxiliary
+	name = "auxiliary managerial console"
+	desc = "Used for various optional actions available to manager."
+	resistance_flags = INDESTRUCTIBLE
+	var/datum/suppression/selected_core_type = null
+
+/obj/machinery/computer/abnormality_auxiliary/Initialize()
+	. = ..()
+	GLOB.abnormality_auxiliary_consoles += src
+	flags_1 |= NODECONSTRUCT_1
+
+/obj/machinery/computer/abnormality_auxiliary/Destroy()
+	GLOB.abnormality_auxiliary_consoles -= src
+	..()
+
+/obj/machinery/computer/abnormality_auxiliary/ui_interact(mob/user)
+	. = ..()
+	var/dat
+	if(istype(SSlobotomy_corp.core_suppression))
+		dat += "<b><span style='color: yellow'>[SSlobotomy_corp.core_suppression.name] is currently in the progress!</span></b><hr>"
+	else
+		if(ispath(selected_core_type))
+			dat += "<b>[initial(selected_core_type.name)]</b><br>"
+			dat += "[initial(selected_core_type.desc)]<br>"
+			dat += "<b>Goal:</b> [initial(selected_core_type.goal_text)]<br>"
+			dat += "<b>Reward:</b> [initial(selected_core_type.reward_text)]<br>"
+			dat += "<A href='byond://?src=[REF(src)];init_suppression=1'>Initiate</A>"
+			dat += "<br><hr><br>"
+		for(var/core_type in SSlobotomy_corp.available_core_suppressions)
+			var/datum/suppression/S = core_type
+			dat += "[initial(S.name)]: <A href='byond://?src=[REF(src)];choose_suppression=[core_type]'>Select</A><br>"
+	var/datum/browser/popup = new(user, "abno_logs", "Auxiliary Managerial Console", 400, 400)
+	popup.set_content(dat)
+	popup.open()
+	return
+
+/obj/machinery/computer/abnormality_auxiliary/Topic(href, href_list)
+	. = ..()
+	if(.)
+		return .
+	if(ishuman(usr))
+		usr.set_machine(src)
+		add_fingerprint(usr)
+		if(href_list["choose_suppression"])
+			var/datum/suppression/core_type = text2path(href_list["choose_suppression"])
+			if(!ispath(core_type) || !(core_type in SSlobotomy_corp.available_core_suppressions))
+				return FALSE
+			selected_core_type = core_type
+			to_chat(usr, "<span class='notice'>[initial(selected_core_type.name)] has been selected!</span>")
+			playsound(get_turf(src), 'sound/machines/terminal_prompt_confirm.ogg', 50, TRUE)
+			updateUsrDialog()
+			return TRUE
+		if(href_list["init_suppression"])
+			if(!ispath(selected_core_type) || !(selected_core_type in SSlobotomy_corp.available_core_suppressions))
+				return FALSE
+			if(istype(SSlobotomy_corp.core_suppression))
+				to_chat(usr, "<span class='warning'>A core suppression is already in the progress!</span>")
+				selected_core_type = null
+				return FALSE
+			SSlobotomy_corp.core_suppression = new selected_core_type
+			to_chat(usr, "<span class='userdanger'>Good luck, Manager.</span>")
+			playsound(get_turf(src), 'sound/machines/terminal_prompt_confirm.ogg', 50, TRUE)
+			updateUsrDialog()
+			addtimer(CALLBACK(SSlobotomy_corp.core_suppression, /datum/suppression/proc/Run), 2 SECONDS)
+			return TRUE

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -106,7 +106,8 @@ GLOBAL_LIST_INIT(admin_verbs_fun, list(
 	/client/proc/show_tip,
 	/client/proc/smite,
 	/client/proc/admin_away,
-	/client/proc/AbnoRadio
+	/client/proc/AbnoRadio,
+	/client/proc/InitCoreSuppression
 	))
 GLOBAL_PROTECT(admin_verbs_fun)
 GLOBAL_LIST_INIT(admin_verbs_spawn, list(/datum/admins/proc/spawn_atom, /datum/admins/proc/podspawn_atom, /datum/admins/proc/spawn_cargo, /datum/admins/proc/spawn_objasmob, /client/proc/respawn_character, /datum/admins/proc/beaker_panel))

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -1110,6 +1110,34 @@ Traitors and the like can also be revived with the previous role mostly intact.
 			continue
 		A.current.AbnoRadio()
 
+// Selects and starts a core suppression
+/client/proc/InitCoreSuppression()
+	set category = "Admin.Fun"
+	set name = "Start Core Suppression"
+	if(!check_rights(R_ADMIN) || !check_rights(R_FUN))
+		return
+
+	if(istype(SSlobotomy_corp.core_suppression))
+		var/confirm = alert(src, "Another Core Suppression is already in progress. Are you sure you want to proceed?", "Replace suppression", "Yes", "No")
+		if(confirm != "Yes")
+			return
+	var/datum/suppression/core_type = input("Select core suppression type","Set Core Type") as null|anything in subtypesof(/datum/suppression)
+	if(!ispath(core_type))
+		return
+	var/run_white = alert(src, "Do you wish to queue white ordeals?", "White Ordeals", "Yes", "No", "Cancel")
+	var/white_ordeals = TRUE
+	if(!(run_white in list("Yes", "No")))
+		return
+	if(run_white == "No")
+		white_ordeals = FALSE
+	SSlobotomy_corp.core_suppression = new core_type
+	SSlobotomy_corp.core_suppression.Run(white_ordeals)
+
+	log_admin("[key_name(usr)] has initiated [SSlobotomy_corp.core_suppression.name].")
+	message_admins("[key_name(usr)] has initiated [SSlobotomy_corp.core_suppression.name].")
+
+	SSblackbox.record_feedback("nested tally", "admin_core_suppression", 1, list("Initiated Core Suppression", "[SSlobotomy_corp.core_suppression.name]")) //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+
 /**
  * firing_squad is a proc for the :B:erforate smite to shoot each individual bullet at them, so that we can add actual delays without sleep() nonsense
  *

--- a/code/modules/ordeals/_ordeal.dm
+++ b/code/modules/ordeals/_ordeal.dm
@@ -43,6 +43,8 @@
 		for(var/mob/M in GLOB.player_list)
 			if(M.client)
 				M.playsound_local(get_turf(M), end_sound, 35, 0)
+	if(level == 4 && !istype(SSlobotomy_corp.core_suppression) && !LAZYLEN(SSlobotomy_corp.available_core_suppressions))
+		addtimer(CALLBACK(SSlobotomy_corp, /datum/controller/subsystem/lobotomy_corp/proc/PickPotentialSuppressions), 5 SECONDS)
 	qdel(src)
 	return
 

--- a/code/modules/ordeals/white_ordeals.dm
+++ b/code/modules/ordeals/white_ordeals.dm
@@ -93,4 +93,5 @@
 /datum/ordeal/white_midnight/End()
 	if(istype(SSlobotomy_corp.core_suppression)) // If it all was a part of core suppression
 		SSlobotomy_corp.core_suppression_state = 3
+		addtimer(CALLBACK(SSlobotomy_corp.core_suppression, /datum/suppression/proc/End), 5 SECONDS)
 	return ..()

--- a/code/modules/suppressions/_core_suppression.dm
+++ b/code/modules/suppressions/_core_suppression.dm
@@ -1,6 +1,12 @@
 /datum/suppression
 	/// This will be displayed as announcement title
 	var/name = "Nothing Core Suppression"
+	/// This is displayed in auxiliary manager's console when selected
+	var/desc = "Normal effects of core suppression will apply. Yell at coders to fix description."
+	/// Same as above, but what facility has to do to win
+	var/goal_text = "Complete the Midnight of White."
+	/// Ditto, but for reward
+	var/reward_text = "N/A"
 	/// Announcement text. Self-explanatory
 	var/run_text = "The core suppression of Nothing department has begun."
 	/// Announcement text on the end.

--- a/code/modules/suppressions/control.dm
+++ b/code/modules/suppressions/control.dm
@@ -1,5 +1,6 @@
 /datum/suppression/control
 	name = "Control Core Suppression"
+	desc = "Assignments on the abnormality work consoles will be scrambled each meltdown/ordeal."
 	run_text = "The core suppression of Control department has begun. The work assignments will be scrambled each meltdown."
 
 /datum/suppression/control/Run(run_white = TRUE)

--- a/code/modules/suppressions/information.dm
+++ b/code/modules/suppressions/information.dm
@@ -1,6 +1,8 @@
 // Most of its effects are applied elsewhere
 /datum/suppression/information
 	name = "Information Core Suppression"
+	desc = "Assignments on the abnormality work consoles will be in random positions.\n\
+			Telecommunications and suit sensors will be negatively impacted."
 	run_text = "The core suppression of Information department has begun. The information and sensors will be distorted for its duration."
 
 /datum/suppression/information/Run(run_white = TRUE)

--- a/code/modules/suppressions/safety.dm
+++ b/code/modules/suppressions/safety.dm
@@ -1,5 +1,9 @@
 /datum/suppression/safety
 	name = "Safety Core Suppression"
+	desc = "Regenerators will stop operating normally, only reactivating for short time after each meltdown.\n\
+			Sleepers will be non-functional.\n\
+			Medi-pens will have a chance to malfunction and require a delay on each activation."
+	reward_text = "All regenerators will receive a permanent +3 boost to healing power."
 	run_text = "The core suppression of Safety department has begun. The regenerators and sleepers will stop operating normally. Regenerators will resume their work for a short while on each meltdown instead."
 
 /datum/suppression/safety/Run(run_white = TRUE)

--- a/code/modules/suppressions/training.dm
+++ b/code/modules/suppressions/training.dm
@@ -1,6 +1,9 @@
 // Right now the only core suppression with a proper reward, which is higher spawning stats.
 /datum/suppression/training
 	name = "Training Core Suppression"
+	desc = "All employees will have a -40 debuff on each attribute for the duration of suppression."
+	reward_text = "Employees that survived through the suppression will be awarded with 20 increase and +5 buff to all attributes.\n\
+			All Agents that will join post-suppression will start with higher attributes."
 	run_text = "The core suppression of Training department has begun. All personnel will be suffering from symptoms of work fatigue."
 	var/list/affected_mobs = list()
 
@@ -16,7 +19,7 @@
 /datum/suppression/training/End()
 	UnregisterSignal(SSdcs, COMSIG_GLOB_CREWMEMBER_JOINED)
 	for(var/mob/living/carbon/human/H in affected_mobs)
-		H.adjust_all_attribute_buffs(40)
+		H.adjust_all_attribute_buffs(45)
 		H.adjust_all_attribute_levels(20) // A tiny reward
 	for(var/datum/job/agent/J in SSjob.occupations)
 		J.normal_attribute_level += 5 // This allows agents to spawn with 100 in all stats

--- a/lobotomy-corp13.dme
+++ b/lobotomy-corp13.dme
@@ -926,6 +926,7 @@
 #include "code\game\machinery\camera\tracking.dm"
 #include "code\game\machinery\computer\_computer.dm"
 #include "code\game\machinery\computer\abnormality_archive.dm"
+#include "code\game\machinery\computer\abnormality_auxilary.dm"
 #include "code\game\machinery\computer\abnormality_ego.dm"
 #include "code\game\machinery\computer\abnormality_logs.dm"
 #include "code\game\machinery\computer\abnormality_queue.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Adds "auxiliary managerial console" which is used for triggering core suppressions. It is located in manager's office.
- Adds an admin verb to begin core suppression.

## Why It's Good For The Game

- Managers no longer need to rely on admins for the epic post-game content. Although be warned, game allows you to only pick from two randomly chosen types.
- Admin QOL.
