### PR TITLE
Reddened Buddy Icon Fix

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/he/red_buddy.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/red_buddy.dm
@@ -107,7 +107,8 @@
 			suffering = 0
 		if(ABNORMALITY_WORK_REPRESSION)
 			AdjustSuffering(10) //my brother in christ you are literally beating the dog up
-	UpdateScars()
+	if(datum_reference?.qliphoth_meter > 0)
+		UpdateScars()
 	if(suffering >= 20)
 		datum_reference.qliphoth_change(-1)
 
@@ -129,7 +130,7 @@
 
 //makes buddy scarred if his suffering is high enough
 /mob/living/simple_animal/hostile/abnormality/red_buddy/proc/UpdateScars()
-	if(!status_flags & GODMODE) //I don't know how you're working on the dog while he's breached but stop
+	if(!IsContained()) //I don't know how you're working on the dog while he's breached but stop
 		return
 	if(suffering >= 20)
 		icon_state = "redbuddy_scratched"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
When Reddened Buddy gained enough Suffering to become beaten up WHILE also breaching containment, he changes sprites TWICE. Once into his breached form and then after that he changes back into his beaten up form. This resolves that issue.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Sprite Fix
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
