### PR TITLE
Various abnormality fixes

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/he/golden_false_apple.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/golden_false_apple.dm
@@ -28,7 +28,6 @@
 	move_to_delay = 4
 	attack_verb_continuous = "tackles"
 	attack_verb_simple = "tackle"
-	faction = list("hostile")
 	attack_sound = "sound/abnormalities/goldenapple/Gold_Attack.ogg"
 	stat_attack = HARD_CRIT
 	melee_damage_lower = 10
@@ -59,7 +58,7 @@
 	gift_type = /datum/ego_gifts/legerdemain
 	gift_message = "You feel a sense of kinship with the apple. Because you're both pests."
 	guaranteed_butcher_results = list(/obj/item/food/grown/apple/gold/abnormality = 1)
-	var/is_maggot = 0
+	var/is_maggot = FALSE
 	var/smash_length = 2
 	var/smash_width = 2
 	var/can_act = TRUE
@@ -236,7 +235,7 @@
 	icon_state = "false_apple"
 	icon_living = "false_apple"
 	icon_dead = "false_egg"
-	deathmessage = "is reduced to a primoridal egg."
+	deathmessage = "is reduced to a primordial egg."
 	name = "False Apple"
 	desc = "The apple ruptured and a swarm of maggots crawled inside, metamorphosing into a hideous face."
 	pixel_x = -48

--- a/code/modules/mob/living/simple_animal/abnormality/he/jangsan.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/jangsan.dm
@@ -22,10 +22,10 @@
 	can_breach = TRUE
 	start_qliphoth = 3
 	work_chances = list(
-						ABNORMALITY_WORK_INSTINCT = 50,
-						ABNORMALITY_WORK_INSIGHT = 50,
-						ABNORMALITY_WORK_ATTACHMENT = 50,
-						ABNORMALITY_WORK_REPRESSION = 50
+						ABNORMALITY_WORK_INSTINCT = 60,
+						ABNORMALITY_WORK_INSIGHT = 60,
+						ABNORMALITY_WORK_ATTACHMENT = 60,
+						ABNORMALITY_WORK_REPRESSION = 60
 						)
 	work_damage_amount = 10
 	work_damage_type = RED_DAMAGE
@@ -70,7 +70,6 @@
 //Init
 /mob/living/simple_animal/hostile/abnormality/jangsan/Initialize()
 	. = ..()
-	AbnoRadio()
 	RegisterSignal(SSdcs, COMSIG_GLOB_MOB_DEATH, .proc/On_Mob_Death) // Hell
 
 /mob/living/simple_animal/hostile/abnormality/jangsan/Destroy()
@@ -93,7 +92,7 @@
 	var/chance_modifier = 1
 	StatCheck(user)
 	for(var/z in 0 to strong_counter)
-		chance_modifier *= 0.9
+		chance_modifier *= 0.85
 	return chance * chance_modifier
 
 /mob/living/simple_animal/hostile/abnormality/jangsan/proc/StatCheck(mob/living/carbon/human/user)
@@ -139,6 +138,8 @@
 //Breach
 /mob/living/simple_animal/hostile/abnormality/jangsan/BreachEffect(mob/living/carbon/human/user)
 	..()
+	if(!datum_reference.abno_radio)
+		AbnoRadio()
 	addtimer(CALLBACK(src, .proc/TryTeleport), 5)
 
 /mob/living/simple_animal/hostile/abnormality/jangsan/proc/TryTeleport() //stolen from knight of despair

--- a/code/modules/mob/living/simple_animal/abnormality/teth/beanstalk.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/beanstalk.dm
@@ -29,7 +29,7 @@
 //Performing instinct work at >4 fortitude starts a special work
 /mob/living/simple_animal/hostile/abnormality/beanstalk/AttemptWork(mob/living/carbon/human/user, work_type)
 	if((get_attribute_level(user, FORTITUDE_ATTRIBUTE) >= 80) && (work_type == ABNORMALITY_WORK_INSTINCT))
-		work_damage_amount = 20
+		work_damage_amount = 25 //hope you put on some armor
 		climbing = TRUE
 	return TRUE
 
@@ -58,13 +58,15 @@
 		step_towards(user, src)
 		sleep(0.5 SECONDS)
 		to_chat(user, "<span class='userdanger'>You start to climb!</span>")
-		//animate(user, alpha = 1,pixel_x = 0, pixel_z = 16, time = 3 SECONDS) works but seemingly can't be undone
-		user.Stun(8 SECONDS)
+		animate(user, alpha = 1,pixel_x = 0, pixel_z = 16, time = 3 SECONDS)
+		user.pixel_z = 16
+		user.Stun(10 SECONDS)
 		sleep(6 SECONDS)
 		var/datum/ego_gifts/giant/BWJEG = new
 		BWJEG.datum_reference = datum_reference
 		user.Apply_Gift(BWJEG)
