### PR TITLE
Adds in Extraction Cargo Console

### DIFF
--- a/_maps/map_files/Alpha/alphacorp.dmm
+++ b/_maps/map_files/Alpha/alphacorp.dmm
@@ -1580,6 +1580,12 @@
 /obj/machinery/camera/autoname,
 /turf/open/floor/carpet/black,
 /area/department_main/records)
+"lZ" = (
+/obj/machinery/computer/extraction_cargo{
+	dir = 8
+	},
+/turf/open/floor/carpet/royalblack,
+/area/department_main/control)
 "mb" = (
 /obj/effect/turf_decal/box/white,
 /obj/structure/toolabnormality/mirror,
@@ -2059,35 +2065,8 @@
 /turf/open/floor/facility/dark,
 /area/department_main/training)
 "pX" = (
-/obj/item/reagent_containers/hypospray/medipen/salacid,
-/obj/item/reagent_containers/hypospray/medipen/salacid,
-/obj/item/reagent_containers/hypospray/medipen/salacid,
-/obj/item/reagent_containers/hypospray/medipen/salacid,
-/obj/item/reagent_containers/hypospray/medipen/salacid,
-/obj/item/reagent_containers/hypospray/medipen/salacid,
-/obj/item/reagent_containers/hypospray/medipen/salacid,
-/obj/item/reagent_containers/hypospray/medipen/salacid,
-/obj/item/reagent_containers/hypospray/medipen/salacid,
-/obj/item/reagent_containers/hypospray/medipen/salacid,
-/obj/item/reagent_containers/hypospray/medipen/salacid,
-/obj/item/reagent_containers/hypospray/medipen/salacid,
-/obj/item/reagent_containers/hypospray/medipen/salacid,
-/obj/item/reagent_containers/hypospray/medipen/salacid,
-/obj/item/reagent_containers/hypospray/medipen/salacid,
-/obj/item/reagent_containers/hypospray/medipen/salacid,
-/obj/item/reagent_containers/hypospray/medipen/salacid,
-/obj/item/reagent_containers/hypospray/medipen/salacid,
-/obj/item/reagent_containers/hypospray/medipen/salacid,
-/obj/item/reagent_containers/hypospray/medipen/salacid,
-/obj/item/reagent_containers/hypospray/medipen/salacid,
-/obj/item/reagent_containers/hypospray/medipen/salacid,
-/obj/item/reagent_containers/hypospray/medipen/salacid,
-/obj/item/reagent_containers/hypospray/medipen/salacid,
-/obj/item/reagent_containers/hypospray/medipen/salacid,
-/obj/item/reagent_containers/hypospray/medipen/salacid,
-/obj/item/reagent_containers/hypospray/medipen/salacid,
-/obj/item/reagent_containers/hypospray/medipen/salacid,
 /obj/structure/rack,
+/obj/item/reagent_containers/hypospray/medipen/salacid,
 /turf/open/floor/carpet/green,
 /area/department_main/safety)
 "qa" = (
@@ -3437,26 +3416,6 @@
 /turf/open/floor/facility,
 /area/facility_hallway/north)
 "zC" = (
-/obj/item/reagent_containers/hypospray/medipen/mental,
-/obj/item/reagent_containers/hypospray/medipen/mental,
-/obj/item/reagent_containers/hypospray/medipen/mental,
-/obj/item/reagent_containers/hypospray/medipen/mental,
-/obj/item/reagent_containers/hypospray/medipen/mental,
-/obj/item/reagent_containers/hypospray/medipen/mental,
-/obj/item/reagent_containers/hypospray/medipen/mental,
-/obj/item/reagent_containers/hypospray/medipen/mental,
-/obj/item/reagent_containers/hypospray/medipen/mental,
-/obj/item/reagent_containers/hypospray/medipen/mental,
-/obj/item/reagent_containers/hypospray/medipen/mental,
-/obj/item/reagent_containers/hypospray/medipen/mental,
-/obj/item/reagent_containers/hypospray/medipen/mental,
-/obj/item/reagent_containers/hypospray/medipen/mental,
-/obj/item/reagent_containers/hypospray/medipen/mental,
-/obj/item/reagent_containers/hypospray/medipen/mental,
-/obj/item/reagent_containers/hypospray/medipen/mental,
-/obj/item/reagent_containers/hypospray/medipen/mental,
-/obj/item/reagent_containers/hypospray/medipen/mental,
-/obj/item/reagent_containers/hypospray/medipen/mental,
 /obj/structure/rack,
 /obj/machinery/camera/autoname{
 	dir = 1
@@ -3464,6 +3423,7 @@
 /obj/machinery/newscaster{
 	pixel_y = -32
 	},
+/obj/item/reagent_containers/hypospray/medipen/mental,
 /turf/open/floor/carpet/green,
 /area/department_main/safety)
 "zI" = (
@@ -42041,8 +42001,8 @@ rg
 Wl
 SH
 Rj
+lZ
 SB
-ci
 rg
 Zj
 iA

--- a/_maps/map_files/Beta/betacorp.dmm
+++ b/_maps/map_files/Beta/betacorp.dmm
@@ -315,6 +315,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/facility_hallway/north)
+"bw" = (
+/obj/structure/table/wood/fancy/green,
+/obj/item/reagent_containers/hypospray/medipen/salacid,
+/turf/open/floor/carpet/green,
+/area/department_main/safety)
 "by" = (
 /obj/effect/turf_decal/siding/blue/corner{
 	color = "#3234B9";
@@ -1420,7 +1425,6 @@
 /obj/item/toy/plush/netzach,
 /obj/effect/turf_decal/bot,
 /obj/item/clothing/neck/stripedgreenscarf,
-/obj/item/reagent_containers/hypospray/emais,
 /turf/open/floor/plasteel/dark,
 /area/department_main/safety)
 "hJ" = (
@@ -1471,7 +1475,6 @@
 /obj/structure/sign/ordealmonitor{
 	pixel_x = 32
 	},
-/obj/item/storage/belt/ego,
 /obj/effect/turf_decal/siding{
 	color = "#440000";
 	dir = 8
@@ -1922,7 +1925,6 @@
 /obj/item/toy/plush/netzach,
 /obj/effect/turf_decal/bot,
 /obj/item/clothing/neck/stripedgreenscarf,
-/obj/item/reagent_containers/hypospray/emais,
 /turf/open/floor/plasteel/dark,
 /area/department_main/safety)
 "jU" = (
@@ -2724,14 +2726,7 @@
 /area/department_main/safety)
 "nl" = (
 /obj/structure/rack,
-/obj/item/reagent_containers/hypospray/medipen/salacid,
-/obj/item/reagent_containers/hypospray/medipen/salacid,
-/obj/item/reagent_containers/hypospray/medipen/salacid,
-/obj/item/reagent_containers/hypospray/medipen/salacid,
-/obj/item/reagent_containers/hypospray/medipen/salacid,
-/obj/item/reagent_containers/hypospray/medipen/salacid,
-/obj/item/reagent_containers/hypospray/medipen/salacid,
-/obj/item/reagent_containers/hypospray/medipen/salacid,
+/obj/item/reagent_containers/hypospray/medipen/mental,
 /turf/open/floor/carpet/royalblue,
 /area/department_main/welfare)
 "nm" = (
@@ -3168,7 +3163,6 @@
 /obj/effect/turf_decal/bot,
 /obj/item/toy/plush/yesod,
 /obj/item/clothing/neck/scarf/purple,
-/obj/item/safety_kit,
 /obj/machinery/camera/autoname{
 	dir = 1
 	},
@@ -3328,22 +3322,9 @@
 /turf/open/floor/plasteel,
 /area/facility_hallway/training)
 "qw" = (
-/obj/item/reagent_containers/hypospray/medipen/mental,
-/obj/item/reagent_containers/hypospray/medipen/mental,
-/obj/item/reagent_containers/hypospray/medipen/mental,
-/obj/item/reagent_containers/hypospray/medipen/mental,
-/obj/item/reagent_containers/hypospray/medipen/mental,
-/obj/item/reagent_containers/hypospray/medipen/mental,
-/obj/item/reagent_containers/hypospray/medipen/mental,
-/obj/item/reagent_containers/hypospray/medipen/mental,
-/obj/item/reagent_containers/hypospray/medipen/mental,
-/obj/item/reagent_containers/hypospray/medipen/mental,
 /obj/structure/table/reinforced,
-/obj/item/reagent_containers/hypospray/medipen/mental,
-/obj/item/reagent_containers/hypospray/medipen/mental,
-/obj/item/reagent_containers/hypospray/medipen/mental,
-/obj/item/reagent_containers/hypospray/medipen/mental,
-/obj/item/reagent_containers/hypospray/medipen/mental,
+/obj/item/reagent_containers/hypospray/medipen/salacid,
+/obj/item/reagent_containers/hypospray/medipen/salacid,
 /turf/open/floor/carpet/green,
 /area/department_main/safety)
 "qA" = (
@@ -3452,11 +3433,10 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/obj/structure/closet/crate/freezer/blood,
-/obj/machinery/iv_drip,
 /obj/machinery/camera/autoname{
 	dir = 10
 	},
+/obj/structure/closet/crate/freezer/surplus_limbs,
 /turf/open/floor/plasteel/dark,
 /area/department_main/safety)
 "rc" = (
@@ -4085,6 +4065,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/facility_hallway/south)
+"tE" = (
+/obj/machinery/light/cold,
+/obj/structure/rack,
+/obj/item/storage/belt/ego,
+/turf/open/floor/carpet/royalblack,
+/area/department_main/discipline)
 "tJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -4232,7 +4218,6 @@
 /obj/effect/turf_decal/bot,
 /obj/item/toy/plush/yesod,
 /obj/item/clothing/neck/scarf/purple,
-/obj/item/safety_kit,
 /turf/open/floor/plasteel/dark,
 /area/department_main/information)
 "uk" = (
@@ -4481,6 +4466,11 @@
 /obj/item/clothing/neck/scarf/yellow,
 /turf/open/floor/plasteel,
 /area/department_main/command)
+"vu" = (
+/obj/structure/table/wood/fancy/green,
+/obj/item/reagent_containers/hypospray/medipen/mental,
+/turf/open/floor/carpet/green,
+/area/department_main/safety)
 "vA" = (
 /obj/effect/turf_decal/siding{
 	color = "#440000";
@@ -4536,7 +4526,6 @@
 /obj/item/toy/plush/netzach,
 /obj/effect/turf_decal/bot,
 /obj/item/clothing/neck/stripedgreenscarf,
-/obj/item/reagent_containers/hypospray/emais,
 /turf/open/floor/plasteel/dark,
 /area/department_main/safety)
 "vY" = (
@@ -5569,14 +5558,7 @@
 /area/department_main/training)
 "Cb" = (
 /obj/structure/rack,
-/obj/item/reagent_containers/hypospray/medipen/mental,
-/obj/item/reagent_containers/hypospray/medipen/mental,
-/obj/item/reagent_containers/hypospray/medipen/mental,
-/obj/item/reagent_containers/hypospray/medipen/mental,
-/obj/item/reagent_containers/hypospray/medipen/mental,
-/obj/item/reagent_containers/hypospray/medipen/mental,
-/obj/item/reagent_containers/hypospray/medipen/mental,
-/obj/item/reagent_containers/hypospray/medipen/mental,
+/obj/item/reagent_containers/hypospray/medipen/salacid,
 /turf/open/floor/carpet/royalblue,
 /area/department_main/welfare)
 "Cc" = (
@@ -6128,7 +6110,6 @@
 /area/department_main/information)
 "EP" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/belt/ego,
 /obj/effect/turf_decal/siding{
 	color = "#440000";
 	dir = 6
@@ -6578,10 +6559,6 @@
 	},
 /turf/closed/indestructible/reinforced,
 /area/department_main/training)
-"GY" = (
-/obj/structure/table/reinforced,
-/turf/open/floor/facility/dark,
-/area/department_main/discipline)
 "Ha" = (
 /obj/effect/turf_decal/siding/red{
 	dir = 1
@@ -8794,8 +8771,6 @@
 /obj/structure/sign/poster/lobotomycorp/random{
 	pixel_x = 32
 	},
-/obj/item/storage/belt/ego,
-/obj/item/storage/belt/ego,
 /obj/effect/turf_decal/siding{
 	color = "#440000";
 	dir = 8
@@ -9363,23 +9338,10 @@
 /turf/open/floor/carpet/stellar,
 /area/department_main/command)
 "Vi" = (
-/obj/item/reagent_containers/hypospray/medipen/salacid,
-/obj/item/reagent_containers/hypospray/medipen/salacid,
-/obj/item/reagent_containers/hypospray/medipen/salacid,
-/obj/item/reagent_containers/hypospray/medipen/salacid,
-/obj/item/reagent_containers/hypospray/medipen/salacid,
-/obj/item/reagent_containers/hypospray/medipen/salacid,
-/obj/item/reagent_containers/hypospray/medipen/salacid,
-/obj/item/reagent_containers/hypospray/medipen/salacid,
-/obj/item/reagent_containers/hypospray/medipen/salacid,
 /obj/structure/table/reinforced,
-/obj/item/reagent_containers/hypospray/medipen/salacid,
-/obj/item/reagent_containers/hypospray/medipen/salacid,
-/obj/item/reagent_containers/hypospray/medipen/salacid,
-/obj/item/reagent_containers/hypospray/medipen/salacid,
-/obj/item/reagent_containers/hypospray/medipen/salacid,
-/obj/item/reagent_containers/hypospray/medipen/salacid,
 /obj/machinery/light,
+/obj/item/reagent_containers/hypospray/medipen/mental,
+/obj/item/reagent_containers/hypospray/medipen/mental,
 /turf/open/floor/carpet/green,
 /area/department_main/safety)
 "Vj" = (
@@ -10169,12 +10131,11 @@
 	},
 /turf/open/floor/wood,
 /area/facility_hallway/south)
-"YJ" = (
-/obj/structure/rack,
-/obj/item/storage/belt/ego,
-/obj/item/storage/belt/ego,
-/obj/item/storage/belt/ego,
-/turf/open/floor/carpet/red,
+"YH" = (
+/obj/machinery/computer/extraction_cargo{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/department_main/discipline)
 "YN" = (
 /obj/effect/turf_decal/siding{
@@ -10335,6 +10296,11 @@
 	dir = 1
 	},
 /turf/open/floor/facility/dark,
+/area/department_main/discipline)
+"ZB" = (
+/obj/structure/rack,
+/obj/item/storage/belt/ego,
+/turf/open/floor/carpet/royalblack,
 /area/department_main/discipline)
 "ZD" = (
 /obj/effect/turf_decal/siding{
@@ -36239,10 +36205,10 @@ JB
 rS
 pG
 nX
-pQ
+YH
 oC
 WH
-GY
+pQ
 xB
 MJ
 bk
@@ -36755,7 +36721,7 @@ xH
 AW
 uk
 zl
-Nh
+tE
 rS
 rS
 Qw
@@ -37010,13 +36976,13 @@ rS
 Sg
 XB
 zl
-uk
+ZB
 zl
 uk
 NR
 aJ
 Ly
-YJ
+xl
 xl
 Px
 NA
@@ -38295,7 +38261,7 @@ rS
 rS
 if
 xo
-uk
+ZB
 zl
 Nh
 rS
@@ -41068,7 +41034,7 @@ ca
 an
 eY
 Pe
-dj
+bw
 Pe
 jy
 Pe
@@ -41582,7 +41548,7 @@ ca
 an
 fo
 Pe
-dj
+vu
 Pe
 cy
 Pe

--- a/_maps/map_files/Delta/deltacorp.dmm
+++ b/_maps/map_files/Delta/deltacorp.dmm
@@ -741,8 +741,8 @@
 "bX" = (
 /obj/machinery/light/floor,
 /obj/effect/turf_decal/plaque{
-	icon_state = "LC4";
-	alpha = 230
+	alpha = 230;
+	icon_state = "LC4"
 	},
 /turf/open/floor/plasteel/white,
 /area/department_main/command)
@@ -912,8 +912,8 @@
 /area/department_main/discipline)
 "cs" = (
 /obj/effect/turf_decal/plaque{
-	icon_state = "LC3";
-	alpha = 230
+	alpha = 230;
+	icon_state = "LC3"
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -1816,7 +1816,7 @@
 /area/department_main/welfare)
 "fx" = (
 /obj/structure/rack,
-/obj/item/ego_weapon/gold_rush{
+/obj/item/ego_weapon/goldrush{
 	force = 0;
 	goldrush_damage = 0
 	},
@@ -1901,8 +1901,8 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/plaque{
-	icon_state = "LC23";
-	alpha = 230
+	alpha = 230;
+	icon_state = "LC23"
 	},
 /turf/open/floor/plasteel/white,
 /area/department_main/command)
@@ -1970,8 +1970,8 @@
 "fQ" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/plaque{
-	icon_state = "LC31";
-	alpha = 230
+	alpha = 230;
+	icon_state = "LC31"
 	},
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel/white,
@@ -2278,8 +2278,8 @@
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/structure/sign/directions/evac{
-	pixel_x = 32;
-	dir = 8
+	dir = 8;
+	pixel_x = 32
 	},
 /obj/effect/turf_decal/siding/purple{
 	dir = 4
@@ -2699,6 +2699,12 @@
 "ib" = (
 /turf/open/floor/facility/dark,
 /area/facility_hallway/discipline)
+"ie" = (
+/obj/machinery/computer/extraction_cargo{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/department_main/extraction)
 "if" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -3049,8 +3055,8 @@
 "jf" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/plaque{
-	icon_state = "LC26";
-	alpha = 230
+	alpha = 230;
+	icon_state = "LC26"
 	},
 /turf/open/floor/plasteel/white,
 /area/department_main/command)
@@ -4201,8 +4207,8 @@
 /area/facility_hallway/control)
 "lR" = (
 /obj/effect/turf_decal/plaque{
-	icon_state = "LC30";
-	alpha = 230
+	alpha = 230;
+	icon_state = "LC30"
 	},
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel/white,
@@ -4365,8 +4371,8 @@
 "mp" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/plaque{
-	icon_state = "LC2";
-	alpha = 230
+	alpha = 230;
+	icon_state = "LC2"
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -5453,8 +5459,8 @@
 "oL" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/plaque{
-	icon_state = "LC6";
-	alpha = 230
+	alpha = 230;
+	icon_state = "LC6"
 	},
 /turf/open/floor/plasteel/white,
 /area/department_main/command)
@@ -5622,8 +5628,8 @@
 "pH" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/plaque{
-	icon_state = "LC27";
-	alpha = 230
+	alpha = 230;
+	icon_state = "LC27"
 	},
 /turf/open/floor/plasteel/white,
 /area/department_main/command)
@@ -5712,8 +5718,8 @@
 /area/department_main/discipline)
 "pW" = (
 /obj/effect/turf_decal/plaque{
-	icon_state = "LC5";
-	alpha = 230
+	alpha = 230;
+	icon_state = "LC5"
 	},
 /turf/open/floor/plasteel/white,
 /area/department_main/command)
@@ -5899,8 +5905,8 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/plaque{
-	icon_state = "LC19";
-	alpha = 230
+	alpha = 230;
+	icon_state = "LC19"
 	},
 /turf/open/floor/plasteel/white,
 /area/department_main/command)
@@ -7153,8 +7159,8 @@
 "uF" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/drinkingglasses{
-	pixel_y = 5;
-	pixel_x = -5
+	pixel_x = -5;
+	pixel_y = 5
 	},
 /obj/item/storage/box/cups{
 	pixel_x = 5;
@@ -7562,23 +7568,23 @@
 /obj/structure/table,
 /obj/machinery/computer/security/telescreen{
 	desc = "Used to access the various cameras on the station.";
+	dir = 1;
 	layer = 3.1;
 	name = "Security Camera Monitor";
 	network = list("ss13");
-	pixel_y = 3;
-	dir = 1
+	pixel_y = 3
 	},
 /turf/open/floor/carpet,
 /area/department_main/control)
 "wh" = (
 /obj/structure/table/wood/fancy/green,
 /obj/item/storage/box/masks{
-	pixel_y = 8;
-	pixel_x = -4
+	pixel_x = -4;
+	pixel_y = 8
 	},
 /obj/item/storage/box/masks{
-	pixel_y = 8;
-	pixel_x = -4
+	pixel_x = -4;
+	pixel_y = 8
 	},
 /obj/item/storage/box/gloves{
 	pixel_x = 8;
@@ -9181,8 +9187,8 @@
 	dir = 6
 	},
 /obj/effect/turf_decal/plaque{
-	icon_state = "LC10";
-	alpha = 230
+	alpha = 230;
+	icon_state = "LC10"
 	},
 /turf/open/floor/plasteel/white,
 /area/department_main/command)
@@ -9192,8 +9198,8 @@
 	dir = 9
 	},
 /obj/effect/turf_decal/plaque{
-	icon_state = "LC11";
-	alpha = 230
+	alpha = 230;
+	icon_state = "LC11"
 	},
 /turf/open/floor/plasteel/white,
 /area/department_main/command)
@@ -9202,8 +9208,8 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/plaque{
-	icon_state = "LC12";
-	alpha = 230
+	alpha = 230;
+	icon_state = "LC12"
 	},
 /turf/open/floor/plasteel/white,
 /area/department_main/command)
@@ -9575,8 +9581,8 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/plaque{
-	icon_state = "LC15";
-	alpha = 230
+	alpha = 230;
+	icon_state = "LC15"
 	},
 /turf/open/floor/plasteel/white,
 /area/department_main/command)
@@ -9590,8 +9596,8 @@
 	},
 /obj/structure/fluff/arc/angela,
 /obj/effect/turf_decal/plaque{
-	icon_state = "LC16";
-	alpha = 230
+	alpha = 230;
+	icon_state = "LC16"
 	},
 /turf/open/floor/plasteel/white,
 /area/department_main/command)
@@ -9603,8 +9609,8 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/plaque{
-	icon_state = "LC17";
-	alpha = 230
+	alpha = 230;
+	icon_state = "LC17"
 	},
 /turf/open/floor/plasteel/white,
 /area/department_main/command)
@@ -9998,8 +10004,8 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/plaque{
-	icon_state = "LC20";
-	alpha = 230
+	alpha = 230;
+	icon_state = "LC20"
 	},
 /turf/open/floor/plasteel/white,
 /area/department_main/command)
@@ -10019,8 +10025,8 @@
 	},
 /obj/effect/landmark/department_center,
 /obj/effect/turf_decal/plaque{
-	icon_state = "LC21";
-	alpha = 230
+	alpha = 230;
+	icon_state = "LC21"
 	},
 /turf/open/floor/plasteel/white,
 /area/department_main/command)
@@ -10032,8 +10038,8 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/plaque{
-	icon_state = "LC22";
-	alpha = 230
+	alpha = 230;
+	icon_state = "LC22"
 	},
 /turf/open/floor/plasteel/white,
 /area/department_main/command)
@@ -10402,8 +10408,8 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/plaque{
-	icon_state = "LC14";
-	alpha = 230
+	alpha = 230;
+	icon_state = "LC14"
 	},
 /turf/open/floor/plasteel/white,
 /area/department_main/command)
