### PR TITLE
Attempts to remove botany exploits

### DIFF
--- a/code/datums/materials/basemats.dm
+++ b/code/datums/materials/basemats.dm
@@ -80,7 +80,7 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 	victim.apply_damage(15, BRUTE, BODY_ZONE_HEAD, wound_bonus = 7)
 	return TRUE
 
-///Is slightly radioactive
+///Is slightly radioactive (not anymore)
 /datum/material/uranium
 	name = "uranium"
 	desc = "Uranium"
@@ -91,20 +91,12 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 	beauty_modifier = 0.3 //It shines so beautiful
 	armor_modifiers = list(MELEE = 1.5, BULLET = 1.4, LASER = 0.5, ENERGY = 0.5, BOMB = 0, BIO = 0, RAD = 0, FIRE = 1, ACID = 1)
 
-/datum/material/uranium/on_applied(atom/source, amount, material_flags)
-	. = ..()
-	source.AddComponent(/datum/component/radioactive, amount / 50, source, 0) //half-life of 0 because we keep on going. amount / 50 means 40 radiation per sheet.
-
-/datum/material/uranium/on_removed(atom/source, amount, material_flags)
-	. = ..()
-	qdel(source.GetComponent(/datum/component/radioactive))
-
 /datum/material/uranium/on_accidental_mat_consumption(mob/living/carbon/victim, obj/item/source_item)
 	victim.reagents.add_reagent(/datum/reagent/uranium, rand(4, 6))
 	source_item?.reagents?.add_reagent(/datum/reagent/uranium, source_item.reagents.total_volume*(2/5))
 	return TRUE
 
-///Adds firestacks on hit (Still needs support to turn into gas on destruction)
+///Adds firestacks on hit (Still needs support to turn into gas on destruction) (not anymore)
 /datum/material/plasma
 	name = "plasma"
 	desc = "Isn't plasma a state of matter? Oh whatever."
@@ -115,17 +107,6 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 	value_per_unit = 0.1
 	beauty_modifier = 0.15
 	armor_modifiers = list(MELEE = 1.4, BULLET = 0.7, LASER = 0, ENERGY = 1.2, BOMB = 0, BIO = 1.2, RAD = 1, FIRE = 0, ACID = 0.5)
