### PR TITLE
Overload chance is reset to 0 on meltdown

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/_abnormality.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_abnormality.dm
@@ -270,6 +270,8 @@
 
 // When qliphoth meltdown begins
 /mob/living/simple_animal/hostile/abnormality/proc/MeltdownStart()
+	if(istype(datum_reference))
+		datum_reference.overload_chance = 0
 	return
 
 /mob/living/simple_animal/hostile/abnormality/proc/OnQliphothChange(mob/living/carbon/human/user, amount = 0)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Instead of resetting to 0 on qliphoth effect specifically, overload chance does that on any meltdown.

## Why It's Good For The Game

Solves issues with Arbiter and Apocalypse Bird causing meltdowns and inevitably leading to -50% overload.
