### PR TITLE
Update Byond and SpacemanDMM versions, remove extools

### DIFF
--- a/SpacemanDMM.toml
+++ b/SpacemanDMM.toml
@@ -1,3 +1,5 @@
+environment = "lobotomy-corp13.dme"
+
 [langserver]
 dreamchecker = true
 

--- a/code/__DEFINES/_tick.dm
+++ b/code/__DEFINES/_tick.dm
@@ -1,15 +1,9 @@
 /// Percentage of tick to leave for master controller to run
 #define MAPTICK_MC_MIN_RESERVE 70
-/// internal_tick_usage is updated every tick by extools
-#if defined(USE_EXTOOLS) || DM_VERSION < 514
-#define MAPTICK_LAST_INTERNAL_TICK_USAGE ((GLOB.internal_tick_usage / world.tick_lag) * 100)
-#else
-#define MAPTICK_LAST_INTERNAL_TICK_USAGE (world.map_cpu)
-#endif
 
 /// Tick limit while running normally
 #define TICK_BYOND_RESERVE 2
-#define TICK_LIMIT_RUNNING (max(100 - TICK_BYOND_RESERVE - MAPTICK_LAST_INTERNAL_TICK_USAGE, MAPTICK_MC_MIN_RESERVE))
+#define TICK_LIMIT_RUNNING (max(100 - TICK_BYOND_RESERVE - world.map_cpu, MAPTICK_MC_MIN_RESERVE))
 /// Tick limit used to resume things in stoplag
 #define TICK_LIMIT_TO_RUN 70
 /// Tick limit for MC while running

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -47,11 +47,6 @@
 #error You need version 513.1514 or higher
 #endif
 
-//Don't load extools on 514 and 513.1539+
-#if DM_VERSION < 514 && DM_BUILD < 1540
-#define USE_EXTOOLS
-#endif
-
 //Additional code for the above flags.
 #ifdef TESTING
 #warn compiling in TESTING mode. testing() debug messages will be visible.

--- a/code/controllers/subsystem/statpanel.dm
+++ b/code/controllers/subsystem/statpanel.dm
@@ -155,7 +155,7 @@ SUBSYSTEM_DEF(statpanels)
 		list("World Time:", "[world.time]"),
 		list("Globals:", GLOB.stat_entry(), "\ref[GLOB]"),
 		list("[config]:", config.stat_entry(), "\ref[config]"),
-		list("Byond:", "(FPS:[world.fps]) (TickCount:[world.time/world.tick_lag]) (TickDrift:[round(Master.tickdrift,1)]([round((Master.tickdrift/(world.time/world.tick_lag))*100,0.1)]%)) (Internal Tick Usage: [round(MAPTICK_LAST_INTERNAL_TICK_USAGE,0.1)]%)"),
+		list("Byond:", "(FPS:[world.fps]) (TickCount:[world.time/world.tick_lag]) (TickDrift:[round(Master.tickdrift,1)]([round((Master.tickdrift/(world.time/world.tick_lag))*100,0.1)]%)) (Internal Tick Usage: [round(world.map_cpu,0.1)]%)"),
 		list("Master Controller:", Master.stat_entry(), "\ref[Master]"),
 		list("Failsafe Controller:", Failsafe.stat_entry(), "\ref[Failsafe]"),
 		list("","")

--- a/code/controllers/subsystem/time_track.dm
+++ b/code/controllers/subsystem/time_track.dm
@@ -75,7 +75,7 @@ SUBSYSTEM_DEF(time_track)
 			time_dilation_avg_fast,
 			time_dilation_avg,
 			time_dilation_avg_slow,
-			MAPTICK_LAST_INTERNAL_TICK_USAGE,
+			world.map_cpu,
 			length(SStimer.timer_id_dict),
 			SSair.cost_turfs,
 			SSair.cost_groups,

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -29,11 +29,6 @@ GLOBAL_VAR(restart_counter)
  *			All atoms in both compiled and uncompiled maps are initialized()
  */
 /world/New()
-#ifdef USE_EXTOOLS
-	var/extools = world.GetConfig("env", "EXTOOLS_DLL") || (world.system_type == MS_WINDOWS ? "./byond-extools.dll" : "./libbyond-extools.so")
-	if (fexists(extools))
-		call(extools, "maptick_initialize")()
-#endif
 	enable_debugger()
 
 	log_world("World loaded at [time_stamp()]!")

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -4,8 +4,8 @@
 #Final authority on what's required to fully build the project
 
 # byond version
-export BYOND_MAJOR=513
-export BYOND_MINOR=1536
+export BYOND_MAJOR=514
+export BYOND_MINOR=1589
 
 #rust_g git tag
 export RUST_G_VERSION=0.4.7
@@ -15,7 +15,7 @@ export NODE_VERSION=14
 export NODE_VERSION_PRECISE=14.16.1
 
 # SpacemanDMM git tag
-export SPACEMAN_DMM_VERSION=suite-1.6
+export SPACEMAN_DMM_VERSION=suite-1.7.3
 
 # Extools git tag
 export EXTOOLS_VERSION=v0.0.7

--- a/tools/tgs4_scripts/PreCompile.sh
+++ b/tools/tgs4_scripts/PreCompile.sh
@@ -64,32 +64,6 @@ env PKG_CONFIG_ALLOW_CROSS=1 ~/.cargo/bin/cargo build --release --target=i686-un
 mv target/i686-unknown-linux-gnu/release/librust_g.so "$1/librust_g.so"
 cd ..
 
-# get dependencies for extools
-apt-get install -y cmake build-essential gcc-multilib g++-multilib cmake wget
-
-# update extools
-if [ ! -d "extools" ]; then
-	echo "Cloning extools..."
-	git clone https://github.com/MCHSL/extools
-	cd extools/byond-extools
-else
-	echo "Fetching extools..."
-	cd extools/byond-extools
-	git fetch
-fi
-
-echo "Deploying extools..."
-git checkout "$EXTOOLS_VERSION"
-if [ -d "build" ]; then
-	rm -R build
-fi
-mkdir build
-cd build
-cmake ..
-make
-mv libbyond-extools.so "$1/libbyond-extools.so"
-cd ../../..
-
 # compile tgui
 echo "Compiling tgui..."
 cd "$1"


### PR DESCRIPTION
## About The Pull Request
- Removes every last trace of extools.
- Updates the Byond CI version to latest 514.
- Updates the SpacemanDMM version used in CI to 1.7.3.

## Why It's Good For The Game
Will hopefully fix warnings not being picked up by CI? Also, extools is super old and defunct and shouldn't be in the codebase anymore.