### PR TITLE
Crumbling Armor Now only does pale if you are wearing armor

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/teth/crumbling_armor.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/crumbling_armor.dm
@@ -12,7 +12,7 @@
 		ABNORMALITY_WORK_ATTACHMENT = 0,
 		ABNORMALITY_WORK_REPRESSION = list(60, 60, 65, 65, 70)
 			)
-	work_damage_amount = 4
+	work_damage_amount = 8
 	work_damage_type = PALE_DAMAGE
 
 	ego_list = list(
@@ -28,6 +28,19 @@
 	// Megalovania?
 	if (prob(1))
 		icon_state = "megalovania"
+
+/mob/living/simple_animal/hostile/abnormality/crumbling_armor/WorkChance(mob/living/carbon/human/user, chance)
+	if (!istype(user,/mob/living/carbon/human))
+		return
+	var/mob/living/carbon/human/myman = user
+	if (isnull(myman.get_item_by_slot(ITEM_SLOT_OCLOTHING)))
+		work_damage_amount = 5
+		work_damage_type = RED_DAMAGE
+	else
+		work_damage_amount = 8
+		work_damage_type = PALE_DAMAGE
+
+	return chance
 
 /mob/living/simple_animal/hostile/abnormality/crumbling_armor/proc/Cut_Head(datum/source, datum/abnormality/datum_sent, mob/living/carbon/human/user, work_type)
 	SIGNAL_HANDLER

--- a/code/modules/paperwork/records/info/teth.dm
+++ b/code/modules/paperwork/records/info/teth.dm
@@ -180,10 +180,11 @@
 	Max PE Boxes : 12	<br>
 	Qliphoth Counter : X	<br>
 	Work Damage Type : PALE	<br>
-	Work Damage : Low	<br>
+	Work Damage : Moderate	<br>
 	- When an employee with Fortitude Level 1 completed the work, they were found with their head cut clean off.	<br>
 	- Upon completing a Repression work with Crumbling Armor, the employee gained a glowing aura. This aura seemed to increase their stats regarding Justice.	<br>
 	- Each time the employee completed Repression work with any Abnormality, the aura intensified.	<br>
+	- When EGO Gear was not worn when working on Crumbling Armor, work dealt RED damage instead.	<br>
 	- WARNING: When an employee with the aura performed Attachment work, they were found with their head sliced clean off.	<br>
 	- WARNING: As the aura intensified, so too did its effect. However, an additional loss of Fortitude was noted.	<br>
 	<br>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Crumbling armor now does 5 red if you aren't wearing armor and 8 pale if you are.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes early game pale armor actually useful for one specific instance.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Crumbling armor only does pale when you're not wearing armor.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
