### PR TITLE
LC13 gamemodes

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -207,6 +207,7 @@
 
 	to_chat(world, "<BR><BR><BR><span class='big bold'>The round has ended.</span>")
 	log_game("The round has ended.")
+	SSvote.initiate_vote("gamemode", "automatic gamemode selection vote")
 
 	for(var/I in round_end_events)
 		var/datum/callback/cb = I

--- a/code/controllers/configuration/configuration.dm
+++ b/code/controllers/configuration/configuration.dm
@@ -248,7 +248,6 @@
 				if(M.votable)
 					votable_modes += M.config_tag
 		qdel(M)
-	votable_modes += "secret"
 
 /datum/controller/configuration/proc/LoadMOTD()
 	motd = file2text("[directory]/motd.txt")

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -344,9 +344,6 @@ GLOBAL_LIST_EMPTY(the_station_areas)
 		if (!(map in global.config.maplist))
 			mapvotes.Remove(map)
 			continue
-		if(map in SSpersistence.blocked_maps)
-			mapvotes.Remove(map)
-			continue
 		var/datum/map_config/VM = global.config.maplist[map]
 		if (!VM)
 			mapvotes.Remove(map)

--- a/code/controllers/subsystem/persistence.dm
+++ b/code/controllers/subsystem/persistence.dm
@@ -123,7 +123,7 @@ SUBSYSTEM_DEF(persistence)
 		return
 	saved_maps = json["data"]
 
-	//Convert the mapping data to a shared blocking list, saves us doing this in several places later.
+	/*/Convert the mapping data to a shared blocking list, saves us doing this in several places later.
 	for(var/map in config.maplist)
 		var/datum/map_config/VM = config.maplist[map]
 		var/run = 0
@@ -134,6 +134,9 @@ SUBSYSTEM_DEF(persistence)
 				run++
 		if(run >= 2) //If run twice in the last KEEP_ROUNDS_MAP + 1 (including current) rounds, disable map for voting and rotation.
 			blocked_maps += VM.map_name
+			*/
+			// Actually, scratch that. Our players know when to pick what map. We trust them.
+			// I'm leaving the code here commented though, because persistence is too dangerous to touch willy-nilly like that.
 
 /datum/controller/subsystem/persistence/proc/LoadAntagReputation()
 	var/json = file2text(FILE_ANTAG_REP)

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -128,9 +128,7 @@ SUBSYSTEM_DEF(vote)
 			if("gamemode")
 				if(GLOB.master_mode != .)
 					SSticker.save_mode(.)
-					if(SSticker.HasRoundStarted())
-						restart = TRUE
-					else
+					if(!SSticker.HasRoundStarted())
 						GLOB.master_mode = .
 			if("map")
 				SSmapping.changemap(global.config.maplist[.])
@@ -212,7 +210,7 @@ SUBSYSTEM_DEF(vote)
 				var/list/maps = list()
 				for(var/map in global.config.maplist)
 					var/datum/map_config/VM = config.maplist[map]
-					if(!VM.votable || (VM.map_name in SSpersistence.blocked_maps))
+					if(!VM.votable)
 						continue
 					var/player_count = GLOB.clients.len
 					if(VM.config_max_users > 0 && player_count >= VM.config_max_users)

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -15,7 +15,7 @@
 /datum/game_mode
 	var/name = "invalid"
 	var/config_tag = null
-	var/votable = 1
+	var/votable = 0 // boy howdy I sure hope setting the default value here to 0 doesn't split the game in half
 	var/probability = 0
 	var/false_report_weight = 0 //How often will this show up incorrectly in a centcom report?
 	var/report_type = "invalid" //gamemodes with the same report type will not show up in the command report together.

--- a/code/game/gamemodes/management/management.dm
+++ b/code/game/gamemodes/management/management.dm
@@ -1,0 +1,51 @@
+/datum/game_mode/management
+	name = "Management"
+	config_tag = "management_basic"
+	report_type = "extended"
+	false_report_weight = 5
+	required_players = 0
+
+	announce_span = "notice"
+	announce_text = "You shouldn't be seeing this!!"
+	var/list/abno_types = list("Lobotomy Corporation", "Altered LC", "Artbook", "Wonderlab", "Library of Ruina", "Limbus Company", "Original")
+	var/list/gamemode_abnos = list(ZAYIN_LEVEL = list(), TETH_LEVEL = list(), HE_LEVEL = list(), WAW_LEVEL = list(), ALEPH_LEVEL = list())
+
+/datum/game_mode/management/post_setup()
+	var/list/all_abnos = subtypesof(/mob/living/simple_animal/hostile/abnormality)
+	for(var/i in all_abnos)
+		var/mob/living/simple_animal/hostile/abnormality/abno = i
+		if(initial(abno.can_spawn) && (initial(abno.abnormality_origin) in abno_types))
+			gamemode_abnos[initial(abno.threat_level)] += abno
+
+	SSabnormality_queue.possible_abnormalities = list()
+	SSabnormality_queue.possible_abnormalities = gamemode_abnos
+	if(LAZYLEN(gamemode_abnos))
+		SSabnormality_queue.pick_abno()
+	return ..()
+
+/datum/game_mode/management/pure
+	name = "Pure"
+	config_tag = "pure"
+	votable = 1
+
+	announce_span = "notice"
+	announce_text = "Manage a selection of abnormalities strictly from Lobotomy Corporation HQ!"
+	abno_types = list("Lobotomy Corporation")
+
+/datum/game_mode/management/classic
+	name = "classic"
+	config_tag = "classic"
+	votable = 1
+
+	announce_span = "notice"
+	announce_text = "Manage a wide cast of abnormalities from all normal sources!"
+	abno_types = list("Lobotomy Corporation", "Altered LC", "Artbook", "Wonderlab", "Library of Ruina", "Limbus Company", "Original")
+
+/datum/game_mode/management/branch
+	name = "Lobotomy Corporation - Side Branch"
+	config_tag = "sidebranch"
+	votable = 0
+
+	announce_span = "notice"
+	announce_text = "Manage all abnormalities not originating from Lobotomy Corporation HQ!"
+	abno_types = list("Artbook", "Wonderlab", "Library of Ruina", "Limbus Company", "Original")

--- a/code/modules/mob/living/simple_animal/abnormality/_abnormality.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_abnormality.dm
@@ -59,6 +59,7 @@
 	var/datum/ego_gifts/gift_type = null
 	var/gift_chance = null
 	var/gift_message = null
+	var/abnormality_origin = "Original"
 
 /mob/living/simple_animal/hostile/abnormality/Initialize(mapload)
 	. = ..()

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/blue_star.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/blue_star.dm
@@ -39,6 +39,7 @@
 		/datum/ego_datum/armor/star_sound
 		)
 	gift_type =  /datum/ego_gifts/star
+	abnormality_origin = "Lobotomy Corporation"
 
 	var/pulse_cooldown
 	var/pulse_cooldown_time = 12 SECONDS

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/censored.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/censored.dm
@@ -44,6 +44,7 @@
 
 	gift_type =  /datum/ego_gifts/censored
 	gift_message = "You feel disgusted just looking at it."
+	abnormality_origin = "Lobotomy Corporation"
 
 	var/can_act = TRUE
 

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/melting_love.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/melting_love.dm
@@ -48,6 +48,7 @@
 	var/sanityheal_cooldown_base = 15 SECONDS
 	ego_list = list(/datum/ego_datum/weapon/adoration, /datum/ego_datum/armor/adoration)
 	gift_type =  /datum/ego_gifts/adoration
+	abnormality_origin = "Lobotomy Corporation"
 
 /mob/living/simple_animal/hostile/abnormality/melting_love/Life()
 	. = ..()

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/mountain.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/mountain.dm
@@ -41,6 +41,7 @@
 		/datum/ego_datum/armor/smile
 		)
 	gift_type =  /datum/ego_gifts/smile
+	abnormality_origin = "Lobotomy Corporation"
 	/// Is user performing work hurt at the beginning?
 	var/agent_hurt = FALSE
 	var/death_counter = 0

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/nothing_there.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/nothing_there.dm
@@ -38,6 +38,7 @@
 		/datum/ego_datum/armor/mimicry
 		)
 	gift_type =  /datum/ego_gifts/mimicry
+	abnormality_origin = "Lobotomy Corporation"
 	var/mob/living/disguise = null
 	var/saved_appearance
 	var/can_act = TRUE

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/silent_orchestra.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/silent_orchestra.dm
@@ -31,6 +31,7 @@
 		/datum/ego_datum/armor/da_capo
 		)
 	gift_type =  /datum/ego_gifts/dacapo
+	abnormality_origin = "Lobotomy Corporation"
 	/// Range of the damage
 	var/symphony_range = 20
 	/// Amount of white damage every tick

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/space_lady.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/space_lady.dm
@@ -26,6 +26,7 @@
 		/datum/ego_datum/armor/space
 		)
 //	gift_type =  /datum/ego_gifts/space
+	abnormality_origin = "Artbook"
 
 	var/explosion_timer = 2 SECONDS
 	var/explosion_state = 3

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/staining_rose.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/staining_rose.dm
@@ -30,6 +30,7 @@
 		/datum/ego_datum/armor/flowering
 		)
 	gift_type = /datum/ego_gifts/blossoming
+	abnormality_origin = "Wonderlab"
 
 	var/chosen
 	var/list/sacrificed = list()

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/titania.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/titania.dm
@@ -34,6 +34,7 @@
 		/datum/ego_datum/armor/soulmate
 		)
 //	gift_type = /datum/ego_gifts/soulmate
+	abnormality_origin = "Wonderlab"
 
 	var/fairies_spawned = 0
 	var/fairy_spawn_number = 2

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/white_night.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/white_night.dm
@@ -45,6 +45,7 @@ GLOBAL_LIST_EMPTY(apostles)
 		/datum/ego_datum/armor/paradise
 		)
 	gift_type =  /datum/ego_gifts/paradise
+	abnormality_origin = "Lobotomy Corporation"
 
 	var/holy_revival_cooldown
 	var/holy_revival_cooldown_base = 75 SECONDS

--- a/code/modules/mob/living/simple_animal/abnormality/he/KHz.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/KHz.dm
@@ -22,6 +22,7 @@
 		/datum/ego_datum/weapon/transmission,
 		/datum/ego_datum/armor/transmission
 	)
+	abnormality_origin = "Original"
 
 	var/input
 	var/bitposition = 4	//You write in bits. You need to successfully write a string of 5 to sucessfully work

--- a/code/modules/mob/living/simple_animal/abnormality/he/blue_shepherd.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/blue_shepherd.dm
@@ -46,6 +46,7 @@
 		/datum/ego_datum/armor/oppression
 		)
 	gift_type = /datum/ego_gifts/oppression
+	abnormality_origin = "Wonderlab"
 
 	var/death_counter //He won't go off a timer, he'll go off deaths. Takes 8 for him.
 	var/slash_current = 4

--- a/code/modules/mob/living/simple_animal/abnormality/he/der_freischutz.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/der_freischutz.dm
@@ -20,6 +20,7 @@
 		/datum/ego_datum/armor/magicbullet
 		)
 	gift_type =  /datum/ego_gifts/magicbullet
+	abnormality_origin = "Lobotomy Corporation"
 
 /mob/living/simple_animal/hostile/abnormality/der_freischutz/PostWorkEffect(mob/living/carbon/human/user, work_type, pe, work_time)
 	if(get_attribute_level(user, JUSTICE_ATTRIBUTE) < 60)

--- a/code/modules/mob/living/simple_animal/abnormality/he/fan.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/fan.dm
@@ -22,6 +22,7 @@
 		/datum/ego_datum/weapon/metal,
 		/datum/ego_datum/armor/metal
 	)
+	abnormality_origin = "Artbook"
 	var/list/safe = list()
 	var/list/warning = list()
 	var/list/danger = list()

--- a/code/modules/mob/living/simple_animal/abnormality/he/funeral.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/funeral.dm
@@ -45,6 +45,7 @@
 		)
 	gift_type =  /datum/ego_gifts/solemnlament
 	gift_message = "The butterflies are waiting for the end of the world."
+	abnormality_origin = "Lobotomy Corporation"
 
 	var/gun_cooldown
 	var/gun_cooldown_time = 4 SECONDS

--- a/code/modules/mob/living/simple_animal/abnormality/he/galaxy_child.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/galaxy_child.dm
@@ -23,6 +23,7 @@
 		/datum/ego_datum/armor/galaxy
 		)
 //	gift_type = /datum/ego_gifts/galaxy
+	abnormality_origin = "Lobotomy Corporation"
 
 	var/heal_cooldown_time = 2 SECONDS
 	var/heal_cooldown

--- a/code/modules/mob/living/simple_animal/abnormality/he/happy_teddy_bear.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/happy_teddy_bear.dm
@@ -34,6 +34,7 @@
 		/datum/ego_datum/armor/paw
 		)
 	gift_type =  /datum/ego_gifts/bearpaw
+	abnormality_origin = "Lobotomy Corporation"
 
 /mob/living/simple_animal/hostile/abnormality/happyteddybear/proc/Strangle(mob/living/carbon/human/user)
 	src.hugging = TRUE

--- a/code/modules/mob/living/simple_animal/abnormality/he/helper.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/helper.dm
@@ -39,6 +39,7 @@
 		)
 	gift_type =  /datum/ego_gifts/grinder
 	gift_message = "Contamination scan complete. Initiating cleaning protocol."
+	abnormality_origin = "Lobotomy Corporation"
 	var/charging = FALSE
 	var/dash_num = 50
 	var/dash_cooldown = 0

--- a/code/modules/mob/living/simple_animal/abnormality/he/jangsan.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/jangsan.dm
@@ -42,6 +42,7 @@
 		/datum/ego_datum/armor/maneater
 		)
 	gift_type =  /datum/ego_gifts/maneater
+	abnormality_origin = "Artbook"
 
 //breach related
 	var/teleport_cooldown

--- a/code/modules/mob/living/simple_animal/abnormality/he/laetitia.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/laetitia.dm
@@ -23,6 +23,7 @@
 		)
 	gift_type = /datum/ego_gifts/prank
 	gift_message = "I hope you're pleased with this!"
+	abnormality_origin = "Lobotomy Corporation"
 
 /mob/living/simple_animal/hostile/abnormality/laetitia/NeutralEffect(mob/living/carbon/human/user, work_type, pe)
 	var/datum/status_effect/pranked/P = user.has_status_effect(STATUS_EFFECT_PRANKED)

--- a/code/modules/mob/living/simple_animal/abnormality/he/pisc_mermaid.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/pisc_mermaid.dm
@@ -42,6 +42,7 @@
 		/datum/ego_datum/armor/unrequited
 		)
 	//gift_type =  /datum/ego_gifts/unrequited_love
+	abnormality_origin = "Wonderlab"
 
 	response_help_continuous = "pets" //You sick fuck
 	response_help_simple = "pet"

--- a/code/modules/mob/living/simple_animal/abnormality/he/porccubus.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/porccubus.dm
@@ -40,6 +40,7 @@
 		/datum/ego_datum/armor/pleasure
 		)
 	//gift_type = /datum/ego_gifts/pleasure
+	abnormality_origin = "Lobotomy Corporation"
 
 	//the agent that started work on porccubus
 	var/agent_ckey

--- a/code/modules/mob/living/simple_animal/abnormality/he/red_buddy.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/red_buddy.dm
@@ -44,6 +44,7 @@
 		/datum/ego_datum/armor/totalitarianism
 		)
 	gift_type = /datum/ego_gifts/totalitarianism
+	abnormality_origin = "Wonderlab"
 
 	///The blue smocked shepherd linked to red buddy
 	var/datum/abnormality/master

--- a/code/modules/mob/living/simple_animal/abnormality/he/red_queen.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/red_queen.dm
@@ -22,6 +22,7 @@
 		/datum/ego_datum/armor/fury
 		)
 	gift_type = /datum/ego_gifts/fury
+	abnormality_origin = "Wonderlab"
 
 	var/liked
 

--- a/code/modules/mob/living/simple_animal/abnormality/he/road_home.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/road_home.dm
@@ -31,6 +31,7 @@
 	ego_list = list(
 		/datum/ego_datum/weapon/homing_instinct,
 		/datum/ego_datum/armor/homing_instinct)
+	abnormality_origin = "Wonderlab"
 	///Stuff related to the house and its path
 	var/obj/road_house/house
 	var/list/house_path

--- a/code/modules/mob/living/simple_animal/abnormality/he/rudolta.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/rudolta.dm
@@ -35,6 +35,7 @@
 		/datum/ego_datum/armor/christmas
 		)
 	gift_type =  /datum/ego_gifts/christmas
+	abnormality_origin = "Lobotomy Corporation"
 	var/pulse_cooldown
 	var/pulse_cooldown_time = 1.8 SECONDS
 	var/pulse_damage = 20

--- a/code/modules/mob/living/simple_animal/abnormality/he/scarecrow.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/scarecrow.dm
@@ -39,6 +39,7 @@
 		/datum/ego_datum/armor/harvest
 		)
 	gift_type =  /datum/ego_gifts/harvest
