### PR TITLE
Removes maintainance pills from wishing well

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/_tools/zayin/wishwell.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_tools/zayin/wishwell.dm
@@ -131,8 +131,7 @@
 		/obj/effect/decal/cleanable/ash,
 		/obj/item/cigbutt,
 		/obj/item/food/urinalcake,
-		/obj/item/shard,
-		/obj/item/reagent_containers/pill/maintenance
+		/obj/item/shard
 		)
 
 //Potential threats


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
![image](https://user-images.githubusercontent.com/35991533/226819038-2cd5d421-3c06-498a-9f47-c58c230c0ed0.png)

## About The Pull Request
Removes maintenance pills - or "floor pills" from the loot list of wishing well.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Some of the chems that can potentially spawn inside of them could be used for exploits - explosions and such. Blacklisting all of the chemicals in question is both tedious and could have potentially unforeseen consequences.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Removed well pills
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
