### PR TITLE
Sanity rework/improvement

### DIFF
--- a/code/datums/ai/sanity/_sanityloss_controller.dm
+++ b/code/datums/ai/sanity/_sanityloss_controller.dm
@@ -126,7 +126,7 @@
 					if(H in currently_scared)
 						continue
 					var/sanity_damage = (H.maxSanity * 0.15) * (get_user_level(living_pawn) - get_user_level(H))
-					H.adjustSanityLoss(min(0, -sanity_damage))
+					H.adjustSanityLoss(min(0, sanity_damage))
 					currently_scared += H
 			current_behaviors += GET_AI_BEHAVIOR(/datum/ai_behavior/insanity_attack_mob)
 			return

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -191,7 +191,7 @@
 	if(!ishuman(owner))
 		return
 	var/mob/living/carbon/human/H = owner
-	H.adjustSanityLoss(10)
+	H.adjustSanityLoss(-10)
 	QDEL_LIST(H.all_scars)
 
 /atom/movable/screen/alert/status_effect/fleshmend

--- a/code/game/machinery/computer/abnormality_work.dm
+++ b/code/game/machinery/computer/abnormality_work.dm
@@ -115,13 +115,13 @@
 	var/sanity_damage = 0
 	switch(sanity_result)
 		if(1)
-			sanity_damage = -(user.maxSanity*0.1)
+			sanity_damage = user.maxSanity*0.1
 		if(2)
-			sanity_damage = -(user.maxSanity*0.3)
+			sanity_damage = user.maxSanity*0.3
 		if(3)
-			sanity_damage = -(user.maxSanity*0.6)
+			sanity_damage = user.maxSanity*0.6
 		if(4 to INFINITY)
-			sanity_damage = -(user.maxSanity)
+			sanity_damage = user.maxSanity
 	var/work_time = datum_reference.max_boxes
 	if(work_type in scramble_list)
 		work_type = scramble_list[work_type]

--- a/code/game/machinery/computer/manager_camera.dm
+++ b/code/game/machinery/computer/manager_camera.dm
@@ -111,7 +111,7 @@
 			if(1)
 				H.adjustBruteLoss(-0.15*H.maxHealth)
 			if(2)
-				H.adjustSanityLoss(0.15*H.maxSanity)
+				H.adjustSanityLoss(-0.15*H.maxSanity)
 			if(3)
 				H.apply_status_effect(/datum/status_effect/interventionshield)
 			if(4)
@@ -331,7 +331,7 @@
 						if(1)
 							H.adjustBruteLoss(-0.15*H.maxHealth)
 						if(2)
-							H.adjustSanityLoss(0.15*H.maxSanity)
+							H.adjustSanityLoss(-0.15*H.maxSanity)
 						if(3)
 							H.apply_status_effect(/datum/status_effect/interventionshield) //shield status effects located in lc13unique items.
 						if(4)

--- a/code/game/machinery/regenerator.dm
+++ b/code/game/machinery/regenerator.dm
@@ -72,7 +72,7 @@
 			continue
 		H.adjustBruteLoss(-H.maxHealth * ((regen_amt+hp_bonus)/100))
 		H.adjustFireLoss(-H.maxHealth * ((regen_amt+hp_bonus)/100))
-		H.adjustSanityLoss(H.maxSanity * ((regen_amt+sp_bonus)/100))
+		H.adjustSanityLoss(-H.maxSanity * ((regen_amt+sp_bonus)/100))
 	if(icon_state != "regen" && !Threat)
 		icon_state = initial(icon_state)
 

--- a/code/game/objects/items/ego_weapons/aleph.dm
+++ b/code/game/objects/items/ego_weapons/aleph.dm
@@ -45,7 +45,7 @@
 		H.adjustStaminaLoss(-damage_dealt*0.2)
 		H.adjustBruteLoss(-damage_dealt*0.1)
 		H.adjustFireLoss(-damage_dealt*0.1)
-		H.adjustSanityLoss(damage_dealt*0.1)
+		H.adjustSanityLoss(-damage_dealt*0.1)
 
 /obj/item/ego_weapon/justitia
 	name = "justitia"

--- a/code/game/objects/items/ego_weapons/he.dm
+++ b/code/game/objects/items/ego_weapons/he.dm
@@ -476,7 +476,7 @@
 	if(M == user && !happy && istype(user))
 		var/mob/living/carbon/human/H = user
 		var/justice_mod = 1 + (get_attribute_level(H, JUSTICE_ATTRIBUTE)/100)
-		H.adjustSanityLoss(-(force * justice_mod)) //we artificially inflict the justice + force damage so it bypass armor. the sanity damage should always feel like a gamble even with armor.
+		H.adjustSanityLoss(force * justice_mod) //we artificially inflict the justice + force damage so it bypass armor. the sanity damage should always feel like a gamble even with armor.
 		missing_sanity = (1 - (H.sanityhealth / H.maxSanity)) * 40 //the weapon gets 40% of your missing % of sanity as force so 90% missing sanity means +36 force.
 		force = 0
 		happy = TRUE

--- a/code/game/objects/items/ego_weapons/teth.dm
+++ b/code/game/objects/items/ego_weapons/teth.dm
@@ -248,7 +248,7 @@
 		playsound(src, 'sound/weapons/taser.ogg', 200, FALSE, 9)
 		for(var/mob/living/carbon/human/L in range(2, get_turf(user)))
 			L.adjustBruteLoss(L.maxHealth*0.1)
-			L.adjustSanityLoss(10)
+			L.adjustSanityLoss(-10)
 			new /obj/effect/temp_visual/dir_setting/bloodsplatter(get_turf(L), pick(GLOB.alldirs))
 	inuse = FALSE
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1008,7 +1008,7 @@
 	remove_all_embedded_objects()
 	set_heartattack(FALSE)
 	drunkenness = 0
-	adjustSanityLoss(maxSanity+1)
+	adjustSanityLoss(-maxSanity)
 	for(var/datum/mutation/human/HM in dna.mutations)
 		if(HM.quality != POSITIVE)
 			dna.remove_mutation(HM.name)
@@ -1230,11 +1230,14 @@
 	return ..()
 
 /mob/living/carbon/human/updatehealth()
-	. = ..()
-	dna?.species.spec_updatehealth(src)
 	if(LAZYLEN(attributes))
 		maxHealth = 100 + round(get_attribute_level(src, FORTITUDE_ATTRIBUTE))
 		maxSanity = 100 + round(get_attribute_level(src, PRUDENCE_ATTRIBUTE))
+	. = ..()
+	dna?.species.spec_updatehealth(src)
+	sanityhealth = maxSanity - sanityloss
+	update_sanity_hud()
+	med_hud_set_sanity()
 	if(HAS_TRAIT(src, TRAIT_IGNOREDAMAGESLOWDOWN))
 		remove_movespeed_modifier(/datum/movespeed_modifier/damage_slowdown)
 		remove_movespeed_modifier(/datum/movespeed_modifier/damage_slowdown_flying)
@@ -1297,25 +1300,25 @@
 			if(-INFINITY to 0)
 				continue
 			if(1)
-				sanity_damage = -(H.maxSanity*0.1)
+				sanity_damage = H.maxSanity*0.1
 				H.apply_status_effect(/datum/status_effect/panicked_lvl_1)
 				if(H.sanity_lost)
 					continue
 				to_chat(H, "<span class='warning'>[result_text]</span>")
 			if(2)
-				sanity_damage = -(H.maxSanity*0.3)
+				sanity_damage = H.maxSanity*0.3
 				H.apply_status_effect(/datum/status_effect/panicked_lvl_2)
 				if(H.sanity_lost)
 					continue
 				to_chat(H, "<span class='danger'>[result_text]</span>")
 			if(3)
-				sanity_damage = -(H.maxSanity*0.6)
+				sanity_damage = H.maxSanity*0.6
 				H.apply_status_effect(/datum/status_effect/panicked_lvl_3)
 				if(H.sanity_lost)
 					continue
 				to_chat(H, "<span class='userdanger'>[result_text]</span>")
 			if(4 to INFINITY)
-				sanity_damage = -(H.maxSanity*0.95)
+				sanity_damage = H.maxSanity*0.95
 				H.apply_status_effect(/datum/status_effect/panicked_lvl_4)
 				if(H.sanity_lost)
 					continue

--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -268,7 +268,7 @@
 	return
 
 /mob/living/proc/getSanityLoss()
-	return maxSanity - sanityhealth
+	return sanityloss
 
 /mob/living/proc/adjustRedLoss(amount, updating_health = TRUE, forced = FALSE)
 	return adjustBruteLoss(amount, forced = forced)

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -25,7 +25,8 @@
 	var/cloneloss = 0	///Damage caused by being cloned or ejected from the cloner early. slimes also deal cloneloss damage to victims
 	var/staminaloss = 0		///Stamina damage, or exhaustion. You recover it slowly naturally, and are knocked down if it gets too high. Holodeck and hallucinations deal this.
 	var/crit_threshold = HEALTH_THRESHOLD_CRIT /// when the mob goes from "normal" to crit
-	var/sanityhealth = 220		// Sanity damage. Humans go insane when it reaches 0
+	var/sanityhealth = 100 // Sanity health. Humans go insane when it reaches 0
+	var/sanityloss = 0
 	var/maxSanity = 100
 	///When the mob enters hard critical state and is fully incapacitated.
 	var/hardcrit_threshold = HEALTH_THRESHOLD_FULLCRIT

--- a/code/modules/mob/living/simple_animal/abnormality/_abnormality.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_abnormality.dm
@@ -135,23 +135,23 @@
 				to_chat(H, "<span class='notice'>[result_text]</span>")
 				continue
 			if(1)
-				sanity_damage = -(H.maxSanity*0.1)
+				sanity_damage = H.maxSanity*0.1
 				H.apply_status_effect(/datum/status_effect/panicked_lvl_1)
 				to_chat(H, "<span class='warning'>[result_text]</span>")
 			if(2)
-				sanity_damage = -(H.maxSanity*0.3)
+				sanity_damage = H.maxSanity*0.3
 				H.apply_status_effect(/datum/status_effect/panicked_lvl_2)
 				to_chat(H, "<span class='danger'>[result_text]</span>")
 			if(3)
-				sanity_damage = -(H.maxSanity*0.6)
+				sanity_damage = H.maxSanity*0.6
 				H.apply_status_effect(/datum/status_effect/panicked_lvl_3)
 				to_chat(H, "<span class='userdanger'>[result_text]</span>")
 			if(4)
-				sanity_damage = -(H.maxSanity*0.95)
+				sanity_damage = H.maxSanity*0.95
 				H.apply_status_effect(/datum/status_effect/panicked_lvl_4)
 				to_chat(H, "<span class='userdanger'><b>[result_text]</b></span>")
 			if(5)
-				sanity_damage = -(H.maxSanity)
+				sanity_damage = H.maxSanity
 				H.apply_status_effect(/datum/status_effect/panicked_lvl_4)
 		H.adjustSanityLoss(sanity_damage)
 	return

--- a/code/modules/mob/living/simple_animal/abnormality/_tools/teth/heart.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_tools/teth/heart.dm
@@ -38,7 +38,7 @@
 	. = ..()
 	var/mob/living/carbon/human/H = owner
 	H.adjustBruteLoss(1) // Your health slowly ticks down
-	H.adjustSanityLoss(-1) // Your health slowly ticks down
+	H.adjustSanityLoss(1) // Your health slowly ticks down
 
 /datum/status_effect/aspiration/on_remove()
 	. = ..()

--- a/code/modules/mob/living/simple_animal/abnormality/_tools/teth/theresia.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_tools/teth/theresia.dm
@@ -55,7 +55,7 @@
 	for(var/mob/living/carbon/human/L in view(8, src))
 		if(L.stat == DEAD)
 			continue
-		L.adjustSanityLoss(pulse_damage)
+		L.adjustSanityLoss(-pulse_damage)
 		if(prob(10))
 			to_chat(L, "<span class='notice'>Despite the challenge, something reassures you that things will be okay.</span>")
 

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/censored.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/censored.dm
@@ -213,7 +213,7 @@
 		if(HAS_TRAIT(H, TRAIT_COMBATFEAR_IMMUNE))
 			continue
 		breach_affected += H
-		H.adjustSanityLoss(-20)
+		H.adjustSanityLoss(20)
 		if(H.sanity_lost)
 			continue
 		to_chat(H, "<span class='warning'>Damn, it's scary.</span>")

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/melting_love.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/melting_love.dm
@@ -147,7 +147,7 @@
 		return
 	if(istype(user) && user == gifted_human)
 		to_chat(gifted_human, "<span class='nicegreen'>Melting Love was happy to see you!</span>")
-		gifted_human.adjustSanityLoss(rand(25,35))
+		gifted_human.adjustSanityLoss(rand(-25,-35))
 		return
 
 /mob/living/simple_animal/hostile/abnormality/melting_love/proc/GiftedAnger(datum/source, datum/abnormality/datum_sent, mob/living/carbon/human/user, work_type)
@@ -158,7 +158,7 @@
 
 /mob/living/simple_animal/hostile/abnormality/melting_love/proc/sanityheal()
 	if(sanityheal_cooldown <= world.time)
-		gifted_human.adjustSanityLoss(30)
+		gifted_human.adjustSanityLoss(-30)
 		sanityheal_cooldown = (world.time + sanityheal_cooldown_base)
 
 /mob/living/simple_animal/hostile/abnormality/melting_love/WorkChance(mob/living/carbon/human/user, chance)

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/white_night.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/white_night.dm
@@ -144,7 +144,7 @@ GLOBAL_LIST_EMPTY(apostles)
 			L.adjustBruteLoss(-(holy_revival_damage * 0.75) * (L.maxHealth/100))
 			if(ishuman(L))
 				var/mob/living/carbon/human/H = L
-				H.adjustSanityLoss((holy_revival_damage * 0.75) * (H.maxSanity/100)) // It actually heals, don't worry
+				H.adjustSanityLoss(-(holy_revival_damage * 0.75) * (H.maxSanity/100))
 			L.regenerate_limbs()
 			L.regenerate_organs()
 			to_chat(L, "<span class='notice'>The holy light heals you!</span>")

--- a/code/modules/mob/living/simple_animal/abnormality/he/KHz.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/KHz.dm
@@ -51,7 +51,7 @@
 	//Heal everyone and reset the bit calculator
 	if(bitcalculator == input && isopen)
 		for(var/mob/living/carbon/human/H in GLOB.player_list)
-			H.adjustSanityLoss(10)
+			H.adjustSanityLoss(-10)
 			to_chat(H, "<span class='notice'>You feel a pleasant sound.</span>")
 
 	//If you fuck it up
@@ -59,7 +59,7 @@
 		for(var/mob/living/carbon/human/H in GLOB.player_list)
 			if(z != H.z)
 				continue
-			H.adjustSanityLoss(-30)
+			H.adjustSanityLoss(30)
 			new /obj/effect/temp_visual/dir_setting/bloodsplatter(get_turf(H), pick(GLOB.alldirs))
 			to_chat(H, "<span class='notice'>You feel a crackling noise in your head.</span>")
 	bitcalculator = 0

--- a/code/modules/mob/living/simple_animal/abnormality/he/porccubus.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/porccubus.dm
@@ -255,7 +255,7 @@
 //wow this sure feels great I sure do hope there are no negative consequences for my hubris
 /datum/status_effect/porccubus_addiction/tick()
 	if(withdrawal_cooldown < world.time)
-		addict.adjustSanityLoss(sanity_gain)
+		addict.adjustSanityLoss(-sanity_gain)
 		addict.adjust_all_attribute_buffs(-1)
 		sanity_gain--
 		withdrawal_cooldown = withdrawal_cooldown_time + world.time

--- a/code/modules/mob/living/simple_animal/abnormality/he/road_home.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/road_home.dm
@@ -258,7 +258,7 @@
 //Bring everyone on the golden tiles back to road home. turn them insane if they aren't already. Also destroys all gold tiles if there are any.
 /mob/living/simple_animal/hostile/abnormality/road_home/proc/BringInsane()
 	for(var/mob/living/carbon/human/H in agent_friends)
-		H.adjustSanityLoss(-1000)
+		H.adjustSanityLoss(1000)
 		if(H.sanity_lost)
 			QDEL_NULL(H.ai_controller)
 			H.forceMove(get_turf(src))

--- a/code/modules/mob/living/simple_animal/abnormality/he/silent_girl.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/silent_girl.dm
@@ -196,7 +196,7 @@
 		H.apply_status_effect(STATUS_EFFECT_SG_GUILTY, datum_reference)
 		return
 	if((insanity_time < world.time) && !driven_insane)
-		H.adjustSanityLoss(-H.sanityhealth*2) // Do double their current sanity in damage, driving them insane instantly.
+		H.adjustSanityLoss(H.sanityhealth*2) // Do double their current sanity in damage, driving them insane instantly.
 		QDEL_NULL(H.ai_controller)
 		H.ai_controller = /datum/ai_controller/insane/release/silent_girl
 		H.InitializeAIController()

--- a/code/modules/mob/living/simple_animal/abnormality/he/singing_machine.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/singing_machine.dm
@@ -83,9 +83,9 @@ Finally, an abnormality that DOESN'T have to do any fancy movement shit. It's a 
 			for(var/mob/living/carbon/human/H in livinginrange(30, src))
 				if(faction_check_mob(H))
 					continue
-				H.adjustSanityLoss(rand(1,2))
+				H.adjustSanityLoss(rand(-1,-2))
 			for(var/mob/living/carbon/human/H in musicalAddicts)
-				H.adjustSanityLoss(rand(1,2))
+				H.adjustSanityLoss(rand(-1,-2))
 	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/singing_machine/PostWorkEffect(mob/living/carbon/human/user, work_type, pe)
@@ -164,7 +164,7 @@ Finally, an abnormality that DOESN'T have to do any fancy movement shit. It's a 
 	if(LAZYLEN(addicts))
 		for(var/mob/living/carbon/human/target in addicts)
 			if (!target.sanity_lost)
-				target.adjustSanityLoss(-500)
+				target.adjustSanityLoss(500)
 			QDEL_NULL(target.ai_controller)
 			target.ai_controller = /datum/ai_controller/insane/murder/singing_machine
 			target.InitializeAIController()
@@ -189,8 +189,8 @@ Finally, an abnormality that DOESN'T have to do any fancy movement shit. It's a 
 	alert_type = /atom/movable/screen/alert/status_effect/singing_machine
 	var/addictionTick = 10 SECONDS
 	var/addictionTimer = 0
-	var/addictionSanityMin = -2
-	var/addictionSanityMax = -6
+	var/addictionSanityMin = 2
+	var/addictionSanityMax = 6
 
 /atom/movable/screen/alert/status_effect/singing_machine
 	name = "Musical Addiction"

--- a/code/modules/mob/living/simple_animal/abnormality/he/white_lake.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/white_lake.dm
@@ -65,7 +65,7 @@
 		waltz(H)
 	//Replaces AI with murder one
 	if (!H.sanity_lost)
-		H.adjustSanityLoss(-500)
+		H.adjustSanityLoss(500)
 	QDEL_NULL(H.ai_controller)
 	H.ai_controller = /datum/ai_controller/insane/murder/whitelake
 	H.InitializeAIController()

--- a/code/modules/mob/living/simple_animal/abnormality/teth/cherry_blossoms.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/cherry_blossoms.dm
@@ -100,7 +100,7 @@
 		for(var/mob/living/carbon/human/H in GLOB.player_list)
 			if(H.stat != DEAD)
 				H.adjustBruteLoss(-500) // It heals everyone to full
-				H.adjustSanityLoss(500) // It heals everyone to full
+				H.adjustSanityLoss(-500) // It heals everyone to full
 				H.remove_status_effect(STATUS_EFFECT_MARKEDFORDEATH)
 
 /datum/status_effect/markedfordeath/on_remove()

--- a/code/modules/mob/living/simple_animal/abnormality/teth/drowned_sisters.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/drowned_sisters.dm
@@ -33,5 +33,5 @@
 /mob/living/simple_animal/hostile/abnormality/drownedsisters/PostWorkEffect(mob/living/carbon/human/user, work_type, pe, work_time)
 // okay so according to the lore you're not really supposed to remember the stories she says so we're going to make it so your sanity goes back up
 	if(!user.sanity_lost && pe != 0)
-		user.adjustSanityLoss(get_attribute_level(user, PRUDENCE_ATTRIBUTE))
+		user.adjustSanityLoss(-get_attribute_level(user, PRUDENCE_ATTRIBUTE))
 	..()

--- a/code/modules/mob/living/simple_animal/abnormality/teth/punishing_bird.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/punishing_bird.dm
@@ -150,7 +150,7 @@
 			if(ishuman(L))
 				var/mob/living/carbon/human/H = L
 				if(H.sanity_lost)
-					H.adjustSanityLoss(10) // Heal sanity
+					H.adjustSanityLoss(-10) // Heal sanity
 					return
 			if(prob(5) || L.health < L.maxHealth*0.5)
 				if(L in enemies)

--- a/code/modules/mob/living/simple_animal/abnormality/teth/shy_look.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/shy_look.dm
@@ -91,9 +91,9 @@
 
 /mob/living/simple_animal/hostile/abnormality/shy_look/PostWorkEffect(mob/living/carbon/human/user, work_type, pe)
 	if(previous_mood == 1 && pe > 0) // heals 20% hp&sp
-		user.adjustSanityLoss(0.2*user.maxSanity)
+		user.adjustSanityLoss(-0.2*user.maxSanity)
 		user.adjustBruteLoss(-0.2*user.maxHealth)
 	if(previous_mood == 2 && pe > 0)
-		user.adjustSanityLoss(0.2*user.maxSanity)
+		user.adjustSanityLoss(-0.2*user.maxSanity)
 	ChangeMood() //Prevents spamming work on the same mood
 	return

--- a/code/modules/mob/living/simple_animal/abnormality/teth/void_dream.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/void_dream.dm
@@ -72,7 +72,7 @@
 	playsound(get_turf(src), 'sound/magic/staff_change.ogg', 100, 0, 12)
 	for(var/mob/living/carbon/human/L in range(10, src))
 		if(L.has_status_effect(STATUS_EFFECT_SLEEPING))
-			L.adjustSanityLoss(-1000)	//Die.
+			L.adjustSanityLoss(1000)	//Die.
 			L.SetSleeping(0)
 		L.apply_damage(pulse_damage, WHITE_DAMAGE, null, L.run_armor_check(null, WHITE_DAMAGE), spread_damage = TRUE)
 

--- a/code/modules/mob/living/simple_animal/abnormality/waw/express_train.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/express_train.dm
@@ -58,20 +58,20 @@
 	switch(datum_reference.qliphoth_meter)
 		if(0)
 			for(var/mob/living/carbon/human/H in GLOB.mob_living_list)
-				H.adjustSanityLoss(50)
+				H.adjustSanityLoss(-50)
 				H.adjustBruteLoss(-50)
 			tickets |= user
 		if(1)
 			for(var/mob/living/carbon/human/H in livinginrange(30))
-				H.adjustSanityLoss(50)
+				H.adjustSanityLoss(-50)
 				H.adjustBruteLoss(-50)
 			tickets |= user
 		if(2)
-			user.adjustSanityLoss(80)
+			user.adjustSanityLoss(-80)
 			user.adjustBruteLoss(-80)
 			tickets |= user
 		if(3)
-			user.adjustSanityLoss(40)
+			user.adjustSanityLoss(-40)
 			user.adjustBruteLoss(-40)
 			tickets |= user
 		if(4)

--- a/code/modules/mob/living/simple_animal/abnormality/waw/fire_bird.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/fire_bird.dm
@@ -223,7 +223,7 @@
 		var/mob/living/carbon/human/L = owner
 		L.adjustBruteLoss(-b_tick)
 		L.adjustFireLoss(-b_tick)
-		L.adjustSanityLoss(b_tick)
+		L.adjustSanityLoss(-b_tick)
 
 #undef STATUS_EFFECT_BLAZING
 

--- a/code/modules/mob/living/simple_animal/abnormality/waw/hatred_queen.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/hatred_queen.dm
@@ -379,7 +379,7 @@
 					L.adjustBruteLoss(-beam_damage_final * 0.5)
 					if(ishuman(L))
 						var/mob/living/carbon/human/H = L
-						H.adjustSanityLoss(beam_damage_final * 0.5)
+						H.adjustSanityLoss(-beam_damage_final * 0.5)
 					continue
 				var/damage_before = L.get_damage_amount(BRUTE)
 				L.apply_damage(beam_damage_final, BLACK_DAMAGE, null, L.run_armor_check(null, BLACK_DAMAGE))

--- a/code/modules/mob/living/simple_animal/abnormality/waw/naked_nest.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/naked_nest.dm
@@ -336,7 +336,7 @@
 	. = ..()
 	if(ishuman(owner))
 		var/mob/living/carbon/human/H = owner
-		H.adjustSanityLoss(-0.1) //the serpents final destination is your frontal lobe
+		H.adjustSanityLoss(0.1) //the serpents final destination is your frontal lobe
 		H.adjustOrganLoss(ORGAN_SLOT_BRAIN, 0.1)
 		if(H.bodytemperature <= INHOSPITABLE_FOR_NESTING) //cure conditions
 			serpentsPoision()

--- a/code/modules/mob/living/simple_animal/abnormality/waw/yang.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/yang.dm
@@ -56,7 +56,7 @@
 	//slowly heals sanity over time
 	var/heal_cooldown
 	var/heal_cooldown_time = 3 SECONDS
-	var/heal_amount =  5
+	var/heal_amount = 5
 
 
 /mob/living/simple_animal/hostile/abnormality/yang/Move()
@@ -110,7 +110,7 @@
 	for(var/mob/living/carbon/human/H in livinginview(15, src))
 		if(H.stat == DEAD)
 			continue
-		H.adjustSanityLoss(heal_amount) // It's healing
+		H.adjustSanityLoss(-heal_amount) // It's healing
 		new /obj/effect/temp_visual/emp/pulse(get_turf(H))
 
 

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/bald.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/bald.dm
@@ -34,7 +34,7 @@
 
 /mob/living/simple_animal/hostile/abnormality/bald/WorktickSuccess(mob/living/carbon/human/user)
 	if(HAS_TRAIT(user, TRAIT_BALD))
-		user.adjustSanityLoss(user.maxSanity * 0.05) // Half of sanity restored for bald people
+		user.adjustSanityLoss(-user.maxSanity * 0.05) // Half of sanity restored for bald people
 	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/bald/PostWorkEffect(mob/living/carbon/human/user, work_type, pe)

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/fairy_festival.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/fairy_festival.dm
@@ -36,7 +36,7 @@
 		if(heal_cooldown <= world.time)
 			P.adjustBruteLoss(-heal_amount*P.getMaxHealth())
 			P.adjustFireLoss(-heal_amount*P.getMaxHealth())
-			P.adjustSanityLoss(heal_amount*P.getMaxSanity())
+			P.adjustSanityLoss(-heal_amount*P.getMaxSanity())
 	heal_cooldown = (world.time + heal_cooldown_base)
 	return
 

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/one_sin.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/one_sin.dm
@@ -69,7 +69,7 @@
 	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/onesin/SuccessEffect(mob/living/carbon/human/user, work_type, pe)
-	user.adjustSanityLoss(user.maxSanity * 0.5) // It's healing
+	user.adjustSanityLoss(-user.maxSanity * 0.5) // It's healing
 	if(pe >= datum_reference.max_boxes)
 		for(var/mob/living/carbon/human/H in GLOB.player_list)
 			if(H.z != z)
@@ -79,5 +79,5 @@
 			var/heal_factor = 0.5
 			if(H.sanity_lost)
 				heal_factor = 0.25
-			H.adjustSanityLoss(H.maxSanity * heal_factor)
+			H.adjustSanityLoss(-H.maxSanity * heal_factor)
 	return ..()

--- a/code/modules/projectiles/projectile/ego_bullets/waw.dm
+++ b/code/modules/projectiles/projectile/ego_bullets/waw.dm
@@ -25,10 +25,10 @@
 		if(user.faction_check_mob(H)) // Our faction
 			switch(damage_type)
 				if(WHITE_DAMAGE)
-					H.adjustSanityLoss(damage*0.2)
+					H.adjustSanityLoss(-damage*0.2)
 				if(BLACK_DAMAGE)
 					H.adjustBruteLoss(-damage*0.1)
-					H.adjustSanityLoss(damage*0.1)
+					H.adjustSanityLoss(-damage*0.1)
 				else // Red or pale
 					H.adjustBruteLoss(-damage*0.2)
 			H.visible_message("<span class='warning'>[src] vanishes on contact with [H]!</span>")
@@ -264,7 +264,7 @@
 	var/mob/living/carbon/human/H = target
 	var/mob/living/user = firer
 	if(user.faction_check_mob(H))//player faction
-		H.adjustSanityLoss(damage*0.2)
+		H.adjustSanityLoss(-damage*0.2)
 		H.electrocute_act(1, src, flags = SHOCK_NOSTUN)
 		H.Knockdown(50)
 		return BULLET_ACT_BLOCK

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -255,7 +255,7 @@
 	M.adjust_bodytemperature(25 * TEMPERATURE_DAMAGE_COEFFICIENT, 0, M.get_body_temp_normal())
 	if(prob(5))
 		var/mob/living/carbon/human/H = M
-		H.adjustSanityLoss(1*REM) // That's healing
+		H.adjustSanityLoss(-1*REM) // That's healing
 	if(holder.has_reagent(/datum/reagent/consumable/frostoil))
 		holder.remove_reagent(/datum/reagent/consumable/frostoil, 5)
 	..()
@@ -278,7 +278,7 @@
 	M.AdjustSleeping(-20)
 	if(prob(5))
 		var/mob/living/carbon/human/H = M
-		H.adjustSanityLoss(0.02*H.maxSanity*REM) // That's healing 2% of max sanity.
+		H.adjustSanityLoss(-0.02*H.maxSanity*REM) // That's healing 2% of max sanity.
 	if(M.getToxLoss() && prob(20))
 		M.adjustToxLoss(-1, 0)
 	M.adjust_bodytemperature(20 * TEMPERATURE_DAMAGE_COEFFICIENT, 0, M.get_body_temp_normal())
@@ -330,7 +330,7 @@
 	M.Jitter(5)
 	if(prob(5))
 		var/mob/living/carbon/human/H = M
-		H.adjustSanityLoss(0.02*H.maxSanity*REM) // That's healing 2% of max sanity.
+		H.adjustSanityLoss(-0.02*H.maxSanity*REM) // That's healing 2% of max sanity.
 	..()
 	. = 1
 
@@ -370,7 +370,7 @@
 	M.AdjustSleeping(-40)
 	if(prob(5))
 		var/mob/living/carbon/human/H = M
