### PR TITLE
Fix lobby music persisting in tutorial

### DIFF
--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -87,6 +87,7 @@
 		return
 	var/obj/effect/mob_spawn/MS = pick(spawnerlist)
 	close_spawn_windows()
+	stop_sound_channel(CHANNEL_LOBBYMUSIC)
 	QDEL_NULL(mind)
 	MS.spawn_user_as_role(src)
 	qdel(src)


### PR DESCRIPTION
## About The Pull Request
Fixes lobby music persisting in the tutorial.
Tested locally.

## Why It's Good For The Game
Lobby music should end when you enter the tutorial.