### PR TITLE
Violet dawn rebalance, noon tweak

### DIFF
--- a/code/game/objects/effects/temporary_visuals/miscellaneous.dm
+++ b/code/game/objects/effects/temporary_visuals/miscellaneous.dm
@@ -234,6 +234,9 @@
 /obj/effect/temp_visual/small_smoke/second
 	duration = 10
 
+/obj/effect/temp_visual/small_smoke/second/fruit
+	color = LIGHT_COLOR_PURPLE
+
 /obj/effect/temp_visual/small_smoke/halfsecond
 	duration = 5
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Violet Dawn
- Pulse attack now does black damage
- **Major Nerf**: Pulse attack reduced to 2 tiles away
- **Buff**: Fruits now have retaliate code
- **Buff**: Death explosion timer lowered
- Death cloud smaller, but drops all qliphoths to 0
- Changed attack visual to look more like a cloud

Violet Noon
- Adds a check for pulse attack
- Adds visual for damage

## Why It's Good For The Game
Violet dawns were the absolute worst with their screen-wide attack. They're supposed to be a time check teaching you how to prioritize threats, not to be an actually dangerous fight. This massively reduces their damage output but allows them to chase people like how they do in LC.

## Changelog
:cl:
tweak: violet noon visuals and text
balance: violet dawn
:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
