### PR TITLE
Work speed and work chance overrides

### DIFF
--- a/code/game/machinery/computer/abnormality_work.dm
+++ b/code/game/machinery/computer/abnormality_work.dm
@@ -166,16 +166,19 @@
 	user.density = FALSE // If they can be walked through they can't be switched! I didn't wanna add chairs because if there WAS it'd nullify the ability to DODGE issues that appear.
 	user.set_anchored(TRUE)
 	user.is_working = TRUE
+	// Initial chance and speed values before work started, in case they get overriden by abnormality
+	var/init_work_chance = work_chance
+	var/init_work_speed = work_speed
 	while(total_boxes < work_time)
 		if(!CheckStatus(user))
 			break
+		work_speed = datum_reference.current.SpeedWorktickOverride(user, work_speed, init_work_speed, work_type)
 		if(do_after(user, work_speed, src, IGNORE_HELD_ITEM))
 			if(!CheckStatus(user))
 				break
-			user.remove_status_effect(/datum/status_effect/interventionshield) //removing status effect doesnt seem to effect all of parent. -IP
-			user.remove_status_effect(/datum/status_effect/interventionshield/white)
-			user.remove_status_effect(/datum/status_effect/interventionshield/black)
-			user.remove_status_effect(/datum/status_effect/interventionshield/pale)
+			for(var/shield_type in typesof(/datum/status_effect/interventionshield))
+				user.remove_status_effect(shield_type)
+			work_chance = datum_reference.current.ChanceWorktickOverride(user, work_chance, init_work_chance, work_type)
 			if(do_work(work_chance))
 				success_boxes++
 				datum_reference.current.WorktickSuccess(user)

--- a/code/modules/mob/living/simple_animal/abnormality/_abnormality.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_abnormality.dm
@@ -265,6 +265,16 @@
 /mob/living/simple_animal/hostile/abnormality/proc/AttemptWork(mob/living/carbon/human/user, work_type)
 	return TRUE
 
+// Overrides the normal work delay. Called in abnormality_work.dm each worktick.
+// init_work_speed is the vanilla value, work_speed is the value as modified by any previous use of SpeedOverride.
+// Remember, this is altering the FINAL value. Returning 0 makes an instant worktick, returning 20 makes a 2 second worktick.
+/mob/living/simple_animal/hostile/abnormality/proc/SpeedWorktickOverride(mob/living/carbon/human/user, work_speed, init_work_speed, work_type)
+	return work_speed
+
+// Overrides the normal work chance. See SpeedWorktickOverride's comments; this behaves identically, but for work chance.
+/mob/living/simple_animal/hostile/abnormality/proc/ChanceWorktickOverride(mob/living/carbon/human/user, work_chance, init_work_chance, work_type)
+	return work_chance
+
 // Effects when qliphoth reaches 0
 /mob/living/simple_animal/hostile/abnormality/proc/ZeroQliphoth(mob/living/carbon/human/user)
 	if(can_breach)

--- a/code/modules/mob/living/simple_animal/abnormality/he/schadenfreude.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/schadenfreude.dm
@@ -39,19 +39,24 @@
 //	gift_type =  /datum/ego_gifts/gaze
 
 	var/seen	//Are you being looked at right now?
+	var/solo_punish	//Is an agent alone on the Z level, but not overall?
 
 //Sight Check
 /mob/living/simple_animal/hostile/abnormality/schadenfreude/Life()
 	. = ..()
 	//Make sure there actually are two players on the Z level
 	var/living_players
+	solo_punish = FALSE
 	for(var/mob/living/carbon/human/H in GLOB.player_list)
 		if(H.z == z && H.stat != DEAD)
 			living_players +=1
+		else if(H.stat != DEAD) //Someone else is alive, just not on the Z level. Probably a manager. Thus, someone else COULD see you...
+			solo_punish = TRUE
 	if(living_players == 1)
 		seen = TRUE
 		damage_coeff = list(BRUTE = 1, RED_DAMAGE = 1.2, WHITE_DAMAGE = 0.5, BLACK_DAMAGE = 1.0, PALE_DAMAGE = 1.5)
 		return
+	solo_punish = FALSE //Reset to normal if the amount of living players on your z-level is something other than 1, to allow normal behavior.
 
 	//Who is watching us
 	var/people_watching
@@ -86,15 +91,16 @@
 	..()
 
 //Work stuff
+//Too many people looking? Reduce final work success rate to 0.
+/mob/living/simple_animal/hostile/abnormality/schadenfreude/ChanceWorktickOverride(mob/living/carbon/human/user, work_chance, init_work_chance, work_type)
+	if(seen && !solo_punish) //If you're only considered "seen" because the other living player(s) are all on another Z level, disregard it during work specifically.
+		to_chat(user, "<span class='warning'>You are injured by [src]!</span>") // Keeping it clear that the bad work is from being seen and not just luck.
+		new /obj/effect/temp_visual/dir_setting/bloodsplatter(get_turf(user), pick(GLOB.alldirs))
+		return 0
+	return init_work_chance
+
 /mob/living/simple_animal/hostile/abnormality/schadenfreude/BreachEffect(mob/living/carbon/human/user)
 	..()
 	icon_living = "schadenfreude_breach"
 	icon_state = icon_living
 	GiveTarget(user)
-
-//I'm not writing more snowflake code for this lol. You just take more damage
-/mob/living/simple_animal/hostile/abnormality/schadenfreude/Worktick(mob/living/carbon/human/user)
-	if(seen)
-		to_chat(user, "<span class='warning'>You are injured by schadenfreude!</span>")
-		user.apply_damage(work_damage_amount, RED_DAMAGE, null, user.run_armor_check(null, RED_DAMAGE), spread_damage = TRUE)
-		new /obj/effect/temp_visual/dir_setting/bloodsplatter(get_turf(user), pick(GLOB.alldirs))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds two new procs (and associated variables) to abnormalities to allow them to alter work speed and success chance on the fly. Alters Schadenfreude to use the latter as a sort of demonstration.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

More functionality enabling abnormalities to go beyond existing behavioral bounds, allowing both LC-accurate behavior for certain ones (including future ones) and more intricate behavior for those beyond the original LC.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
code: work speed and chance overrides
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