-		H.adjustSanityLoss(0.02*H.maxSanity*REM) // That's healing 2% of max sanity.
+		H.adjustSanityLoss(-0.02*H.maxSanity*REM) // That's healing 2% of max sanity.
 	if(M.getToxLoss() && prob(20))
 		M.adjustToxLoss(-1, 0)
 	M.adjust_bodytemperature(-5 * TEMPERATURE_DAMAGE_COEFFICIENT, M.get_body_temp_normal())
@@ -646,7 +646,7 @@
 	M.Jitter(5)
 	if(prob(5))
 		var/mob/living/carbon/human/H = M
-		H.adjustSanityLoss(0.02*H.maxSanity*REM) // That's healing 2% of max sanity.
+		H.adjustSanityLoss(-0.02*H.maxSanity*REM) // That's healing 2% of max sanity.
 	if(M.getBruteLoss() && prob(20))
 		M.heal_bodypart_damage(1,0, 0)
 	..()
@@ -670,7 +670,7 @@
 	M.Jitter(5)
 	if(prob(5))
 		var/mob/living/carbon/human/H = M
-		H.adjustSanityLoss(0.02*H.maxSanity*REM) // That's healing 2% of max sanity.
+		H.adjustSanityLoss(-0.02*H.maxSanity*REM) // That's healing 2% of max sanity.
 	if(M.getBruteLoss() && prob(20))
 		M.heal_bodypart_damage(1,0, 0)
 	..()
@@ -985,7 +985,7 @@
 	if(!ishuman(M))
 		return
 	var/mob/living/carbon/human/H = M
-	H.adjustSanityLoss(5) // That's healing
+	H.adjustSanityLoss(-5) // That's healing
 	return ..()
 
 /datum/reagent/consumable/wellcheers_purple
@@ -1002,5 +1002,5 @@
 		return
 	var/mob/living/carbon/human/H = M
 	H.adjustBruteLoss(-3.5)
-	H.adjustSanityLoss(3.5) // That's healing
+	H.adjustSanityLoss(-3.5) // That's healing
 	return ..()

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -65,7 +65,7 @@
 	M.AdjustImmobilized(-5)
 	if(prob(1))
 		var/mob/living/carbon/human/H = M
-		H.adjustSanityLoss(3*REM) // That's healing
+		H.adjustSanityLoss(-3*REM) // That's healing
 	..()
 	. = 1
 
@@ -74,7 +74,7 @@
 	M.adjustOxyLoss(1.1*REM, 0)
 	if(prob(10))
 		var/mob/living/carbon/human/H = M
-		H.adjustSanityLoss(-5*REM) // That's BAD
+		H.adjustSanityLoss(5*REM) // That's BAD
 	..()
 	. = 1
 

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -536,7 +536,7 @@
 	if(overdosed)
 		return
 	var/mob/living/carbon/human/H = M
-	H.adjustSanityLoss(5*REM) // That's healing 5 units.
+	H.adjustSanityLoss(-5*REM) // That's healing 5 units.
 	..()
 	. = 1
 
@@ -1187,7 +1187,7 @@
 		C.disgust = max(0, C.disgust-6)
 	if(prob(10))
 		var/mob/living/carbon/human/H = M
-		H.adjustSanityLoss(1*REM) // That's healing
+		H.adjustSanityLoss(-1*REM) // That's healing
 	..()
 	. = 1
 

--- a/code/modules/spells/ability_types/realized_aimed.dm
+++ b/code/modules/spells/ability_types/realized_aimed.dm
@@ -83,7 +83,7 @@
 		if(user.faction_check_mob(L))
 			if(ishuman(L))
 				var/mob/living/carbon/human/H = L
-				H.adjustSanityLoss(damage_amount)
+				H.adjustSanityLoss(-damage_amount)
 			continue
 		var/distance_decrease = get_dist(T, L) * 10
 		L.apply_damage((damage_amount - distance_decrease), WHITE_DAMAGE, null, L.run_armor_check(null, WHITE_DAMAGE))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- adjustSanityLoss is no longer reverse. Doing 50 sanity damage reduces sanityhealth by 50, not the other way around.
- Sanity health is now more in line with other damage types. Added sanityloss variable.
- Sanity loss check now takes stat buffs into account when choosing insanity type.

## Why It's Good For The Game

- No more weird code.
- Solves issues with prudence increase putting your current sanity below maximum, easier to get the exact damage numbers.
- Should've been done a long time ago. This mostly affects end-game 130 stats, where +5 buff will decide if you should murder everyone or yourself.
