### PR TITLE
Recycler and morgue tray changes

### DIFF
--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -16,6 +16,7 @@
 	var/crush_damage = 1000
 	var/eat_victim_items = TRUE
 	var/item_recycle_sound = 'sound/items/welder.ogg'
+	var/static/list/forbidden_items = typecacheof(list(/obj/item/ego_weapon, /obj/item/gun/ego_gun, /obj/item/clothing/suit/armor/ego_gear, /obj/item/toy/plush, /obj/structure/toolabnormality))
 
 /obj/machinery/recycler/Initialize()
 	AddComponent(/datum/component/butchering/recycler, 1, amount_produced,amount_produced/5)
@@ -111,7 +112,8 @@
 		return
 	if(!isturf(AM0.loc))
 		return //I don't know how you called Crossed() but stop it.
-
+	if(is_type_in_typecache(AM0, forbidden_items))
+		return
 	var/list/to_eat = AM0.GetAllContents()
 
 	var/living_detected = FALSE //technically includes silicons as well but eh

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -137,6 +137,8 @@ GLOBAL_LIST_EMPTY(bodycontainers) //Let them act as spawnpoints for revenants an
 	playsound(src, 'sound/effects/roll.ogg', 5, TRUE)
 	playsound(src, 'sound/items/deconstruct.ogg', 50, TRUE)
 	for(var/atom/movable/AM in connected.loc)
+		if(iseffect(AM))
+			continue
 		if(!AM.anchored || AM == connected)
 			if(ismob(AM) && !isliving(AM))
 				continue


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Recycler no longer qdels egos, plushies, and Theresia. Fixes body containers changing icons due to effects like cleanable dust.

## Why It's Good For The Game
This should make cleaning the facility and sorting egos much easier, and limits how much ego is destroyed. Morgues just looked weird lighting up due to dirt.

## Changelog
:cl:
tweak: recycler and morgue trays
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