+	abnormality_origin = "Lobotomy Corporation"
 	/// Can't move/attack when it's TRUE
 	var/finishing = FALSE
 

--- a/code/modules/mob/living/simple_animal/abnormality/he/scaredy_cat.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/scaredy_cat.dm
@@ -40,6 +40,7 @@
 		/datum/ego_datum/armor/courage
 		)
 	gift_type =  /datum/ego_gifts/courage_cat //the sprites for the EGO are shitty codersprites placeholders and are only here so that there's EGO to use
+	abnormality_origin = "Wonderlab"
 	/// The list of abnormality scaredy cat will automatically join when they breach, add any "Oz" abno to this list if possible
 	var/list/prefered_abno_list = list(
 									/mob/living/simple_animal/hostile/abnormality/woodsman,

--- a/code/modules/mob/living/simple_animal/abnormality/he/schadenfreude.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/schadenfreude.dm
@@ -37,6 +37,7 @@
 		/datum/ego_datum/armor/gaze
 		)
 //	gift_type =  /datum/ego_gifts/gaze
+	abnormality_origin = "Lobotomy Corporation"
 
 	var/seen	//Are you being looked at right now?
 

--- a/code/modules/mob/living/simple_animal/abnormality/he/silent_girl.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/silent_girl.dm
@@ -30,6 +30,7 @@
 		/datum/ego_datum/armor/remorse
 		)
 	gift_type = /datum/ego_gifts/remorse
+	abnormality_origin = "Artbook"
 
 
 /mob/living/simple_animal/hostile/abnormality/silent_girl/proc/OnWorkStart(datum/source, datum/abnormality/datum_reference, mob/living/carbon/human/user, work_type)

--- a/code/modules/mob/living/simple_animal/abnormality/he/singing_machine.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/singing_machine.dm
@@ -26,6 +26,7 @@ Finally, an abnormality that DOESN'T have to do any fancy movement shit. It's a 
 		/datum/ego_datum/weapon/harmony,
 		/datum/ego_datum/armor/harmony
 		)
+	abnormality_origin = "Altered LC"
 	pixel_x = -8
 	base_pixel_x = -8
 	buckled_mobs = list()

--- a/code/modules/mob/living/simple_animal/abnormality/he/siren.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/siren.dm
@@ -26,6 +26,7 @@
 		/datum/ego_datum/armor/song
 		)
 	gift_type = /datum/ego_gifts/song
+	abnormality_origin = "Original"
 
 //meltdown effects
 	var/meltdown_cooldown_time = 144 SECONDS

--- a/code/modules/mob/living/simple_animal/abnormality/he/watchman.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/watchman.dm
@@ -35,6 +35,7 @@
 		/datum/ego_datum/weapon/alleyway,
 		/datum/ego_datum/armor/alleyway
 		)
+	abnormality_origin = "Original"
 //	gift_type =  /datum/ego_gifts/alleyway
 	light_color = "FFFFFFF"
 	light_power = -10

--- a/code/modules/mob/living/simple_animal/abnormality/he/white_lake.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/white_lake.dm
@@ -30,6 +30,7 @@
 		)
 	gift_type = /datum/ego_gifts/waltz
 	gift_chance = 0
+	abnormality_origin = "Wonderlab"
 
 
 /mob/living/simple_animal/hostile/abnormality/whitelake/WorkChance(mob/living/carbon/human/user, chance)

--- a/code/modules/mob/living/simple_animal/abnormality/he/woodsman.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/woodsman.dm
@@ -40,6 +40,7 @@
 		/datum/ego_datum/armor/logging
 		)
 	gift_type =  /datum/ego_gifts/loggging
+	abnormality_origin = "Lobotomy Corporation"
 	var/flurry_cooldown = 0
 	var/flurry_cooldown_time = 15 SECONDS
 	var/flurry_count = 7

--- a/code/modules/mob/living/simple_animal/abnormality/teth/MHz.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/MHz.dm
@@ -25,6 +25,7 @@
 		/datum/ego_datum/weapon/noise,
 		/datum/ego_datum/armor/noise
 		)
+	abnormality_origin = "Lobotomy Corporation"
 
 	var/reset_time = 4 MINUTES //Qliphoth resets after this time. To prevent bugs
 

--- a/code/modules/mob/living/simple_animal/abnormality/teth/beanstalk.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/beanstalk.dm
@@ -24,6 +24,7 @@
 		/datum/ego_datum/armor/bean
 	)
 	gift_type = /datum/ego_gifts/bean
+	abnormality_origin = "Artbook"
 	var/climbing = FALSE
 
 //Performing instinct work at >4 fortitude starts a special work

--- a/code/modules/mob/living/simple_animal/abnormality/teth/beauty_beast.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/beauty_beast.dm
@@ -27,6 +27,7 @@
 		/datum/ego_datum/armor/horn
 		)
 	gift_type =  /datum/ego_gifts/horn
+	abnormality_origin = "Lobotomy Corporation"
 	var/injured = FALSE
 
 //it needs to use PostSpawn or we can't get the datum of beauty

--- a/code/modules/mob/living/simple_animal/abnormality/teth/blood_bath.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/blood_bath.dm
@@ -23,6 +23,8 @@
 
 	//gift_type =  /datum/ego_gifts/bloodbath
 
+	abnormality_origin = "Lobotomy Corporation"
+
 	var/hands = 0
 
 /mob/living/simple_animal/hostile/abnormality/bloodbath/PostWorkEffect(mob/living/carbon/human/user, work_type, pe, work_time)

--- a/code/modules/mob/living/simple_animal/abnormality/teth/cherry_blossoms.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/cherry_blossoms.dm
@@ -26,6 +26,7 @@
 		/datum/ego_datum/armor/blossom
 		)
 //	gift_type = /datum/ego_gifts/blossom
+	abnormality_origin = "Altered LC"
 	var/numbermarked = 5
 
 

--- a/code/modules/mob/living/simple_animal/abnormality/teth/crumbling_armor.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/crumbling_armor.dm
@@ -21,6 +21,7 @@
 		)
 	gift_type = null
 	gift_chance = 100
+	abnormality_origin = "Lobotomy Corporation"
 	var/buff_icon = 'ModularTegustation/Teguicons/tegu_effects.dmi'
 
 /mob/living/simple_animal/hostile/abnormality/crumbling_armor/Initialize(mapload)

--- a/code/modules/mob/living/simple_animal/abnormality/teth/dingle_dangle.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/dingle_dangle.dm
@@ -22,6 +22,7 @@
 		/datum/ego_datum/armor/lutemia
 		)
 	gift_type = /datum/ego_gifts/lutemis
+	abnormality_origin = "Wonderlab"
 
 	var/injured = FALSE
 	var/dead = FALSE

--- a/code/modules/mob/living/simple_animal/abnormality/teth/drowned_sisters.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/drowned_sisters.dm
@@ -22,6 +22,7 @@
 		/datum/ego_datum/weapon/sorority,
 		/datum/ego_datum/armor/sorority
 	)
+	abnormality_origin = "Wonderlab"
 
 
 /mob/living/simple_animal/hostile/abnormality/drownedsisters/AttemptWork(mob/living/carbon/human/user, work_type)

--- a/code/modules/mob/living/simple_animal/abnormality/teth/forsaken_murderer.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/forsaken_murderer.dm
@@ -51,6 +51,7 @@
 		/datum/ego_datum/armor/regret
 		) //ego_list is the things you can buy with its unique type of PE
 	gift_type =  /datum/ego_gifts/regret //special thing you get from interacting with the abnormality
+	abnormality_origin = "Lobotomy Corporation"
 
 /mob/living/simple_animal/hostile/abnormality/forsaken_murderer/FailureEffect(mob/living/carbon/human/user, work_type, pe) //when work type is bad the qliphoth counter lowers with no chance.
 	datum_reference.qliphoth_change(-1)

--- a/code/modules/mob/living/simple_animal/abnormality/teth/fragment.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/fragment.dm
@@ -37,6 +37,7 @@
 		/datum/ego_datum/armor/fragment
 		)
 	gift_type =  /datum/ego_gifts/fragments
+	abnormality_origin = "Lobotomy Corporation"
 	var/song_cooldown
 	var/song_cooldown_time = 10 SECONDS
 	var/song_damage = 4 // Dealt 8 times

--- a/code/modules/mob/living/simple_animal/abnormality/teth/my_sweet_home.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/my_sweet_home.dm
@@ -52,6 +52,8 @@
 
 	gift_type =  /datum/ego_gifts/hearth
 
+	abnormality_origin = "Wonderlab"
+
 
 /mob/living/simple_animal/hostile/abnormality/my_sweet_home/FailureEffect(mob/living/carbon/human/user, work_type, pe)
 	to_chat(user, "<span class='danger'>It whispers in your mind...</span>")

--- a/code/modules/mob/living/simple_animal/abnormality/teth/old_lady.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/old_lady.dm
@@ -20,6 +20,7 @@
 		/datum/ego_datum/armor/solitude
 		)
 //	gift_type =  /datum/ego_gifts/solitude
+	abnormality_origin = "Lobotomy Corporation"
 	var/meltdown_cooldown_time = 120 SECONDS
 	var/meltdown_cooldown
 //for solitude effects

--- a/code/modules/mob/living/simple_animal/abnormality/teth/penitent_girl.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/penitent_girl.dm
@@ -22,6 +22,7 @@
 		/datum/ego_datum/weapon/sorrow,
 		/datum/ego_datum/armor/sorrow
 	)
+	abnormality_origin = "Wonderlab"
 
 
 /mob/living/simple_animal/hostile/abnormality/penitentgirl/AttemptWork(mob/living/carbon/human/user, work_type)

--- a/code/modules/mob/living/simple_animal/abnormality/teth/ppodae.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/ppodae.dm
@@ -36,6 +36,7 @@
 		/datum/ego_datum/armor/cute
 		)
 	gift_type =  /datum/ego_gifts/cute
+	abnormality_origin = "Lobotomy Corporation"
 
 /mob/living/simple_animal/hostile/abnormality/ppodae/Move()
 	if(!can_act)

--- a/code/modules/mob/living/simple_animal/abnormality/teth/punishing_bird.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/punishing_bird.dm
@@ -50,6 +50,7 @@
 		/datum/ego_datum/armor/beak
 		)
 	gift_type =  /datum/ego_gifts/beak
+	abnormality_origin = "Lobotomy Corporation"
 	var/list/enemies = list()
 	var/list/pecking_targets = list()
 	var/list/already_punished = list()

--- a/code/modules/mob/living/simple_animal/abnormality/teth/scorched_girl.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/scorched_girl.dm
@@ -31,6 +31,7 @@
 		/datum/ego_datum/armor/match
 		)
 	gift_type =  /datum/ego_gifts/match
+	abnormality_origin = "Lobotomy Corporation"
 	/// Restrict movement when this is set to TRUE
 	var/exploding = FALSE
 	/// Current cooldown for the players

--- a/code/modules/mob/living/simple_animal/abnormality/teth/shy_look.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/shy_look.dm
@@ -26,6 +26,7 @@
 		/datum/ego_datum/armor/shy
 		)
 	gift_type =  /datum/ego_gifts/shy
+	abnormality_origin = "Lobotomy Corporation"
 
 	var/chance_modifier = 1
 	var/previous_mood

--- a/code/modules/mob/living/simple_animal/abnormality/teth/simple_smile.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/simple_smile.dm
@@ -41,6 +41,7 @@
 		/datum/ego_datum/armor/trick
 		)
 //	gift_type =  /datum/ego_gifts/trick
