### PR TITLE
Patrol fix attempts

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/aleph/mountain.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/mountain.dm
@@ -313,7 +313,7 @@
 
 /mob/living/simple_animal/hostile/abnormality/mountain/CanStartPatrol()
 	if(phase <= 1) // Still phase one, we need corpses and can't really fight
-		return TRUE
+		return !(status_flags & GODMODE)
 	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/mountain/patrol_reset()
@@ -347,6 +347,8 @@
 	var/turf/target_turf
 	if(LAZYLEN(high_priority_turfs))
 		target_turf = get_closest_atom(/turf/open, high_priority_turfs, src)
+		if(phase <= 1)
+			target = null
 	else if(LAZYLEN(medium_priority_turfs))
 		target_turf = get_closest_atom(/turf/open, medium_priority_turfs, src)
 	else if(LAZYLEN(low_priority_turfs))

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -703,13 +703,14 @@
 	patrol_path = get_path_to(src, target_center, /turf/proc/Distance_cardinal, 0, 200)
 
 /mob/living/simple_animal/hostile/proc/patrol_reset()
-	patrol_path = null
+	patrol_path = list()
 	patrol_tries = 0
 	stop_automated_movement = 0
 	patrol_cooldown = world.time + patrol_cooldown_time
 
 /mob/living/simple_animal/hostile/proc/patrol_move(dest)
 	if(client || target || status_flags & GODMODE)
+		patrol_reset()
 		return FALSE
 	if(!dest || !patrol_path || !patrol_path.len) //A-star failed or a path/destination was not set.
 		return FALSE
@@ -746,4 +747,3 @@
 		step_to(src, dest)
 		patrol_reset()
 	return TRUE
-


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Attempts to fix patrol issues with MoSB and potentially some other abnos and mobs.

- patrol_reset() is called if mob has target/client/godmode while trying to move by patrol path.
- MoSB target is set to null if high priority turf is found while on phase 1.

## Why It's Good For The Game

Probably fixes something..?
