### PR TITLE
Locks "Red Roll" behind secrets button

### DIFF
--- a/code/controllers/subsystem/abnormality_queue.dm
+++ b/code/controllers/subsystem/abnormality_queue.dm
@@ -25,6 +25,8 @@ SUBSYSTEM_DEF(abnormality_queue)
 	var/next_abno_spawn_time = 4 MINUTES
 	/// Tracks if the current pick is forced
 	var/fucked_it_lets_rolled = FALSE
+	/// Due to Managers not passing the Litmus Test, divine approval is now necessary for red roll
+	var/hardcore_roll_enabled = FALSE
 
 /datum/controller/subsystem/abnormality_queue/Initialize(timeofday)
 	var/list/all_abnos = subtypesof(/mob/living/simple_animal/hostile/abnormality)

--- a/code/game/machinery/computer/abnormality_queue.dm
+++ b/code/game/machinery/computer/abnormality_queue.dm
@@ -22,6 +22,7 @@
 /obj/machinery/computer/abnormality_queue/ui_data(mob/user)
 	var/list/data = list()
 	data["current"] = "ERROR - Please yell at coders"
+	data["enablehardcore"] = SSabnormality_queue.hardcore_roll_enabled
 
 	if(!LAZYLEN(SSabnormality_queue.picking_abnormalities) && !ispath(SSabnormality_queue.queued_abnormality))
 		data["current"] = "ERROR - No data. Please try again later."
@@ -79,8 +80,11 @@
 			var/mob/living/simple_animal/hostile/abnormality/target_type = SSabnormality_queue.GetRandomPossibleAbnormality()
 			UpdateAnomaly(target_type, "fucked it lets rolled", TRUE)
 		if("hardcore_fuck_it_lets_roll")
-			var/mob/living/simple_animal/hostile/abnormality/target_type = pick(pick(SSabnormality_queue.possible_abnormalities))
-			UpdateAnomaly(target_type, "hardcore fucked it and rolled", TRUE)
+			if (SSabnormality_queue.hardcore_roll_enabled)
+				var/mob/living/simple_animal/hostile/abnormality/target_type = pick(pick(SSabnormality_queue.possible_abnormalities))
+				UpdateAnomaly(target_type, "hardcore fucked it and rolled", TRUE)
+			else
+				message_admins("[usr] has managed to send a TGUI signal to hardcore fuck it and roll despite the option being disabled. This is indicative of hacking.")
 
 	update_icon()
 

--- a/code/modules/admin/verbs/secrets.dm
+++ b/code/modules/admin/verbs/secrets.dm
@@ -445,6 +445,15 @@
 			message_admins("<span class='boldannounce'>[key_name_admin(holder)] changed the bomb cap to [GLOB.MAX_EX_DEVESTATION_RANGE], [GLOB.MAX_EX_HEAVY_RANGE], [GLOB.MAX_EX_LIGHT_RANGE]</span>")
 			log_admin("[key_name(holder)] changed the bomb cap to [GLOB.MAX_EX_DEVESTATION_RANGE], [GLOB.MAX_EX_HEAVY_RANGE], [GLOB.MAX_EX_LIGHT_RANGE]")
 		//buttons that are fun for exactly you and nobody else.
+		if("enablehardcore")
+			if(!is_funmin)
+				return
+			SSabnormality_queue.hardcore_roll_enabled = !SSabnormality_queue.hardcore_roll_enabled
+			message_admins("<span class='adminnotice'>[key_name_admin(holder)] has toggled mortal souls' ability to Red Roll.</span>")
+			var/state = "Disabled" // too lazy to write a BOOLEAN_TO_TEXT function - wouldnt it be funny if someone found this line by trying to search for one in the future
+			if (SSabnormality_queue.hardcore_roll_enabled)
+				state = "Enabled"
+			log_admin("[key_name(holder)] toggled hardcore rolling the abnormality queue - new state: [state]")
 		if("monkey")
 			if(!is_funmin)
 				return

--- a/tgui/packages/tgui/interfaces/AbnormalityQueue.js
+++ b/tgui/packages/tgui/interfaces/AbnormalityQueue.js
@@ -7,6 +7,7 @@ export const AbnormalityQueue = (props, context) => {
   const {
     current,
     threatcurrent,
+    enablehardcore,
   } = data;
 
   const items = data.choices || [];
@@ -77,15 +78,17 @@ export const AbnormalityQueue = (props, context) => {
                 color="yellow"
                 onClick={() => act("fuck_it_lets_roll")} />
             </Flex.Item>
-            <Flex.Item grow={1} mb={0.3}>
-              <Button
-                icon="bomb"
-                fluid
-                bold
-                content={"Hardcore Fuck It Lets Roll"}
-                color="red"
-                onClick={() => act("hardcore_fuck_it_lets_roll")} />
-            </Flex.Item>
+            {!!data.enablehardcore && (
+              <Flex.Item grow={1} mb={0.3}>
+                <Button
+                  icon="bomb"
+                  fluid
+                  bold
+                  content={"Hardcore Fuck It Lets Roll"}
+                  color="red"
+                  onClick={() => act("hardcore_fuck_it_lets_roll")} />
+              </Flex.Item>
+            )}
           </Flex>
         </Section>
       </Window.Content>

--- a/tgui/packages/tgui/interfaces/Secrets.js
+++ b/tgui/packages/tgui/interfaces/Secrets.js
@@ -454,6 +454,16 @@ const FunForYouTab = (props, context) => {
         <NoticeBox danger>
           <Button
             color="red"
+            icon="bomb"
+            fluid
+            content="Toggle Hardcore Fuck It Let's Roll"
+            onClick={() => act("enablehardcore")} />
+        </NoticeBox>
+      </Flex.Item>
+      <Flex.Item>
+        <NoticeBox danger>
+          <Button
+            color="red"
             icon="paw"
             fluid
             content="Turn all humans into monkeys"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Litmus Test Result: Failed

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This is actually good as it removes Manager grief potential.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Red Roll is now locked behind Admeme Secrets Button
admin: Secrets -> Only Fun For You -> Toggle Hardcore Fuck It Let's Roll -> Await Admin Complaint
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
