### PR TITLE
Halves Chems inside pens

### DIFF
--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -198,14 +198,14 @@
 	desc = "An autoinjector containing salicylic acid, used to treat severe brute damage."
 	icon_state = "salacid"
 	inhand_icon_state = "salacid"
-	list_reagents = list(/datum/reagent/medicine/sal_acid = 10)
+	list_reagents = list(/datum/reagent/medicine/sal_acid = 5)
 
 /obj/item/reagent_containers/hypospray/medipen/mental
 	name = "mental stabilizator medipen"
 	desc = "An autoinjector containing mental stabilizator, used to treat severe anxiety and panic."
 	icon_state = "morphen"
 	inhand_icon_state = "morphen"
-	list_reagents = list(/datum/reagent/medicine/mental_stabilizator = 10)
+	list_reagents = list(/datum/reagent/medicine/mental_stabilizator = 5)
 
 /obj/item/reagent_containers/hypospray/medipen/salbutamol
 	name = "salbutamol medipen"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Pen chems are halved
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Healing 150 is a little much, now they should heal only 60 or so
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: The amount of chemicals in pens is halved
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
