### PR TITLE
Fix murder insanity moving while dead

### DIFF
--- a/code/datums/ai/sanity/_sanityloss_controller.dm
+++ b/code/datums/ai/sanity/_sanityloss_controller.dm
@@ -90,7 +90,7 @@
 
 /datum/ai_controller/insane/murder/MoveTo(delta_time)
 	var/mob/living/living_pawn = pawn
-	if(!current_movement_target || QDELETED(current_movement_target) || current_movement_target.z != living_pawn.z || get_dist(living_pawn, current_movement_target) > max_target_distance)
+	if(!able_to_run() || !current_movement_target || QDELETED(current_movement_target) || current_movement_target.z != living_pawn.z || get_dist(living_pawn, current_movement_target) > max_target_distance)
 		timerid = null
 		return FALSE
 	timerid = addtimer(CALLBACK(src, .proc/MoveTo, delta_time), living_pawn.cached_multiplicative_slowdown)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Murder insanity will not walk toward targets when dead or incapacitated.

## Why It's Good For The Game

Fix.
