### PR TITLE
Improves custom vendors

### DIFF
--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -1021,7 +1021,7 @@ GLOBAL_LIST_EMPTY(vending_products)
 	/// where the money is sent
 	var/datum/bank_account/private_a
 	/// max number of items that the custom vendor can hold
-	var/max_loaded_items = 20
+	var/max_loaded_items = 1000 //incresed from 20 to 1000. let people store E.G.O. dammit
 	/// Base64 cache of custom icons.
 	var/list/base64_cache = list()
 
@@ -1054,19 +1054,21 @@ GLOBAL_LIST_EMPTY(vending_products)
 			var/base64
 			var/price = 0
 			for(var/obj/T in contents)
-				if(T.name == O)
+				if(format_text(T.name) == O)
 					price = T.custom_price
 					if(!base64)
 						if(base64_cache[T.type])
 							base64 = base64_cache[T.type]
 						else
-							base64 = icon2base64(icon(T.icon, T.icon_state))
+							base64 = icon2base64(getFlatIcon(T, no_anim=TRUE))
 							base64_cache[T.type] = base64
 					break
 			var/list/data = list(
 				name = O,
 				price = price,
-				img = base64
+				img = base64,
+				amount = vending_machine_input[O],
+				colorable = FALSE
 			)
 			.["vending_machine_input"] += list(data)
 
@@ -1098,7 +1100,7 @@ GLOBAL_LIST_EMPTY(vending_products)
 				return
 			var/datum/bank_account/account = C.registered_account
 			for(var/obj/O in contents)
-				if(O.name == N)
+				if(format_text(O.name) == N)
 					S = O
 					break
 			if(S)

--- a/tgui/packages/tgui/interfaces/Vending.js
+++ b/tgui/packages/tgui/interfaces/Vending.js
@@ -30,7 +30,7 @@ const VendingRow = (props, context) => {
   return (
     <Table.Row>
       <Table.Cell collapsing>
-        {product.base64 && (
+        {product.img && (
           <img
             src={`data:image/jpeg;base64,${product.img}`}
             style={{
@@ -60,7 +60,7 @@ const VendingRow = (props, context) => {
             || productStock <= (product.max_amount / 2) && 'average'
             || 'good'
           )}>
-          {productStock} in stock
+          {custom ? product.amount : productStock.amount} in stock
         </Box>
       </Table.Cell>
       <Table.Cell collapsing textAlign="center">
@@ -75,7 +75,7 @@ const VendingRow = (props, context) => {
           <Button
             fluid
             disabled={(
-              productStock === 0
+              productStock.amount === 0
               || !free && (
                 !data.user
                 || product.price > data.user.cash


### PR DESCRIPTION
## About The Pull Request

Increases the limit of custom vendors from 20 to 1000 in terms of how much they can store

Fixes wrong images being displayed for custom vendors

<details>
<summary>Before and after screenshots</summary>

![Before](https://user-images.githubusercontent.com/82319946/225350565-a1966148-1888-46d7-bf17-9a230b7d32c7.png)
![After](https://user-images.githubusercontent.com/82319946/225350633-30e97ae3-3620-4339-8735-f799763f26c8.png)

</details>

Port of:

https://github.com/tgstation/tgstation/pull/60668 (Fixes custom vendors)

Lil list (literally one) of things to fix when im not lazy:

- [ ] E.G.O. with the same name stack, even if they are different (armor & weapons)

## Why It's Good For The Game

-for images: Actually seeing images instead of smoke packets or other random things is good.
-for amount: Seeing the amount of EGO currently in the machine is good for EO's that want to keep track of that easier
-for increasing the limit of vendors: well... why not? we have over 100 abnormalities and most of them have an armor and a weapon, add realizations and the fact that some abnos have multiple weapons... and you got yourself way too many abnos for 20 slots.

## Changelog
:cl:
tweak: vendors can hold 1000 instead of 20 items.
fix: fixed the item count not showing properly, and images being wrong in the vendor screen
imageadd: added images of actual items that are in the vendors
imagedel: deleted random images that were shown in custom vendors instead of the actual sprites of items
code: changed vendor code, a bit
/:cl:
