### PR TITLE
Miscellaneous abnormality tweaks

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/_tools/he/fateloom.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_tools/he/fateloom.dm
@@ -11,7 +11,7 @@
 	if(!do_after(user, 10))
 		return
 	if(usage_cooldown > world.time) //just to prevent sfx spam
-		to_chat(user, "<span class='warning'>The loom is alraedy spinning!</span>")
+		to_chat(user, "<span class='warning'>The loom is already spinning!</span>")
 		return
 	usage_cooldown = world.time + usage_cooldown_time
 
@@ -19,6 +19,9 @@
 	if(!S)
 		to_chat(user, "<span class='userdanger'>As you touch the loom, threads are sewn into your flesh.</span>")
 		user.apply_status_effect(STATUS_EFFECT_REDSTRING)
+	else if (S.stacks == 4)
+		to_chat(user, "<span class='warning'>You don't need to use this.</span>")
+		return
 	else
 		to_chat(user, "<span class='userdanger'>The threads which were once sparse are now reinforced.</span>")
 		to_chat(user, "<span class='userdanger'>You feel weaker.</span>")

--- a/code/modules/mob/living/simple_animal/abnormality/_tools/zayin/wishwell.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_tools/zayin/wishwell.dm
@@ -200,7 +200,7 @@
 	if(!output)
 		return
 
-	if(!do_after(user, 15 SECONDS))
+	if(!do_after(user, 7 SECONDS))
 		to_chat(user, "<span class='userdanger'>The well goes silent as it detects your impatience.</span>")
 		return
 

--- a/code/modules/mob/living/simple_animal/abnormality/waw/silence.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/silence.dm
@@ -42,6 +42,12 @@
 	to_chat(user, "<span class='nicegreen'>The bells do not toll for thee. Not yet.</span>")
 	return
 
+/mob/living/simple_animal/hostile/abnormality/silence/NeutralEffect(mob/living/carbon/human/user, work_type, pe)
+	if(prob(50))
+		safe = TRUE
+		to_chat(user, "<span class='nicegreen'>The bells do not toll for thee. Not yet.</span>")
+	return
+
 /mob/living/simple_animal/hostile/abnormality/silence/Life()
 	. = ..()
 	if(meltdown_cooldown < world.time)

--- a/code/modules/mob/living/simple_animal/abnormality/waw/snow_whites_apple.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/snow_whites_apple.dm
@@ -51,7 +51,8 @@ GLOBAL_LIST_EMPTY(vine_list)
 	gift_type =  /datum/ego_gifts/stem
 
 /mob/living/simple_animal/hostile/abnormality/snow_whites_apple/NeutralEffect(mob/living/carbon/human/user, work_type, pe)
-	datum_reference.qliphoth_change(-1)
+	if(prob(50))
+		datum_reference.qliphoth_change(-1)
 	return
 
 /mob/living/simple_animal/hostile/abnormality/snow_whites_apple/FailureEffect(mob/living/carbon/human/user, work_type, pe)

--- a/code/modules/paperwork/records/info/waw.dm
+++ b/code/modules/paperwork/records/info/waw.dm
@@ -131,7 +131,9 @@
 	abno_code = "O-04-120"
 	abno_info = list(
 		"Every 13 minutes, the bell tolled.",
-		"If The Price of Silence did not have a Good work result between the bells tolling, every employee took massive PALE damage.")
+		"When the work result was Good, the abnormality was satisfied with a high probability.",
+		"When the work result was Normal, the abnormality was satisfied with a medium probability.",
+		"If neither of the above conditions were fulfilled between the bells tolling, every employee took massive PALE damage.")
 
 //The Dreaming Current
 /obj/item/paper/fluff/info/waw/current


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes some small, but necessary balance changes to certain abnormalities.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

- Cut the use time of wishing well by a little more than half.
- Third fate's loom can no longer be used while at maximum stacks of thread.
- Price of silence can now be satisfied with a normal result at 50% probability, previously 0%.
- Snow white's apple will now only breach at a 50% probability on a normal result, previously 100%.

## Why It's Good For The Game
These changes are long overdue.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: rebalanced some abnormalities
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
