### PR TITLE
WAW armor requirements, and Teth armor rebalance

### DIFF
--- a/code/modules/clothing/suits/ego_gear/teth.dm
+++ b/code/modules/clothing/suits/ego_gear/teth.dm
@@ -17,14 +17,14 @@
 	desc = "The archetype was already charred from the moment of extraction. \
 	Although the exterior is scorched, it has no adverse effects on the E.G.O's performance."
 	icon_state = "match"
-	armor = list(RED_DAMAGE = 40, WHITE_DAMAGE = 0, BLACK_DAMAGE = -20, PALE_DAMAGE = 0) // 20
+	armor = list(RED_DAMAGE = 40, WHITE_DAMAGE = -20, BLACK_DAMAGE = -20, PALE_DAMAGE = 0) // 20
 
 /obj/item/clothing/suit/armor/ego_gear/fragment
 	name = "fragments from somewhere"
 	desc = "Do not attempt to understand it, just use it. \
 	Sometimes, the wielder may see things we have long forgotten."
 	icon_state = "fragment"
-	armor = list(RED_DAMAGE = 0, WHITE_DAMAGE = -20, BLACK_DAMAGE = 40, PALE_DAMAGE = 0) // 20
+	armor = list(RED_DAMAGE = -20, WHITE_DAMAGE = -20, BLACK_DAMAGE = 40, PALE_DAMAGE = 0) // 20
 
 /obj/item/clothing/suit/armor/ego_gear/horn
 	name = "horn"
@@ -36,7 +36,7 @@
 	name = "dear lutemia"
 	desc = "Your sadness, woes, cast them all aside."
 	icon_state = "lutemia"
-	armor = list(RED_DAMAGE = -20, WHITE_DAMAGE = 40, BLACK_DAMAGE = 0, PALE_DAMAGE = 0) // 20
+	armor = list(RED_DAMAGE = -20, WHITE_DAMAGE = 40, BLACK_DAMAGE = -20, PALE_DAMAGE = 0) // 20
 
 /obj/item/clothing/suit/armor/ego_gear/eyes
 	name = "red eyes"
@@ -84,7 +84,7 @@
 	name = "cherry blossoms"
 	desc = "Sitting under the tree’s shadow makes you feel like these gloomy days will flutter away like the petals of a flower."
 	icon_state = "blossoms"
-	armor = list(RED_DAMAGE = 20, WHITE_DAMAGE = 40, BLACK_DAMAGE = -50, PALE_DAMAGE = -20)
+	armor = list(RED_DAMAGE = 20, WHITE_DAMAGE = 30, BLACK_DAMAGE = -30, PALE_DAMAGE = 0)
 
 /obj/item/clothing/suit/armor/ego_gear/regret
 	name = "regret"
@@ -102,7 +102,7 @@
 	name = "todays expression"
 	desc = "One sunny day, just like that day they sincerely dried the laundry, they dried their own skin."
 	icon_state = "shy"
-	armor = list(RED_DAMAGE = 30, WHITE_DAMAGE = 30, BLACK_DAMAGE = -40, PALE_DAMAGE = 0)
+	armor = list(RED_DAMAGE = 30, WHITE_DAMAGE = 20, BLACK_DAMAGE = -30, PALE_DAMAGE = 0)
 
 /obj/item/clothing/suit/armor/ego_gear/trick
 	name = "hat trick"
@@ -121,7 +121,7 @@
 	desc = "The more entrancing it is, the bigger the disappointment will be when dawn breaks."
 	icon_state = "dream"
 	armor = list(RED_DAMAGE = 0, WHITE_DAMAGE = 30, BLACK_DAMAGE = -10, PALE_DAMAGE = 0)
-	
+
 /obj/item/clothing/suit/armor/ego_gear/bean
 	name = "magic bean"
 	desc = "The handful of magic beans grew into a massive, towering beanstalk."

--- a/code/modules/clothing/suits/ego_gear/waw.dm
+++ b/code/modules/clothing/suits/ego_gear/waw.dm
@@ -84,7 +84,8 @@
 	icon_state = "tiara"
 	armor = list(RED_DAMAGE = 10, WHITE_DAMAGE = 50, BLACK_DAMAGE = 30, PALE_DAMAGE = 50)
 	attribute_requirements = list(
-							TEMPERANCE_ATTRIBUTE = 60
+							TEMPERANCE_ATTRIBUTE = 60,
+							JUSTICE_ATTRIBUTE = 60
 							)
 
 /obj/item/clothing/suit/armor/ego_gear/wife
@@ -93,7 +94,7 @@
 	icon_state = "wife"
 	armor = list(RED_DAMAGE = 10, WHITE_DAMAGE = 60, BLACK_DAMAGE = 40, PALE_DAMAGE = 30)
 	attribute_requirements = list(
-							PRUDENCE_ATTRIBUTE = 60
+							PRUDENCE_ATTRIBUTE = 80
 							)
 
 /obj/item/clothing/suit/armor/ego_gear/cobalt
@@ -102,7 +103,7 @@
 	icon_state = "cobalt_scar"
 	armor = list(RED_DAMAGE = 60, WHITE_DAMAGE = 30, BLACK_DAMAGE = 40, PALE_DAMAGE = 10)
 	attribute_requirements = list(
-							FORTITUDE_ATTRIBUTE = 60
+							FORTITUDE_ATTRIBUTE = 80
 							)
 
 /obj/item/clothing/suit/armor/ego_gear/spore
@@ -111,6 +112,7 @@
 	icon_state = "spore"
 	armor = list(RED_DAMAGE = 10, WHITE_DAMAGE = 60, BLACK_DAMAGE = 30, PALE_DAMAGE = 40)
 	attribute_requirements = list(
+							FORTITUDE_ATTRIBUTE = 60,
 							TEMPERANCE_ATTRIBUTE = 60
 							)
 
@@ -120,6 +122,7 @@
 	icon_state = "green_stem"
 	armor = list(RED_DAMAGE = 40, WHITE_DAMAGE = 10, BLACK_DAMAGE = 70, PALE_DAMAGE = 20)
 	attribute_requirements = list(
+							TEMPERANCE_ATTRIBUTE = 60,
 							PRUDENCE_ATTRIBUTE = 60)
 
 /obj/item/clothing/suit/armor/ego_gear/loyalty
@@ -128,7 +131,7 @@
 	icon_state = "loyalty"
 	armor = list(RED_DAMAGE = 60, WHITE_DAMAGE = 30, BLACK_DAMAGE = 30, PALE_DAMAGE = 20)
 	attribute_requirements = list(
-							FORTITUDE_ATTRIBUTE = 60)
+							FORTITUDE_ATTRIBUTE = 80)
 
 /obj/item/clothing/suit/armor/ego_gear/executive
 	name = "executive"
@@ -146,7 +149,7 @@
 	icon_state = "ecstasy"
 	armor = list(RED_DAMAGE = 40, WHITE_DAMAGE = 70, BLACK_DAMAGE = 10, PALE_DAMAGE = 20)
 	attribute_requirements = list(
-							TEMPERANCE_ATTRIBUTE = 60)
+							TEMPERANCE_ATTRIBUTE = 80)
 
 /obj/item/clothing/suit/armor/ego_gear/throne
 	name = "false throne"
@@ -154,7 +157,8 @@
 	icon_state = "throne"
 	armor = list(RED_DAMAGE = 30, WHITE_DAMAGE = 0, BLACK_DAMAGE = 40, PALE_DAMAGE = 70)
 	attribute_requirements = list(
-							PRUDENCE_ATTRIBUTE = 60)
+							PRUDENCE_ATTRIBUTE = 60,
+							JUSTICE_ATTRIBUTE = 60)
 
 /obj/item/clothing/suit/armor/ego_gear/intentions
 	name = "good intentions"
@@ -162,6 +166,7 @@
 	icon_state = "intentions"
 	armor = list(RED_DAMAGE = 40, WHITE_DAMAGE = 10, BLACK_DAMAGE = 60, PALE_DAMAGE = 30)
 	attribute_requirements = list(
+							TEMPERANCE_ATTRIBUTE = 60,
 							FORTITUDE_ATTRIBUTE = 60)
 
 /obj/item/clothing/suit/armor/ego_gear/aroma
@@ -171,7 +176,8 @@
 	icon_state = "aroma"
 	armor = list(RED_DAMAGE = 0, WHITE_DAMAGE = 60, BLACK_DAMAGE = 50, PALE_DAMAGE = 30) // 140
 	attribute_requirements = list(
-							FORTITUDE_ATTRIBUTE = 60
+							FORTITUDE_ATTRIBUTE = 60,
+							PRUDENCE_ATTRIBUTE = 60
 							)
 
 /obj/item/clothing/suit/armor/ego_gear/thirteen
@@ -180,7 +186,7 @@
 	icon_state = "thirteen"
 	armor = list(RED_DAMAGE = 10, WHITE_DAMAGE = 10, BLACK_DAMAGE = 50, PALE_DAMAGE = 70) // 140
 	attribute_requirements = list(
-							JUSTICE_ATTRIBUTE = 60
+							JUSTICE_ATTRIBUTE = 80
 							)
 
 /obj/item/clothing/suit/armor/ego_gear/assonance
@@ -189,7 +195,7 @@
 	icon_state = "assonance"
 	armor = list(RED_DAMAGE = 30, WHITE_DAMAGE = 60, BLACK_DAMAGE = 20, PALE_DAMAGE = 30) // 140
 	attribute_requirements = list(
-							PRUDENCE_ATTRIBUTE = 60
+							PRUDENCE_ATTRIBUTE = 80
 							)
 
 /obj/item/clothing/suit/armor/ego_gear/exuviae
@@ -198,5 +204,6 @@
 	icon_state = "exuviae"
 	armor = list(RED_DAMAGE = 60, WHITE_DAMAGE = 40, BLACK_DAMAGE = 20, PALE_DAMAGE = 20) // 140
 	attribute_requirements = list(
+							FORTITUDE_ATTRIBUTE = 60,
 							TEMPERANCE_ATTRIBUTE = 60
 							)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
4th Match Flame, Dear Lutemia and Fragments from Somewhere have all be nerfed to a statline of 4/0/-2/-2. 
All WAW armor has been changed to require either 2x60 stat or 1x80 stats. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This PR is an attempt to increase the usefulness of HE armor by nerfing the 4 armor teth, as well as making the gap between teth and WAW armor larger.

Also, rather than totally removing the 4/0/0/-2 meta teth armor, this is an attempt to change it into tech picks, akin to Blind Fury.


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: increased all waw armor requirements.
balance: rebalanced 4/0/0/-2 teth armor.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
