### PR TITLE
Changes Stat Maximums

### DIFF
--- a/code/datums/attributes/_attribute.dm
+++ b/code/datums/attributes/_attribute.dm
@@ -104,6 +104,15 @@ GLOBAL_LIST_INIT(attribute_types, subtypesof(/datum/attribute))
 		atr.adjust_buff(src, addition)
 	return TRUE
 
+//Set attribute levels
+/mob/living/carbon/human/proc/set_attribute_limit(attribute_set)
+	for(var/atr_type in attributes)
+		var/datum/attribute/atr = attributes[atr_type]
+		if(!istype(atr))
+			continue
+		atr.level_limit = attribute_set
+	return TRUE
+
 // Returns a combination of attributes, giving a "level" from 1 to 5
 /proc/get_user_level(mob/living/carbon/human/user)
 	if(!istype(user))

--- a/code/modules/jobs/job_types/assistant.dm
+++ b/code/modules/jobs/job_types/assistant.dm
@@ -20,9 +20,11 @@ Assistant
 	allow_bureaucratic_error = FALSE
 
 
-//they start at -50 all, you max out at level 4
+//Cannot Gain stats.
 /datum/job/assistant/after_spawn(mob/living/carbon/human/H, mob/M, latejoin = FALSE)
-	H.adjust_all_attribute_buffs(-50)
+	H.set_attribute_limit(0)
+	H.adjust_attribute_buff(TEMPERANCE_ATTRIBUTE, 10)
+	H.adjust_attribute_buff(PRUDENCE_ATTRIBUTE, 10)
 
 /datum/outfit/job/assistant
 	name = "Clerk"

--- a/code/modules/jobs/job_types/command.dm
+++ b/code/modules/jobs/job_types/command.dm
@@ -38,10 +38,11 @@
 								JUSTICE_ATTRIBUTE = 20
 								)
 
-/datum/job/command/after_spawn(mob/living/H, mob/M)
+/datum/job/command/after_spawn(mob/living/carbon/human/H, mob/M)
 	. = ..()
 	ADD_TRAIT(H, TRAIT_COMBATFEAR_IMMUNE, JOB_TRAIT)
 	H.grant_language(/datum/language/bong, TRUE, FALSE, LANGUAGE_MIND) //So they can understand the bong-bong better but not speak it
+	H.set_attribute_limit(60)		//Level limit set to 60, they'll be able to get defend themselves but not use Aleph or a lot of WAW gear
 
 /datum/outfit/job/command/extraction
 	name = "Extraction Officer"

--- a/code/modules/jobs/job_types/manager.dm
+++ b/code/modules/jobs/job_types/manager.dm
@@ -27,10 +27,11 @@
 	..()
 	SSticker.OnRoundstart(CALLBACK(GLOBAL_PROC, .proc/minor_announce, "Manager [H.real_name] has arrived to the facility."))
 
-/datum/job/manager/after_spawn(mob/living/H, mob/M)
+/datum/job/manager/after_spawn(mob/living/carbon/human/H, mob/M)
 	. = ..()
 	ADD_TRAIT(H, TRAIT_COMBATFEAR_IMMUNE, JOB_TRAIT)
 	H.grant_language(/datum/language/bong, TRUE, FALSE, LANGUAGE_MIND) //So they can understand the bong-bong better but not speak it
+	H.set_attribute_limit(60)
 
 /datum/outfit/job/manager
 	name = "Manager"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes the stat cap of all roles that aren't Agent.

Officers are locked to 60.
Clerks at 0, with a temp/pru buff
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Clarification, and preparation for a future thing to give Officers more stats as the round goes on so they aren't fucking paper lategame despite being rather important.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added stat caps to non-agent roles
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