@@ -10758,8 +10764,8 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/plaque{
-	icon_state = "LC33";
-	alpha = 230
+	alpha = 230;
+	icon_state = "LC33"
 	},
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel/white,
@@ -11043,8 +11049,8 @@
 	dir = 4
 	},
 /obj/structure/sign/directions/evac{
-	pixel_x = 32;
-	dir = 8
+	dir = 8;
+	pixel_x = 32
 	},
 /turf/open/floor/plasteel,
 /area/facility_hallway/control)
@@ -11159,8 +11165,8 @@
 "GL" = (
 /obj/machinery/light/floor,
 /obj/effect/turf_decal/plaque{
-	icon_state = "LC28";
-	alpha = 230
+	alpha = 230;
+	icon_state = "LC28"
 	},
 /turf/open/floor/plasteel/white,
 /area/department_main/command)
@@ -12034,8 +12040,8 @@
 /area/facility_hallway/safety)
 "Jr" = (
 /obj/effect/turf_decal/plaque{
-	icon_state = "LC13";
-	alpha = 230
+	alpha = 230;
+	icon_state = "LC13"
 	},
 /turf/open/floor/plasteel/white,
 /area/department_main/command)
@@ -12093,8 +12099,8 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/plaque{
-	icon_state = "LC18";
-	alpha = 230
+	alpha = 230;
+	icon_state = "LC18"
 	},
 /turf/open/floor/plasteel/white,
 /area/department_main/command)
@@ -12410,8 +12416,8 @@
 "Kz" = (
 /obj/machinery/light/floor,
 /obj/effect/turf_decal/plaque{
-	icon_state = "LC8";
-	alpha = 230
+	alpha = 230;
+	icon_state = "LC8"
 	},
 /turf/open/floor/plasteel/white,
 /area/department_main/command)
@@ -12969,8 +12975,8 @@
 /area/department_main/command)
 "Mj" = (
 /obj/structure/bodycontainer/crematorium{
-	id = "incinerator1";
-	dir = 4
+	dir = 4;
+	id = "incinerator1"
 	},
 /obj/machinery/button/crematorium/indestructible{
 	id = "incinerator1";
@@ -13574,8 +13580,8 @@
 /area/department_main/extraction)
 "Oh" = (
 /obj/effect/turf_decal/plaque{
-	icon_state = "LC7";
-	alpha = 230
+	alpha = 230;
+	icon_state = "LC7"
 	},
 /turf/open/floor/plasteel/white,
 /area/department_main/command)
@@ -15168,8 +15174,8 @@
 /area/department_main/welfare)
 "RZ" = (
 /obj/effect/turf_decal/plaque{
-	icon_state = "LC25";
-	alpha = 230
+	alpha = 230;
+	icon_state = "LC25"
 	},
 /turf/open/floor/plasteel/white,
 /area/department_main/command)
@@ -17187,8 +17193,8 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/plaque{
-	icon_state = "LC29";
-	alpha = 230
+	alpha = 230;
+	icon_state = "LC29"
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -17254,8 +17260,8 @@
 /area/department_main/information)
 "Xf" = (
 /obj/effect/turf_decal/plaque{
-	icon_state = "LC1";
-	alpha = 230
+	alpha = 230;
+	icon_state = "LC1"
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -17388,8 +17394,8 @@
 /area/department_main/safety)
 "Xv" = (
 /obj/effect/turf_decal/plaque{
-	icon_state = "LC9";
-	alpha = 230
+	alpha = 230;
+	icon_state = "LC9"
 	},
 /turf/open/floor/plasteel/white,
 /area/department_main/command)
@@ -18222,8 +18228,8 @@
 "ZL" = (
 /obj/machinery/light/floor,
 /obj/effect/turf_decal/plaque{
-	icon_state = "LC24";
-	alpha = 230
+	alpha = 230;
+	icon_state = "LC24"
 	},
 /turf/open/floor/plasteel/white,
 /area/department_main/command)
@@ -65965,7 +65971,7 @@ Cu
 Lz
 Mz
 MP
-Nl
+ie
 NN
 mw
 Cu

--- a/_maps/map_files/Epsilon/epsiloncorp.dmm
+++ b/_maps/map_files/Epsilon/epsiloncorp.dmm
@@ -174,7 +174,6 @@
 	color = "#7D6521";
 	dir = 4
 	},
-/obj/item/storage/belt/ego,
 /obj/machinery/light{
 	dir = 4
 	},
@@ -295,6 +294,12 @@
 /obj/machinery/telecomms/receiver/preset_right,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/department_main/information)
+"fu" = (
+/obj/machinery/computer/extraction_cargo{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/department_main/extraction)
 "fy" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/telecomms/receiver/preset_left,
@@ -328,15 +333,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/facility_hallway/safety)
-"gk" = (
-/obj/structure/rack,
-/obj/item/storage/belt/ego,
-/obj/effect/turf_decal/siding{
-	color = "#7D6521";
-	dir = 1
-	},
-/turf/open/floor/carpet/royalblack,
-/area/department_main/extraction)
 "gm" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood,
@@ -843,7 +839,6 @@
 	color = "#7D6521";
 	dir = 10
 	},
-/obj/item/storage/belt/ego,
 /turf/open/floor/carpet/royalblack,
 /area/department_main/extraction)
 "mO" = (
@@ -2254,6 +2249,10 @@
 "IE" = (
 /turf/open/floor/wood,
 /area/department_main/welfare)
+"IR" = (
+/obj/structure/rack,
+/turf/open/floor/plasteel/dark,
+/area/department_main/extraction)
 "IX" = (
 /obj/structure/table/wood,
 /obj/item/clothing/accessory/armband/lobotomy/training,
@@ -2734,7 +2733,6 @@
 	color = "#7D6521";
 	dir = 8
 	},
-/obj/item/storage/belt/ego,
 /turf/open/floor/carpet/royalblack,
 /area/department_main/extraction)
 "OY" = (
@@ -3184,7 +3182,7 @@
 /area/department_main/safety)
 "Uj" = (
 /obj/structure/rack,
-/obj/item/ego_weapon/gold_rush{
+/obj/item/ego_weapon/goldrush{
 	force = 0;
 	goldrush_damage = 0
 	},
@@ -52679,7 +52677,7 @@ We
 XJ
 pw
 pw
-Xx
+Bp
 ot
 pw
 pw
@@ -53441,7 +53439,7 @@ hK
 kU
 aA
 KP
-gk
+hd
 DU
 DU
 DU
@@ -53953,7 +53951,7 @@ QD
 KP
 VR
 kU
-aA
+IR
 KP
 gw
 DU
@@ -54466,7 +54464,7 @@ QD
 QD
 KP
 KP
-kU
+fu
 kU
 kU
 kU

--- a/code/game/machinery/computer/extraction_cargo.dm
+++ b/code/game/machinery/computer/extraction_cargo.dm
@@ -1,0 +1,167 @@
+#define CAT_GADGET 1
+#define CAT_EQUIP 2
+#define CAT_MEDICAL 3
+#define CAT_SCORP 4
+#define CAT_OTHER 5
+//CONSOLE CODE uses a altered form of mining_vendor
+
+/obj/machinery/computer/extraction_cargo
+	name = "corporate trade console"
+	desc = "Used to purchase supplies at the expense of energy."
+	icon_screen = "supply"
+	resistance_flags = INDESTRUCTIBLE
+	var/selected_level = CAT_GADGET
+
+	var/list/order_list = list( //if you add something to this, please, for the love of god, sort it by price/type. use tabs and not spaces.
+		//Gadgets - More Technical Equipment, Usually active
+		new /datum/data/extraction_cargo("Barrier Grenade Kit ",		/obj/item/storage/box/barrier,										60, CAT_GADGET) = 1,
+		new /datum/data/extraction_cargo("Spare Manager Bullet ",		/obj/item/managerbullet,											80, CAT_GADGET) = 1,
+		new /datum/data/extraction_cargo("Forcefield Projector ",		/obj/item/forcefield_projector,										150, CAT_GADGET) = 1,
+		new /datum/data/extraction_cargo("Tracking Implant Kit ", 		/obj/item/storage/box/minertracker,									150, CAT_GADGET) = 1,
+		new /datum/data/extraction_cargo("Command Projector ",			/obj/item/commandprojector,											150, CAT_GADGET) = 1,
+		new /datum/data/extraction_cargo("'DEEPSCAN' Kit ",				/obj/item/deepscanner,												150, CAT_GADGET) = 1,
+		new /datum/data/extraction_cargo("Qliphoth Field Projector ",	/obj/item/powered_gadget/slowingtrapmk1,							150, CAT_GADGET) = 1,
+		new /datum/data/extraction_cargo("Regenerator Augmentor ",		/obj/item/safety_kit,												150, CAT_GADGET) = 1,
+		new /datum/data/extraction_cargo("Drain Monitor ",				/obj/item/powered_gadget/detector_gadget/abnormality,				200, CAT_GADGET) = 1,
+		new /datum/data/extraction_cargo("Keen-Sense Rangefinder ",		/obj/item/powered_gadget/detector_gadget/ordeal,					200, CAT_GADGET) = 1,
+		new /datum/data/extraction_cargo("EMAIS	Capacity Upgrade ",		/obj/item/hypo_upgrade/cap_increase,								200, CAT_GADGET) = 1,
+		new /datum/data/extraction_cargo("EMAIS	Autoinjector ",			/obj/item/reagent_containers/hypospray/emais,						300, CAT_GADGET) = 1,
+		new /datum/data/extraction_cargo("W-Corp Teleporter ",			/obj/item/powered_gadget/teleporter,								300, CAT_GADGET) = 1,
+		new /datum/data/extraction_cargo("Meson Scanner Goggles ",		/obj/item/clothing/glasses/meson,									500, CAT_GADGET) = 1,
+		new /datum/data/extraction_cargo("Gar Meson Scanner Goggles ",	/obj/item/clothing/glasses/meson/gar,								600, CAT_GADGET) = 1,
+
+		//Equipment - Passive equipment, or less technical stuff.
+		new /datum/data/extraction_cargo("'Seclite' Flashlight ",		/obj/item/flashlight/seclite,										30, CAT_EQUIP) = 1,
+		new /datum/data/extraction_cargo("Hunting Knife ",				/obj/item/kitchen/knife/hunting,									30, CAT_EQUIP) = 1,
+		new /datum/data/extraction_cargo("Throwing Bola ",				/obj/item/restraints/legcuffs/bola,									50, CAT_EQUIP) = 1,
+		new /datum/data/extraction_cargo("EGO Small Arms Belt ",		/obj/item/storage/belt/ego,											50, CAT_EQUIP) = 1,
+		new /datum/data/extraction_cargo("Nitrile Gloves ",				/obj/item/clothing/gloves/color/latex/nitrile,						50, CAT_EQUIP) = 1,
+		new /datum/data/extraction_cargo("Combat Webbing ",				/obj/item/storage/belt/military,									60, CAT_EQUIP) = 1,
+		new /datum/data/extraction_cargo("EZ Light Replacer ",			/obj/item/lightreplacer,											60, CAT_EQUIP) = 1,
+		new /datum/data/extraction_cargo("Toolbox ",					/obj/item/storage/toolbox/mechanical,								60, CAT_EQUIP) = 1,
+		new /datum/data/extraction_cargo("Push Broom ",					/obj/item/pushbroom,												60, CAT_EQUIP) = 1,
+		new /datum/data/extraction_cargo("Super Power Cell ",			/obj/item/stock_parts/cell/super,									150, CAT_EQUIP) = 1,
+		new /datum/data/extraction_cargo("Megaphone ",					/obj/item/megaphone,												150, CAT_EQUIP) = 1,
+		new /datum/data/extraction_cargo("Binoculars ",					/obj/item/binoculars,												200, CAT_EQUIP) = 1,
+
+		//Medical
+		new /datum/data/extraction_cargo("Epinepherine Medi-Pen ",		/obj/item/reagent_containers/hypospray/medipen,						40, CAT_MEDICAL) = 1,
+		new /datum/data/extraction_cargo("Sal-Acid Medi-Pen ",			/obj/item/reagent_containers/hypospray/medipen/salacid,				50, CAT_MEDICAL) = 1,
+		new /datum/data/extraction_cargo("Mental-Stabilizer Medi-Pen ",	/obj/item/reagent_containers/hypospray/medipen/mental,				50, CAT_MEDICAL) = 1,
+		new /datum/data/extraction_cargo("Standard First-Aid Kit ",		/obj/item/storage/firstaid/regular,									250, CAT_MEDICAL) = 1,
+		new /datum/data/extraction_cargo("Naked Nest Cure Vial ",		/obj/item/serpentspoision,											400, CAT_MEDICAL) = 1,
+		new /datum/data/extraction_cargo("Prosthetic Limb Crate ",		/obj/structure/closet/crate/freezer/surplus_limbs,					500, CAT_MEDICAL) = 1,
+		new /datum/data/extraction_cargo("Assorted Medi-Pen Kit ",		/obj/item/storage/firstaid/revival,									500, CAT_MEDICAL) = 1,
+
+		//Scorp - for the funny
+		new /datum/data/extraction_cargo("Wellcheers Code Red ",		/obj/item/reagent_containers/food/drinks/soda_cans/wellcheers_red,	40, CAT_SCORP) = 1,
+		new /datum/data/extraction_cargo("Wellcheers Baja Blast ",		/obj/item/reagent_containers/food/drinks/soda_cans/wellcheers_white,40, CAT_SCORP) = 1,
+		new /datum/data/extraction_cargo("Wellcheers Purple Thunder ",	/obj/item/reagent_containers/food/drinks/soda_cans/wellcheers_purple,60, CAT_SCORP) = 1,
+		new /datum/data/extraction_cargo("S-Corp Elite Assassin ",		/mob/living/simple_animal/hostile/shrimp,							200, CAT_SCORP) = 1,
+		new /datum/data/extraction_cargo("S-Corp Brand Soda Shotgun ",	/obj/item/gun/ego_gun/sodashotty,									400, CAT_SCORP) = 1,
+		new /datum/data/extraction_cargo("S-Corp Brand Soda Rifle ",	/obj/item/gun/ego_gun/sodarifle,									400, CAT_SCORP) = 1,
+		new /datum/data/extraction_cargo("S-Corp Brand Soda SMG ",		/obj/item/gun/ego_gun/sodasmg,										400, CAT_SCORP) = 1,
+		new /datum/data/extraction_cargo("S-Corp Brand Shrimp Squad ",	/obj/item/grenade/spawnergrenade/shrimp,							800, CAT_SCORP) = 1,
+
+		//Random stuff
+		new /datum/data/extraction_cargo("Bubblegum Gum Packet ",		/obj/item/storage/box/gum/bubblegum,								15, CAT_OTHER) = 1,
+		new /datum/data/extraction_cargo("Cigar ",						/obj/item/clothing/mask/cigarette/cigar/havana,						25, CAT_OTHER) = 1,
+		new /datum/data/extraction_cargo("Beer ",						/obj/item/reagent_containers/food/drinks/beer,						25, CAT_OTHER) = 1,
+		new /datum/data/extraction_cargo("Spraycan ",					/obj/item/toy/crayon/spraycan,										40, CAT_OTHER) = 1,
+		new /datum/data/extraction_cargo("Magic 8-Ball ",				/obj/item/toy/eightball,											70, CAT_OTHER) = 1,
+		new /datum/data/extraction_cargo("Six-Pack ",					/obj/item/storage/cans,												70, CAT_OTHER) = 1,
+		new /datum/data/extraction_cargo("Whiskey ",					/obj/item/reagent_containers/food/drinks/bottle/whiskey,			100, CAT_OTHER) = 1,
+		new /datum/data/extraction_cargo("Absinthe ",					/obj/item/reagent_containers/food/drinks/bottle/absinthe/premium,	100, CAT_OTHER) = 1,
+		new /datum/data/extraction_cargo("Skateboard ",					/obj/item/melee/skateboard,											100, CAT_OTHER) = 1,
+		new /datum/data/extraction_cargo("Gar Glasses ",				/obj/item/clothing/glasses/sunglasses/gar,							100, CAT_OTHER) = 1,
+		new /datum/data/extraction_cargo("Skub ",						/obj/item/skub,														200, CAT_OTHER) = 1,
+		new /datum/data/extraction_cargo("1000 Ahn ",					/obj/item/stack/spacecash/c10000,									200, CAT_OTHER) = 1,
+		new /datum/data/extraction_cargo("Margherita Pizza ",			/obj/item/food/pizza/margherita,									300, CAT_OTHER) = 1,
+		new /datum/data/extraction_cargo("Super Gar Glasses ",			/obj/item/clothing/glasses/sunglasses/gar/supergar,					500, CAT_OTHER) = 1,
+		new /datum/data/extraction_cargo("Agent Captain's Cloak ",		/obj/item/clothing/neck/cloak/hos/agent,							500, CAT_OTHER) = 1,
+		new /datum/data/extraction_cargo("Agent Captain's Cap ",		/obj/item/clothing/head/hos/agent,									500, CAT_OTHER) = 1,
+		new /datum/data/extraction_cargo("Binah Doll ",					/obj/item/toy/plush/binah,											1000, CAT_OTHER) = 1,
+
+
+	)
+
+//Everything below this you should test before finalizing -IP
+/datum/data/extraction_cargo
+	var/equipment_name = "ERROR"
+	var/equipment_path = null
+	var/cost = 0
+	var/catagory = CAT_OTHER
+
+/datum/data/extraction_cargo/New(name, path, cost, catagory) //This is the weirdest code. Instantly create a datum by defining it in the above list.
+	src.equipment_name = name
+	src.equipment_path = path
+	src.cost = cost
+	src.catagory = catagory
+
+/obj/machinery/computer/extraction_cargo/ui_interact(mob/user) //Unsure if this can stand on its own as a structure, later on we may fiddle with that to break out of computer variables. -IP
+	. = ..()
+	if(isliving(user))
+		playsound(src, 'sound/machines/terminal_prompt_confirm.ogg', 50, FALSE)
+	var/dat
+	dat += "[SSlobotomy_corp.current_box]/[SSlobotomy_corp.box_goal] PE <br>"
+	for(var/level = CAT_GADGET to CAT_OTHER) //IF YOU ADD A NEW CATAGORY GO FROM FIRST DEFINED CATAGORY TO LAST TO AVOID BREAKAGE  -IP
+		dat += "<A href='byond://?src=[REF(src)];set_level=[level]'>[level == selected_level ? "<b><u>[name_catagory(level)]</u></b>" : "[name_catagory(level)]"]</A>"
+	dat += "<br>"
+	for(var/datum/data/extraction_cargo/A in order_list)
+		if(A.catagory != selected_level)
+			continue
+		dat += " <A href='byond://?src=[REF(src)];purchase=[REF(A)]'>[A.equipment_name]([A.cost] PE)</A><br>"
+	var/datum/browser/popup = new(user, "extraction_cargo", "L Corp Energy Trade", 440, 640)
+	popup.set_content(dat)
+	popup.open()
+	return
+
+/obj/machinery/computer/extraction_cargo/Topic(href, href_list)
+	. = ..()
+	if(.)
+		return .
+	if(ishuman(usr))
+		usr.set_machine(src)
+		add_fingerprint(usr)
+		if(href_list["set_level"])
+			var/level = text2num(href_list["set_level"])
+			if(!(level < CAT_GADGET || level > CAT_OTHER) && level != selected_level)
+				selected_level = level
+				playsound(get_turf(src), 'sound/machines/terminal_prompt_confirm.ogg', 50, TRUE)
+				updateUsrDialog()
+				return TRUE
+			return FALSE
+		if(href_list["purchase"])
+			var/datum/data/extraction_cargo/product_datum = locate(href_list["purchase"]) in order_list //The href_list returns the individual number code and only works if we have it in the first column. -IP
+			if(!product_datum)
+				to_chat(usr, "<span class='warning'>ERROR.</span>")
+				return FALSE
+			if(SSlobotomy_corp.current_box < product_datum.cost)
+				to_chat(usr, "<span class='warning'>Not enough PE boxes stored for this operation.</span>")
+				playsound(get_turf(src), 'sound/machines/terminal_prompt_deny.ogg', 50, TRUE)
+				return FALSE
+			new product_datum.equipment_path(get_turf(src))
+			SSlobotomy_corp.AdjustBoxes(-1 * product_datum.cost)
+			playsound(get_turf(src), 'sound/machines/terminal_prompt_confirm.ogg', 50, TRUE)
+			updateUsrDialog()
+			return TRUE
+
+/obj/machinery/computer/extraction_cargo/proc/name_catagory(cat) //for each catagory please place the number its defined as -IP
+	switch(cat)
+		if(1)
+			return "Gadget"
+		if(2)
+			return "Equipment"
+		if(3)
+			return "Medical"
+		if(4)
+			return "SCorp"
+		if(5)
+			return "Misc"
+
+
+#undef CAT_GADGET
+#undef CAT_EQUIP
+#undef CAT_MEDICAL
+#undef CAT_SCORP
+#undef CAT_OTHER

--- a/code/game/objects/items/devices/forcefieldprojector.dm
+++ b/code/game/objects/items/devices/forcefieldprojector.dm
@@ -1,18 +1,18 @@
 /obj/item/forcefield_projector
-	name = "forcefield projector"
+	name = "protoype forcefield projector"
 	desc = "An experimental device that can create several forcefields at a distance."
 	icon = 'icons/obj/device.dmi'
 	icon_state = "signmaker_forcefield"
 	slot_flags = ITEM_SLOT_BELT
-	w_class = WEIGHT_CLASS_SMALL
+	w_class = WEIGHT_CLASS_BULKY
 	item_flags = NOBLUDGEON
 	inhand_icon_state = "electronic"
 	worn_icon_state = "electronic"
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
 	custom_materials = list(/datum/material/iron=250, /datum/material/glass=500)
-	var/max_shield_integrity = 250
-	var/shield_integrity = 250
+	var/max_shield_integrity = 100
+	var/shield_integrity = 100
 	var/max_fields = 3
 	var/list/current_fields
 	var/field_distance_limit = 7
@@ -47,7 +47,7 @@
 	user.visible_message("<span class='warning'>[user] projects a forcefield!</span>","<span class='notice'>You project a forcefield.</span>")
 	var/obj/structure/projected_forcefield/F = new(T, src)
 	current_fields += F
-	user.changeNext_move(CLICK_CD_MELEE)
+	user.changeNext_move(CLICK_CD_MELEE*5)
 
 /obj/item/forcefield_projector/attack_self(mob/user)
 	if(LAZYLEN(current_fields))

--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -54,8 +54,8 @@
 	slot_flags = ITEM_SLOT_BELT
 	force = 8
 
-	var/max_uses = 20
-	var/uses = 10
+	var/max_uses = 200
+	var/uses = 100
 	// How much to increase per each glass?
 	var/increment = 5
 	// How much to take from the glass?

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -381,7 +381,7 @@
 
 /obj/item/storage/belt/military
 	name = "chest rig"
-	desc = "A set of tactical webbing worn by Syndicate boarding parties."
+	desc = "A set of tactical webbing worn by outskirts reconnaissance parties."
 	icon_state = "militarywebbing"
 	inhand_icon_state = "militarywebbing"
 	worn_icon_state = "militarywebbing"

--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -31,9 +31,9 @@
 	if(empty)
 		return
 	var/static/items_inside = list(
-		/obj/item/stack/medical/gauze = 1,
-		/obj/item/stack/medical/suture = 2,
-		/obj/item/stack/medical/mesh = 2,
+		/obj/item/stack/medical/suture = 4,
+		/obj/item/reagent_containers/hypospray/medipen/salacid = 1,
+		/obj/item/reagent_containers/hypospray/medipen/mental = 1,
 		/obj/item/reagent_containers/hypospray/medipen = 1)
 	generate_items_inside(items_inside,src)
 

--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -173,6 +173,11 @@
 	name = "syndicate beret"
 	desc = "A black beret with thick armor padding inside. Stylish and robust."
 
+/obj/item/clothing/head/hos/agent
+	name = "agent captain cap"
+	desc = "A rather expensive cap worn by agent captains. A show of who's the best"
+	armor = list()
+
 /obj/item/clothing/head/zwei
 	name = "zwei association hat"
 	desc = "It's a special armored hat issued to those who reach the rank of Zwei Association Captain. Clean and professional."

--- a/code/modules/clothing/suits/cloaks.dm
+++ b/code/modules/clothing/suits/cloaks.dm
@@ -19,6 +19,10 @@
 	desc = "Worn by Securistan, ruling the station with an iron fist."
 	icon_state = "hoscloak"
 
+/obj/item/clothing/neck/cloak/hos/agent
+	name = "agent captain's cloak"
+	desc = "A sign of exceptional agent captains."
+
 /obj/item/clothing/neck/cloak/qm
 	name = "quartermaster's cloak"
 	desc = "Worn by Cargonia, supplying the station with the necessary tools for survival."

--- a/code/modules/jobs/job_types/assistant.dm
+++ b/code/modules/jobs/job_types/assistant.dm
@@ -31,9 +31,6 @@ Assistant
 	l_pocket = /obj/item/sensor_device
 	r_pocket = /obj/item/modular_computer/tablet/preset/advanced/medical
 	backpack_contents = list(
-		/obj/item/clothing/gloves/color/latex/nitrile = 1,
-		/obj/item/flashlight/seclite = 1,
 		/obj/item/healthanalyzer = 1,
-		/obj/item/gun/ego_gun/clerk = 1,
-		/obj/item/kitchen/knife/hunting = 1)
+		/obj/item/gun/ego_gun/clerk = 1)
 	implants = list(/obj/item/organ/cyberimp/eyes/hud/medical)

--- a/code/modules/jobs/job_types/command.dm
+++ b/code/modules/jobs/job_types/command.dm
@@ -61,3 +61,5 @@
 	name = "Records Officer"
 	jobtype = /datum/job/command/records
 	suit =  /obj/item/clothing/suit/armor/records
+
+	backpack_contents = list(/obj/item/price_tagger = 1)

--- a/lobotomy-corp13.dme
+++ b/lobotomy-corp13.dme
@@ -944,6 +944,7 @@
 #include "code\game\machinery\computer\communications.dm"
 #include "code\game\machinery\computer\crew.dm"
 #include "code\game\machinery\computer\dna_console.dm"
+#include "code\game\machinery\computer\extraction_cargo.dm"
 #include "code\game\machinery\computer\launchpad_control.dm"
 #include "code\game\machinery\computer\law.dm"
 #include "code\game\machinery\computer\manager_camera.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds in the Cargo console.
Removes almost medipens on maps, and adds the cargo console into extraction.
Removes half the clerk kit. it can now be found in the cargo console.

UI done by @InsightfulParasite.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Cleans out Clerk gear, and it's new content for the EO to mess about with.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added Extraction cargo console
del: Removed half of Clerk spawning gear
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
