### PR TITLE
Makes Galaxy EGO fire faster without homing

### DIFF
--- a/code/modules/projectiles/guns/ego_gun/he.dm
+++ b/code/modules/projectiles/guns/ego_gun/he.dm
@@ -31,10 +31,10 @@
 	name = "galaxy"
 	desc = "A shimmering wand."
 	icon_state = "galaxy"
-	special = "Use in hand to turn on homing mode. This mode homes in on a random target within 15 metres.	\
+	special = "Use in hand to turn on homing mode. This mode fires slower, but homes in on a random target within 15 metres.	\
 			WARNING: This feature is not accurate."
 	ammo_type =	/obj/item/ammo_casing/caseless/ego_galaxy
-	fire_delay = 8
+	fire_delay = 6
 	fire_sound = 'sound/magic/wand_teleport.ogg'
 	weapon_weight = WEAPON_HEAVY
 	fire_sound_volume = 70
@@ -48,10 +48,12 @@
 	if(homing)
 		to_chat(user,"<span class='warning'>You release your energy, and turn off homing.</span>")
 		ammo_type = /obj/item/ammo_casing/caseless/ego_galaxy
+		fire_delay = 6
 		homing = FALSE
 		return
 	if(!homing)
 		to_chat(user,"<span class='warning'>You channel your energy, enabling homing.</span>")
+		fire_delay = 8
 		ammo_type = /obj/item/ammo_casing/caseless/ego_galaxy/homing
 		homing = TRUE
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
![image](https://user-images.githubusercontent.com/35991533/222951221-dc8f5a12-f879-4040-8b57-71a24b04fb34.png)

## About The Pull Request
Reduces the fire delay when homing is disabled on child of the galaxy's EGO weapon from 8 to 6
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
There is currently no benefit to disabling homing apart from its unreliability at times. While homing is sometimes useful, this weapon is below par when fired normally. This brings the manual firing mode up to the ballpark of most regular semi's. It is still a projectile weapon that can be difficult to aim at times.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: galaxy EGO fires faster without homing
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
