### PR TITLE
Left Behind Objects Framework

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/_abnormality.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_abnormality.dm
@@ -59,6 +59,8 @@
 	var/datum/ego_gifts/gift_type = null
 	var/gift_chance = null
 	var/gift_message = null
+	/// Variable that stores any objects the abno may bring with it on spawn (Example: /obj/structure/pbird_perch). Reccomended to define what the object is in the same file as the abno.
+	var/abno_object = null
 
 /mob/living/simple_animal/hostile/abnormality/Initialize(mapload)
 	. = ..()
@@ -171,7 +173,9 @@
 
 // Called by datum_reference when the abnormality has been fully spawned
 /mob/living/simple_animal/hostile/abnormality/proc/PostSpawn()
-	return
+	if((locate(abno_object) in get_turf(src))||(!abno_object))
+		return
+	new abno_object(get_turf(src))
 
 // transfers a var to the datum to be used later
 /mob/living/simple_animal/hostile/abnormality/proc/TransferVar(index, value)


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Abnormalities now have a new var and framework allowing them to spawn an object into their containment PostSpawn. Mostly for abnos like pbird and firebird who leave behind trees/branches when they breach.

## Why It's Good For The Game

Adds additional game accuracy with stuff like perches and things left behind in the cell, could possibly also be used for mechanics in the future.

## Changelog
:cl:
add: Framework stuff
code: utilized the PostSpawn proc which was previously just a return proc
/:cl:

