### PR TITLE
Hits some awkward HE armor sets

### DIFF
--- a/code/modules/clothing/suits/ego_gear/he.dm
+++ b/code/modules/clothing/suits/ego_gear/he.dm
@@ -162,7 +162,7 @@
 	desc = "Their weapons did not hurt me, but when I looked back and you were not there; It felt as if I was on the verge of death."
 	icon_state = "courage"
 	//because SC is essentially physically immortal but a coward, he has good physical resistances and god awful "sanity" resistances
-	armor = list (RED_DAMAGE = 40, WHITE_DAMAGE = -10, BLACK_DAMAGE = 0, PALE_DAMAGE = 50) //80
+	armor = list (RED_DAMAGE = 40, WHITE_DAMAGE = -20, BLACK_DAMAGE = 0, PALE_DAMAGE = 50) //70
 	attribute_requirements = list(
 								FORTITUDE_ATTRIBUTE = 40
 								)
@@ -181,7 +181,7 @@
 	name = "pleasure"
 	desc = "Dying happy was my only wish, and you granted it. What more could I ask for?"
 	icon_state = "pleasure"
-	armor = list(RED_DAMAGE = -20, WHITE_DAMAGE = 50, BLACK_DAMAGE = 50, PALE_DAMAGE = 0) //80 because requiring a level 4 stat on a HE is pretty big
+	armor = list(RED_DAMAGE = -30, WHITE_DAMAGE = 40, BLACK_DAMAGE = 40, PALE_DAMAGE = 20) //70
 	attribute_requirements = list(
 							TEMPERANCE_ATTRIBUTE = 40)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
A couple sets had an 80 stat total, this removes two of them.

The only ones remaining are Lutemia, which is an event armor,
and Magic bullet, which no one in their right mind would ever argue is good.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
EGO equalization
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: removed 80 armor HE
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
