### PR TITLE
Porccubus buff

### DIFF
--- a/code/datums/abnormality/datum/abnormality.dm
+++ b/code/datums/abnormality/datum/abnormality.dm
@@ -166,6 +166,8 @@
 		if(ALEPH_LEVEL)
 			maximum_attribute_level = 130
 	var/datum/attribute/user_attribute = user.attributes[attribute_type]
+	if(!user_attribute) //To avoid runtime if it's a custom work type like "Release".
+		return
 	var/user_attribute_level = max(1, user_attribute.level)
 	var/attribute_given = clamp(((maximum_attribute_level / (user_attribute_level * 0.25)) * (0.25 + (pe / max_boxes))), 0, 16)
 	if((user_attribute_level + attribute_given) >= maximum_attribute_level) // Already/Will be at maximum.

--- a/code/modules/mob/living/simple_animal/abnormality/he/porccubus.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/porccubus.dm
@@ -13,7 +13,8 @@
 		ABNORMALITY_WORK_INSTINCT = 60,
 		ABNORMALITY_WORK_INSIGHT = 40,
 		ABNORMALITY_WORK_ATTACHMENT = 50,
-		ABNORMALITY_WORK_REPRESSION = 30
+		ABNORMALITY_WORK_REPRESSION = 30,
+		"Touch" = 100
 			) //for some reason all its work rates are uniform through attribute levels in LC
 	damage_coeff = list(BRUTE = 1, RED_DAMAGE = 1, WHITE_DAMAGE = 0.5, BLACK_DAMAGE = 1, PALE_DAMAGE = 1.5)
 	ranged = TRUE
@@ -48,14 +49,13 @@
 	var/teleport_cooldown
 	var/damage_taken = FALSE
 
-
 /mob/living/simple_animal/hostile/abnormality/porccubus/SuccessEffect(mob/living/carbon/human/user, work_type, pe)
 	datum_reference.qliphoth_change(1)
 	var/datum/status_effect/porccubus_addiction/PA = user.has_status_effect(STATUS_EFFECT_ADDICTION)
 
 	if(PA)
 		PA.IncreaseTolerance()
-	else if(get_attribute_level(user, TEMPERANCE_ATTRIBUTE) < 80)
+	else if(get_attribute_level(user, TEMPERANCE_ATTRIBUTE) < 60 || work_type == "Touch")
 		if(LAZYFIND(datum_reference.transferable_var, agent_ckey )) //if they were already drugged before we basically drug them to death for trying to pull that shit again
 			DrugOverdose(user, agent_ckey)
 			return ..()
@@ -172,7 +172,7 @@
 		if(!H.sanity_lost)
 			return
 		var/nirvana = FALSE
-		if(get_attribute_level(H, TEMPERANCE_ATTRIBUTE) < 80) //if they have under 80 temp they actually get all the stats from overdose, otherwise they just get fucked.
+		if(get_attribute_level(H, TEMPERANCE_ATTRIBUTE) < 60) //if they have under 60 temp they actually get all the stats from overdose, otherwise they just get fucked.
 			nirvana = TRUE
 		DrugOverdose(H, H.ckey, nirvana)
 		LoseTarget()
@@ -206,17 +206,16 @@
 //ideally, we want the drug to feel like an excellent short term decision and a terrible long term one.
 //random stats :
 //3 drug uses before max tolerance
-//22.5 minutes before the stats start going into the negative on first use
-//if you take a drug the moment your buffed stat reaches 0, you can technically keep your stats in the positive for up to 30 minutes before you're truly screwed
-//at max tolerance, your stats will go up to +60 but decrease every 5 seconds, which will take around 5 minutes to reach 0, and then another 5 minutes to become -60
-//at max tolerance it will also only take 25 seconds before your sanity starts decreasing exponentially
+//30 minutes before the stats start going into the negative on first use
+//if you take a drug the moment your buffed stat reaches 0, you can technically keep your stats in the positive for up to 40 minutes before you're truly screwed
+//at max tolerance, your stats will go up to +60 but decrease every 10 seconds, which will take around 10 minutes to reach 0, and then another 10 minutes to become -60
 //a lot of these numbers are bound to change as balancing this is really hard without it being not worth the risk or too broken because of the duration
 /datum/status_effect/porccubus_addiction
 	id = "porccubus_addiction"
 	status_type = STATUS_EFFECT_UNIQUE
 	alert_type = /atom/movable/screen/alert/status_effect/porccubus_addiction
 	var/withdrawal_cooldown
-	var/withdrawal_cooldown_time = 45 SECONDS
+	var/withdrawal_cooldown_time = 60 SECONDS
 	var/tolerance_sanity_gain = 60
 	var/sanity_gain = 60
 	var/attribute_gain = 30
@@ -267,8 +266,8 @@
 //every time you take another hit the effects decrease
 /datum/status_effect/porccubus_addiction/proc/IncreaseTolerance(extra_attribute = TRUE, tolerance_amount = 0)
 	for(var/i = 0 to tolerance_amount)
-		if(withdrawal_cooldown_time > 5 SECONDS)
-			withdrawal_cooldown_time -= 20 SECONDS //"I can stop whenever I want"
+		if(withdrawal_cooldown_time > 30 SECONDS)
+			withdrawal_cooldown_time -= 25 SECONDS //"I can stop whenever I want"
 
 		if(attribute_gain > 0)
 			attribute_gain -= 10

--- a/code/modules/paperwork/records/info/he.dm
+++ b/code/modules/paperwork/records/info/he.dm
@@ -155,7 +155,6 @@
 	abno_breach_damage_type = "Red"
 	abno_breach_damage_count = "Medium"
 
-
 //Porccubus
 /obj/item/paper/fluff/info/he/porccubus
 	abno_type = /mob/living/simple_animal/hostile/abnormality/porccubus
@@ -163,9 +162,10 @@
 	abno_info = list(
 		"When the work result was Bad, the Qliphoth counter lowered.",
 		"When the work result was good, the Qliphoth counter increased.",
-		"When employees with Temperance Level 3 or lower had a Good work result, they were drugged by an unknown chemical with addictive properties.",
+		"When employees with Temperance Level 2 or lower had a Good work result, they were drugged by an unknown chemical with addictive properties.",
+		"Employees were also drugged if they touched the abnormality on purpose regardless of their Temperance.",
 		"Drugged employees could receive another dose of the chemical from Porccubus even if they had Temperance Level 4 or higher.",
-		"The chemical greatly improved all stats of the employee and healed their sanity periodically. However, withdrawal symptoms included lowered stats and eventual death.",
+		"The chemical greatly improved all attributes of the employee and healed their sanity periodically. However, withdrawal symptoms included lowered attributes and eventual death.",
 		"Porccubus was unaffected by any attack dealt to it from outside of its reach.",
 		"When an employee panicked during work or from Porccubus's attacks, they were drugged beyond saving.")
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Porccubus had this issue of being the only HE requiring a level 4 stat, with very little to give back for it.

- The drug now lasts around 25% longer, and can be taken at any attribute level with a special work, the threat of death is usually enough of a deterrent to make people not want to take the drug, and I don't think the temperance barrier was ultimately necessary.

- Temperance requirement is now level 3, which means his high attachment rate actually has a reason to exist now.

I also changed a part of the code that would runtime when special works were done, functionally it's the same thing, I've tested it.

## Why It's Good For The Game

This should make porccubus a more viable pick instead of a meme pick, while still keeping his trademark temperance check and giving his drugs a little bit more versatility and use in the endgame.

## Changelog
:cl:
tweak: Porccubus now has a special work to drug yourself at any time.
balance: Porccubus now requires temperance level 3 instead of 4 and his drug lasts longer.
fix: fixes a runtime that triggered on special works.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