+	abnormality_origin = "Wonderlab"
 	var/list/stats = list(FORTITUDE_ATTRIBUTE,
 			PRUDENCE_ATTRIBUTE,
 			TEMPERANCE_ATTRIBUTE,

--- a/code/modules/mob/living/simple_animal/abnormality/teth/spider_bud.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/spider_bud.dm
@@ -22,6 +22,7 @@
 		/datum/ego_datum/armor/eyes
 		)
 	gift_type =  /datum/ego_gifts/redeyes
+	abnormality_origin = "Lobotomy Corporation"
 
 /mob/living/simple_animal/hostile/abnormality/spider/PostWorkEffect(mob/living/carbon/human/user, work_type, pe, work_time)
 	// If you do insight or have low prudence, fuck you and die for stepping on a spider

--- a/code/modules/mob/living/simple_animal/abnormality/teth/training_rabbit.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/training_rabbit.dm
@@ -24,6 +24,7 @@
 	//ego_list = list(datum/ego_datum/weapon/training, datum/ego_datum/armor/training)
 	gift_type =  /datum/ego_gifts/standard
 	can_patrol = FALSE
+	abnormality_origin = "Lobotomy Corporation"
 
 /mob/living/simple_animal/hostile/abnormality/training_rabbit/Initialize()	//1 in 100 chance for bunny girl waifu
 	. = ..()

--- a/code/modules/mob/living/simple_animal/abnormality/teth/void_dream.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/void_dream.dm
@@ -33,6 +33,7 @@
 		/datum/ego_datum/armor/dream
 		)
 //	gift_type =  /datum/ego_gifts/dream
+	abnormality_origin = "Lobotomy Corporation"
 	var/punched = FALSE
 	var/pulse_damage = 50
 	var/ability_cooldown

--- a/code/modules/mob/living/simple_animal/abnormality/waw/alriune.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/alriune.dm
@@ -44,6 +44,7 @@
 		/datum/ego_datum/armor/aroma
 		)
 	//gift_type =  /datum/ego_gifts/aroma
+	abnormality_origin = "Lobotomy Corporation"
 
 /* Combat */
 

--- a/code/modules/mob/living/simple_animal/abnormality/waw/big_bird.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/big_bird.dm
@@ -49,6 +49,7 @@
 		/datum/ego_datum/armor/lamp
 		)
 	gift_type =  /datum/ego_gifts/lamp
+	abnormality_origin = "Lobotomy Corporation"
 
 	var/bite_cooldown
 	var/bite_cooldown_time = 8 SECONDS

--- a/code/modules/mob/living/simple_animal/abnormality/waw/clown_smiling.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/clown_smiling.dm
@@ -54,6 +54,7 @@
 		)
 	gift_type =  /datum/ego_gifts/darkcarnival
 	gift_message = "Life isn't scary when you don't fear death."
+	abnormality_origin = "Artbook"
 
 	del_on_death = FALSE //for explosions
 	var/finishing = FALSE

--- a/code/modules/mob/living/simple_animal/abnormality/waw/contract.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/contract.dm
@@ -24,6 +24,7 @@
 		/datum/ego_datum/armor/infinity,
 		)
 //	gift_type = /datum/ego_gifts/eight
+	abnormality_origin = "Original"
 
 	var/list/spawnables = list()
 

--- a/code/modules/mob/living/simple_animal/abnormality/waw/despair_knight.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/despair_knight.dm
@@ -41,6 +41,7 @@
 		/datum/ego_datum/armor/despair
 		)
 	gift_type =  /datum/ego_gifts/tears
+	abnormality_origin = "Lobotomy Corporation"
 	var/mob/living/carbon/human/blessed_human = null
 	var/teleport_cooldown
 	var/teleport_cooldown_time = 20 SECONDS

--- a/code/modules/mob/living/simple_animal/abnormality/waw/dimension_refraction.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/dimension_refraction.dm
@@ -36,6 +36,7 @@
 		/datum/ego_datum/armor/diffraction
 		)
 //	gift_type =  /datum/ego_gifts/diffraction
+	abnormality_origin = "Lobotomy Corporation"
 
 	var/cooldown_time = 3
 	var/aoe_damage = 8

--- a/code/modules/mob/living/simple_animal/abnormality/waw/dreaming_current.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/dreaming_current.dm
@@ -34,6 +34,7 @@
 		/datum/ego_datum/weapon/ecstasy,
 		/datum/ego_datum/armor/ecstasy
 		)
+	abnormality_origin = "Lobotomy Corporation"
 
 	var/list/movement_path = list()
 	var/list/been_hit = list()

--- a/code/modules/mob/living/simple_animal/abnormality/waw/ebony_queen.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/ebony_queen.dm
@@ -52,6 +52,7 @@
 	/datum/ego_datum/armor/ebony_stem
 	)
 	gift_type =  /datum/ego_gifts/ebony_stem
+	abnormality_origin = "Limbus Company"
 
 /mob/living/simple_animal/hostile/abnormality/ebony_queen/NeutralEffect(mob/living/carbon/human/user, work_type, pe)
 	if(prob(50))

--- a/code/modules/mob/living/simple_animal/abnormality/waw/express_train.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/express_train.dm
@@ -25,6 +25,7 @@
 		/datum/ego_datum/armor/intentions,
 		/datum/ego_datum/weapon/laststop
 		)
+	abnormality_origin = "Altered LC"
 
 	var/meltdown_tick = 60 SECONDS
 	var/meltdown_timer

--- a/code/modules/mob/living/simple_animal/abnormality/waw/fire_bird.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/fire_bird.dm
@@ -33,6 +33,7 @@
 	loot = list(/obj/item/gun/ego_gun/feather)
 	ego_list = list(/datum/ego_datum/armor/feather)
 	gift_type = /datum/ego_gifts/feather
+	abnormality_origin = "Lobotomy Corporation"
 	friendly_verb_continuous = "grazes"
 	friendly_verb_simple = "grazes"
 	var/pulse_cooldown

--- a/code/modules/mob/living/simple_animal/abnormality/waw/flesh_idol.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/flesh_idol.dm
@@ -24,6 +24,7 @@
 		/datum/ego_datum/armor/heart
 		)
 //	gift_type = /datum/ego_gifts/heart
+	abnormality_origin = "Altered LC"
 
 	var/work_count = 0
 	var/reset_time = 1 MINUTES

--- a/code/modules/mob/living/simple_animal/abnormality/waw/generalb.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/generalb.dm
@@ -34,6 +34,7 @@
 	armortype = RED_DAMAGE
 	stat_attack = HARD_CRIT
 	//She has a Quad Artillery Cannon
+	abnormality_origin = "Original"
 	var/fire_cooldown_time = 3 SECONDS	//She has 4 cannons, fires 4 times faster than the artillery bees
 	var/fire_cooldown
 	var/fireball_range = 30

--- a/code/modules/mob/living/simple_animal/abnormality/waw/greed_king.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/greed_king.dm
@@ -45,6 +45,7 @@
 		/datum/ego_datum/armor/goldrush
 		)
 	gift_type =  /datum/ego_gifts/goldrush
+	abnormality_origin = "Lobotomy Corporation"
 
 /datum/action/innate/abnormality_attack/kog_dash
 	name = "Ravenous Charge"

--- a/code/modules/mob/living/simple_animal/abnormality/waw/hatred_queen.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/hatred_queen.dm
@@ -10,6 +10,7 @@
 	var/icon_inverted
 	faction = list("neutral")
 	is_flying_animal = TRUE
+	abnormality_origin = "Lobotomy Corporation"
 
 	ranged = TRUE
 	retreat_distance = 1

--- a/code/modules/mob/living/simple_animal/abnormality/waw/judgement_bird.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/judgement_bird.dm
@@ -40,6 +40,7 @@
 		/datum/ego_datum/armor/justitia
 		)
 	gift_type =  /datum/ego_gifts/justitia
+	abnormality_origin = "Lobotomy Corporation"
 	var/judgement_cooldown = 10 SECONDS
 	var/judgement_cooldown_base = 10 SECONDS
 	var/judgement_damage = 65

--- a/code/modules/mob/living/simple_animal/abnormality/waw/little_prince.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/little_prince.dm
@@ -21,6 +21,7 @@
 		/datum/ego_datum/armor/spore
 		)
 	gift_type = /datum/ego_gifts/spore
+	abnormality_origin = "Lobotomy Corporation"
 
 	var/insight_count = 0
 	var/non_insight_count = 0

--- a/code/modules/mob/living/simple_animal/abnormality/waw/luna.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/luna.dm
@@ -27,6 +27,7 @@
 		/datum/ego_datum/armor/moonlight
 		)
 //	gift_type =  /datum/ego_gifts/moonlight
+	abnormality_origin = "Lobotomy Corporation"
 	var/performance = FALSE
 	var/performance_length = 60 SECONDS
 	var/breach_length = 404 SECONDS		//How long the song is (when I finally finish it)

--- a/code/modules/mob/living/simple_animal/abnormality/waw/naked_nest.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/naked_nest.dm
@@ -29,6 +29,7 @@
 		)
 	gift_type =  /datum/ego_gifts/exuviae
 	gift_message = "You manage to shave off a patch of scales."
+	abnormality_origin = "Lobotomy Corporation"
 
 	can_patrol = FALSE
 	damage_coeff = list(BRUTE = 1, RED_DAMAGE = 0.6, WHITE_DAMAGE = 0.8, BLACK_DAMAGE = 1.2, PALE_DAMAGE = 1.5) //same stats as original armor

--- a/code/modules/mob/living/simple_animal/abnormality/waw/queen_bee.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/queen_bee.dm
@@ -26,6 +26,7 @@
 		/datum/ego_datum/armor/hornet
 		)
 	gift_type =  /datum/ego_gifts/hornet
+	abnormality_origin = "Lobotomy Corporation"
 	var/datum/looping_sound/queenbee/soundloop
 	var/breached_others = FALSE
 

--- a/code/modules/mob/living/simple_animal/abnormality/waw/shrimp.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/shrimp.dm
@@ -23,6 +23,7 @@
 		/datum/ego_datum/armor/executive
 		)
 //	gift_type =  /datum/ego_gifts/executive
+	abnormality_origin = "Original"
 
 	var/liked
 	var/happy = TRUE

--- a/code/modules/mob/living/simple_animal/abnormality/waw/silence.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/silence.dm
@@ -20,6 +20,7 @@
 		/datum/ego_datum/armor/thirteen,
 		)
 //	gift_type = /datum/ego_gifts/thirteen
+	abnormality_origin = "Artbook"
 
 	var/meltdown_cooldown_time = 13 MINUTES
 	var/meltdown_cooldown

--- a/code/modules/mob/living/simple_animal/abnormality/waw/snow_whites_apple.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/snow_whites_apple.dm
@@ -49,6 +49,7 @@ GLOBAL_LIST_EMPTY(vine_list)
 	/datum/ego_datum/armor/stem
 	)
 	gift_type =  /datum/ego_gifts/stem
+	abnormality_origin = "Lobotomy Corporation"
 
 /mob/living/simple_animal/hostile/abnormality/snow_whites_apple/NeutralEffect(mob/living/carbon/human/user, work_type, pe)
 	if(prob(50))

--- a/code/modules/mob/living/simple_animal/abnormality/waw/thunder_bird.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/thunder_bird.dm
@@ -53,6 +53,7 @@ GLOBAL_LIST_EMPTY(zombies)
 		)
 	gift_type =  /datum/ego_gifts/warring
 	gift_message = "The totem somehow dons a seemingly ridiculous hat on your head."
+	abnormality_origin = "Original"
 
 /*---Combat---*/
 	//range and attack speed for thunder bombs, taken from general bee

--- a/code/modules/mob/living/simple_animal/abnormality/waw/warden.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/warden.dm
@@ -40,6 +40,7 @@
 		/datum/ego_datum/armor/correctional
 		)
 	gift_type =  /datum/ego_gifts/correctional
+	abnormality_origin = "Artbook"
 	var/finishing = FALSE
 
 /mob/living/simple_animal/hostile/abnormality/warden/AttackingTarget()

--- a/code/modules/mob/living/simple_animal/abnormality/waw/yang.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/yang.dm
@@ -33,6 +33,7 @@
 		/datum/ego_datum/armor/assonance
 		)
 //	gift_type = /datum/ego_gifts/assonance
+	abnormality_origin = "Altered LC"
 
 	//Melee
 	damage_coeff = list(BRUTE = 1, RED_DAMAGE = 1, WHITE_DAMAGE = 0.2, BLACK_DAMAGE = 1.7, PALE_DAMAGE = 2)

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/bald.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/bald.dm
@@ -24,6 +24,7 @@
 	gift_type =  /datum/ego_gifts/tough
 	gift_chance = 10
 	gift_message = "Now we're feeling awesome!"
+	abnormality_origin = "Lobotomy Corporation"
 
 	var/bald_users = list()
 

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/bottle.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/bottle.dm
@@ -25,6 +25,7 @@
 		)
 	gift_type = /datum/ego_gifts/alice
 	gift_message = "Welcome to your very own Wonderland~"
+	abnormality_origin = "Wonderlab"
 
 	max_boxes = 10
 	var/cake = 5 //How many cake charges are there (4)

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/fairy_festival.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/fairy_festival.dm
@@ -30,6 +30,7 @@
 	var/heal_cooldown = 2 SECONDS
 	var/heal_cooldown_base = 2 SECONDS
 	var/list/mob/living/carbon/human/protected_people = list()
+	abnormality_origin = "Lobotomy Corporation"
 
 /mob/living/simple_animal/hostile/abnormality/fairy_festival/proc/FairyHeal()
 	for(var/mob/living/carbon/human/P in protected_people)

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/one_sin.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/one_sin.dm
@@ -25,6 +25,7 @@
 	max_boxes = 10
 	gift_type =  /datum/ego_gifts/penitence
 	gift_message = "From this day forth, you shall never forget his words."
+	abnormality_origin = "Lobotomy Corporation"
 
 /mob/living/simple_animal/hostile/abnormality/onesin/WorkChance(mob/living/carbon/human/user, chance)
 	if(istype(user.ego_gift_list[HAT], /datum/ego_gifts/penitence))

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/sleeping_beauty.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/sleeping_beauty.dm
@@ -29,6 +29,7 @@
 		)
 	max_boxes = 10
 	gift_type =  /datum/ego_gifts/doze
+	abnormality_origin = "Artbook"
 
 	var/grab_cooldown
 	var/grab_cooldown_time = 20 SECONDS

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/we_can_change_anything.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/we_can_change_anything.dm
@@ -24,6 +24,7 @@
 
 	gift_type =  /datum/ego_gifts/change
 	gift_message = "Your heart beats with new vigor."
+	abnormality_origin = "Altered LC"
 
 
 /mob/living/simple_animal/hostile/abnormality/we_can_change_anything/Worktick(mob/living/carbon/human/user)

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/wellcheers.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/wellcheers.dm
@@ -23,6 +23,7 @@
 		)
 	gift_type = /datum/ego_gifts/soda
 	gift_message = "You feel like you've been doing this your whole life."
+	abnormality_origin = "Lobotomy Corporation"
 
 /mob/living/simple_animal/hostile/abnormality/wellcheers/SuccessEffect(mob/living/carbon/human/user, work_type, pe)
 	var/obj/item/dropped_can

--- a/config/config.txt
+++ b/config/config.txt
@@ -188,7 +188,7 @@ ID_CONSOLE_JOBSLOT_DELAY 30
 VOTE_DELAY 6000
 
 ## time period (deciseconds) which voting session will last (default 1 minute)
-VOTE_PERIOD 900
+VOTE_PERIOD 800
 
 ## prevents dead players from voting or starting votes
 # NO_DEAD_VOTE

--- a/lobotomy-corp13.dme
+++ b/lobotomy-corp13.dme
@@ -842,6 +842,7 @@
 #include "code\game\gamemodes\gang\gang_handler.dm"
 #include "code\game\gamemodes\gang\gang_things.dm"
 #include "code\game\gamemodes\infiltration\infiltration.dm"
+#include "code\game\gamemodes\management\management.dm"
 #include "code\game\gamemodes\meteor\meteor.dm"
 #include "code\game\gamemodes\meteor\meteors.dm"
 #include "code\game\gamemodes\monkey\monkey.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds three game modes that allow players to select a subset of abnormalities they'd like to manage:

- Lobotomy Corporation Plus - The game as it currently exists. All abnormalities.
- Lobotomy Corporation Pure - Only abnormalities from the original Lobotomy Corporation game. Does not include abnormalities present in, but radically changed from, vanilla Lobotomy Corporation.
- Lobotomy Corporation Side Branch - All abnormalities derived from side material, e.g. the artbook, Wonderlab, Limbus Company, and our original creations.

A vote between them is performed at the end of each round, and will set the gamemode of the next round. __(Warning: It may be advisable to adjust the length of votes so this vote can be concluded before the server restarts rather than exactly as it does.)__

This PR also prevents maps from being removed from the map vote pool just because they've been played recently.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Gives players a bit more control over how they play the game, and creates a framework by which future abnormality-selection-altering gamemodes may be added.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added gamemodes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
