### PR TITLE
Warden is now faster and has a cap on her speed

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/waw/warden.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/warden.dm
@@ -12,7 +12,7 @@
 	damage_coeff = list(BRUTE = 1, RED_DAMAGE = 0.7, WHITE_DAMAGE = 1.2, BLACK_DAMAGE = 0.4, PALE_DAMAGE = 1.5)
 
 	speed = 4
-	move_to_delay = 5
+	move_to_delay = 4
 	melee_damage_lower = 70
 	melee_damage_upper = 70
 	melee_damage_type = BLACK_DAMAGE
@@ -62,14 +62,13 @@
 			H.dust()
 
 			// it gets faster.
-			move_to_delay -= move_to_delay*0.2
-			speed += speed*0.2
+			if(move_to_delay>1)
+				move_to_delay -= move_to_delay*0.25
+				speed += speed*0.2
+				if(melee_damage_lower > 30)
+					melee_damage_lower -=5
 
-			if(melee_damage_lower>30)
-				melee_damage_lower -=5
-				melee_damage_upper -=5
-
-			adjustBruteLoss(-(maxHealth*0.1)) // Heals 10% HP, fuck you that's why. Still not as bad as judgement or big bird
+			adjustBruteLoss(-(maxHealth*0.2)) // Heals 20% HP, fuck you that's why. Still not as bad as judgement or big bird
 
 			finishing = FALSE
 			icon_state = "warden"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Warden now starts at 4 move to delay, and gets 25% faster instead of 20% faster.
Warden now has a cap on her speed, at 1 MTD
Warden now heals 20% HP instead of 10%
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Warden does need a slight buff; I rarely see her get started.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Warden moves faster and her speed has a cap
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
