### PR TITLE
Crumbling Armor now does Pale Damage

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/teth/crumbling_armor.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/crumbling_armor.dm
@@ -12,8 +12,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = 0,
 		ABNORMALITY_WORK_REPRESSION = list(60, 60, 65, 65, 70)
 			)
-	work_damage_amount = 5
-	work_damage_type = RED_DAMAGE
+	work_damage_amount = 4
+	work_damage_type = PALE_DAMAGE
 
 	ego_list = list(
 		/datum/ego_datum/weapon/daredevil,

--- a/code/modules/paperwork/records/info/teth.dm
+++ b/code/modules/paperwork/records/info/teth.dm
@@ -179,7 +179,7 @@
 	Risk Class : TETH	<br>
 	Max PE Boxes : 12	<br>
 	Qliphoth Counter : X	<br>
-	Work Damage Type : Red	<br>
+	Work Damage Type : PALE	<br>
 	Work Damage : Low	<br>
 	- When an employee with Fortitude Level 1 completed the work, they were found with their head cut clean off.	<br>
 	- Upon completing a Repression work with Crumbling Armor, the employee gained a glowing aura. This aura seemed to increase their stats regarding Justice.	<br>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Crumbling Armor now does pale damage.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Life For a Daredevil is a very good weapon; Crumbling armor is a very easy abnormality.
This changes that a little bit. It is still in theme.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Crumbling Armor now does pale.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