-		//animate(user, alpha = 1,pixel_x = 0, pixel_z = -16, time = 3 SECONDS) doesn't work if the previous animate goes off
+		animate(user, alpha = 255,pixel_x = 0, pixel_z = -16, time = 3 SECONDS)
+		user.pixel_z = 0
 		to_chat(user, "<span class='userdanger'>You return with the giant's treasure!</span>")
 
 	work_damage_amount = 7

--- a/code/modules/mob/living/simple_animal/abnormality/waw/ebony_queen.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/ebony_queen.dm
@@ -67,15 +67,6 @@
 	update_icon()
 	addtimer(CALLBACK(src, .proc/TryTeleport), 5)
 
-/mob/living/simple_animal/hostile/abnormality/ebony_queen/update_icon_state()
-	if(status_flags & GODMODE) // Not breaching
-		icon_state = initial(icon)
-	else if(health < 1)
-		icon_state = icon_dead
-	else // Breaching
-		icon_state = icon_aggro
-	icon_living = icon_state
-
 /mob/living/simple_animal/hostile/abnormality/ebony_queen/Move()
 	if(!can_act)
 		return FALSE

--- a/code/modules/mob/living/simple_animal/abnormality/waw/shrimp.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/shrimp.dm
@@ -26,6 +26,13 @@
 
 	var/liked
 	var/happy = TRUE
+	pet_bonus = "blurbles" //saves a few lines of code by allowing funpet() to be called by attack_hand()
+	var/hint_cooldown
+	var/hint_cooldown_time = 30 SECONDS
+	var/list/cooldown = list(
+				"Stop meandering around and get to work!",
+				"I can be quite patient at times, but you are beginning to test me!",
+				"The service here can be dreadful at times. Why don't you just make yourself useful?")
 	var/list/instinct = list(
 				"I am getting quite old, and my back is hurting me. Could you send a chiropractor to my office immediately?",
 				"I am quite peckish, could you send me a charcuterie board?",
@@ -101,6 +108,23 @@
 			new /mob/living/simple_animal/hostile/shrimp(T)
 		else
 			new /mob/living/simple_animal/hostile/shrimp_soldier(T)
+
+//repeat lines
+/mob/living/simple_animal/hostile/abnormality/shrimp_exec/funpet()
+	if(!liked)
+		return
+	if(hint_cooldown > world.time)
+		say(pick(cooldown))
+		return
+	hint_cooldown = world.time + hint_cooldown_time
+	switch(liked)
+		if(ABNORMALITY_WORK_INSTINCT)
+			say(pick(instinct))
+		if(ABNORMALITY_WORK_INSIGHT)
+			say(pick(insight))
+		if(ABNORMALITY_WORK_ATTACHMENT)
+			say(pick(attachment))
+	return
 
 /* Shrimpo boys */
 /mob/living/simple_animal/hostile/shrimp

--- a/code/modules/paperwork/records/info/teth.dm
+++ b/code/modules/paperwork/records/info/teth.dm
@@ -187,7 +187,8 @@
 	abno_code = "F-03-16"
 	abno_info = list(
 		"When an Agent with Level 1 Temperance and Prudence completed the work, they climbed up the beanstalk and were never seen again.",
-		" Upon attempting an Instinct work with level 4 Fortitude or above, the Agent climbed up the beanstalk willingly.",
+		"Upon attempting an Instinct work with level 4 Fortitude or above, the Agent climbed up the beanstalk willingly.",
+		"Agent Yum Yum perished and fell off the beanstalk after being forced to endure extreme BLACK damage when climbing.",
 		"No agent has ever returned from the top of the beanstalk, if it even has the concept of a top.")
 
 //My Sweet Home

--- a/code/modules/paperwork/records/info/waw.dm
+++ b/code/modules/paperwork/records/info/waw.dm
@@ -92,6 +92,7 @@
 		"When the work result was Bad, the Qliphoth Counter lowered.",
 		"When the Qliphoth Counter reached 0, a shrimp strike force arrived at the main room of a department.",
 		"After an employee completed their work, Shrimp Association Executive requested an idea or service.",
+		"The abnormality repeated its request when approached by an employee.",
 		"Observations have concluded that each request corresponded to a specific work type. Performing this work type will result in significantly increased work success rate.",
 		"When the work result was Good, Shrimp Association Executive ordered shrimp-themed merchandise for the employee. Possible items included:<br>\
 		<ol type=1>\


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes some eons old problems (mostly my fault) and some new ones. Problems vary between a runtime on jangsan tiger to animations on beanstalk without jack not being implemented. Here are some notable changes.

- Abnormality information on beanstalk without jack now less subtly hints towards the secret work type. However, the damage dealt by the work type has been increased to compensate. Its animations are actually coded in now, too.
- Ebony queen's apple should no longer rarely find a hidden cloaking device in her containment cell.
- Fixed runtimes with jangsan tiger and improved its work rates to be more appropriate for the danger it poses.
- Adds suicide by wishing well
-Shrimp executive will now repeat his request when interacted with an empty hand.
Previous crumbling armor changes have been moved to #793 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Stuff actually working is good
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: changed description of beanstalk
fix: fixed a few things
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
