### PR TITLE
Fix manager camera examination

### DIFF
--- a/code/__HELPERS/abnormalities.dm
+++ b/code/__HELPERS/abnormalities.dm
@@ -1,29 +1,29 @@
 /// This proc returns text explanation of simple mob's resistances
 /proc/SimpleResistanceToText(resist = 1)
 	switch(resist)
+		if(0 to 0) //Just putting 0 doesn't work.
+			return "Immune"
 		if(-INFINITY to 0)
 			return "Absorbed"
-		if(0)
-			return "Immune"
 		if(0 to 0.5)
 			return "Resistant"
 		if(0.5 to 1)
 			return "Endured"
 		if(1 to 1.5)
 			return "Weak"
-		if(1.5 to 2)
-			return "Vulnerable"
 		if(2 to INFINITY)
 			return "Fatal"
+		if(1.5 to 2)
+			return "Vulnerable"
 	return "Unknown ([resist])"
 
 /// Returns text description for combat damage
 /proc/SimpleDamageToText(damage = 10)
 	switch(damage)
+		if(0 to 0)
+			return "None"
 		if(-INFINITY to 0)
 			return "Healing"
-		if(0)
-			return "None"
 		if(0 to 15)
 			return "Very Low"
 		if(15 to 30)
@@ -32,19 +32,20 @@
 			return "Moderate"
 		if(50 to 70)
 			return "High"
-		if(70 to 100)
-			return "Very High"
 		if(100 to INFINITY)
 			return "Extreme"
+		if(70 to 100)
+			return "Very High"
+
 	return "Unknown ([damage])"
 
 /// Returns text description of work damage
 /proc/SimpleWorkDamageToText(damage = 1)
 	switch(damage)
+		if(0 to 0)
+			return "None"
 		if(-INFINITY to 0)
 			return "Healing"
-		if(0)
-			return "None"
 		if(0 to 3)
 			return "Very Low"
 		if(3 to 6)
@@ -53,10 +54,11 @@
 			return "Moderate"
 		if(9 to 12)
 			return "High"
-		if(12 to 15)
-			return "Very High"
 		if(15 to INFINITY)
 			return "Extreme"
+		if(12 to 15)
+			return "Very High"
+
 	return "Unknown ([damage])"
 
 /// Returns text description of work success rate
@@ -68,8 +70,9 @@
 			return "Low"
 		if(30 to 50)
 			return "Common"
-		if(50 to 70)
-			return "High"
 		if(70 to INFINITY)
 			return "Very High"
+		if(50 to 70)
+			return "High"
+
 	return "Unknown ([rate])"

--- a/code/game/machinery/computer/manager_camera.dm
+++ b/code/game/machinery/computer/manager_camera.dm
@@ -171,35 +171,18 @@
 		to_chat(user, "<span class='notice'>Justice level [get_attribute_level(H, JUSTICE_ATTRIBUTE)].</span>")
 		return
 
-	if(istype(clicked_atom, /mob/living/simple_animal/hostile))
-		var/mob/living/simple_animal/hostile/monster = clicked_atom
+	if(istype(clicked_atom, /mob/living/simple_animal))
+		var/mob/living/simple_animal/monster = clicked_atom
 		if(!LAZYLEN(monster.damage_coeff))
 			return
 
 		to_chat(user, "<span class='notice'>[clicked_atom]'s resistances are : </span>")
 		var/list/damage_types = list(RED_DAMAGE, WHITE_DAMAGE, BLACK_DAMAGE, PALE_DAMAGE)
 		for(var/i in damage_types)
-			var/resistance = monster.damage_coeff[i]
+			var/resistance = SimpleResistanceToText(monster.damage_coeff[i])
 			if(isnull(resistance))
 				continue
-
-//I could use the standard roman numeral system, but I prefer making the resistances more like records.
-			switch(resistance)
-				if(-INFINITY to -0.1)
-					resistance = "Absorbed"
-				if(0)
-					resistance = "Immune"
-				if(0 to 0.5)
-					resistance = "Endured"
-				if(0.5 to 0.9)
-					resistance = "Resistant"
-				if(0.9 to 1)
-					resistance = "Normal"
-				if(1 to 1.5)
-					resistance = "Weak"
-				if(1.5 to INFINITY)
-					resistance = "Fatal"
-			to_chat(user, "<span class='notice'>[i] : [resistance].</span>")
+			to_chat(user, "<span class='notice'>[i]: [resistance].</span>")
 
 /obj/machinery/computer/camera_advanced/manager/proc/on_alt_click(mob/living/user, turf/open/T)
 	var/mob/living/C = user


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The camera examination showed abnormalities that were immune to a specific type of damage as endured, this fixes that.
The camera is also now capable of showing the resistances of most mobs including apocalypse bird eggs, and anything that could be considered a "mob structure". Codewise this just means the check extends to simple animals instead of just hostile mobs.
This also fixes a problem with the abnormalities helper code that would show absorbed instead of immune

## Why It's Good For The Game

The camera showing false information is kind of bad I think.

## Changelog
:cl:
fix: The camera examination now properly shows when something is "immune" to a certain damage type.
fix: The camera examination now shows the damage resistances of most non-human mobs, including apocalypse bird eggs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
