### PR TITLE
WN's good effect calls async instead of normal proc

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/aleph/white_night.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/white_night.dm
@@ -186,7 +186,7 @@ GLOBAL_LIST_EMPTY(apostles)
 	if(prob(66))
 		datum_reference.qliphoth_change(1)
 		if(prob(66)) // Rare effect, mmmm
-			revive_humans(48, "neutral") // Big heal
+			INVOKE_ASYNC(src, .proc/revive_humans, 48, "neutral") // Big heal
 	return
 
 /mob/living/simple_animal/hostile/abnormality/white_night/FailureEffect(mob/living/carbon/human/user, work_type, pe)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- WN's good effect is called by INVOKE_ASYNC instead of directly.

## Why It's Good For The Game

- Post-work effect(gift-giving, result reporting, etc) isn't delayed if WN does the pulse now.
