### PR TITLE
Lets dead ordeals be picked up by bodybags

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/ordeal/_ordeal.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/_ordeal.dm
@@ -10,6 +10,7 @@
 	var/ordeal_remove_ondeath = TRUE
 
 /mob/living/simple_animal/hostile/ordeal/death(gibbed)
+	mob_size = MOB_SIZE_HUMAN //let body bags carry dead ordeals
 	if(ordeal_reference && ordeal_remove_ondeath)
 		ordeal_reference.OnMobDeath(src)
 		ordeal_reference = null


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Ordeal mob_size goes back to human size when they die.

## Why It's Good For The Game
Please I just want to clean up ordeal bodies easier.

## Changelog
:cl:
tweak: ordeal size upon death
:cl: