### PR TITLE
road home nerf

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/he/road_home.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/road_home.dm
@@ -7,7 +7,7 @@
 	maxHealth = 1000
 	health = 1000
 	move_resist = MOVE_FORCE_STRONG //So she can't be yeeted away and delayed indefinitely
-	move_to_delay = 10 //She needs to be slow so she doesn't reach home too fast
+	move_to_delay = 13 //She needs to be slow so she doesn't reach home too fast
 	damage_coeff = list(BRUTE = 1, RED_DAMAGE = 0.3, WHITE_DAMAGE = 2, BLACK_DAMAGE = 2, PALE_DAMAGE = 2) //Endure red because catt mentions physical attacks can't hurt her at all.
 	melee_damage_lower = 1
 	melee_damage_upper = 1 //Irrelevant, she does not attack of her own volition
@@ -140,7 +140,7 @@
 		return
 
 	playsound(src, 'sound/abnormalities/roadhome/House_NormalAtk.ogg', 100, FALSE, 8)
-	for(var/mob/living/L in livinginrange(15, src))
+	for(var/mob/living/L in view(15, src))
 		if(!ishuman(L) || L.stat == DEAD || L.has_status_effect(/datum/status_effect/stay_home))
 			continue
 		L.apply_status_effect(/datum/status_effect/stay_home)
@@ -350,7 +350,7 @@
 
 /datum/ai_controller/insane/road_home/PossessPawn(atom/new_pawn)
 	. = ..()
-	move_speed = rand(10, 15) //Everyone has a slightly different move speed so they don't trip over each other. They should also be slower than the road home.
+	move_speed = rand(14, 23) //Everyone has a slightly different move speed so they don't trip over each other. They should also be slower than the road home.
 	addtimer(CALLBACK(src, .proc/MoveToBrick), move_speed)
 
 /datum/ai_controller/insane/road_home/proc/MoveToBrick()

--- a/code/modules/paperwork/records/info/he.dm
+++ b/code/modules/paperwork/records/info/he.dm
@@ -538,8 +538,8 @@
 
 //The Road Home
 /obj/item/paper/fluff/info/he/road_home
-	name = "F-02-136"
-	info = {"<h1><center>F-02-136</center></h1>    <br>
+	name = "F-01-136"
+	info = {"<h1><center>F-01-136</center></h1>    <br>
 	Name : The Road Home   <br>
 	Risk Class : HE    <br>
 	Max PE Boxes : 18    <br>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Nerfs road home to be a little a slower and only hits people with her AOE if she can see them.
I also changed her records from 02 to 01 since I mixed animal and human.

## Why It's Good For The Game

Road home has an instant insanity and insane CC. Despite the fact she's rather easy to kill, it should at least be a lot easier to dodge her status effect considering how big the effect actually is, especially since she's a HE.

## Changelog
:cl:
balance: road home is now slower and only hits people in view with her flip.
/:cl:
