### PR TITLE
WAW+ Pale Weapon Damage Reduction

### DIFF
--- a/code/game/objects/items/ego_weapons/aleph.dm
+++ b/code/game/objects/items/ego_weapons/aleph.dm
@@ -52,7 +52,7 @@
 	desc = "A sharp sword covered in bandages. It may be able to not only cut flesh but trace of sins as well."
 	special = "This weapon has a combo system."
 	icon_state = "justitia"
-	force = 35
+	force = 25
 	damtype = PALE_DAMAGE
 	armortype = PALE_DAMAGE
 	attack_verb_continuous = list("attacks", "slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "cuts")

--- a/code/game/objects/items/ego_weapons/waw.dm
+++ b/code/game/objects/items/ego_weapons/waw.dm
@@ -308,7 +308,7 @@
 	desc = "There is nothing else than now. There is neither yesterday, certainly, nor is there any tomorrow."
 	special = "This weapon deals an absurd amount of damage on the 13th hit."
 	icon_state = "thirteen"
-	force = 35
+	force = 30
 	damtype = PALE_DAMAGE
 	armortype = PALE_DAMAGE
 	attack_verb_continuous = list("cuts", "attacks", "slashes")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Justitia's base damage has been reduced from 35 to 25. (DPS from 89 > 67)
Bell Toll's Base Damage has been reduced from 35 > 30
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Justitia is an over-centralizing weapon, dealing the best damage type and having a tiny AOE.
This brings it into check and line with other aleph weapons, rather than out-DPSing every single one, on the best damage type.

I ran some calculations.
A Single Combo deals 272.5 damage, not adjusted for justice
This combo takes 2.9x cooldown to finish.
Justitia does 89 PALE Converted DPS, with a tiny AOE on the last hit.
This pull request brings it into line, now dealing 67 DPS, on the best damage type. 
It still out-DPSes Blooming's pale damage pretty significantly.

Here's some comparisons to other aleph weapons (only the easily calculable ones):
Mimicry - 80 DPS
Da Capo - 93 DPS (Single Target) 80 DPS (Multi-target)
Smile - 68 DPS
CENSORED - 86.8 DPS (Includes ranged damage)
Out of Space - 70 DPS (Split between white and black, so this is dubious.)
Blooming - 80/70/50 Red/White/Pale

Not only does Justitia have the best damage type out of all aleph weapons, it also out-DPSes all of them.
Now It has slightly worse DPS, on a significantly better damage type, making it a more generalist weapon than the 5 aleph weapons listed above at the slight cost of DPS (Not including blooming)


Bell Tolls, also being a pale damage, is not as meta centralizing, but does have good representation.
This keeps it's damage still mostly in line, being 25% worse than other ego in class, on a significantly better damage type (Nothing in WAW tier is immune to pale, unlike red and black). This makes it more consistently a good choice, but not often the best choice


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Justitia base damage nerfed from 35 to 25
balance: For Whom the Bell Tolls damage reduced from 35 to 30
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