-
-/datum/material/plasma/on_applied(atom/source, amount, material_flags)
-	. = ..()
-	if(ismovable(source))
-		source.AddElement(/datum/element/firestacker, amount=1)
-		source.AddComponent(/datum/component/explodable, 0, 0, amount / 2500, amount / 1250)
-
-/datum/material/plasma/on_removed(atom/source, amount, material_flags)
-	. = ..()
-	source.RemoveElement(/datum/element/firestacker, amount=1)
-	qdel(source.GetComponent(/datum/component/explodable))
 
 /datum/material/plasma/on_accidental_mat_consumption(mob/living/carbon/victim, obj/item/source_item)
 	victim.reagents.add_reagent(/datum/reagent/toxin/plasma, rand(6, 8))

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -263,10 +263,7 @@ GLOBAL_LIST_INIT(wood_recipes, list ( \
  * Bamboo
  */
 
-GLOBAL_LIST_INIT(bamboo_recipes, list ( \
-	new/datum/stack_recipe("punji sticks trap", /obj/structure/punji_sticks, 5, time = 30, one_per_turf = TRUE, on_floor = TRUE), \
-	new/datum/stack_recipe("blow gun", /obj/item/gun/syringe/blowgun, 10, time = 70), \
-	))
+GLOBAL_LIST_INIT(bamboo_recipes, list())
 
 /obj/item/stack/sheet/mineral/bamboo
 	name = "bamboo cuttings"

--- a/code/modules/hydroponics/grown/ambrosia.dm
+++ b/code/modules/hydroponics/grown/ambrosia.dm
@@ -25,7 +25,7 @@
 	icon_dead = "ambrosia-dead"
 	genes = list(/datum/plant_gene/trait/repeated_harvest)
 	mutatelist = list(/obj/item/seeds/ambrosia/deus)
-	reagents_add = list(/datum/reagent/medicine/c2/aiuri = 0.1, /datum/reagent/medicine/c2/libital = 0.1 ,/datum/reagent/drug/space_drugs = 0.15, /datum/reagent/consumable/nutriment/vitamin = 0.04, /datum/reagent/consumable/nutriment = 0.05, /datum/reagent/toxin = 0.1)
+	reagents_add = list(/datum/reagent/drug/space_drugs = 0.15, /datum/reagent/consumable/nutriment/vitamin = 0.04, /datum/reagent/consumable/nutriment = 0.05, /datum/reagent/toxin = 0.1)
 
 /obj/item/food/grown/ambrosia/vulgaris
 	seed = /obj/item/seeds/ambrosia
@@ -42,7 +42,7 @@
 	plantname = "Ambrosia Deus"
 	product = /obj/item/food/grown/ambrosia/deus
 	mutatelist = list(/obj/item/seeds/ambrosia/gaia)
-	reagents_add = list(/datum/reagent/medicine/omnizine = 0.15, /datum/reagent/medicine/synaptizine = 0.15, /datum/reagent/drug/space_drugs = 0.1, /datum/reagent/consumable/nutriment/vitamin = 0.04, /datum/reagent/consumable/nutriment = 0.05)
+	reagents_add = list(/datum/reagent/drug/space_drugs = 0.1, /datum/reagent/consumable/nutriment/vitamin = 0.04, /datum/reagent/consumable/nutriment = 0.05)
 	rarity = 40
 
 /obj/item/food/grown/ambrosia/deus
@@ -61,7 +61,7 @@
 	plantname = "Ambrosia Gaia"
 	product = /obj/item/food/grown/ambrosia/gaia
 	mutatelist = list(/obj/item/seeds/ambrosia/deus)
-	reagents_add = list(/datum/reagent/medicine/earthsblood = 0.05, /datum/reagent/consumable/nutriment = 0.06, /datum/reagent/consumable/nutriment/vitamin = 0.05)
+	reagents_add = list(/datum/reagent/consumable/nutriment = 0.06, /datum/reagent/consumable/nutriment/vitamin = 0.05)
 	rarity = 30 //These are some pretty good plants right here
 	genes = list()
 	weed_rate = 4

--- a/code/modules/hydroponics/grown/banana.dm
+++ b/code/modules/hydroponics/grown/banana.dm
@@ -11,10 +11,9 @@
 	instability = 10
 	growing_icon = 'icons/obj/hydroponics/growing_fruits.dmi'
 	icon_dead = "banana-dead"
-	genes = list(/datum/plant_gene/trait/slip, /datum/plant_gene/trait/repeated_harvest)
+	genes = list(/datum/plant_gene/trait/repeated_harvest)
 	mutatelist = list(/obj/item/seeds/banana/mime)
 	reagents_add = list(/datum/reagent/consumable/banana = 0.1, /datum/reagent/potassium = 0.1, /datum/reagent/consumable/nutriment/vitamin = 0.04, /datum/reagent/consumable/nutriment = 0.02)
-	graft_gene = /datum/plant_gene/trait/slip
 
 /obj/item/food/grown/banana
 	seed = /obj/item/seeds/banana

--- a/code/modules/hydroponics/grown/random.dm
+++ b/code/modules/hydroponics/grown/random.dm
@@ -16,8 +16,6 @@
 /obj/item/seeds/random/Initialize()
 	. = ..()
 	randomize_stats()
-	if(prob(60))
-		add_random_reagents(1, 3)
 	if(prob(50))
 		add_random_traits(1, 2)
 	add_random_plant_type(35)

--- a/code/modules/hydroponics/grown/tomato.dm
+++ b/code/modules/hydroponics/grown/tomato.dm
@@ -64,7 +64,6 @@
 	genes = list(/datum/plant_gene/trait/repeated_harvest)
 	reagents_add = list(/datum/reagent/consumable/nutriment/vitamin = 0.04, /datum/reagent/consumable/nutriment = 0.1)
 	rarity = 20
-	graft_gene = /datum/plant_gene/trait/slip
 
 /obj/item/food/grown/tomato/blue
 	seed = /obj/item/seeds/tomato/blue

--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -243,29 +243,6 @@
 	// Squash the plant on slip.
 	G.squash(C)
 
-/datum/plant_gene/trait/slip
-	// Makes plant slippery, unless it has a grown-type trash. Then the trash gets slippery.
-	// Applies other trait effects (teleporting, etc) to the target by on_slip.
-	name = "Slippery Skin"
-	rate = 1.6
-	examine_line = "<span class='info'>It has a very slippery skin.</span>"
-
-/datum/plant_gene/trait/slip/on_new(obj/item/food/grown/G, newloc)
-	..()
-	if(istype(G) && ispath(G.trash_type, /obj/item/grown))
-		return
-	var/obj/item/seeds/seed = G.seed
-	var/stun_len = seed.potency * rate
-
-	if(!istype(G, /obj/item/grown/bananapeel) && (!G.reagents || !G.reagents.has_reagent(/datum/reagent/lube)))
-		stun_len /= 3
-
-	G.AddComponent(/datum/component/slippery, min(stun_len,140), NONE, CALLBACK(src, .proc/handle_slip, G))
-
-/datum/plant_gene/trait/slip/proc/handle_slip(obj/item/food/grown/G, mob/M)
-	for(var/datum/plant_gene/trait/T in G.seed.genes)
-		T.on_slip(G, M)
-
 /datum/plant_gene/trait/cell_charge
 	// Cell recharging trait. Charges all mob's power cells to (potency*rate)% mark when eaten.
 	// Generates sparks on squash.
@@ -366,32 +343,6 @@
 	//gay tide station pride
 	name = "Pink Bioluminescence"
 	glow_color = "#FFB3DA"
-
-
-
-/datum/plant_gene/trait/teleport
-	// Makes plant teleport people when squashed or slipped on.
-	// Teleport radius is calculated as max(round(potency*rate), 1)
-	name = "Bluespace Activity"
-	rate = 0.1
-
-/datum/plant_gene/trait/teleport/on_squash(obj/item/food/grown/G, atom/target)
-	if(isliving(target))
-		var/teleport_radius = max(round(G.seed.potency / 10), 1)
-		var/turf/T = get_turf(target)
-		new /obj/effect/decal/cleanable/molten_object(T) //Leave a pile of goo behind for dramatic effect...
-		do_teleport(target, T, teleport_radius, channel = TELEPORT_CHANNEL_BLUESPACE)
-
-/datum/plant_gene/trait/teleport/on_slip(obj/item/food/grown/G, mob/living/carbon/C)
-	var/teleport_radius = max(round(G.seed.potency / 10), 1)
-	var/turf/T = get_turf(C)
-	to_chat(C, "<span class='warning'>You slip through spacetime!</span>")
-	do_teleport(C, T, teleport_radius, channel = TELEPORT_CHANNEL_BLUESPACE)
-	if(prob(50))
-		do_teleport(G, T, teleport_radius, channel = TELEPORT_CHANNEL_BLUESPACE)
-	else
-		new /obj/effect/decal/cleanable/molten_object(T) //Leave a pile of goo behind for dramatic effect...
-		qdel(G)
 
 /**
  * A plant trait that causes the plant's capacity to double.

--- a/lobotomy-corp13.dme
+++ b/lobotomy-corp13.dme
@@ -3163,7 +3163,6 @@
 #include "code\modules\reagents\chemistry\recipes\drugs.dm"
 #include "code\modules\reagents\chemistry\recipes\medicine.dm"
 #include "code\modules\reagents\chemistry\recipes\others.dm"
-#include "code\modules\reagents\chemistry\recipes\pyrotechnics.dm"
 #include "code\modules\reagents\chemistry\recipes\slime_extracts.dm"
 #include "code\modules\reagents\chemistry\recipes\special.dm"
 #include "code\modules\reagents\chemistry\recipes\toxins.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
- Uranium and plasma mats no longer do their things
- Bamboo recipes removed
- Gaia no more
- Cotton can no longer become durathread
- Slip and bluespace traits removed
- All pyrotechnic recipes no longer exist

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Look, botany is fun. I would rather not have to remove every reagent from plants and make mutations impossible. This should solve the biggest issues we've had with botany while also allowing for some hijinks.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: botany and chemistry and mats
:cl: