### PR TITLE
Please for the love of God give player-contolled clowns a click cooldown!

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/ordeal/crimson.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/crimson.dm
@@ -43,6 +43,7 @@
 			console_attack_counter += 1
 			visible_message("<span class='warning'>[src] hits [CA]'s buttons at random!</span>")
 			playsound(get_turf(CA), "sound/machines/terminal_button0[rand(1,8)].ogg", 50, 1)
+			changeNext_move(CLICK_CD_MELEE * 2)
 		else
 			console_attack_counter = 0
 			visible_message("<span class='warning'>[CA]'s screen produces an error!</span>")


### PR DESCRIPTION

## About The Pull Request

Makes the clowns have a cooldown on clicking the consoles.

## Why It's Good For The Game

I dunno chief, a single clown breaching every abno in 30 seconds while being a pain in the ass to stop is funny the first few times, but it gets annoying real quick.

## Changelog
:cl:
balance: Clowns no longer gain super breaching powers the second they become sentient.
/:cl:
