### PR TITLE
Fixes courage sprite update

### DIFF
--- a/code/game/objects/items/ego_weapons/he.dm
+++ b/code/game/objects/items/ego_weapons/he.dm
@@ -401,7 +401,7 @@
 	else if(friend_count && icon_state == "courage_broken")
 		to_chat(user, "<span class='nicegreen'>Your weapon puffs back up to impress your allies!")
 		icon_state = "courage"
-	user.update_icon_state()
+	user.update_inv_hands()
 	..()
 	force = initial(force)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes the courage E.G.O. properly update in-hands when switching between forms.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This thing has been bugged for millennia and its about time it gets fixed.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixed courage inhands
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
