### PR TITLE
Adds a tutorial button to the lobby menu

### DIFF
--- a/code/__HELPERS/tegutranslate.dm
+++ b/code/__HELPERS/tegutranslate.dm
@@ -85,6 +85,9 @@ GLOBAL_LIST_INIT(tegu_translation_list, list(
 	"Join Game!" = list(
 		"Russian" = "Присоединиться к Игре!",
 		),
+	"Tutorial" = list(
+		"Russian" = "Обучение",
+		),
 	// To chat warnings in lobby
 	"The round is either not ready, or has already finished..." = list(
 		"Russian" = "Раунд либо ещё не готов, или уже закончился...",
@@ -98,6 +101,12 @@ GLOBAL_LIST_INIT(tegu_translation_list, list(
 	"Are you sure you wish to observe?" = list(
 		"Russian" = "Уверены что хотите наблюдать?",
 		),
+	"Are you sure you wish to play the tutorial?" = list(
+		"Russian" = "Вы уверены что хотите пройти обучение?",
+		),
+	"Sorry, the tutorial is not available at this time! Try again later." = list(
+		"Russian" = "Извините, в данный момент обучение недоступно. Попробуйте позже.",
+	),
 	"Now teleporting." = list(
 		"Russian" = "Телепортируемся.",
 		),

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -36,12 +36,8 @@
 	var/banType = ROLE_LAVALAND
 	var/ghost_usable = TRUE
 
-//ATTACK GHOST IGNORING PARENT RETURN VALUE
-/obj/effect/mob_spawn/attack_ghost(mob/user)
-	if(!SSticker.HasRoundStarted() || !loc || !ghost_usable)
-		return
-	var/ghost_role = alert("Become [mob_name]? (Warning, You can no longer be revived!)",,"Yes","No")
-	if(ghost_role == "No" || !loc || QDELETED(user))
+/obj/effect/mob_spawn/proc/spawn_user_as_role(mob/user)
+	if(!SSticker.HasRoundStarted() || !loc)
 		return
 	if(!(GLOB.ghost_role_flags & GHOSTROLE_SPAWNER) && !(flags_1 & ADMIN_SPAWNED_1))
 		to_chat(user, "<span class='warning'>An admin has temporarily disabled non-admin ghost roles!</span>")
@@ -50,7 +46,7 @@
 		to_chat(user, "<span class='warning'>This spawner is out of charges!</span>")
 		return
 	if(is_banned_from(user.key, banType))
-		to_chat(user, "<span class='warning'>You are jobanned!</span>")
+		to_chat(user, "<span class='warning'>You are job-banned from this role!</span>")
 		return
 	if(!allow_spawn(user))
 		return
@@ -58,6 +54,15 @@
 		return
 	log_game("[key_name(user)] became [mob_name]")
 	create(ckey = user.ckey)
+
+//ATTACK GHOST IGNORING PARENT RETURN VALUE
+/obj/effect/mob_spawn/attack_ghost(mob/user)
+	if(!ghost_usable)
+		return
+	var/ghost_role = alert("Become [mob_name]? (Warning, You can no longer be revived!)",,"Yes","No")
+	if(ghost_role == "No" || !loc || QDELETED(user))
+		return
+	spawn_user_as_role(user)
 
 /obj/effect/mob_spawn/Initialize(mapload)
 	. = ..()

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -63,6 +63,7 @@
 		output += "<p><a href='byond://?src=[REF(src)];manifest=1'>[TeguTranslate("View the Crew Manifest", src)]</a></p>"
 		output += "<p><a href='byond://?src=[REF(src)];late_join=1'>[TeguTranslate("Join Game!", src)]</a></p>"
 		output += "<p>[LINKIFY_READY(TeguTranslate("Observe", src), PLAYER_READY_TO_OBSERVE)]</p>"
+		output += "<p><a href='byond://?src=[REF(src)];tutorial=1'>[TeguTranslate("Tutorial", src)]</a></p>"
 
 	if(!IsGuestKey(src.key))
 		output += playerpolls()
@@ -73,6 +74,22 @@
 	popup.set_window_options("can_close=0")
 	popup.set_content(output.Join())
 	popup.open(FALSE)
+
+/mob/dead/new_player/proc/join_tutorial()
+	var/yes_text = TeguTranslate("Yes", src)
+	var/join_tutorial = alert(src, TeguTranslate("Are you sure you wish to play the tutorial?", src), "Player Setup", yes_text, TeguTranslate("No", src))
+	if(join_tutorial != yes_text)
+		return
+	var/obj/effect/mob_spawn/tutorial_spawner = /obj/effect/mob_spawn/human/tutorial
+	var/list/spawnerlist = GLOB.mob_spawners[initial(tutorial_spawner.name)]
+	if(!length(spawnerlist))
+		to_chat(src, TeguTranslate("Sorry, the tutorial is not available at this time! Try again later.", src))
+		return
+	var/obj/effect/mob_spawn/MS = pick(spawnerlist)
+	close_spawn_windows()
+	QDEL_NULL(mind)
+	MS.spawn_user_as_role(src)
+	qdel(src)
 
 /mob/dead/new_player/proc/playerpolls()
 	var/list/output = list()
@@ -143,6 +160,11 @@
 		if(!SSticker.current_state < GAME_STATE_PREGAME && tready == PLAYER_READY_TO_OBSERVE)
 			ready = tready
 			make_me_an_observer()
+			return
+
+	if(href_list["tutorial"])
+		if(SSticker.current_state > GAME_STATE_PREGAME)
+			join_tutorial()
 			return
 
 	if(href_list["refresh"])


### PR DESCRIPTION
## About The Pull Request
You can now play the tutorial from the lobby instead of having to spawn in as a ghost.

TODO:
- [x] Add confirmation prompt
- [x] Add Russian translation for confirmation prompt
- [x] Confirm Russian translation for "Tutorial"

## Why It's Good For The Game
It makes it easier for new players to actually find the tutorial instead of having to be linked a guide on how to find it, or luck into pressing an unlabeled button as an observer.

## Changelog
:cl: Penelope Haze
add: Added a tutorial button to the lobby menu.
/:cl: