### PR TITLE
Removes Armortype Variable

### DIFF
--- a/ModularTegustation/tegu_borg_code/medborg_holobed.dm
+++ b/ModularTegustation/tegu_borg_code/medborg_holobed.dm
@@ -107,7 +107,7 @@
 	visible_message("<span class='warning'>[src] suddenly flickers and vanishes!</span>")
 	return ..()
 
-/obj/structure/bed/holobed/play_attack_sound(damage_amount, damage_type = BRUTE, damage_flag = 0)
+/obj/structure/bed/holobed/play_attack_sound(damage_amount, damage_type = BRUTE)
 	playsound(src, 'sound/effects/empulse.ogg', 50, TRUE)
 
 /obj/structure/bed/holobed/attackby(obj/item/W, mob/user, params)

--- a/ModularTegustation/tegu_items/apostle_items.dm
+++ b/ModularTegustation/tegu_items/apostle_items.dm
@@ -152,7 +152,6 @@
 	name = "guardian scythe"
 	desc = "The divine light will grant you protection."
 	damtype = PALE_DAMAGE
-	armortype = PALE_DAMAGE
 	force = 25
 	throwforce = 6
 	spin_force = 75
@@ -217,7 +216,6 @@
 /obj/projectile/magic/arcane_barrage/apostle
 	damage = 20
 	damage_type = WHITE_DAMAGE
-	flag = WHITE_DAMAGE
 
 /obj/projectile/magic/arcane_barrage/apostle/on_hit(target)
 	if(ismob(target))
@@ -241,7 +239,6 @@
 	force = 30 // Weaker in melee, but kills everyone with its active ability.
 	throwforce = 35
 	damtype = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
 	throw_speed = 4
 	throw_range = 11
 	embedding = list("impact_pain_mult" = 2, "remove_pain_mult" = 4, "jostle_chance" = 2.5)

--- a/ModularTegustation/tegu_items/gadgets/powered.dm
+++ b/ModularTegustation/tegu_items/gadgets/powered.dm
@@ -254,7 +254,7 @@
 	health = 150
 	maxHealth = 150
 	melee_damage_type = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	damage_coeff = list(RED_DAMAGE = 0.9, WHITE_DAMAGE = 0.9, BLACK_DAMAGE = 0.9, PALE_DAMAGE = 1.5)
 	melee_damage_lower = 12
 	melee_damage_upper = 14

--- a/ModularTegustation/tegu_items/gadgets/powered.dm
+++ b/ModularTegustation/tegu_items/gadgets/powered.dm
@@ -254,7 +254,6 @@
 	health = 150
 	maxHealth = 150
 	melee_damage_type = RED_DAMAGE
-
 	damage_coeff = list(RED_DAMAGE = 0.9, WHITE_DAMAGE = 0.9, BLACK_DAMAGE = 0.9, PALE_DAMAGE = 1.5)
 	melee_damage_lower = 12
 	melee_damage_upper = 14

--- a/ModularTegustation/tegu_items/workshop/_materials.dm
+++ b/ModularTegustation/tegu_items/workshop/_materials.dm
@@ -139,7 +139,6 @@
 	creation.attack_speed *= attack_mult
 	if(type_override)
 		creation.damtype = type_override
-		creation.armortype = type_override
 		creation.type_overriden = TRUE
 	if(hitsound_override)
 		creation.hitsound = hitsound_override

--- a/ModularTegustation/tegu_items/workshop/_templates.dm
+++ b/ModularTegustation/tegu_items/workshop/_templates.dm
@@ -5,7 +5,7 @@
 	force = 0
 	attack_speed = 1
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	attack_verb_continuous = list("pokes", "jabs", "tears", "lacerates", "gores")
 	attack_verb_simple = list("poke", "jab", "tear", "lacerate", "gore")
 	hitsound = 'sound/weapons/ego/spear1.ogg'
@@ -46,7 +46,6 @@
 
 	if(!type_overriden)
 		damtype = mod.damagetype
-		armortype = mod.damagetype
 	if(!color)
 		// Material color overwrites
 		color = mod.weaponcolor

--- a/ModularTegustation/tegu_items/workshop/templates/basic.dm
+++ b/ModularTegustation/tegu_items/workshop/templates/basic.dm
@@ -12,7 +12,7 @@ Katana - Use in hand to dash
 	reach = 2		//Has 2 Square Reach.
 	attack_speed = 1.2
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	attack_verb_continuous = list("pokes", "jabs", "tears", "lacerates", "gores")
 	attack_verb_simple = list("poke", "jab", "tear", "lacerate", "gore")
 	hitsound = 'sound/weapons/ego/spear1.ogg'
@@ -28,7 +28,7 @@ Katana - Use in hand to dash
 	icon_state = "swordtemplate"
 	force = 22
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb_continuous = list("attacks", "slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "cuts")
 	attack_verb_simple = list("attack", "slash", "stab", "slice", "tear", "lacerate", "rip", "dice", "cut")
@@ -45,7 +45,7 @@ Katana - Use in hand to dash
 	force = 20
 	attack_speed = 0.7
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb_continuous = list("attacks", "slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "cuts")
 	attack_verb_simple = list("attack", "slash", "stab", "slice", "tear", "lacerate", "rip", "dice", "cut")
@@ -62,7 +62,7 @@ Katana - Use in hand to dash
 	force = 30
 	attack_speed = 1.5
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	hitsound = 'sound/abnormalities/woodsman/woodsman_attack.ogg'
 	attack_verb_continuous = list("attacks", "slashes", "cleaves", "slices", "cuts")
 	attack_verb_simple = list("attack", "slash", "cleave", "slice", "cut")
@@ -80,7 +80,7 @@ Katana - Use in hand to dash
 	attack_speed = 1.8
 	aoe_range = 1
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	hitsound = 'sound/abnormalities/woodsman/woodsman_attack.ogg'
 	attack_verb_continuous = list("bashes", "beats")
 	attack_verb_simple = list("bash", "beat")
@@ -99,7 +99,7 @@ Katana - Use in hand to dash
 	attack_speed = 1.7	//not really for melee and is therefore really slow.
 	throwforce = 50
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	attack_verb_continuous = list("pokes", "jabs", "tears", "lacerates", "gores")
 	attack_verb_simple = list("poke", "jab", "tear", "lacerate", "gore")
 	hitsound = 'sound/weapons/ego/spear1.ogg'
@@ -117,7 +117,7 @@ Katana - Use in hand to dash
 	attack_speed = 0.8	//melee is shit lol
 	throwforce = 38
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	attack_verb_continuous = list("bonks", "bashes")
 	attack_verb_simple = list("bonk", "bash")
 
@@ -141,7 +141,7 @@ Katana - Use in hand to dash
 	force = 38
 	attack_speed =  2
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	hitsound = 'sound/abnormalities/woodsman/woodsman_attack.ogg'
 	attack_verb_continuous = list("attacks", "slashes", "cleaves", "slices", "cuts")
 	attack_verb_simple = list("attack", "slash", "cleave", "slice", "cut")
@@ -157,7 +157,7 @@ Katana - Use in hand to dash
 	force = 12
 	attack_speed = 0.4
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	attack_verb_continuous = list("rends", "tears", "lacerates", "rips", "cuts")
 	attack_verb_simple = list("rend", "tear", "lacerate", "rip", "cut")
 
@@ -173,7 +173,7 @@ Katana - Use in hand to dash
 	force = 20
 	attack_speed =  1.6
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	attack_verb_continuous = list("pounds", "crushes", "smashes", "whacks", "smacks")
 	attack_verb_simple = list("pound", "crush", "smash", "whack", "smack")
 

--- a/ModularTegustation/tegu_items/workshop/templates/basic.dm
+++ b/ModularTegustation/tegu_items/workshop/templates/basic.dm
@@ -11,8 +11,6 @@ Katana - Use in hand to dash
 	force = 22
 	reach = 2		//Has 2 Square Reach.
 	attack_speed = 1.2
-	damtype = RED_DAMAGE
-
 	attack_verb_continuous = list("pokes", "jabs", "tears", "lacerates", "gores")
 	attack_verb_simple = list("poke", "jab", "tear", "lacerate", "gore")
 	hitsound = 'sound/weapons/ego/spear1.ogg'
@@ -27,8 +25,6 @@ Katana - Use in hand to dash
 	desc = "A blank sword workshop template."
 	icon_state = "swordtemplate"
 	force = 22
-	damtype = RED_DAMAGE
-
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb_continuous = list("attacks", "slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "cuts")
 	attack_verb_simple = list("attack", "slash", "stab", "slice", "tear", "lacerate", "rip", "dice", "cut")
@@ -44,8 +40,6 @@ Katana - Use in hand to dash
 	icon_state = "knifetemplate"
 	force = 20
 	attack_speed = 0.7
-	damtype = RED_DAMAGE
-
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb_continuous = list("attacks", "slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "cuts")
 	attack_verb_simple = list("attack", "slash", "stab", "slice", "tear", "lacerate", "rip", "dice", "cut")
@@ -61,8 +55,6 @@ Katana - Use in hand to dash
 	icon_state = "axetemplate"
 	force = 30
 	attack_speed = 1.5
-	damtype = RED_DAMAGE
-
 	hitsound = 'sound/abnormalities/woodsman/woodsman_attack.ogg'
 	attack_verb_continuous = list("attacks", "slashes", "cleaves", "slices", "cuts")
 	attack_verb_simple = list("attack", "slash", "cleave", "slice", "cut")
@@ -79,8 +71,6 @@ Katana - Use in hand to dash
 	force = 26
 	attack_speed = 1.8
 	aoe_range = 1
-	damtype = RED_DAMAGE
-
 	hitsound = 'sound/abnormalities/woodsman/woodsman_attack.ogg'
 	attack_verb_continuous = list("bashes", "beats")
 	attack_verb_simple = list("bash", "beat")
@@ -98,8 +88,6 @@ Katana - Use in hand to dash
 	reach = 2		//Has 2 Square Reach.
 	attack_speed = 1.7	//not really for melee and is therefore really slow.
 	throwforce = 50
-	damtype = RED_DAMAGE
-
 	attack_verb_continuous = list("pokes", "jabs", "tears", "lacerates", "gores")
 	attack_verb_simple = list("poke", "jab", "tear", "lacerate", "gore")
 	hitsound = 'sound/weapons/ego/spear1.ogg'
@@ -116,8 +104,6 @@ Katana - Use in hand to dash
 	force = 16
 	attack_speed = 0.8	//melee is shit lol
 	throwforce = 38
-	damtype = RED_DAMAGE
-
 	attack_verb_continuous = list("bonks", "bashes")
 	attack_verb_simple = list("bonk", "bash")
 
@@ -140,8 +126,6 @@ Katana - Use in hand to dash
 	icon_state = "greatswordtemplate"
 	force = 38
 	attack_speed =  2
-	damtype = RED_DAMAGE
-
 	hitsound = 'sound/abnormalities/woodsman/woodsman_attack.ogg'
 	attack_verb_continuous = list("attacks", "slashes", "cleaves", "slices", "cuts")
 	attack_verb_simple = list("attack", "slash", "cleave", "slice", "cut")
@@ -156,8 +140,6 @@ Katana - Use in hand to dash
 	icon_state = "clawtemplate"
 	force = 12
 	attack_speed = 0.4
-	damtype = RED_DAMAGE
-
 	attack_verb_continuous = list("rends", "tears", "lacerates", "rips", "cuts")
 	attack_verb_simple = list("rend", "tear", "lacerate", "rip", "cut")
 
@@ -172,8 +154,6 @@ Katana - Use in hand to dash
 	icon_state = "clubtemplate"
 	force = 20
 	attack_speed =  1.6
-	damtype = RED_DAMAGE
-
 	attack_verb_continuous = list("pounds", "crushes", "smashes", "whacks", "smacks")
 	attack_verb_simple = list("pound", "crush", "smash", "whack", "smack")
 

--- a/ModularTegustation/tegu_items/workshop/templates/chargeblade.dm
+++ b/ModularTegustation/tegu_items/workshop/templates/chargeblade.dm
@@ -4,8 +4,6 @@
 	desc = "A glowing weapon made using Wcorp charge technology."
 	icon_state = "chargetemplate"
 	force = 18
-	damtype = RED_DAMAGE
-
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb_continuous = list("attacks", "slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "cuts")
 	attack_verb_simple = list("attack", "slash", "stab", "slice", "tear", "lacerate", "rip", "dice", "cut")

--- a/ModularTegustation/tegu_items/workshop/templates/chargeblade.dm
+++ b/ModularTegustation/tegu_items/workshop/templates/chargeblade.dm
@@ -5,7 +5,7 @@
 	icon_state = "chargetemplate"
 	force = 18
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb_continuous = list("attacks", "slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "cuts")
 	attack_verb_simple = list("attack", "slash", "stab", "slice", "tear", "lacerate", "rip", "dice", "cut")

--- a/ModularTegustation/tegu_items/workshop/templates/dice.dm
+++ b/ModularTegustation/tegu_items/workshop/templates/dice.dm
@@ -6,7 +6,7 @@
 	force = 40
 	throwforce = 20
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	finishedicon = list("finisheddice")
 	finishedname = list("dice")
 	finisheddesc = "A finished dice, ready for use."

--- a/ModularTegustation/tegu_items/workshop/templates/dice.dm
+++ b/ModularTegustation/tegu_items/workshop/templates/dice.dm
@@ -5,8 +5,6 @@
 	icon_state = "dicetemplate"
 	force = 40
 	throwforce = 20
-	damtype = RED_DAMAGE
-
 	finishedicon = list("finisheddice")
 	finishedname = list("dice")
 	finisheddesc = "A finished dice, ready for use."

--- a/ModularTegustation/tegu_items/workshop/templates/gauntlet.dm
+++ b/ModularTegustation/tegu_items/workshop/templates/gauntlet.dm
@@ -5,7 +5,7 @@
 	icon_state = "gauntlettemplate"
 	force = 40
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	finishedicon = list("finishedgauntlet")
 	finishedname = list("fist", "gauntlet", "glove")
 	finisheddesc = "A finished gauntlet, ready for use."
@@ -32,7 +32,7 @@
 		if(ishuman(target))
 			punch_damage = 50
 
-		target.apply_damage(punch_damage, damtype, null, target.run_armor_check(null, armortype), spread_damage = TRUE)		//MASSIVE fuckoff punch
+		target.apply_damage(punch_damage, damtype, null, target.run_armor_check(null, damtype), spread_damage = TRUE)		//MASSIVE fuckoff punch
 
 		playsound(src, 'sound/weapons/resonator_blast.ogg', 50, TRUE)
 		var/atom/throw_target = get_edge_target_turf(target, user.dir)

--- a/ModularTegustation/tegu_items/workshop/templates/gauntlet.dm
+++ b/ModularTegustation/tegu_items/workshop/templates/gauntlet.dm
@@ -4,8 +4,6 @@
 	special = "This weapon deals it's damage after a short windup."
 	icon_state = "gauntlettemplate"
 	force = 40
-	damtype = RED_DAMAGE
-
 	finishedicon = list("finishedgauntlet")
 	finishedname = list("fist", "gauntlet", "glove")
 	finisheddesc = "A finished gauntlet, ready for use."

--- a/ModularTegustation/tegu_items/workshop/templates/katana.dm
+++ b/ModularTegustation/tegu_items/workshop/templates/katana.dm
@@ -5,8 +5,6 @@
 	icon_state = "katanatemplate"
 	force = 22
 	attack_speed = 1.3
-	damtype = RED_DAMAGE
-
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb_continuous = list("attacks", "slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "cuts")
 	attack_verb_simple = list("attack", "slash", "stab", "slice", "tear", "lacerate", "rip", "dice", "cut")

--- a/ModularTegustation/tegu_items/workshop/templates/katana.dm
+++ b/ModularTegustation/tegu_items/workshop/templates/katana.dm
@@ -6,7 +6,7 @@
 	force = 22
 	attack_speed = 1.3
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb_continuous = list("attacks", "slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "cuts")
 	attack_verb_simple = list("attack", "slash", "stab", "slice", "tear", "lacerate", "rip", "dice", "cut")

--- a/ModularTegustation/tegu_items/workshop/templates/scythe.dm
+++ b/ModularTegustation/tegu_items/workshop/templates/scythe.dm
@@ -5,8 +5,6 @@
 	icon_state = "scythetemplate"
 	force = 20
 	attack_speed = 0.9
-	damtype = RED_DAMAGE
-
 	attack_verb_continuous = list("slashes", "slices", "rips", "cuts")
 	attack_verb_simple = list("slash", "slice", "rip", "cut")
 	hitsound = 'sound/weapons/ego/da_capo1.ogg'

--- a/ModularTegustation/tegu_items/workshop/templates/scythe.dm
+++ b/ModularTegustation/tegu_items/workshop/templates/scythe.dm
@@ -6,7 +6,7 @@
 	force = 20
 	attack_speed = 0.9
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	attack_verb_continuous = list("slashes", "slices", "rips", "cuts")
 	attack_verb_simple = list("slash", "slice", "rip", "cut")
 	hitsound = 'sound/weapons/ego/da_capo1.ogg'

--- a/ModularTegustation/tegu_mobs/lc13_outskirtdwellers.dm
+++ b/ModularTegustation/tegu_mobs/lc13_outskirtdwellers.dm
@@ -491,7 +491,6 @@ Mobs that mostly focus on dealing RED damage, they are all a bit more frail than
 	move_to_delay = 4
 	stat_attack = HARD_CRIT
 	melee_damage_type = RED_DAMAGE
-
 	butcher_results = list(/obj/item/food/meat/slab = 1)
 	guaranteed_butcher_results = list(/obj/item/food/meat/slab = 1)
 	damage_coeff = list(BRUTE = 1, RED_DAMAGE = 1.6, WHITE_DAMAGE = 0.8, BLACK_DAMAGE = 1, PALE_DAMAGE = 2)
@@ -683,7 +682,6 @@ Mobs that mostly focus on dealing RED damage, they are all a bit more frail than
 	melee_damage_lower = 25
 	melee_damage_upper = 30
 	melee_damage_type = RED_DAMAGE
-
 	attack_sound = 'sound/creatures/lc13/lovetown/slam.ogg'
 	attack_verb_continuous = "grapples"
 	attack_verb_simple = "grapple"

--- a/ModularTegustation/tegu_mobs/lc13_outskirtdwellers.dm
+++ b/ModularTegustation/tegu_mobs/lc13_outskirtdwellers.dm
@@ -491,7 +491,7 @@ Mobs that mostly focus on dealing RED damage, they are all a bit more frail than
 	move_to_delay = 4
 	stat_attack = HARD_CRIT
 	melee_damage_type = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	butcher_results = list(/obj/item/food/meat/slab = 1)
 	guaranteed_butcher_results = list(/obj/item/food/meat/slab = 1)
 	damage_coeff = list(BRUTE = 1, RED_DAMAGE = 1.6, WHITE_DAMAGE = 0.8, BLACK_DAMAGE = 1, PALE_DAMAGE = 2)
@@ -683,7 +683,7 @@ Mobs that mostly focus on dealing RED damage, they are all a bit more frail than
 	melee_damage_lower = 25
 	melee_damage_upper = 30
 	melee_damage_type = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	attack_sound = 'sound/creatures/lc13/lovetown/slam.ogg'
 	attack_verb_continuous = "grapples"
 	attack_verb_simple = "grapple"

--- a/ModularTegustation/tegu_mobs/necromancer.dm
+++ b/ModularTegustation/tegu_mobs/necromancer.dm
@@ -597,7 +597,6 @@
 	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
 	force = 66
 	damtype = PALE_DAMAGE
-	armortype = PALE_DAMAGE
 	attack_verb_continuous = list("cuts", "slices", "dices")
 	attack_verb_simple = list("cut", "slice", "dice")
 	w_class = WEIGHT_CLASS_BULKY

--- a/ModularTegustation/tegu_mobs/necromancer_mobs.dm
+++ b/ModularTegustation/tegu_mobs/necromancer_mobs.dm
@@ -24,7 +24,6 @@
 	ranged = 1
 	ranged_cooldown_time = 40
 	melee_damage_type = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
 	melee_damage_lower = 24
 	melee_damage_upper = 28
 	retreat_distance = 2

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -566,7 +566,7 @@
 
 // /obj signals
 
-///from base of [/obj/proc/take_damage]: (damage_amount, damage_type, damage_flag, sound_effect, attack_dir, aurmor_penetration)
+///from base of [/obj/proc/take_damage]: (damage_amount, damage_type, sound_effect, attack_dir, aurmor_penetration)
 #define COMSIG_OBJ_TAKE_DAMAGE	"obj_take_damage"
 	/// Return bitflags for the above signal which prevents the object taking any damage.
 	#define COMPONENT_NO_TAKE_DAMAGE	(1<<0)

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -130,7 +130,7 @@
 					"<span class='danger'>You hit [src] with [I]!</span>", null, COMBAT_MESSAGE_RANGE)
 		//only witnesses close by and the victim see a hit message.
 		log_combat(user, src, "attacked", I)
-	take_damage(I.force, I.damtype, I.armortype, 1)
+	take_damage(I.force, I.damtype, I.damtype, 1)
 
 /mob/living/attacked_by(obj/item/I, mob/living/user)
 	send_item_attack_message(I, user)
@@ -147,7 +147,7 @@
 		return TRUE //successful attack
 
 /mob/living/simple_animal/attacked_by(obj/item/I, mob/living/user)
-	if(!attack_threshold_check(I.force, I.damtype, I.armortype, FALSE))
+	if(!attack_threshold_check(I.force, I.damtype, FALSE))
 		playsound(loc, 'sound/weapons/tap.ogg', I.get_clamped_volume(), TRUE, -1)
 	else
 		return ..()

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -299,7 +299,7 @@
 	var/a_incidence_s = abs(incidence_s)
 	if(a_incidence_s > 90 && a_incidence_s < 270)
 		return FALSE
-	if((P.flag in list(BULLET, BOMB)) && P.ricochet_incidence_leeway)
+	if((P.damage_type in list(BULLET, BOMB)) && P.ricochet_incidence_leeway)
 		if((a_incidence_s < 90 && a_incidence_s < 90 - P.ricochet_incidence_leeway) || (a_incidence_s > 270 && a_incidence_s -270 > P.ricochet_incidence_leeway))
 			return FALSE
 	var/new_angle_s = SIMPLIFY_DEGREES(face_angle + incidence_s)

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -349,7 +349,7 @@
 	return ..()
 
 
-/obj/machinery/camera/run_obj_armor(damage_amount, damage_type, damage_flag = 0, attack_dir)
+/obj/machinery/camera/run_obj_armor(damage_amount, damage_type, attack_dir)
 	if(machine_stat & BROKEN)
 		return damage_amount
 	. = ..()

--- a/code/game/machinery/computer/_computer.dm
+++ b/code/game/machinery/computer/_computer.dm
@@ -60,7 +60,7 @@
 			deconstruct(TRUE, user)
 	return TRUE
 
-/obj/machinery/computer/play_attack_sound(damage_amount, damage_type = BRUTE, damage_flag = 0)
+/obj/machinery/computer/play_attack_sound(damage_amount, damage_type = BRUTE)
 	switch(damage_type)
 		if(BRUTE)
 			if(machine_stat & BROKEN)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1328,8 +1328,8 @@
 		log_combat(user, src, message)
 		add_hiddenprint(user)
 
-/obj/machinery/door/airlock/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir)
-	if((damage_amount >= obj_integrity) && (damage_flag == BOMB))
+/obj/machinery/door/airlock/take_damage(damage_amount, damage_type = BRUTE, sound_effect = 1, attack_dir)
+	if((damage_amount >= obj_integrity) && (damage_type == BOMB))
 		flags_1 |= NODECONSTRUCT_1  //If an explosive took us out, don't drop the assembly
 	. = ..()
 	if(obj_integrity < (0.75 * max_integrity))

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -232,13 +232,13 @@
 		return TRUE
 	return ..()
 
-/obj/machinery/door/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir)
+/obj/machinery/door/take_damage(damage_amount, damage_type = BRUTE, sound_effect = 1, attack_dir)
 	. = ..()
 	if(. && obj_integrity > 0)
 		if(damage_amount >= 10 && prob(30))
 			spark_system.start()
 
-/obj/machinery/door/play_attack_sound(damage_amount, damage_type = BRUTE, damage_flag = 0)
+/obj/machinery/door/play_attack_sound(damage_amount, damage_type = BRUTE)
 	switch(damage_type)
 		if(BRUTE)
 			if(glass)

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -186,7 +186,7 @@
 	operating = FALSE
 	return 1
 
-/obj/machinery/door/window/play_attack_sound(damage_amount, damage_type = BRUTE, damage_flag = 0)
+/obj/machinery/door/window/play_attack_sound(damage_amount, damage_type = BRUTE)
 	switch(damage_type)
 		if(BRUTE)
 			playsound(src, 'sound/effects/glasshit.ogg', 90, TRUE)

--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -305,7 +305,7 @@
 			return TRUE
 	return FALSE
 
-/obj/machinery/firealarm/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir)
+/obj/machinery/firealarm/take_damage(damage_amount, damage_type = BRUTE, sound_effect = 1, attack_dir)
 	. = ..()
 	if(.) //damage received
 		if(obj_integrity > 0 && !(machine_stat & BROKEN) && buildstage != 0)

--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -267,7 +267,7 @@ GLOBAL_LIST_EMPTY(allCasters)
 		else
 			. += "crack3"
 
-/obj/machinery/newscaster/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir)
+/obj/machinery/newscaster/take_damage(damage_amount, damage_type = BRUTE, sound_effect = 1, attack_dir)
 	. = ..()
 	update_icon()
 
@@ -754,7 +754,7 @@ GLOBAL_LIST_EMPTY(allCasters)
 	else
 		return ..()
 
-/obj/machinery/newscaster/play_attack_sound(damage, damage_type = BRUTE, damage_flag = 0)
+/obj/machinery/newscaster/play_attack_sound(damage, damage_type = BRUTE)
 	switch(damage_type)
 		if(BRUTE)
 			if(machine_stat & BROKEN)

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -381,7 +381,7 @@ DEFINE_BITFIELD(turret_flags, list(
 
 		addtimer(CALLBACK(src, .proc/toggle_on, TRUE), rand(60,600))
 
-/obj/machinery/porta_turret/take_damage(damage, damage_type = BRUTE, damage_flag = 0, sound_effect = 1)
+/obj/machinery/porta_turret/take_damage(damage, damage_type = BRUTE, sound_effect = 1)
 	. = ..()
 	if(. && obj_integrity > 0) //damage received
 		if(prob(30))

--- a/code/game/machinery/shieldgen.dm
+++ b/code/game/machinery/shieldgen.dm
@@ -35,14 +35,14 @@
 		if(2)
 			take_damage(50, BRUTE, ENERGY, 0)
 
-/obj/structure/emergency_shield/play_attack_sound(damage, damage_type = BRUTE, damage_flag = 0)
+/obj/structure/emergency_shield/play_attack_sound(damage, damage_type = BRUTE)
 	switch(damage_type)
 		if(BURN)
 			playsound(loc, 'sound/effects/empulse.ogg', 75, TRUE)
 		if(BRUTE)
 			playsound(loc, 'sound/effects/empulse.ogg', 75, TRUE)
 
-/obj/structure/emergency_shield/take_damage(damage, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir)
+/obj/structure/emergency_shield/take_damage(damage, damage_type = BRUTE, sound_effect = 1, attack_dir)
 	. = ..()
 	if(.) //damage was dealt
 		new /obj/effect/temp_visual/impact_effect/ion(loc)
@@ -481,7 +481,7 @@
 
 		drain_power(10)
 
-/obj/machinery/shieldwall/play_attack_sound(damage_amount, damage_type = BRUTE, damage_flag = 0)
+/obj/machinery/shieldwall/play_attack_sound(damage_amount, damage_type = BRUTE)
 	switch(damage_type)
 		if(BURN)
 			playsound(loc, 'sound/effects/empulse.ogg', 75, TRUE)
@@ -489,7 +489,7 @@
 			playsound(loc, 'sound/effects/empulse.ogg', 75, TRUE)
 
 //the shield wall is immune to damage but it drains the stored power of the generators.
-/obj/machinery/shieldwall/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir)
+/obj/machinery/shieldwall/take_damage(damage_amount, damage_type = BRUTE, sound_effect = 1, attack_dir)
 	. = ..()
 	if(damage_type == BRUTE || damage_type == BURN)
 		drain_power(damage_amount)

--- a/code/game/objects/effects/effect_system/effects_foam.dm
+++ b/code/game/objects/effects/effect_system/effects_foam.dm
@@ -285,7 +285,7 @@
 /obj/structure/foamedmetal/attack_paw(mob/user)
 	return attack_hand(user)
 
-/obj/structure/foamedmetal/play_attack_sound(damage_amount, damage_type = BRUTE, damage_flag = 0)
+/obj/structure/foamedmetal/play_attack_sound(damage_amount, damage_type = BRUTE)
 	playsound(src.loc, 'sound/weapons/tap.ogg', 100, TRUE)
 
 /obj/structure/foamedmetal/attack_hand(mob/user)

--- a/code/game/objects/effects/effects.dm
+++ b/code/game/objects/effects/effects.dm
@@ -8,7 +8,7 @@
 	obj_flags = NONE
 	vis_flags = VIS_INHERIT_PLANE
 
-/obj/effect/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir)
+/obj/effect/take_damage(damage_amount, damage_type = BRUTE, sound_effect = 1, attack_dir)
 	return
 
 /obj/effect/fire_act(exposed_temperature, exposed_volume)

--- a/code/game/objects/effects/glowshroom.dm
+++ b/code/game/objects/effects/glowshroom.dm
@@ -234,7 +234,7 @@
 	if (myseed.endurance < 1) // Plant is gone
 		qdel(src)
 
-/obj/structure/glowshroom/play_attack_sound(damage_amount, damage_type = BRUTE, damage_flag = 0)
+/obj/structure/glowshroom/play_attack_sound(damage_amount, damage_type = BRUTE)
 	if(damage_type == BURN && damage_amount)
 		playsound(src.loc, 'sound/items/welder.ogg', 100, TRUE)
 

--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -62,7 +62,7 @@
 
 	triggermine(AM)
 
-/obj/effect/mine/take_damage(damage_amount, damage_type, damage_flag, sound_effect, attack_dir)
+/obj/effect/mine/take_damage(damage_amount, damage_type, sound_effect, attack_dir)
 	//Stops us for exploding more then once
 	if(safety_check())
 		return

--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -11,17 +11,16 @@
 	. = ..()
 	AddElement(/datum/element/atmos_sensitive)
 
-/obj/structure/spider/play_attack_sound(damage_amount, damage_type = BRUTE, damage_flag = 0)
+/obj/structure/spider/play_attack_sound(damage_amount, damage_type = BRUTE)
 	if(damage_type == BURN)//the stickiness of the web mutes all attack sounds except fire damage type
 		playsound(loc, 'sound/items/welder.ogg', 100, TRUE)
 
-/obj/structure/spider/run_obj_armor(damage_amount, damage_type, damage_flag = 0, attack_dir)
-	if(damage_flag == MELEE)
-		switch(damage_type)
-			if(BURN)
-				damage_amount *= 2
-			if(BRUTE)
-				damage_amount *= 0.25
+/obj/structure/spider/run_obj_armor(damage_amount, damage_type, attack_dir)
+	switch(damage_type)
+		if(BURN)
+			damage_amount *= 2
+		if(BRUTE)
+			damage_amount *= 0.25
 	. = ..()
 
 /obj/structure/spider/should_atmos_process(datum/gas_mixture/air, exposed_temperature)

--- a/code/game/objects/items/devices/forcefieldprojector.dm
+++ b/code/game/objects/items/devices/forcefieldprojector.dm
@@ -103,10 +103,10 @@
 	generator = null
 	return ..()
 
-/obj/structure/projected_forcefield/play_attack_sound(damage_amount, damage_type = BRUTE, damage_flag = 0)
+/obj/structure/projected_forcefield/play_attack_sound(damage_amount, damage_type = BRUTE)
 	playsound(loc, 'sound/weapons/egloves.ogg', 80, TRUE)
 
-/obj/structure/projected_forcefield/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir)
+/obj/structure/projected_forcefield/take_damage(damage_amount, damage_type = BRUTE, sound_effect = 1, attack_dir)
 	if(sound_effect)
-		play_attack_sound(damage_amount, damage_type, damage_flag)
+		play_attack_sound(damage_amount, damage_type)
 	generator.shield_integrity = max(generator.shield_integrity - damage_amount, 0)

--- a/code/game/objects/items/ego_weapons/aleph.dm
+++ b/code/game/objects/items/ego_weapons/aleph.dm
@@ -239,7 +239,6 @@
 	var/finisher_on = TRUE //this is for a subtype, it should NEVER be false on this item.
 	damtype = RED_DAMAGE
 
-
 //Replaces the normal attack with the gigafuck punch
 /obj/item/ego_weapon/goldrush/attack(mob/living/target, mob/living/user)
 	if(!CanUseEgo(user))
@@ -610,7 +609,6 @@
 	icon_state = "spring"
 	force = 80
 	damtype = RED_DAMAGE
-
 	attack_verb_continuous = list("pokes", "jabs")
 	attack_verb_simple = list("poke", "jab")
 	hitsound = 'sound/weapons/ego/spear1.ogg'
@@ -714,7 +712,6 @@
 	force = 180 //Just make sure you don't hit anyone!
 	attack_speed = 3
 	damtype = RED_DAMAGE
-
 	attack_verb_continuous = list("pulverizes", "bashes", "slams", "blockades")
 	attack_verb_simple = list("pulverize", "bash", "slam", "blockade")
 	hitsound = 'sound/abnormalities/distortedform/slam.ogg'
@@ -777,7 +774,6 @@
 	force = 84
 	attack_speed = 1.3
 	damtype = RED_DAMAGE
-
 	attack_verb_continuous = list("slashes", "slices", "rips", "cuts", "reaps")
 	attack_verb_simple = list("slash", "slice", "rip", "cut", "reap")
 	hitsound = 'sound/weapons/ego/farmwatch.ogg'
@@ -837,7 +833,6 @@
 	reach = 2
 	attack_speed = 1.2
 	damtype = WHITE_DAMAGE
-
 	attack_verb_continuous = list("slashes", "slices", "pokes", "cuts", "stabs")
 	attack_verb_simple = list("slash", "slice", "poke", "cut", "stab")
 	hitsound = 'sound/weapons/ego/spicebush.ogg'
@@ -936,7 +931,6 @@
 	force = 105	//Still lower DPS
 	attack_speed = 1.4
 	damtype = RED_DAMAGE
-
 	attack_verb_continuous = list("bashes", "clubs")
 	attack_verb_simple = list("bashes", "clubs")
 	hitsound = 'sound/weapons/fixer/generic/club1.ogg'
@@ -968,7 +962,6 @@
 	force = 80 // Quite high with passive buffs, but deals pure damage to yourself
 	attack_speed = 0.8
 	damtype = RED_DAMAGE
-
 	attack_verb_continuous = list("slash", "stab", "scorch")
 	attack_verb_simple = list("slashes", "stabs", "scorches")
 	hitsound = 'sound/weapons/ego/burn_sword.ogg'
@@ -1126,7 +1119,6 @@
 	attack_speed = 0.5
 	reach = 3
 	damtype = BLACK_DAMAGE
-
 	attack_verb_continuous = list("lacerates", "disciplines")
 	attack_verb_simple = list("lacerate", "discipline")
 	hitsound = 'sound/weapons/whip.ogg'

--- a/code/game/objects/items/ego_weapons/aleph.dm
+++ b/code/game/objects/items/ego_weapons/aleph.dm
@@ -7,7 +7,6 @@
 	worn_icon_state = "paradise"
 	force = 70
 	damtype = PALE_DAMAGE
-	armortype = PALE_DAMAGE
 	attack_verb_continuous = list("purges", "purifies")
 	attack_verb_simple = list("purge", "purify")
 	hitsound = 'sound/weapons/ego/paradise.ogg'
@@ -57,7 +56,6 @@
 	icon_state = "justitia"
 	force = 25
 	damtype = PALE_DAMAGE
-	armortype = PALE_DAMAGE
 	attack_verb_continuous = list("attacks", "slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "cuts")
 	attack_verb_simple = list("attack", "slash", "stab", "slice", "tear", "lacerate", "rip", "dice", "cut")
 	hitsound = 'sound/weapons/ego/justitia1.ogg'
@@ -114,7 +112,6 @@
 	force = 40 // It attacks very fast
 	attack_speed = 0.5
 	damtype = WHITE_DAMAGE
-	armortype = WHITE_DAMAGE
 	attack_verb_continuous = list("slashes", "slices", "rips", "cuts")
 	attack_verb_simple = list("slash", "slice", "rip", "cut")
 	hitsound = 'sound/weapons/ego/da_capo1.ogg'
@@ -168,7 +165,6 @@
 	inhand_y_dimension = 64
 	force = 70
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
 	attack_verb_continuous = list("slashes", "slices", "rips", "cuts")
 	attack_verb_simple = list("slash", "slice", "rip", "cut")
 	hitsound = 'sound/abnormalities/nothingthere/attack.ogg'
@@ -205,7 +201,6 @@
 	worn_icon_state = "twilight"
 	force = 35
 	damtype = RED_DAMAGE // It's all damage types, actually
-	armortype = RED_DAMAGE
 	attack_verb_continuous = list("slashes", "slices", "rips", "cuts")
 	attack_verb_simple = list("slash", "slice", "rip", "cut")
 	hitsound = 'sound/weapons/ego/twilight.ogg'
@@ -222,10 +217,8 @@
 	..()
 	for(var/damage_type in list(WHITE_DAMAGE, BLACK_DAMAGE, PALE_DAMAGE))
 		damtype = damage_type
-		armortype = damage_type
 		M.attacked_by(src, user)
 	damtype = initial(damtype)
-	armortype = initial(armortype)
 
 /obj/item/ego_weapon/twilight/EgoAttackInfo(mob/user)
 	return "<span class='notice'>It deals [force * 4] red, white, black and pale damage combined.</span>"
@@ -245,7 +238,7 @@
 	var/goldrush_damage = 140
 	var/finisher_on = TRUE //this is for a subtype, it should NEVER be false on this item.
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 
 //Replaces the normal attack with the gigafuck punch
 /obj/item/ego_weapon/goldrush/attack(mob/living/target, mob/living/user)
@@ -297,7 +290,6 @@
 	force = 110 //Slightly less damage, has an ability
 	attack_speed = 1.6
 	damtype = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
 	attack_verb_continuous = list("slams", "attacks")
 	attack_verb_simple = list("slam", "attack")
 	hitsound = 'sound/weapons/ego/hammer.ogg'
@@ -326,7 +318,6 @@
 	icon_state = "rosered"
 	force = 80 //Less damage, can swap damage type
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
 	attack_verb_continuous = list("cuts", "slices")
 	attack_verb_simple = list("cuts", "slices")
 	hitsound = 'sound/weapons/ego/rapier2.ogg'
@@ -351,7 +342,6 @@
 			damtype = RED_DAMAGE
 			force = 80
 			icon_state = "rosered"
-	armortype = damtype
 	to_chat(user, "<span class='notice'>\[src] will now deal [force] [damtype] damage.</span>")
 	playsound(src, 'sound/items/screwdriver2.ogg', 50, TRUE)
 
@@ -364,7 +354,6 @@
 	worn_icon_state = "censored"
 	force = 70	//there's a focus on the ranged attack here.
 	damtype = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
 	attack_verb_continuous = list("attacks")
 	attack_verb_simple = list("attack")
 	hitsound = 'sound/weapons/ego/censored1.ogg'
@@ -437,7 +426,6 @@
 	icon_state = "soulmate"
 	force = 40
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
 	attack_speed = 0.8
 	attack_verb_continuous = list("cuts", "slices")
 	attack_verb_simple = list("cuts", "slices")
@@ -536,7 +524,6 @@
 	name = "energy bullet"
 	damage = 40
 	damage_type = RED_DAMAGE
-	flag = RED_DAMAGE
 	icon_state = "ice_1"
 
 /obj/item/ego_weapon/space
@@ -546,7 +533,6 @@
 	icon_state = "space"
 	force = 50	//Half white, half black.
 	damtype = WHITE_DAMAGE
-	armortype = WHITE_DAMAGE
 	attack_verb_continuous = list("cuts", "attacks", "slashes")
 	attack_verb_simple = list("cut", "attack", "slash")
 	hitsound = 'sound/weapons/rapierhit.ogg'

--- a/code/game/objects/items/ego_weapons/aleph.dm
+++ b/code/game/objects/items/ego_weapons/aleph.dm
@@ -610,7 +610,7 @@
 	icon_state = "spring"
 	force = 80
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	attack_verb_continuous = list("pokes", "jabs")
 	attack_verb_simple = list("poke", "jab")
 	hitsound = 'sound/weapons/ego/spear1.ogg'
@@ -691,7 +691,6 @@
 	hitsound = season_list[current_season][6]
 	name = season_list[current_season][7]
 	damtype = season_list[current_season][8]
-	armortype = season_list[current_season][9]
 	desc = season_list[current_season][10]
 
 /obj/item/ego_weapon/seasons/attack(mob/living/target, mob/living/user) //other forms could probably use something. Probably.
@@ -715,7 +714,7 @@
 	force = 180 //Just make sure you don't hit anyone!
 	attack_speed = 3
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	attack_verb_continuous = list("pulverizes", "bashes", "slams", "blockades")
 	attack_verb_simple = list("pulverize", "bash", "slam", "blockade")
 	hitsound = 'sound/abnormalities/distortedform/slam.ogg'
@@ -778,7 +777,7 @@
 	force = 84
 	attack_speed = 1.3
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	attack_verb_continuous = list("slashes", "slices", "rips", "cuts", "reaps")
 	attack_verb_simple = list("slash", "slice", "rip", "cut", "reap")
 	hitsound = 'sound/weapons/ego/farmwatch.ogg'
@@ -838,7 +837,7 @@
 	reach = 2
 	attack_speed = 1.2
 	damtype = WHITE_DAMAGE
-	armortype = WHITE_DAMAGE
+
 	attack_verb_continuous = list("slashes", "slices", "pokes", "cuts", "stabs")
 	attack_verb_simple = list("slash", "slice", "poke", "cut", "stab")
 	hitsound = 'sound/weapons/ego/spicebush.ogg'
@@ -937,7 +936,7 @@
 	force = 105	//Still lower DPS
 	attack_speed = 1.4
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	attack_verb_continuous = list("bashes", "clubs")
 	attack_verb_simple = list("bashes", "clubs")
 	hitsound = 'sound/weapons/fixer/generic/club1.ogg'
@@ -969,7 +968,7 @@
 	force = 80 // Quite high with passive buffs, but deals pure damage to yourself
 	attack_speed = 0.8
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	attack_verb_continuous = list("slash", "stab", "scorch")
 	attack_verb_simple = list("slashes", "stabs", "scorches")
 	hitsound = 'sound/weapons/ego/burn_sword.ogg'
@@ -1127,7 +1126,7 @@
 	attack_speed = 0.5
 	reach = 3
 	damtype = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
+
 	attack_verb_continuous = list("lacerates", "disciplines")
 	attack_verb_simple = list("lacerate", "discipline")
 	hitsound = 'sound/weapons/whip.ogg'

--- a/code/game/objects/items/ego_weapons/he.dm
+++ b/code/game/objects/items/ego_weapons/he.dm
@@ -731,7 +731,6 @@
 	attack_speed = 1
 	reach = 2
 	damtype = RED_DAMAGE
-
 	attack_verb_continuous = list("pokes", "jabs")
 	attack_verb_simple = list("poke", "jab")
 	hitsound = 'sound/weapons/ego/spear1.ogg'
@@ -808,7 +807,6 @@
 	attack_speed = 2
 	hitsound = 'sound/abnormalities/doomsdaycalendar/Doomsday_Attack.ogg'
 	damtype = BLACK_DAMAGE
-
 	attack_verb_continuous = list("bashes", "clubs")
 	attack_verb_simple = list("bashes", "clubs")
 	attribute_requirements = list(
@@ -852,7 +850,6 @@
 	force = 55
 	attack_speed = 2
 	damtype = BLACK_DAMAGE
-
 	attack_verb_continuous = list("slams", "attacks")
 	attack_verb_simple = list("slam", "attack")
 	hitsound = 'sound/abnormalities/ichthys/hammer1.ogg'
@@ -931,7 +928,6 @@
 	force = 40//about 1.5x the average dps
 	attack_speed = 1
 	damtype = RED_DAMAGE
-
 	attack_verb_continuous = list("hacks", "slashes", "attacks")
 	attack_verb_simple = list("hack", "slash", "attack")
 	hitsound = 'sound/abnormalities/redshoes/RedShoes_Attack.ogg'
@@ -952,7 +948,6 @@
 	icon_state = "replica"
 	force = 25
 	damtype = BLACK_DAMAGE
-
 	attack_verb_continuous = list("grabs", "pinches", "snips", "attacks")
 	attack_verb_simple = list("grab", "pinch", "snip", "attack")
 	hitsound = 'sound/abnormalities/kqe/hitsound2.ogg'
@@ -1033,7 +1028,6 @@
 	force = 24
 	attack_speed = 0.8
 	damtype = RED_DAMAGE
-
 	attack_verb_continuous = list("stabs", "slashes", "attacks")
 	attack_verb_simple = list("stab", "slash", "attack")
 	hitsound = 'sound/abnormalities/wayward_passenger/attack2.ogg'
@@ -1147,7 +1141,6 @@
 	force = 40
 	attack_speed = 1.5
 	damtype = BLACK_DAMAGE
-
 	attack_verb_continuous = list("slices", "cleaves", "chops")
 	attack_verb_simple = list("slice", "cleave", "chop")
 	hitsound = 'sound/abnormalities/pinocchio/attack.ogg'
@@ -1162,7 +1155,6 @@
 	force = 40//it has no special effect. Just damage
 	attack_speed = 2
 	damtype = PALE_DAMAGE
-
 	attack_verb_continuous = list("stabs", "slashes", "attacks")
 	attack_verb_simple = list("stab", "slash", "attack")
 	hitsound = 'sound/weapons/bladeslice.ogg'
@@ -1177,7 +1169,6 @@
 	force = 25
 	attack_speed = 2
 	damtype = RED_DAMAGE
-
 	attack_verb_continuous = list("punches", "slaps", "scratches")
 	attack_verb_simple = list("punch", "slap", "scratch")
 	hitsound = 'sound/effects/hit_kick.ogg'
@@ -1236,7 +1227,6 @@
 	icon_state = "destiny"
 	force = 30
 	damtype = RED_DAMAGE
-
 	attack_verb_continuous = list("stabs", "slashes", "attacks")
 	attack_verb_simple = list("stab", "slash", "attack")
 	hitsound = 'sound/abnormalities/fateloom/garrote_bloody.ogg'//it's a bit loud
@@ -1263,7 +1253,6 @@
 	icon_state = "rhythm"
 	force = 25
 	damtype = WHITE_DAMAGE
-
 	attack_verb_continuous = list("slices", "saws", "rips")
 	attack_verb_simple = list("slice", "saw", "rip")
 	hitsound = 'sound/abnormalities/singingmachine/crunch.ogg'
@@ -1290,7 +1279,6 @@
 	force = 54
 	attack_speed = 3
 	damtype = WHITE_DAMAGE
-
 	attack_verb_continuous = list("shoves", "bashes")
 	attack_verb_simple = list("shove", "bash")
 	hitsound = 'sound/weapons/bite.ogg'
@@ -1312,7 +1300,6 @@
 	force = 35
 	attack_speed = 0.8//about 44 dps
 	damtype = WHITE_DAMAGE
-
 	attack_verb_continuous = list("whips", "slaps", "flicks")
 	attack_verb_simple = list("whip", "slap", "flick")
 	hitsound = 'sound/weapons/whip.ogg'
@@ -1339,7 +1326,6 @@
 	inhand_y_dimension = 64
 	force = 25
 	damtype = RED_DAMAGE
-
 	attack_verb_continuous = list("bashes", "crushes")
 	attack_verb_simple = list("bash", "crush")
 	attribute_requirements = list(
@@ -1383,7 +1369,6 @@
 	reach = 2		//Has 2 Square Reach.
 	attack_speed = 1.8// really slow
 	damtype = RED_DAMAGE
-
 	attack_verb_continuous = list("stabs", "impales")
 	attack_verb_simple = list("stab", "impale")
 	hitsound = 'sound/weapons/ego/spear1.ogg'
@@ -1414,7 +1399,6 @@
 	reach = 2		//Has 2 Square Reach.
 	attack_speed = 2.0 // really slow
 	damtype = BLACK_DAMAGE
-
 	attack_verb_continuous = list("burns", "boils")
 	attack_verb_simple = list("burn", "boil")
 	hitsound = 'sound/weapons/fixer/generic/fire1.ogg'
@@ -1456,7 +1440,6 @@
 	force = 45	//Low dps. You'll see why later
 	attack_speed = 2
 	damtype = BLACK_DAMAGE
-
 	attack_verb_continuous = list("burns", "boils")
 	attack_verb_simple = list("burn", "boil")
 	hitsound = 'sound/weapons/fixer/generic/fire2.ogg'
@@ -1538,7 +1521,6 @@
 	force = 40	//Very low dps. You'll see why later
 	attack_speed = 2
 	damtype = RED_DAMAGE
-
 	attack_verb_continuous = list("pokes", "slashes")
 	attack_verb_simple = list("poke", "slash")
 	hitsound = 'sound/weapons/fixer/generic/sword1.ogg'
@@ -1643,7 +1625,6 @@
 	lefthand_file = 'icons/mob/inhands/96x96_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/96x96_righthand.dmi'
 	damtype = WHITE_DAMAGE
-
 	force = 50
 	inhand_x_dimension = 96
 	inhand_y_dimension = 96
@@ -1719,7 +1700,6 @@
 	reach = 4		//Has 4 Square Reach.
 	attack_speed = 1.8
 	damtype = BLACK_DAMAGE
-
 	attack_verb_continuous = list("whips", "lashes", "tears")
 	attack_verb_simple = list("whip", "lash", "tear")
 	hitsound = 'sound/weapons/whip.ogg'
@@ -1734,7 +1714,6 @@
 	special = "This weapon deals both red and white damage."
 	force = 20
 	damtype = WHITE_DAMAGE
-
 	attack_verb_continuous = list("stabs", "slashes", "attacks")
 	attack_verb_simple = list("stab", "slash", "attack")
 	hitsound = 'sound/weapons/bladeslice.ogg'

--- a/code/game/objects/items/ego_weapons/he.dm
+++ b/code/game/objects/items/ego_weapons/he.dm
@@ -6,7 +6,6 @@
 	icon_state = "grinder"
 	force = 30
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
 	attack_verb_continuous = list("slices", "saws", "rips")
 	attack_verb_simple = list("slice", "saw", "rip")
 	hitsound = 'sound/abnormalities/helper/attack.ogg'
@@ -35,7 +34,6 @@
 	icon_state = "harvest"
 	force = 30
 	damtype = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
 	attack_verb_continuous = list("attacks", "bashes", "tills")
 	attack_verb_simple = list("attack", "bash", "till")
 	hitsound = 'sound/weapons/ego/harvest.ogg'
@@ -86,7 +84,6 @@
 	force = 41
 	attack_speed = 1.5
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
 	attack_verb_continuous = list("slices", "slashes", "stabs")
 	attack_verb_simple = list("slice", "slash", "stab")
 	hitsound = 'sound/weapons/ego/axe2.ogg'
@@ -120,7 +117,6 @@
 	force = 12
 	attack_speed = 0.3
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
 	attack_verb_continuous = list("punches", "jabs", "slaps")
 	attack_verb_simple = list("punches", "jabs", "slaps")
 	hitsound = 'sound/weapons/punch1.ogg'
@@ -140,7 +136,6 @@
 	force = 12
 	attack_speed = 0.5
 	damtype = PALE_DAMAGE
-	armortype = PALE_DAMAGE
 	attack_verb_continuous = list("decimates", "bisects")
 	attack_verb_simple = list("decimate", "bisect")
 	hitsound = 'sound/weapons/bladeslice.ogg'
@@ -231,7 +226,6 @@
 	force = 54	//Still lower DPS
 	attack_speed = 2
 	damtype = WHITE_DAMAGE
-	armortype = WHITE_DAMAGE
 	attack_verb_continuous = list("bashes", "clubs")
 	attack_verb_simple = list("bashes", "clubs")
 	hitsound = 'sound/weapons/fixer/generic/club1.ogg'
@@ -255,7 +249,6 @@
 	icon_state = "logging"
 	force = 33
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
 	attack_verb_continuous = "chops"
 	attack_verb_simple = "chop"
 	hitsound = 'sound/abnormalities/woodsman/woodsman_attack.ogg'
@@ -379,7 +372,6 @@
 	icon_state = "courage"
 	force = 10 //if 4 people are around, the weapon can deal up to 70 damage per strike, but alone it's a glorified baton.
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
 	attack_verb_continuous = "slash"
 	attack_verb_simple = "slash"
 	hitsound = 'sound/weapons/bladeslice.ogg'
@@ -415,7 +407,6 @@
 	icon_state = "bravery"
 	force = 54
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
 	attack_verb_continuous = list("shoves", "bashes")
 	attack_verb_simple = list("shove", "bash")
 	hitsound = 'sound/weapons/bite.ogg'
@@ -459,7 +450,6 @@
 	icon_state = "pleasure"
 	force = 30
 	damtype = WHITE_DAMAGE
-	armortype = WHITE_DAMAGE
 	attack_verb_continuous = "slash"
 	attack_verb_simple = "slash"
 	hitsound = 'sound/weapons/bladeslice.ogg'
@@ -502,7 +492,6 @@
 	force = 40
 	attack_speed = 1.5
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
 	attack_verb_continuous = list("slices", "cleaves", "chops")
 	attack_verb_simple = list("slice", "cleave", "chop")
 	hitsound = 'sound/weapons/bladeslice.ogg'
@@ -517,7 +506,6 @@
 	force = 9
 	attack_speed = 0.3
 	damtype = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
 	attack_verb_continuous = list("slices", "cleaves", "chops")
 	attack_verb_simple = list("slice", "cleave", "chop")
 	hitsound = 'sound/weapons/bladeslice.ogg'
@@ -532,7 +520,6 @@
 	icon_state = "giant"
 	force = 54
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
 	attack_verb_continuous = list("shoves", "bashes")
 	attack_verb_simple = list("shove", "bash")
 	hitsound = 'sound/weapons/genhit2.ogg'
@@ -552,8 +539,7 @@
 	special = "This weapon's damage scale with the number of steps you've taken before striking."
 	icon_state = "homing_instinct"
 	damtype = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
-	force = 22 //Damage is crushed down
+	force = 0 //Literally does no damage by default
 	attack_speed = 3
 	attack_verb_continuous = list("pierces", "stabs")
 	attack_verb_simple = list("pierce", "stab")
@@ -596,7 +582,6 @@
 	force = 30
 	attack_speed = 1
 	damtype = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
 	attack_verb_continuous = list("cuts", "smacks", "bashes")
 	attack_verb_simple = list("cuts", "smacks", "bashes")
 	hitsound = 'sound/weapons/ego/axe2.ogg'
@@ -621,7 +606,6 @@
 	force = 25
 	attack_speed = 1.5
 	damtype = PALE_DAMAGE
-	armortype = PALE_DAMAGE
 	attack_verb_continuous = list("slashes", "slices", "rips", "cuts")
 	attack_verb_simple = list("slash", "slice", "rip", "cut")
 	hitsound = 'sound/weapons/ego/da_capo2.ogg'
@@ -645,7 +629,6 @@
 	icon_state = "inheritance"
 	force = 12
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
 	attack_verb_continuous = list("stabs", "attacks", "slashes")
 	attack_verb_simple = list("stab", "attack", "slash")
 	hitsound = 'sound/weapons/ego/rapier1.ogg'
@@ -698,7 +681,6 @@
 	force = 50
 	attack_speed = 1.8
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
 	attack_verb_continuous = list("bashes", "hammers", "smacks")
 	attack_verb_simple = list("bash", "hammer", "smack")
 	hitsound = 'sound/abnormalities/goldenapple/Legerdemain.ogg'

--- a/code/game/objects/items/ego_weapons/he.dm
+++ b/code/game/objects/items/ego_weapons/he.dm
@@ -731,7 +731,7 @@
 	attack_speed = 1
 	reach = 2
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	attack_verb_continuous = list("pokes", "jabs")
 	attack_verb_simple = list("poke", "jab")
 	hitsound = 'sound/weapons/ego/spear1.ogg'
@@ -808,7 +808,7 @@
 	attack_speed = 2
 	hitsound = 'sound/abnormalities/doomsdaycalendar/Doomsday_Attack.ogg'
 	damtype = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
+
 	attack_verb_continuous = list("bashes", "clubs")
 	attack_verb_simple = list("bashes", "clubs")
 	attribute_requirements = list(
@@ -852,7 +852,7 @@
 	force = 55
 	attack_speed = 2
 	damtype = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
+
 	attack_verb_continuous = list("slams", "attacks")
 	attack_verb_simple = list("slam", "attack")
 	hitsound = 'sound/abnormalities/ichthys/hammer1.ogg'
@@ -931,7 +931,7 @@
 	force = 40//about 1.5x the average dps
 	attack_speed = 1
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	attack_verb_continuous = list("hacks", "slashes", "attacks")
 	attack_verb_simple = list("hack", "slash", "attack")
 	hitsound = 'sound/abnormalities/redshoes/RedShoes_Attack.ogg'
@@ -952,7 +952,7 @@
 	icon_state = "replica"
 	force = 25
 	damtype = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
+
 	attack_verb_continuous = list("grabs", "pinches", "snips", "attacks")
 	attack_verb_simple = list("grab", "pinch", "snip", "attack")
 	hitsound = 'sound/abnormalities/kqe/hitsound2.ogg'
@@ -1033,7 +1033,7 @@
 	force = 24
 	attack_speed = 0.8
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	attack_verb_continuous = list("stabs", "slashes", "attacks")
 	attack_verb_simple = list("stab", "slash", "attack")
 	hitsound = 'sound/abnormalities/wayward_passenger/attack2.ogg'
@@ -1147,7 +1147,7 @@
 	force = 40
 	attack_speed = 1.5
 	damtype = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
+
 	attack_verb_continuous = list("slices", "cleaves", "chops")
 	attack_verb_simple = list("slice", "cleave", "chop")
 	hitsound = 'sound/abnormalities/pinocchio/attack.ogg'
@@ -1162,7 +1162,7 @@
 	force = 40//it has no special effect. Just damage
 	attack_speed = 2
 	damtype = PALE_DAMAGE
-	armortype = PALE_DAMAGE
+
 	attack_verb_continuous = list("stabs", "slashes", "attacks")
 	attack_verb_simple = list("stab", "slash", "attack")
 	hitsound = 'sound/weapons/bladeslice.ogg'
@@ -1177,7 +1177,7 @@
 	force = 25
 	attack_speed = 2
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	attack_verb_continuous = list("punches", "slaps", "scratches")
 	attack_verb_simple = list("punch", "slap", "scratch")
 	hitsound = 'sound/effects/hit_kick.ogg'
@@ -1236,7 +1236,7 @@
 	icon_state = "destiny"
 	force = 30
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	attack_verb_continuous = list("stabs", "slashes", "attacks")
 	attack_verb_simple = list("stab", "slash", "attack")
 	hitsound = 'sound/abnormalities/fateloom/garrote_bloody.ogg'//it's a bit loud
@@ -1263,7 +1263,7 @@
 	icon_state = "rhythm"
 	force = 25
 	damtype = WHITE_DAMAGE
-	armortype = WHITE_DAMAGE
+
 	attack_verb_continuous = list("slices", "saws", "rips")
 	attack_verb_simple = list("slice", "saw", "rip")
 	hitsound = 'sound/abnormalities/singingmachine/crunch.ogg'
@@ -1290,7 +1290,7 @@
 	force = 54
 	attack_speed = 3
 	damtype = WHITE_DAMAGE
-	armortype = WHITE_DAMAGE
+
 	attack_verb_continuous = list("shoves", "bashes")
 	attack_verb_simple = list("shove", "bash")
 	hitsound = 'sound/weapons/bite.ogg'
@@ -1312,7 +1312,7 @@
 	force = 35
 	attack_speed = 0.8//about 44 dps
 	damtype = WHITE_DAMAGE
-	armortype = WHITE_DAMAGE
+
 	attack_verb_continuous = list("whips", "slaps", "flicks")
 	attack_verb_simple = list("whip", "slap", "flick")
 	hitsound = 'sound/weapons/whip.ogg'
@@ -1339,7 +1339,7 @@
 	inhand_y_dimension = 64
 	force = 25
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	attack_verb_continuous = list("bashes", "crushes")
 	attack_verb_simple = list("bash", "crush")
 	attribute_requirements = list(
@@ -1383,7 +1383,7 @@
 	reach = 2		//Has 2 Square Reach.
 	attack_speed = 1.8// really slow
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	attack_verb_continuous = list("stabs", "impales")
 	attack_verb_simple = list("stab", "impale")
 	hitsound = 'sound/weapons/ego/spear1.ogg'
@@ -1414,7 +1414,7 @@
 	reach = 2		//Has 2 Square Reach.
 	attack_speed = 2.0 // really slow
 	damtype = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
+
 	attack_verb_continuous = list("burns", "boils")
 	attack_verb_simple = list("burn", "boil")
 	hitsound = 'sound/weapons/fixer/generic/fire1.ogg'
@@ -1456,7 +1456,7 @@
 	force = 45	//Low dps. You'll see why later
 	attack_speed = 2
 	damtype = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
+
 	attack_verb_continuous = list("burns", "boils")
 	attack_verb_simple = list("burn", "boil")
 	hitsound = 'sound/weapons/fixer/generic/fire2.ogg'
@@ -1527,7 +1527,7 @@
 	hitsound = 'sound/abnormalities/ichthys/jump.ogg'
 	damage = 35
 	damage_type = BLACK_DAMAGE
-	flag = BLACK_DAMAGE
+
 
 #define STATUS_EFFECT_FAIRYBITE /datum/status_effect/fairybite
 /obj/item/ego_weapon/faelantern
@@ -1538,7 +1538,7 @@
 	force = 40	//Very low dps. You'll see why later
 	attack_speed = 2
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	attack_verb_continuous = list("pokes", "slashes")
 	attack_verb_simple = list("poke", "slash")
 	hitsound = 'sound/weapons/fixer/generic/sword1.ogg'
@@ -1604,7 +1604,7 @@
 	hitsound = 'sound/abnormalities/orangetree/ding.ogg'
 	damage = 25
 	damage_type = RED_DAMAGE
-	flag = RED_DAMAGE
+
 
 /obj/projectile/ego_bullet/faelantern/on_hit(target)
 	. = ..()
@@ -1643,7 +1643,7 @@
 	lefthand_file = 'icons/mob/inhands/96x96_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/96x96_righthand.dmi'
 	damtype = WHITE_DAMAGE
-	armortype = WHITE_DAMAGE
+
 	force = 50
 	inhand_x_dimension = 96
 	inhand_y_dimension = 96
@@ -1719,7 +1719,7 @@
 	reach = 4		//Has 4 Square Reach.
 	attack_speed = 1.8
 	damtype = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
+
 	attack_verb_continuous = list("whips", "lashes", "tears")
 	attack_verb_simple = list("whip", "lash", "tear")
 	hitsound = 'sound/weapons/whip.ogg'
@@ -1734,7 +1734,7 @@
 	special = "This weapon deals both red and white damage."
 	force = 20
 	damtype = WHITE_DAMAGE
-	armortype = WHITE_DAMAGE
+
 	attack_verb_continuous = list("stabs", "slashes", "attacks")
 	attack_verb_simple = list("stab", "slash", "attack")
 	hitsound = 'sound/weapons/bladeslice.ogg'

--- a/code/game/objects/items/ego_weapons/non_abnormality/black_silence.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/black_silence.dm
@@ -10,7 +10,7 @@
 	righthand_file = 'icons/mob/inhands/weapons/black_silence_righthand.dmi'
 	force = 1
 	damtype = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
+
 	attack_verb_continuous = list("taps", "pats")
 	attack_verb_simple = list("tap", "pat")
 	hitsound = 'sound/effects/hit_punch.ogg'
@@ -627,7 +627,7 @@
 	speed = 0.3
 	icon_state = "logic"
 	damage_type = BLACK_DAMAGE
-	flag = BLACK_DAMAGE
+
 
 /obj/projectile/ego_bullet/atelier_logic/iff
 	nodamage = TRUE

--- a/code/game/objects/items/ego_weapons/non_abnormality/blue_sicko.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/blue_sicko.dm
@@ -10,7 +10,7 @@
 	inhand_icon_state = "reverberation"
 	force = 60 // 85 DPS w/o Vibration, 128 with.
 	damtype = WHITE_DAMAGE
-	armortype = WHITE_DAMAGE
+
 	attack_speed = 0.7
 	hitsound = 'sound/weapons/fixer/reverb_normal.ogg'
 	attack_verb_continuous = list("slashes", "cuts",)
@@ -73,7 +73,7 @@
 	if(S)
 		if(S.stacks == vibration)
 			damtype = PALE_DAMAGE
-			armortype = PALE_DAMAGE
+
 			force = 90
 			hitsound = "sound/weapons/fixer/reverb_strong[rand(1, 2)].ogg"
 			VFX = new /obj/effect/temp_visual/reverb_slash/vertical(get_turf(user))
@@ -88,7 +88,7 @@
 		VFX.layer = user.layer - 0.1 // Below them, but sometimes above the target.
 	. = ..()
 	damtype = WHITE_DAMAGE
-	armortype = WHITE_DAMAGE
+
 	force = 60
 	hitsound = temp_sound
 	if(!. || target.stat == DEAD)

--- a/code/game/objects/items/ego_weapons/non_abnormality/cane.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/cane.dm
@@ -5,7 +5,7 @@
 	desc = "This is a template and should not be seen."
 	force = 18
 	damtype = WHITE_DAMAGE
-	armortype = WHITE_DAMAGE
+
 	attack_verb_continuous = list("bashes", "crushes")
 	attack_verb_simple = list("bash", "crush")
 	release_message = "You release your charge, damaging your opponent!"

--- a/code/game/objects/items/ego_weapons/non_abnormality/cinq.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/cinq.dm
@@ -6,7 +6,7 @@
 	icon_state = "cinq"
 	force = 28
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	attack_verb_continuous = list("pokes", "jabs", "tears", "lacerates", "gores")
 	attack_verb_simple = list("poke", "jab", "tear", "lacerate", "gore")
 	hitsound = 'sound/weapons/fixer/generic/nail1.ogg'
@@ -69,11 +69,11 @@
 /obj/item/ego_weapon/city/cinq/proc/Return(mob/living/carbon/human/user)
 	force = initial(force)
 	reach = 1
-	to_chat(user, "<span class='notice'>À bout de souffle.</span>")
+	to_chat(user, "<span class='notice'>ï¿½ bout de souffle.</span>")
 
 /obj/item/ego_weapon/city/cinq/proc/Reset(mob/living/carbon/human/user)
 	force = initial(force)
 	reach = 1
 	ready = TRUE
-	to_chat(user, "<span class='notice'>Prêt à nouveau.</span>")
+	to_chat(user, "<span class='notice'>Prï¿½t ï¿½ nouveau.</span>")
 

--- a/code/game/objects/items/ego_weapons/non_abnormality/color_fixer.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/color_fixer.dm
@@ -11,7 +11,7 @@
 	inhand_y_dimension = 64
 	force = 90
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	attack_verb_continuous = list("bashes", "crushes")
 	attack_verb_simple = list("bash", "crush")
 	attribute_requirements = list(

--- a/code/game/objects/items/ego_weapons/non_abnormality/dawn.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/dawn.dm
@@ -6,7 +6,7 @@
 	icon_state = "philip"
 	inhand_icon_state = "philip"
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	attack_verb_continuous = list("bashes", "crushes")
 	attack_verb_simple = list("bash", "crush")
 	var/aoe_range

--- a/code/game/objects/items/ego_weapons/non_abnormality/gradeone.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/gradeone.dm
@@ -8,7 +8,7 @@
 	force = 60
 	attack_speed = 0.8
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb_continuous = list("attacks", "slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "cuts")
 	attack_verb_simple = list("attack", "slash", "stab", "slice", "tear", "lacerate", "rip", "dice", "cut")

--- a/code/game/objects/items/ego_weapons/non_abnormality/hana.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/hana.dm
@@ -6,7 +6,7 @@
 	icon_state = "hana_sword"
 	force = 50
 	damtype = PALE_DAMAGE
-	armortype = PALE_DAMAGE
+
 	attack_verb_continuous = list("cuts", "slices")
 	attack_verb_simple = list("cuts", "slices")
 	hitsound = 'sound/weapons/fixer/hana_slash.ogg'

--- a/code/game/objects/items/ego_weapons/non_abnormality/index.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/index.dm
@@ -8,7 +8,7 @@
 	inhand_icon_state = "index"
 	force = 37
 	damtype = PALE_DAMAGE
-	armortype = PALE_DAMAGE
+
 	attack_verb_continuous = list("smacks", "hammers", "beats")
 	attack_verb_simple = list("smack", "hammer", "beat")
 	var/prescript_target

--- a/code/game/objects/items/ego_weapons/non_abnormality/jcorp.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/jcorp.dm
@@ -9,7 +9,7 @@
 	force = 27
 	attack_speed = 1
 	damtype = WHITE_DAMAGE //Almost everyone and their mother in this god forsaken district does something with sanity.
-	armortype = WHITE_DAMAGE
+
 	attack_verb_continuous = list("slices", "gashes", "stabs")
 	attack_verb_simple = list("slice", "gash", "stab")
 	hitsound = 'sound/weapons/fixer/generic/knife3.ogg'
@@ -66,7 +66,7 @@
 	inhand_icon_state = "maracas"
 	force = 22
 	damtype = WHITE_DAMAGE
-	armortype = WHITE_DAMAGE
+
 	attack_verb_continuous = list("bashes", "clubs")
 	attack_verb_simple = list("bashes", "clubs")
 	hitsound = 'sound/weapons/fixer/generic/maracas1.ogg'
@@ -108,7 +108,7 @@
 	inhand_icon_state = "mariachi_blades"
 	force = 22
 	damtype = WHITE_DAMAGE
-	armortype = WHITE_DAMAGE
+
 	attack_verb_continuous = list("slashes", "slices")
 	attack_verb_simple = list("slash", "slice")
 	hitsound = 'sound/weapons/fixer/generic/blade1.ogg'

--- a/code/game/objects/items/ego_weapons/non_abnormality/jeong.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/jeong.dm
@@ -8,7 +8,7 @@
 	force = 30
 	attack_speed = 0.7
 	damtype = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
+
 	attack_verb_continuous = list("slices", "stabs")
 	attack_verb_simple = list("slice", "stab")
 	hitsound = 'sound/weapons/bladeslice.ogg'

--- a/code/game/objects/items/ego_weapons/non_abnormality/kcorp.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/kcorp.dm
@@ -5,7 +5,7 @@
 	inhand_icon_state = "kbatong"
 	force = 22
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	attack_verb_continuous = list("bashes", "crushes")
 	attack_verb_simple = list("bash", "crush")
 
@@ -33,7 +33,7 @@
 	reach = 2
 	attack_speed = 1.2
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	attack_verb_continuous = list("whacks", "slashes")
 	attack_verb_simple = list("whack", "slash")
 	attribute_requirements = list(
@@ -56,7 +56,7 @@
 	reach = 2
 	attack_speed = 0.6
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	attack_verb_continuous = list("whacks", "slashes")
 	attack_verb_simple = list("whack", "slash")
 	attribute_requirements = list(
@@ -78,7 +78,7 @@
 	force = 15
 	slowdown = 0.7
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	attack_verb_continuous = list("shoves", "bashes")
 	attack_verb_simple = list("shove", "bash")
 	hitsound = 'sound/weapons/genhit2.ogg'

--- a/code/game/objects/items/ego_weapons/non_abnormality/leaflet.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/leaflet.dm
@@ -5,7 +5,7 @@
 	icon_state = "leaflet"
 	force = 20
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	attack_verb_continuous = list("bashes", "crushes")
 	attack_verb_simple = list("bash", "crush")
 	attribute_requirements = list(

--- a/code/game/objects/items/ego_weapons/non_abnormality/limbus_ego.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/limbus_ego.dm
@@ -12,7 +12,7 @@
 	reach = 2 //Has 2 Square Reach.
 	attack_speed = 3 // really slow
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	attack_verb_continuous = list("bludgeons", "whacks")
 	attack_verb_simple = list("bludgeon", "whack")
 	hitsound = 'sound/weapons/fixer/generic/spear3.ogg'

--- a/code/game/objects/items/ego_weapons/non_abnormality/limbus_sinner.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/limbus_sinner.dm
@@ -35,7 +35,7 @@
 	force = 35
 	attack_speed = 1.6
 	damtype = WHITE_DAMAGE
-	armortype = WHITE_DAMAGE
+
 	attack_verb_continuous = list("cuts", "smacks", "bashes")
 	attack_verb_simple = list("cuts", "smacks", "bashes")
 	hitsound = 'sound/weapons/bladeslice.ogg'
@@ -62,7 +62,7 @@
 	reach = 2		//Has 2 Square Reach.
 	attack_speed = 1.8// really slow
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	attack_verb_continuous = list("bludgeons", "whacks")
 	attack_verb_simple = list("bludgeon", "whack")
 	hitsound = 'sound/weapons/fixer/generic/spear2.ogg'
@@ -78,7 +78,7 @@
 	force = 13
 	attack_speed = 0.5
 	damtype = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
+
 	attack_verb_continuous = list("pokes", "jabs", "tears", "lacerates", "gores")
 	attack_verb_simple = list("poke", "jab", "tear", "lacerate", "gore")
 	reductions = list(20, 20, 20, 0) // 60 - Diet Diet Daredevil
@@ -103,7 +103,7 @@
 	force = 11
 	attack_speed = 0.5
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 
 /obj/item/ego_weapon/taixuhuanjing
 	name = "tai xuhuan jing"
@@ -116,7 +116,7 @@
 	reach = 2		//Has 2 Square Reach.
 	attack_speed = 1.2
 	damtype = WHITE_DAMAGE
-	armortype = WHITE_DAMAGE
+
 	attack_verb_continuous = list("pokes", "jabs", "tears", "lacerates", "gores")
 	attack_verb_simple = list("poke", "jab", "tear", "lacerate", "gore")
 	hitsound = 'sound/weapons/ego/sword1.ogg'
@@ -131,7 +131,7 @@
 	force = 35
 	attack_speed = 1.6
 	damtype = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
+
 	attack_verb_continuous = list("beats", "smacks")
 	attack_verb_simple = list("beat", "smack")
 
@@ -153,7 +153,7 @@
 	righthand_file = 'icons/mob/inhands/weapons/limbus_righthand.dmi'
 	force = 33				//Lots of damage, way less DPS
 	damtype = WHITE_DAMAGE
-	armortype = WHITE_DAMAGE
+
 	attack_speed = 2 // Really Slow
 	attack_verb_continuous = list("smashes", "bludgeons", "crushes")
 	attack_verb_simple = list("smash", "bludgeon", "crush")
@@ -168,7 +168,7 @@
 	righthand_file = 'icons/mob/inhands/weapons/limbus_righthand.dmi'
 	force = 40
 	damtype = WHITE_DAMAGE
-	armortype = WHITE_DAMAGE
+
 	attack_verb_continuous = list("shoves", "bashes")
 	attack_verb_simple = list("shove", "bash")
 	hitsound = 'sound/weapons/genhit2.ogg'
@@ -190,7 +190,7 @@
 	throw_speed = 1
 	throw_range = 7
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	hitsound = 'sound/weapons/ego/axe2.ogg'
 
 /obj/item/ego_weapon/raskolot/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
@@ -213,7 +213,7 @@
 	reach = 2		//Has 2 Square Reach.
 	attack_speed = 1.2
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	attack_verb_continuous = list("pokes", "jabs", "tears", "lacerates", "gores")
 	attack_verb_simple = list("poke", "jab", "tear", "lacerate", "gore")
 	hitsound = 'sound/weapons/ego/axe2.ogg'
@@ -228,7 +228,7 @@
 	righthand_file = 'icons/mob/inhands/weapons/limbus_righthand.dmi'
 	force = 20
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	attack_speed = 0.8
 	attack_verb_continuous = list("cuts", "slices")
 	attack_verb_simple = list("cuts", "slices")
@@ -267,7 +267,7 @@
 	name = "gunblade bullet"
 	damage = 20
 	damage_type = RED_DAMAGE
-	flag = RED_DAMAGE
+
 
 /obj/item/ego_weapon/ungezifer
 	name = "ungezifer"
@@ -278,7 +278,7 @@
 	righthand_file = 'icons/mob/inhands/weapons/limbus_righthand.dmi'
 	force = 38				//Lots of damage, way less DPS
 	damtype = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
+
 	attack_speed = 2 // Really Slow
 	attack_verb_continuous = list("smashes", "bludgeons", "crushes")
 	attack_verb_simple = list("smash", "bludgeon", "crush")

--- a/code/game/objects/items/ego_weapons/non_abnormality/limbus_sinner.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/limbus_sinner.dm
@@ -10,7 +10,6 @@
 	force = 7
 	attack_speed = 0.3
 	damtype = WHITE_DAMAGE
-	armortype = WHITE_DAMAGE
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	var/dodgelanding
 

--- a/code/game/objects/items/ego_weapons/non_abnormality/liu.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/liu.dm
@@ -2,7 +2,7 @@
 /obj/item/ego_weapon/city/liu
 	name = "Liu template"
 	damtype = WHITE_DAMAGE
-	armortype = WHITE_DAMAGE
+
 
 /obj/item/ego_weapon/city/liu/examine(mob/user)
 	. = ..()

--- a/code/game/objects/items/ego_weapons/non_abnormality/mirae.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/mirae.dm
@@ -6,7 +6,7 @@
 	icon_state = "miraecane"
 	force = 50
 	damtype = WHITE_DAMAGE	//Also does a small bit of pale, because lawyers hurt your mind and soul.
-	armortype = WHITE_DAMAGE
+
 	attack_verb_continuous = list("bashes", "crushes")
 	attack_verb_simple = list("bash", "crush")
 	attribute_requirements = list(
@@ -44,6 +44,6 @@
 	icon_state = "insurance"
 	force = 45
 	damtype = WHITE_DAMAGE	//Also does a small bit of pale, because lawyers eat your soul.
-	armortype = WHITE_DAMAGE
+
 	ahn_amount = 700
 	boxchance = 30

--- a/code/game/objects/items/ego_weapons/non_abnormality/miscbackstreet.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/miscbackstreet.dm
@@ -7,7 +7,7 @@
 	force = 32
 	attack_speed = 1.4
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	attack_verb_continuous = list("slices", "slashes", "stabs")
 	attack_verb_simple = list("slice", "slash", "stab")
 	hitsound = 'sound/weapons/ego/axe2.ogg'

--- a/code/game/objects/items/ego_weapons/non_abnormality/miscfixer.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/miscfixer.dm
@@ -7,7 +7,7 @@
 	reach = 2		//Has 2 Square Reach.
 	attack_speed = 1.2
 	damtype = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
+
 	attack_verb_continuous = list("pokes", "jabs", "tears", "lacerates", "gores")
 	attack_verb_simple = list("poke", "jab", "tear", "lacerate", "gore")
 	hitsound = 'sound/weapons/ego/spear1.ogg'
@@ -24,7 +24,7 @@
 	icon_state = "fixer_blade"
 	force = 22
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb_continuous = list("attacks", "slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "cuts")
 	attack_verb_simple = list("attack", "slash", "stab", "slice", "tear", "lacerate", "rip", "dice", "cut")
@@ -36,7 +36,7 @@
 	force = 38
 	attack_speed = 2
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	hitsound = 'sound/weapons/genhit3.ogg'
 	attack_verb_continuous = list("attacks", "slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "cuts")
 	attack_verb_simple = list("attack", "slash", "stab", "slice", "tear", "lacerate", "rip", "dice", "cut")
@@ -48,7 +48,7 @@
 	force = 32
 	attack_speed = 1.4
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	attack_verb_continuous = list("bashes", "clubs")
 	attack_verb_simple = list("bashes", "clubs")
 	hitsound = 'sound/weapons/fixer/generic/club1.ogg'

--- a/code/game/objects/items/ego_weapons/non_abnormality/molar.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/molar.dm
@@ -6,7 +6,7 @@
 	icon_state = "mika"
 	force = 44
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	attack_verb_continuous = list("slices", "saws", "rips")
 	attack_verb_simple = list("slice", "saw", "rip")
 	hitsound = 'sound/abnormalities/helper/attack.ogg'

--- a/code/game/objects/items/ego_weapons/non_abnormality/ncorp.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/ncorp.dm
@@ -7,7 +7,7 @@
 	icon_state = "mark"
 	force = 40
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	attack_verb_continuous = list("marks")
 	attack_verb_simple = list("mark")
 
@@ -19,19 +19,19 @@
 	name = "n-corp white seal"
 	icon_state = "wmark"
 	damtype = WHITE_DAMAGE
-	armortype = WHITE_DAMAGE
+
 
 /obj/item/ego_weapon/city/ncorp_mark/black
 	name = "n-corp black seal"
 	icon_state = "bmark"
 	damtype = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
+
 
 /obj/item/ego_weapon/city/ncorp_mark/pale
 	name = "n-corp pale seal"
 	icon_state = "pmark"
 	damtype = PALE_DAMAGE
-	armortype = PALE_DAMAGE
+
 
 //Nails - These mark enemies to enable the hammer
 /obj/item/ego_weapon/city/ncorp_nail
@@ -42,7 +42,7 @@
 	icon_state = "kleinnagel"
 	force = 18
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	attack_verb_continuous = list("jabs", "stabs")
 	attack_verb_simple = list("jab", "stab")
 	hitsound = 'sound/weapons/fixer/generic/nail1.ogg'
@@ -94,7 +94,7 @@
 	icon_state = "gripnagel"
 	force = 50
 	damtype = WHITE_DAMAGE
-	armortype = WHITE_DAMAGE
+
 	attribute_requirements = list(
 							FORTITUDE_ATTRIBUTE = 60,
 							PRUDENCE_ATTRIBUTE = 80,
@@ -113,7 +113,7 @@
 	force = 30
 	attack_speed = 1.5
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	attack_verb_continuous = list("marks")
 	attack_verb_simple = list("mark")
 	hitsound = 'sound/weapons/fixer/generic/club2.ogg'
@@ -126,7 +126,6 @@
 		charges-=1
 	if(charges <= 0 && charged)
 		damtype = initial(damtype)
-		armortype = initial(damtype)
 		to_chat(user, "<span class='notice'>Your hammer has run out of charges.</span>")
 		charged = FALSE
 	force = initial(force)
@@ -137,7 +136,6 @@
 		return
 	to_chat(user, "<span class='notice'>You apply a mark to your hammer, changing its damage type.</span>")
 	damtype = I.damtype
-	armortype = I.damtype
 	charges = 10
 	charged = TRUE
 	qdel(I)
@@ -178,7 +176,7 @@
 	force = 60
 	attack_speed = 1
 	damtype = WHITE_DAMAGE
-	armortype = WHITE_DAMAGE
+
 	hitsound = 'sound/weapons/fixer/generic/fist2.ogg'
 	attribute_requirements = list(
 							FORTITUDE_ATTRIBUTE = 60,
@@ -197,7 +195,7 @@
 	icon_state = "messingnagel"
 	force = 18
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	attack_verb_continuous = list("jabs", "stabs")
 	attack_verb_simple = list("jab", "stab")
 	hitsound = 'sound/weapons/fixer/generic/nail1.ogg'
@@ -254,5 +252,5 @@
 							JUSTICE_ATTRIBUTE = 100
 							)
 	damtype = WHITE_DAMAGE
-	armortype = WHITE_DAMAGE
+
 

--- a/code/game/objects/items/ego_weapons/non_abnormality/pierre.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/pierre.dm
@@ -8,7 +8,7 @@
 	force = 30
 	attack_speed = 2
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	attack_verb_continuous = list("cleavess", "cuts")
 	attack_verb_simple = list("slash", "slice", "rip", "cut")
 	hitsound = 'sound/weapons/guillotine.ogg'

--- a/code/game/objects/items/ego_weapons/non_abnormality/purple_tear.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/purple_tear.dm
@@ -5,7 +5,7 @@
 	desc = "You really shouldn't be seeing this."
 	icon_state = "Jeong"
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	attribute_requirements = list(
 							FORTITUDE_ATTRIBUTE = 120,
 							PRUDENCE_ATTRIBUTE = 120,
@@ -145,7 +145,7 @@
 	force = 45
 	attack_speed = 0.5
 	damtype = RED_DAMAGE //Iori's quite physical with this stance
-	armortype = RED_DAMAGE
+
 	attack_verb_continuous = list("slashes", "rends")
 	attack_verb_simple = list("slash", "rend")
 	hitsound = 'sound/weapons/purple_tear/slash1.ogg'
@@ -181,7 +181,7 @@
 	force = 90
 	attack_speed = 1
 	damtype = WHITE_DAMAGE //tbh white does not fit but also i don't think Iori should use pale, thats Blue Sicko's job
-	armortype = WHITE_DAMAGE
+
 	attack_verb_continuous = list("pierces", "stabs")
 	attack_verb_simple = list("pierce", "stab")
 	hitsound = 'sound/weapons/purple_tear/stab1.ogg'
@@ -271,7 +271,7 @@
 	force = 135
 	attack_speed = 1.5
 	damtype = BLACK_DAMAGE //Blunt stance deals both high damage and stagger damage
-	armortype = BLACK_DAMAGE
+
 	attack_verb_continuous = list("bludgeons", "smacks")
 	attack_verb_simple = list("bludgeon", "smack")
 	hitsound = 'sound/weapons/purple_tear/blunt1.ogg'
@@ -344,7 +344,7 @@
 	var/buff_check = FALSE
 	var/list/reductions = list(90, 90, 90, 90) //wild
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	attack_verb_continuous = list("smashes", "bashes")
 	attack_verb_simple = list("smash", "bash")
 	hitsound = 'sound/weapons/purple_tear/blunt2.ogg'
@@ -409,12 +409,10 @@
 	if(parry_buff)
 		force = force*1.5
 		damtype = BRUTE
-		armortype = MELEE
 	..()
 	if(parry_buff)
 		force = force/1.5
 		damtype = RED_DAMAGE
-		armortype = RED_DAMAGE
 		parry_buff = FALSE
 
 // Mirage Storm, fittingly stolen from blue sicko and black silence
@@ -453,7 +451,7 @@
 	inhand_y_dimension = 32
 	force = 45
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	attack_verb_continuous = list("slashes", "rends")
 	attack_verb_simple = list("slash", "rend")
 	hitsound = 'sound/weapons/purple_tear/slash2.ogg'
@@ -471,7 +469,7 @@
 	inhand_y_dimension = 64
 	force = 135
 	damtype = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
+
 	attack_verb_continuous = list("bludgeons", "smacks")
 	attack_verb_simple = list("bludgeon", "smack")
 	hitsound = 'sound/weapons/purple_tear/blunt2.ogg'
@@ -489,7 +487,7 @@
 	inhand_y_dimension = 32
 	force = 90
 	damtype = WHITE_DAMAGE
-	armortype = WHITE_DAMAGE
+
 	attack_verb_continuous = list("pierces", "stabs")
 	attack_verb_simple = list("pierce", "stab")
 	hitsound = 'sound/weapons/purple_tear/stab2.ogg'

--- a/code/game/objects/items/ego_weapons/non_abnormality/rats.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/rats.dm
@@ -5,7 +5,7 @@
 	icon_state = "rathammer"
 	force = 18
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	attack_verb_continuous = list("smacks", "hammers", "beats")
 	attack_verb_simple = list("smack", "hammer", "beat")
 
@@ -53,7 +53,7 @@
 	force = 55
 	attack_speed = 3
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	attack_verb_continuous = list("pipes", "smashes", "shatters", "nails over the head")
 	attack_verb_simple = list("pipe", "smash", "shatter", "nail in the head")
 	hitsound = 'sound/weapons/ego/pipesuffering.ogg'

--- a/code/game/objects/items/ego_weapons/non_abnormality/rcorp.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/rcorp.dm
@@ -30,7 +30,6 @@
 		if(PALE_DAMAGE)
 			damtype = RED_DAMAGE
 			force = 35
-	armortype = damtype // TODO: In future, armortype should be gone entirely
 	to_chat(user, "<span class='notice'>\The [src] will now deal [damtype] damage.</span>")
 	playsound(src, 'sound/items/screwdriver2.ogg', 50, TRUE)
 
@@ -60,7 +59,6 @@
 			damtype = PALE_DAMAGE
 		if(PALE_DAMAGE)
 			damtype = RED_DAMAGE
-	armortype = damtype // TODO: In future, armortype should be gone entirely
 	to_chat(user, "<span class='notice'>\The [src] will now deal [damtype] damage.</span>")
 	playsound(src, 'sound/items/screwdriver2.ogg', 50, TRUE)
 
@@ -75,7 +73,7 @@
 	righthand_file = 'icons/mob/inhands/weapons/staves_righthand.dmi'
 	force = 40
 	damtype = WHITE_DAMAGE
-	armortype = WHITE_DAMAGE
+
 	attribute_requirements = list(
 							FORTITUDE_ATTRIBUTE = 60,
 							PRUDENCE_ATTRIBUTE = 60,
@@ -256,7 +254,7 @@
 	force = 20
 	throwforce = 24
 	damtype = PALE_DAMAGE
-	armortype = PALE_DAMAGE
+
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb_continuous = list("stabs", "slices")
 	attack_verb_simple = list("stab", "slice")

--- a/code/game/objects/items/ego_weapons/non_abnormality/rosespanner.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/rosespanner.dm
@@ -6,7 +6,7 @@
 	inhand_icon_state = "rosespanner"
 	force = 18
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	attack_verb_continuous = list("bashes", "crushes")
 	attack_verb_simple = list("bash", "crush")
 	release_message = "You release your charge, dealing a massive burst of damage!"
@@ -33,7 +33,6 @@
 		return
 	to_chat(user, "<span class='notice'>You apply a gear to your weapon, changing its damage type.</span>")
 	damtype = I.damtype
-	armortype = I.damtype
 	charged = TRUE
 	qdel(I)
 
@@ -63,12 +62,11 @@
 		for(var/mob/living/L in T)
 			if(!overcharged && (L == user || ishuman(L)))
 				continue
-			L.apply_damage(aoe, damtype, null, L.run_armor_check(null, armortype), spread_damage = TRUE)
+			L.apply_damage(aoe, damtype, null, L.run_armor_check(null, damtype), spread_damage = TRUE)
 
 	overcharged = FALSE
 	charged = FALSE
 	damtype = initial(damtype)
-	armortype = initial(damtype)
 
 //Grade 5
 /obj/item/ego_weapon/city/charge/rosespanner/minihammer
@@ -128,22 +126,22 @@
 	lefthand_file = 'ModularTegustation/Teguicons/lc13_left.dmi'
 	righthand_file = 'ModularTegustation/Teguicons/lc13_right.dmi'
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 
 /obj/item/rosespanner_gear/white
 	name = "rosespanner white gear"
 	icon_state = "whitegear"
 	damtype = WHITE_DAMAGE
-	armortype = WHITE_DAMAGE
+
 
 /obj/item/rosespanner_gear/black
 	name = "rosespanner black gear"
 	icon_state = "blackgear"
 	damtype = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
+
 
 /obj/item/rosespanner_gear/pale
 	name = "rosespanner pale gear"
 	icon_state = "palegear"
 	damtype = PALE_DAMAGE
-	armortype = PALE_DAMAGE
+

--- a/code/game/objects/items/ego_weapons/non_abnormality/seven.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/seven.dm
@@ -15,7 +15,7 @@
 	inhand_icon_state = "sevenassociation"
 	force = 38
 	damtype = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
+
 	var/stored_target
 	var/stored_target_hp
 	var/hit_number
@@ -134,7 +134,7 @@
 	hitsound = 'sound/weapons/rapierhit.ogg'
 	force = 38
 	damtype = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
+
 	var/fencing_target
 	attribute_requirements = list(
 							FORTITUDE_ATTRIBUTE = 60,

--- a/code/game/objects/items/ego_weapons/non_abnormality/shi.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/shi.dm
@@ -8,7 +8,7 @@
 	icon_state = "shi_dagger"
 	force = 44
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	attack_verb_continuous = list("pokes", "jabs", "tears", "lacerates", "gores")
 	attack_verb_simple = list("poke", "jab", "tear", "lacerate", "gore")
 	hitsound = 'sound/weapons/bladeslice.ogg'
@@ -46,7 +46,7 @@
 	force = 44
 	attack_speed = 1.2
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	attack_verb_continuous = list("pokes", "jabs", "tears", "lacerates", "gores")
 	attack_verb_simple = list("poke", "jab", "tear", "lacerate", "gore")
 	hitsound = 'sound/weapons/bladeslice.ogg'
@@ -72,7 +72,6 @@
 	to_chat(user, "<span class='userdanger'>Draw.</span>")
 	force*=multiplier
 	damtype = PALE_DAMAGE
-	armortype = damtype
 	user.adjustBruteLoss(user.maxHealth*0.25)
 
 	addtimer(CALLBACK(src, .proc/Return, user), 5 SECONDS)
@@ -84,14 +83,12 @@
 		new /obj/effect/temp_visual/BoD(get_turf(target))
 		force = initial(force)
 	damtype = initial(damtype)
-	armortype = damtype
 
 /obj/item/ego_weapon/city/shi_assassin/proc/Return(mob/living/carbon/human/user)
 	force = initial(force)
 	ready = TRUE
 	to_chat(user, "<span class='notice'>Your blade is ready.</span>")
 	damtype = initial(damtype)
-	armortype = damtype
 
 /obj/effect/temp_visual/BoD
 	icon_state = "BoD"
@@ -130,14 +127,14 @@
 	desc = "A unique specialized assassin blade that is used by Shi Section 2. Created for highly armored targets, this one deals white damage"
 	icon_state = "shi_sakura"
 	damtype = WHITE_DAMAGE
-	armortype = WHITE_DAMAGE
+
 
 /obj/item/ego_weapon/city/shi_assassin/serpent
 	name = "shi association seperant blade"
 	desc = "A unique specialized assassin blade that is used by Shi Section 2. Created for highly armored targets, this one deals black damage"
 	icon_state = "shi_serpent"
 	damtype = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
+
 
 /obj/item/ego_weapon/city/shi_assassin/yokai
 	name = "shi association yokai blade"
@@ -145,5 +142,5 @@
 	force = 20
 	icon_state = "shi_yokai"
 	damtype = PALE_DAMAGE
-	armortype = PALE_DAMAGE
+
 	multiplier = 4

--- a/code/game/objects/items/ego_weapons/non_abnormality/streetlight.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/streetlight.dm
@@ -7,7 +7,7 @@
 	force = 38
 	attack_speed = 2
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	inhand_icon_state = "claymore"
 	lefthand_file = 'icons/mob/inhands/weapons/swords_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
@@ -22,7 +22,7 @@
 	force = 30
 	attack_speed = 1.5
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	attack_verb_continuous = list("bashes", "crushes")
 	attack_verb_simple = list("bash", "crush")
 
@@ -42,7 +42,7 @@
 	inhand_icon_state = "streetlight_founder"
 	force = 32
 	damtype = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
+
 	attack_verb_continuous = list("bashes", "crushes")
 	attack_verb_simple = list("bash", "crush")
 	defense_buff_self = 0.6

--- a/code/game/objects/items/ego_weapons/non_abnormality/sweeper.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/sweeper.dm
@@ -6,7 +6,7 @@
 	icon_state = "sweeper_hook"
 	force = 27
 	damtype = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
+
 	attack_verb_continuous = "stabs"
 	attack_verb_simple = "stab"
 	hitsound = 'sound/effects/ordeals/indigo/stab_1.ogg'

--- a/code/game/objects/items/ego_weapons/non_abnormality/syndicate.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/syndicate.dm
@@ -7,7 +7,7 @@
 	force = 40
 	attack_speed = 1.2
 	damtype = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
+
 	attack_verb_continuous = list("pokes", "jabs", "tears", "lacerates", "gores")
 	attack_verb_simple = list("poke", "jab", "tear", "lacerate", "gore")
 	hitsound = 'sound/weapons/ego/spear1.ogg'
@@ -38,7 +38,7 @@
 	force = 52
 	attack_speed = 1.2
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	attack_verb_continuous = list("pokes", "jabs", "tears", "lacerates", "gores")
 	attack_verb_simple = list("poke", "jab", "tear", "lacerate", "gore")
 	hitsound = 'sound/weapons/bladeslice.ogg'
@@ -84,7 +84,7 @@
 	force = 46
 	attack_speed = 1.2
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	attack_verb_continuous = list("pokes", "jabs", "tears", "lacerates", "gores")
 	attack_verb_simple = list("poke", "jab", "tear", "lacerate", "gore")
 	hitsound = 'sound/weapons/bladeslice.ogg'

--- a/code/game/objects/items/ego_weapons/non_abnormality/thumb.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/thumb.dm
@@ -94,7 +94,7 @@
 	icon_state = "thumb_duster"
 	force = 44
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	attack_verb_continuous = list("beats")
 	attack_verb_simple = list("beat")
 	hitsound = 'sound/weapons/fixer/generic/fist2.ogg'
@@ -105,7 +105,7 @@
 	icon_state = "thumb_cane"
 	force = 65
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	attack_verb_continuous = list("beats")
 	attack_verb_simple = list("beat")
 	hitsound = 'sound/weapons/fixer/generic/club1.ogg'

--- a/code/game/objects/items/ego_weapons/non_abnormality/wcorp.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/wcorp.dm
@@ -6,7 +6,7 @@
 	inhand_icon_state = "wbatong"
 	force = 18
 	damtype = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
+
 	attack_verb_continuous = list("bashes", "crushes")
 	attack_verb_simple = list("bash", "crush")
 	release_message = "You release your charge, damaging your opponent!"

--- a/code/game/objects/items/ego_weapons/non_abnormality/weak_edits/city.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/weak_edits/city.dm
@@ -18,7 +18,7 @@
 	inhand_icon_state = "index"
 	force = 20
 	damtype = PALE_DAMAGE
-	armortype = PALE_DAMAGE
+
 	attack_verb_continuous = list("smacks", "hammers", "beats")
 	attack_verb_simple = list("smack", "hammer", "beat")
 	attribute_requirements = list(

--- a/code/game/objects/items/ego_weapons/non_abnormality/weak_edits/ecorp.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/weak_edits/ecorp.dm
@@ -13,7 +13,7 @@
 //Philip's Sword
 /obj/item/ego_weapon/city/dawn/sword/white
 	damtype = WHITE_DAMAGE
-	armortype = WHITE_DAMAGE
+
 	attribute_requirements = list(
 							FORTITUDE_ATTRIBUTE = 60,
 							PRUDENCE_ATTRIBUTE = 60,
@@ -24,7 +24,7 @@
 //Yuna's Cello Case
 /obj/item/ego_weapon/city/dawn/cello/white
 	damtype = WHITE_DAMAGE
-	armortype = WHITE_DAMAGE
+
 	attribute_requirements = list(
 							FORTITUDE_ATTRIBUTE = 60,
 							PRUDENCE_ATTRIBUTE = 60,
@@ -35,7 +35,7 @@
 //Salvador's Zweihander
 /obj/item/ego_weapon/city/dawn/zwei/white
 	damtype = WHITE_DAMAGE
-	armortype = WHITE_DAMAGE
+
 	attribute_requirements = list(
 							FORTITUDE_ATTRIBUTE = 60,
 							PRUDENCE_ATTRIBUTE = 60,

--- a/code/game/objects/items/ego_weapons/non_abnormality/yun.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/yun.dm
@@ -5,7 +5,7 @@
 	icon_state = "yun_fixer"
 	force = 18
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	attack_verb_continuous = list("slices", "slashes", "stabs")
 	attack_verb_simple = list("slice", "slash", "stab")
 

--- a/code/game/objects/items/ego_weapons/non_abnormality/zwei.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/zwei.dm
@@ -10,7 +10,7 @@
 	force = 55
 	attack_speed = 2
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb_continuous = list("attacks", "slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "cuts")
 	attack_verb_simple = list("attack", "slash", "stab", "slice", "tear", "lacerate", "rip", "dice", "cut")
@@ -115,7 +115,7 @@
 	force = 30
 	attack_speed = 2
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	attack_verb_continuous = list("bashes", "crushes")
 	attack_verb_simple = list("bash", "crush")
 	attribute_requirements = list(

--- a/code/game/objects/items/ego_weapons/special.dm
+++ b/code/game/objects/items/ego_weapons/special.dm
@@ -352,7 +352,6 @@
 	icon_state = "rookie"
 	force = 7
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
 	attack_verb_continuous = list("cuts", "stabs", "slashes")
 	attack_verb_simple = list("cuts", "stabs", "slashes")
 
@@ -360,16 +359,13 @@
 	name = "fledgling dagger"
 	icon_state = "fledgling"
 	damtype = WHITE_DAMAGE
-	armortype = WHITE_DAMAGE
 
 /obj/item/ego_weapon/tutorial/black
 	name = "apprentice dagger"
 	icon_state = "apprentice"
 	damtype = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
 
 /obj/item/ego_weapon/tutorial/pale
 	name = "freshman dagger"
 	icon_state = "freshman"
 	damtype = PALE_DAMAGE
-	armortype = PALE_DAMAGE

--- a/code/game/objects/items/ego_weapons/special.dm
+++ b/code/game/objects/items/ego_weapons/special.dm
@@ -7,7 +7,7 @@
 	icon_state = "eyeball1"
 	force = 20
 	damtype = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
+
 	attack_verb_continuous = list("cuts", "smacks", "bashes")
 	attack_verb_simple = list("cuts", "smacks", "bashes")
 	attribute_requirements = list(
@@ -39,14 +39,14 @@
 				resistance = 100
 		if(resistance >= 100) // If the eyeball wielder is going no-balls and using one fucking weapon, let's throw them a bone.
 			force *= 0.1
-			armortype = MELEE //Armor-piercing
+			damtype = BRUTE //Armor-piercing
 	else
 		icon_state = "eyeball1"				//Cool sprite gone
 	if(ishuman(target))
 		force*=1.3						//I've seen Catt one shot someone, This is also only a detriment lol
 	..()
 	force = initial(force)
-	armortype = initial(armortype)
+	damtype = initial(damtype)
 
 	/*Here's how it works. It scales with Fortitude. This is more balanced than it sounds. Think of it as if Fortitude adjusted base force.
 	Once you get yourself to 80, an additional scaling factor begins to kick in that will let you keep up through the endgame.
@@ -62,7 +62,7 @@
 	force = 12
 	attack_speed = 1.2
 	damtype = WHITE_DAMAGE
-	armortype = WHITE_DAMAGE
+
 	attack_verb_continuous = list("slams", "bashes", "strikes")
 	attack_verb_simple = list("slams", "bashes", "strikes")
 	attribute_requirements = list(TEMPERANCE_ATTRIBUTE = 20) //pesky clerks!
@@ -90,7 +90,7 @@
 	reach = 2		//Has 2 Square Reach.
 	attack_speed = 1.8// really slow
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	attack_verb_continuous = list("bludgeons", "whacks")
 	attack_verb_simple = list("bludgeon", "whack")
 	hitsound = 'sound/weapons/ego/mace1.ogg'
@@ -128,7 +128,7 @@
 	icon_state = "iron_maiden"
 	force = 25 //DPS of 25, 50, 75, 100 at each ramping level
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	attack_verb_continuous = list("clamps")
 	attack_verb_simple = list("clamp")
 	hitsound = 'sound/abnormalities/helper/attack.ogg'
@@ -284,7 +284,7 @@
 	force = 40
 	attack_speed = 1
 	damtype = WHITE_DAMAGE
-	armortype = WHITE_DAMAGE
+
 	attack_verb_continuous = list("stabs", "attacks", "slashes")
 	attack_verb_simple = list("stab", "attack", "slash")
 	hitsound = 'sound/weapons/ego/rapier1.ogg'

--- a/code/game/objects/items/ego_weapons/teth.dm
+++ b/code/game/objects/items/ego_weapons/teth.dm
@@ -4,7 +4,6 @@
 	icon_state = "training"
 	force = 22
 	damtype = WHITE_DAMAGE
-	armortype = WHITE_DAMAGE
 	attack_verb_continuous = list("smacks", "hammers", "beats")
 	attack_verb_simple = list("smack", "hammer", "beat")
 
@@ -17,7 +16,6 @@
 	reach = 2		//Has 2 Square Reach.
 	attack_speed = 1.2
 	damtype = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
 	attack_verb_continuous = list("pokes", "jabs", "tears", "lacerates", "gores")
 	attack_verb_simple = list("poke", "jab", "tear", "lacerate", "gore")
 	hitsound = 'sound/weapons/ego/spear1.ogg'
@@ -31,7 +29,6 @@
 	throw_speed = 5
 	throw_range = 7
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
 	attack_verb_continuous = list("pokes", "jabs", "tears", "lacerates", "gores")
 	attack_verb_simple = list("poke", "jab", "tear", "lacerate", "gore")
 	hitsound = 'sound/weapons/ego/spear1.ogg'
@@ -43,7 +40,6 @@
 	force = 22
 	attack_speed = 1
 	damtype = WHITE_DAMAGE
-	armortype = WHITE_DAMAGE
 	attack_verb_continuous = list("pokes", "jabs", "tears", "lacerates", "gores")
 	attack_verb_simple = list("poke", "jab", "tear", "lacerate", "gore")
 	hitsound = 'sound/weapons/ego/spear1.ogg'
@@ -67,7 +63,6 @@
 	force = 35					//Still less DPS, replaces baseball bat
 	attack_speed = 1.6
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
 	attack_verb_continuous = list("beats", "smacks")
 	attack_verb_simple = list("beat", "smack")
 	hitsound = 'sound/weapons/fixer/generic/gen1.ogg'
@@ -89,7 +84,6 @@
 	force = 7
 	attack_speed = 0.3
 	damtype = WHITE_DAMAGE
-	armortype = WHITE_DAMAGE
 	hitsound = 'sound/weapons/fixer/generic/knife2.ogg'
 	var/dodgelanding
 
@@ -111,7 +105,6 @@
 	icon_state = "regret"
 	force = 38				//Lots of damage, way less DPS
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
 	attack_speed = 2 // Really Slow. This is the slowest teth we have, +0.4 to Eyes 1.6
 	attack_verb_continuous = list("smashes", "bludgeons", "crushes")
 	attack_verb_simple = list("smash", "bludgeon", "crush")
@@ -127,7 +120,6 @@
 	throw_speed = 1
 	throw_range = 7
 	damtype = WHITE_DAMAGE
-	armortype = WHITE_DAMAGE
 	hitsound = 'sound/weapons/bladeslice.ogg'
 
 /obj/item/ego_weapon/mini/blossom/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
@@ -147,7 +139,6 @@
 	force = 13
 	attack_speed = 0.5
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
 	hitsound = 'sound/weapons/slashmiss.ogg'
 
 /obj/item/ego_weapon/mini/trick
@@ -159,7 +150,6 @@
 	throw_speed = 5
 	throw_range = 7
 	damtype = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
 	attack_verb_continuous = list("jabs")
 	attack_verb_simple = list("jabs")
 	hitsound = 'sound/weapons/slashmiss.ogg'
@@ -172,7 +162,6 @@
 	force = 32					//Bad DPS, can teleport
 	attack_speed = 1.5
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
 	attack_verb_continuous = list("cleaves", "cuts")
 	attack_verb_simple = list("cleave", "cut")
 	hitsound = 'sound/weapons/fixer/generic/blade4.ogg'
@@ -199,7 +188,6 @@
 	icon_state = "sorority"
 	force = 17					//Also a support weapon
 	damtype = WHITE_DAMAGE
-	armortype = WHITE_DAMAGE
 	attack_verb_continuous = list("zaps", "prods")
 	attack_verb_simple = list("zap", "prod")
 	hitsound = 'sound/weapons/fixer/generic/baton4.ogg'
@@ -218,7 +206,6 @@
 	icon_state = "bean"
 	force = 20
 	damtype = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
 	attack_verb_continuous = list("slices", "slashes", "stabs")
 	attack_verb_simple = list("slice", "slash", "stab")
 	hitsound = 'sound/weapons/fixer/generic/knife3.ogg'
@@ -237,7 +224,6 @@
 	force = 18
 	attack_speed = 1.2
 	damtype = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
 	attack_verb_continuous = list("swipes", "slashes")
 	attack_verb_simple = list("swipe", "slash")
 	hitsound = 'sound/weapons/fixer/generic/sword3.ogg'
@@ -297,7 +283,6 @@
 	icon_state = "lantern"
 	force = 8 //less than the baton, don't hit things with it
 	damtype = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
 	hitsound = 'sound/weapons/fixer/generic/gen1.ogg'
 
 	var/mode = LANTERN_MODE_REMOTE

--- a/code/game/objects/items/ego_weapons/teth.dm
+++ b/code/game/objects/items/ego_weapons/teth.dm
@@ -373,7 +373,7 @@
 	force = 38
 	attack_speed = 2
 	damtype = WHITE_DAMAGE
-	armortype = WHITE_DAMAGE
+
 	hitsound = 'sound/abnormalities/fairygentleman/ego_sloshing.ogg'
 	attack_verb_continuous = list("smacks", "strikes", "beats")
 	attack_verb_simple = list("smack", "strike", "beat")
@@ -385,7 +385,7 @@
 	icon_state = "red_sheet"
 	force = 22
 	damtype = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
+
 	hitsound = 'sound/abnormalities/nocry/ego_redsheet.ogg'
 	var/hit_count = 0
 
@@ -413,7 +413,7 @@
 	force = 22
 	attack_speed = 1
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	attack_verb_continuous = list("pokes", "jabs", "tears", "lacerates", "gores")
 	attack_verb_simple = list("poke", "jab", "tear", "lacerate", "gore")
 	hitsound = 'sound/weapons/ego/spear1.ogg'
@@ -433,7 +433,7 @@
 	force = 12
 	attack_speed = 0.5
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	attack_verb_continuous = list("slices", "slashes", "stabs")
 	attack_verb_simple = list("slice", "slash", "stab")
 	hitsound = 'sound/weapons/fixer/generic/knife2.ogg'
@@ -465,7 +465,7 @@
 	icon_state = "zauberhorn"
 	force = 10
 	damtype = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
+
 	attack_speed = 0.5
 	attack_verb_continuous = list("cuts", "slices")
 	attack_verb_simple = list("cuts", "slices")
@@ -504,7 +504,7 @@
 	hitsound = 'sound/weapons/fixer/generic/club3.ogg'
 	damage = 20
 	damage_type = BLACK_DAMAGE
-	flag = BLACK_DAMAGE
+
 
 
 /obj/item/ego_weapon/sanitizer
@@ -515,7 +515,7 @@
 	force = 35					//Still less DPS, replaces baseball bat
 	attack_speed = 1.6
 	damtype = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
+
 	attack_verb_continuous = list("beats", "smacks")
 	attack_verb_simple = list("beat", "smack")
 	hitsound = 'sound/weapons/fixer/generic/gen1.ogg'
@@ -541,7 +541,7 @@
 	reach = 2		//Has 2 Square Reach.
 	attack_speed = 1.8// really slow
 	damtype = WHITE_DAMAGE
-	armortype = WHITE_DAMAGE
+
 	attack_verb_continuous = list("bludgeons", "whacks")
 	attack_verb_simple = list("bludgeon", "whack")
 	hitsound = 'sound/weapons/fixer/generic/spear2.ogg'

--- a/code/game/objects/items/ego_weapons/teth.dm
+++ b/code/game/objects/items/ego_weapons/teth.dm
@@ -284,7 +284,6 @@
 	force = 8 //less than the baton, don't hit things with it
 	damtype = BLACK_DAMAGE
 	hitsound = 'sound/weapons/fixer/generic/gen1.ogg'
-
 	var/mode = LANTERN_MODE_REMOTE
 	var/traplimit = 6
 	var/list/traps = list()
@@ -373,7 +372,6 @@
 	force = 38
 	attack_speed = 2
 	damtype = WHITE_DAMAGE
-
 	hitsound = 'sound/abnormalities/fairygentleman/ego_sloshing.ogg'
 	attack_verb_continuous = list("smacks", "strikes", "beats")
 	attack_verb_simple = list("smack", "strike", "beat")
@@ -385,7 +383,6 @@
 	icon_state = "red_sheet"
 	force = 22
 	damtype = BLACK_DAMAGE
-
 	hitsound = 'sound/abnormalities/nocry/ego_redsheet.ogg'
 	var/hit_count = 0
 
@@ -413,7 +410,6 @@
 	force = 22
 	attack_speed = 1
 	damtype = RED_DAMAGE
-
 	attack_verb_continuous = list("pokes", "jabs", "tears", "lacerates", "gores")
 	attack_verb_simple = list("poke", "jab", "tear", "lacerate", "gore")
 	hitsound = 'sound/weapons/ego/spear1.ogg'
@@ -433,7 +429,6 @@
 	force = 12
 	attack_speed = 0.5
 	damtype = RED_DAMAGE
-
 	attack_verb_continuous = list("slices", "slashes", "stabs")
 	attack_verb_simple = list("slice", "slash", "stab")
 	hitsound = 'sound/weapons/fixer/generic/knife2.ogg'
@@ -465,7 +460,6 @@
 	icon_state = "zauberhorn"
 	force = 10
 	damtype = BLACK_DAMAGE
-
 	attack_speed = 0.5
 	attack_verb_continuous = list("cuts", "slices")
 	attack_verb_simple = list("cuts", "slices")
@@ -515,7 +509,6 @@
 	force = 35					//Still less DPS, replaces baseball bat
 	attack_speed = 1.6
 	damtype = BLACK_DAMAGE
-
 	attack_verb_continuous = list("beats", "smacks")
 	attack_verb_simple = list("beat", "smack")
 	hitsound = 'sound/weapons/fixer/generic/gen1.ogg'
@@ -541,7 +534,6 @@
 	reach = 2		//Has 2 Square Reach.
 	attack_speed = 1.8// really slow
 	damtype = WHITE_DAMAGE
-
 	attack_verb_continuous = list("bludgeons", "whacks")
 	attack_verb_simple = list("bludgeon", "whack")
 	hitsound = 'sound/weapons/fixer/generic/spear2.ogg'

--- a/code/game/objects/items/ego_weapons/waw.dm
+++ b/code/game/objects/items/ego_weapons/waw.dm
@@ -8,7 +8,6 @@
 	force = 25
 	attack_speed = 1.3
 	damtype = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
 	attack_verb_continuous = list("slams", "attacks")
 	attack_verb_simple = list("slam", "attack")
 	hitsound = 'sound/weapons/ego/hammer.ogg'
@@ -41,7 +40,6 @@
 	icon_state = "despair"
 	force = 20
 	damtype = WHITE_DAMAGE
-	armortype = WHITE_DAMAGE
 	attack_verb_continuous = list("stabs", "attacks", "slashes")
 	attack_verb_simple = list("stab", "attack", "slash")
 	hitsound = 'sound/weapons/ego/rapier1.ogg'
@@ -101,7 +99,6 @@
 	force = 80
 	attack_speed = 3
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
 	attack_verb_continuous = list("cleaves", "cuts")
 	attack_verb_simple = list("cleaves", "cuts")
 	hitsound = 'sound/weapons/fixer/generic/finisher1.ogg'
@@ -132,7 +129,6 @@
 	force = 13
 	attack_speed = 0.3
 	damtype = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
 	attack_verb_continuous = list("cleaves", "cuts")
 	attack_verb_simple = list("cleaves", "cuts")
 	hitsound = 'sound/weapons/fixer/generic/blade4.ogg'
@@ -174,7 +170,6 @@
 		The Hammer mode deals bonus damage to all marked."
 	force = 30	//Does more damage later.
 	damtype = WHITE_DAMAGE
-	armortype = WHITE_DAMAGE
 	attack_verb_continuous = list("Smashes", "Pierces", "Cracks")
 	attack_verb_simple = list("Smash", "Pierce", "Crack")
 	hitsound = 'sound/weapons/ego/remorse.ogg'
@@ -225,7 +220,6 @@
 	force = 18
 	attack_speed = 0.5
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
 	hitsound = 'sound/abnormalities/redhood/attack_1.ogg'
 	attribute_requirements = list(
 							FORTITUDE_ATTRIBUTE = 80
@@ -329,7 +323,6 @@
 	icon_state = "thirteen"
 	force = 30
 	damtype = PALE_DAMAGE
-	armortype = PALE_DAMAGE
 	attack_verb_continuous = list("cuts", "attacks", "slashes")
 	attack_verb_simple = list("cut", "attack", "slash")
 	hitsound = 'sound/weapons/rapierhit.ogg'
@@ -367,7 +360,6 @@
 	reach = 2		//Has 2 Square Reach.
 	attack_speed = 1.2
 	damtype = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
 	attack_verb_continuous = list("pokes", "jabs", "tears", "lacerates", "gores")
 	attack_verb_simple = list("poke", "jab", "tear", "lacerate", "gore")
 	hitsound = 'sound/weapons/ego/spear1.ogg'
@@ -422,7 +414,6 @@
 	icon_state = "ebony_stem"
 	force = 35
 	damtype = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
 	attack_verb_continuous = list("admonishes", "rectifies", "conquers")
 	attack_verb_simple = list("admonish", "rectify", "conquer")
 	hitsound = 'sound/weapons/ego/rapier2.ogg'
@@ -469,7 +460,6 @@
 	force = 10
 	attack_speed = 0.6
 	damtype = WHITE_DAMAGE
-	armortype = WHITE_DAMAGE
 	attack_verb_continuous = list("slashes", "claws")
 	attack_verb_simple = list("slashes", "claws")
 	hitsound = 'sound/weapons/fixer/generic/dodge3.ogg'
@@ -642,7 +632,6 @@
 	force = 15
 	attack_speed = 0.5
 	damtype = WHITE_DAMAGE
-	armortype = WHITE_DAMAGE
 	attack_verb_continuous = list("cuts", "attacks", "slashes")
 	attack_verb_simple = list("cut", "attack", "slash")
 	hitsound = 'sound/weapons/ego/sword1.ogg'
@@ -688,10 +677,8 @@
 	if(combo)
 		for(var/damage_type in list(RED_DAMAGE))
 			damtype = damage_type
-			armortype = damage_type
 			M.attacked_by(src, user)
 		damtype = initial(damtype)
-		armortype = initial(armortype)
 
 /obj/item/ego_weapon/mini/mirth/afterattack(atom/A, mob/living/user, proximity_flag, params)
 	if(!CanUseEgo(user))
@@ -721,7 +708,6 @@
 	force = 15
 	attack_speed = 0.5
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
 	attack_verb_continuous = list("cuts", "attacks", "slashes")
 	attack_verb_simple = list("cut", "attack", "slash")
 	hitsound = 'sound/weapons/fixer/generic/knife3.ogg'
@@ -766,10 +752,8 @@
 	if(combo)
 		for(var/damage_type in list(WHITE_DAMAGE))
 			damtype = damage_type
-			armortype = damage_type
 			M.attacked_by(src, user)
 		damtype = initial(damtype)
-		armortype = initial(armortype)
 
 /obj/item/ego_weapon/mini/malice/afterattack(atom/A, mob/living/user, proximity_flag, params)
 	if(!CanUseEgo(user))
@@ -799,7 +783,6 @@
 	force = 17
 	attack_speed = 0.5
 	damtype = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
 	attack_verb_continuous = list("bashs", "whaps", "beats", "prods", "pokes")
 	attack_verb_simple = list("bash", "whap", "beat", "prod", "poke")
 	hitsound = 'sound/weapons/fixer/generic/spear1.ogg'
@@ -886,7 +869,6 @@
 	icon_state = "moonlight"
 	force = 32					//One of the best support weapons. Does HE damage in its stead.
 	damtype = WHITE_DAMAGE
-	armortype = WHITE_DAMAGE
 	attack_verb_continuous = list("beats", "jabs")
 	attack_verb_simple = list("beat", "jab")
 	var/inuse
@@ -923,7 +905,6 @@
 	throw_range = 7
 	attack_speed = 1.2
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
 	attack_verb_continuous = list("pokes", "jabs", "tears", "lacerates", "gores")
 	attack_verb_simple = list("poke", "jab", "tear", "lacerate", "gore")
 	hitsound = 'sound/weapons/fixer/generic/nail1.ogg'
@@ -944,7 +925,6 @@
 	reach = 2		//Has 2 Square Reach.
 	attack_speed = 1.2
 	damtype = WHITE_DAMAGE
-	armortype = WHITE_DAMAGE
 	attack_verb_continuous = list("pokes", "jabs", "tears", "lacerates", "gores")
 	attack_verb_simple = list("poke", "jab", "tear", "lacerate", "gore")
 	hitsound = 'sound/weapons/ego/spear1.ogg'
@@ -970,7 +950,6 @@
 	icon_state = "dipsia"
 	force = 32
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
 	attack_verb_continuous = list("pokes", "jabs", "tears", "lacerates", "gores")
 	attack_verb_simple = list("poke", "jab", "tear", "lacerate", "gore")
 	hitsound = 'sound/weapons/pierce_slow.ogg'
@@ -1000,7 +979,6 @@
 	force = 20
 	attack_speed = 0.5
 	damtype = WHITE_DAMAGE
-	armortype = WHITE_DAMAGE
 	attack_verb_continuous = list("decimates", "bisects")
 	attack_verb_simple = list("decimate", "bisect")
 	hitsound = 'sound/weapons/bladeslice.ogg'
@@ -1033,7 +1011,6 @@
 	attack_speed = 1.2
 	special = "This weapon possesses a devastating Red AND Black damage AoE. Be careful! \nUse in hand to hold back the AoE!"
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
 	attack_verb_continuous = list("smashes", "crushes", "flattens")
 	attack_verb_simple = list("smash", "crush", "flatten")
 	hitsound = 'sound/abnormalities/wrath_servant/big_smash1.ogg'
@@ -1105,7 +1082,6 @@
 	inhand_icon_state = "bloodbath"
 	force = 30
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attribute_requirements = list(FORTITUDE_ATTRIBUTE = 80)
 
@@ -1127,7 +1103,6 @@
 	icon_state = "diffraction"
 	force = 40
 	damtype = WHITE_DAMAGE
-	armortype = WHITE_DAMAGE
 	attack_verb_continuous = list("slices", "cuts")
 	attack_verb_simple = list("slice", "cut")
 	hitsound = 'sound/weapons/blade1.ogg'
@@ -1150,7 +1125,6 @@
 							JUSTICE_ATTRIBUTE = 80
 							)
 	damtype = PALE_DAMAGE
-	armortype = PALE_DAMAGE
 	var/mark_damage
 	var/mark_type = RED_DAMAGE
 
@@ -1216,7 +1190,6 @@
 	throw_range = 7
 	attack_speed = 1.3
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
 	attack_verb_continuous = list("slams", "attacks")
 	attack_verb_simple = list("slam", "attack")
 	hitsound = 'sound/abnormalities/clouded_monk/monk_attack.ogg'
@@ -1282,7 +1255,6 @@
 							FORTITUDE_ATTRIBUTE = 80
 							)
 	damtype = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
 	var/wielded = FALSE
 
 /obj/item/ego_weapon/discord/Initialize()
@@ -1350,7 +1322,6 @@
 	icon_state = "innocence"
 	force = 72
 	damtype = WHITE_DAMAGE
-	armortype = WHITE_DAMAGE
 	attack_verb_continuous = list("shoves", "bashes")
 	attack_verb_simple = list("shove", "bash")
 	hitsound = 'sound/weapons/fixer/generic/gen2.ogg'
@@ -1371,7 +1342,6 @@
 	force = 75
 	attack_speed = 2
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
 	attack_verb_continuous = list("slams", "attacks")
 	attack_verb_simple = list("slam", "attack")
 	hitsound = 'sound/abnormalities/babayaga/attack.ogg'
@@ -1449,7 +1419,6 @@
 	force = 20
 	attack_speed = 1.3
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
 	attack_verb_continuous = list("slices", "saws", "rips")
 	attack_verb_simple = list("slice", "saw", "rip")
 	hitsound = 'sound/abnormalities/helper/attack.ogg'
@@ -1476,7 +1445,6 @@
 	force = 13
 	attack_speed = 0.3
 	damtype = WHITE_DAMAGE
-	armortype = WHITE_DAMAGE
 	hitsound = 'sound/weapons/fixer/generic/knife4.ogg'
 	var/dodgelanding
 
@@ -1500,7 +1468,6 @@
 	force = 16
 	attack_speed = 0.5
 	damtype = PALE_DAMAGE
-	armortype = PALE_DAMAGE
 	attack_verb_continuous = list("cuts", "attacks", "slashes")
 	attack_verb_simple = list("cut", "attack", "slash")
 	hitsound = 'sound/weapons/fixer/generic/knife2.ogg'
@@ -1554,7 +1521,6 @@
 	force = 20
 	attack_speed = 0.5
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
 	attack_verb_continuous = list("claws")
 	attack_verb_simple = list("claw")
 	hitsound = 'sound/abnormalities/big_wolf/Wolf_Hori.ogg'
@@ -1603,7 +1569,6 @@
 	icon_state = "scenario"
 	force = 38
 	damtype = WHITE_DAMAGE
-	armortype = WHITE_DAMAGE
 	attack_verb_continuous = list("disrespects", "sullies")
 	attack_verb_simple = list("disrespect", "sully")
 	hitsound = 'sound/effects/fish_splash.ogg'
@@ -1662,7 +1627,6 @@
 	reach = 2		//Has 2 Square Reach.
 	attack_speed = 1.2 //same speed as Spore
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
 	attack_verb_continuous = list("pierces", "jabs")
 	default_attack_verbs = list("pierce", "jab")
 	hitsound = 'sound/weapons/fixer/generic/spear2.ogg'

--- a/code/game/objects/items/ego_weapons/waw.dm
+++ b/code/game/objects/items/ego_weapons/waw.dm
@@ -858,7 +858,7 @@
 	icon_state = "neurotoxin"
 	damage = 30
 	damage_type = BLACK_DAMAGE
-	flag = BLACK_DAMAGE
+
 	hitsound = 'sound/abnormalities/wrath_servant/small_smash1.ogg'
 	hitsound_wall = 'sound/abnormalities/wrath_servant/small_smash1.ogg'
 

--- a/code/game/objects/items/ego_weapons/zayin.dm
+++ b/code/game/objects/items/ego_weapons/zayin.dm
@@ -57,7 +57,6 @@
 	damtype = WHITE_DAMAGE
 	attack_verb_continuous = list("smacks", "strikes", "beats")
 	attack_verb_simple = list("smack", "strike", "beat")
-
 	matching_armor = /obj/item/clothing/suit/armor/ego_gear/zayin/penitence
 	pulse_enable_toggle = TRUE
 	use_message = "You use penitence to emit sanity healing pulses!"
@@ -82,7 +81,6 @@
 	attack_verb_continuous = list("slices", "slashes", "stabs")
 	attack_verb_simple = list("slices", "slashes", "stabs")
 	hitsound = 'sound/weapons/bladeslice.ogg'
-
 	matching_armor = /obj/item/clothing/suit/armor/ego_gear/zayin/little_alice
 	use_message = "You use little alice to share snacks!"
 	use_sound = "sound/items/eatfood.ogg"
@@ -108,7 +106,6 @@
 	damtype = RED_DAMAGE
 	attack_verb_continuous = list("smacks", "strikes", "beats")
 	attack_verb_simple = list("smack", "strike", "beat")
-
 	matching_armor = /obj/item/clothing/suit/armor/ego_gear/zayin/wingbeat
 	pulse_enable_toggle = TRUE
 	use_message = "You use wingbeat to emit healing pulses!"
@@ -160,7 +157,6 @@
 	attack_verb_continuous = list("slams", "strikes", "smashes")
 	attack_verb_simple = list("slam", "strike", "smash")
 	hitsound = 'sound/abnormalities/happyteddy/teddy_guard.ogg'
-
 	matching_armor = /obj/item/clothing/suit/armor/ego_gear/zayin/doze
 	use_message = "You use the doze to emit healing pulses! It knocks you right out!"
 	use_sound = "sound/abnormalities/happyteddy/teddy_lullaby.ogg"
@@ -191,10 +187,8 @@
 	icon_state = "evening"
 	force = 12
 	damtype = PALE_DAMAGE
-
 	attack_verb_continuous = list("slams", "strikes", "smashes")
 	attack_verb_simple = list("slam", "strike", "smash")
-
 	matching_armor = /obj/item/clothing/suit/armor/ego_gear/zayin/evening
 	use_message = "You use evening to generate pale shields!"
 	use_sound = "sound/abnormalities/lighthammer/chain.ogg"
@@ -237,7 +231,6 @@
 	icon_state = "melty_eyeball"
 	force = 14
 	damtype = BLACK_DAMAGE
-
 	attack_verb_continuous = list("slams", "strikes", "smashes")
 	attack_verb_simple = list("slam", "strike", "smash")
 	hitsound = 'sound/abnormalities/blubbering_toad/attack.ogg'
@@ -267,11 +260,9 @@
 	icon_state = "letteropener"
 	force = 14
 	damtype = RED_DAMAGE
-
 	attack_verb_continuous = list("slices", "slashes", "stabs")
 	attack_verb_simple = list("slices", "slashes", "stabs")
 	hitsound = 'sound/weapons/bladeslice.ogg'
-
 	ability_cooldown_time = 30 SECONDS
 	matching_armor = /obj/item/clothing/suit/armor/ego_gear/zayin/letter_opener
 	use_message = "You use letter opener to send a message!"
@@ -314,7 +305,6 @@
 	icon_state = "eclipse"
 	force = 14
 	damtype = WHITE_DAMAGE
-
 	attack_verb_continuous = list("smacks", "strikes", "beats")
 	attack_verb_simple = list("smack", "strike", "beat")
 

--- a/code/game/objects/items/ego_weapons/zayin.dm
+++ b/code/game/objects/items/ego_weapons/zayin.dm
@@ -55,7 +55,6 @@
 	icon_state = "penitence"
 	force = 14
 	damtype = WHITE_DAMAGE
-	armortype = WHITE_DAMAGE
 	attack_verb_continuous = list("smacks", "strikes", "beats")
 	attack_verb_simple = list("smack", "strike", "beat")
 
@@ -80,7 +79,6 @@
 	icon_state = "little_alice"
 	force = 14
 	damtype = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
 	attack_verb_continuous = list("slices", "slashes", "stabs")
 	attack_verb_simple = list("slices", "slashes", "stabs")
 	hitsound = 'sound/weapons/bladeslice.ogg'
@@ -108,7 +106,6 @@
 	special = "Use this weapon in your hand when wearing matching armor to heal the HP of others nearby."
 	force = 14
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
 	attack_verb_continuous = list("smacks", "strikes", "beats")
 	attack_verb_simple = list("smack", "strike", "beat")
 
@@ -133,7 +130,6 @@
 	icon_state = "change"
 	force = 14
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
 	attack_verb_continuous = list("slams", "strikes", "smashes")
 	attack_verb_simple = list("slam", "strike", "smash")
 
@@ -161,7 +157,6 @@
 	icon_state = "doze"
 	force = 14
 	damtype = WHITE_DAMAGE
-	armortype = WHITE_DAMAGE
 	attack_verb_continuous = list("slams", "strikes", "smashes")
 	attack_verb_simple = list("slam", "strike", "smash")
 	hitsound = 'sound/abnormalities/happyteddy/teddy_guard.ogg'

--- a/code/game/objects/items/ego_weapons/zayin.dm
+++ b/code/game/objects/items/ego_weapons/zayin.dm
@@ -191,7 +191,7 @@
 	icon_state = "evening"
 	force = 12
 	damtype = PALE_DAMAGE
-	armortype = PALE_DAMAGE
+
 	attack_verb_continuous = list("slams", "strikes", "smashes")
 	attack_verb_simple = list("slam", "strike", "smash")
 
@@ -237,7 +237,7 @@
 	icon_state = "melty_eyeball"
 	force = 14
 	damtype = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
+
 	attack_verb_continuous = list("slams", "strikes", "smashes")
 	attack_verb_simple = list("slam", "strike", "smash")
 	hitsound = 'sound/abnormalities/blubbering_toad/attack.ogg'
@@ -267,7 +267,7 @@
 	icon_state = "letteropener"
 	force = 14
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	attack_verb_continuous = list("slices", "slashes", "stabs")
 	attack_verb_simple = list("slices", "slashes", "stabs")
 	hitsound = 'sound/weapons/bladeslice.ogg'
@@ -314,7 +314,7 @@
 	icon_state = "eclipse"
 	force = 14
 	damtype = WHITE_DAMAGE
-	armortype = WHITE_DAMAGE
+
 	attack_verb_continuous = list("smacks", "strikes", "beats")
 	attack_verb_simple = list("smack", "strike", "beat")
 

--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -779,7 +779,6 @@
 	slot_flags = ITEM_SLOT_BELT
 	force = 14
 	damtype = WHITE_DAMAGE
-	armortype = WHITE_DAMAGE
 	w_class = WEIGHT_CLASS_BULKY
 	throwforce = 8
 	block_chance = 10

--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -1,30 +1,30 @@
 
 ///the essential proc to call when an obj must receive damage of any kind.
-/obj/proc/take_damage(damage_amount, damage_type = BRUTE, damage_flag = "", sound_effect = TRUE, attack_dir, armour_penetration = 0)
+/obj/proc/take_damage(damage_amount, damage_type = BRUTE, sound_effect = TRUE, attack_dir, armour_penetration = 0)
 	if(QDELETED(src))
 		stack_trace("[src] taking damage after deletion")
 		return
 	if(sound_effect)
-		play_attack_sound(damage_amount, damage_type, damage_flag)
+		play_attack_sound(damage_amount, damage_type, damage_type)
 	if((resistance_flags & INDESTRUCTIBLE) || obj_integrity <= 0)
 		return
-	damage_amount = run_obj_armor(damage_amount, damage_type, damage_flag, attack_dir, armour_penetration)
+	damage_amount = run_obj_armor(damage_amount, damage_type, attack_dir, armour_penetration)
 	if(damage_amount < DAMAGE_PRECISION)
 		return
-	if(SEND_SIGNAL(src, COMSIG_OBJ_TAKE_DAMAGE, damage_amount, damage_type, damage_flag, sound_effect, attack_dir, armour_penetration) & COMPONENT_NO_TAKE_DAMAGE)
+	if(SEND_SIGNAL(src, COMSIG_OBJ_TAKE_DAMAGE, damage_amount, damage_type, sound_effect, attack_dir, armour_penetration) & COMPONENT_NO_TAKE_DAMAGE)
 		return
 
 	. = damage_amount
 	obj_integrity = max(obj_integrity - damage_amount, 0)
 	//BREAKING FIRST
 	if(integrity_failure && obj_integrity <= integrity_failure * max_integrity)
-		obj_break(damage_flag)
+		obj_break(damage_type)
 	//DESTROYING SECOND
 	if(obj_integrity <= 0)
-		obj_destruction(damage_flag)
+		obj_destruction(damage_type)
 
 ///returns the damage value of the attack after processing the obj's various armor protections
-/obj/proc/run_obj_armor(damage_amount, damage_type, damage_flag = 0, attack_dir, armour_penetration = 0)
+/obj/proc/run_obj_armor(damage_amount, damage_type, attack_dir, armour_penetration = 0)
 	if(damage_amount < damage_deflection)
 		return 0
 	switch(damage_type)
@@ -33,14 +33,14 @@
 		else
 			return 0
 	var/armor_protection = 0
-	if(damage_flag)
-		armor_protection = armor.getRating(damage_flag)
+	if(damage_type)
+		armor_protection = armor.getRating(damage_type)
 	if(armor_protection)		//Only apply weak-against-armor/hollowpoint effects if there actually IS armor.
 		armor_protection = clamp(armor_protection - armour_penetration, min(armor_protection, 0), 100)
 	return round(damage_amount * (100 - armor_protection)*0.01, DAMAGE_PRECISION)
 
 ///the sound played when the obj is damaged.
-/obj/proc/play_attack_sound(damage_amount, damage_type = BRUTE, damage_flag = 0)
+/obj/proc/play_attack_sound(damage_amount, damage_type = BRUTE)
 	switch(damage_type)
 		if(BRUTE, RED_DAMAGE, WHITE_DAMAGE, BLACK_DAMAGE, PALE_DAMAGE) // Guh
 			if(damage_amount)
@@ -102,10 +102,10 @@
 			return
 	take_damage(400, BRUTE, MELEE, 0, get_dir(src, B))
 
-/obj/proc/attack_generic(mob/user, damage_amount = 0, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, armor_penetration = 0) //used by attack_alien, attack_animal, and attack_slime
+/obj/proc/attack_generic(mob/user, damage_amount = 0, damage_type = BRUTE, sound_effect = 1, armor_penetration = 0) //used by attack_alien, attack_animal, and attack_slime
 	user.do_attack_animation(src)
 	user.changeNext_move(CLICK_CD_MELEE)
-	return take_damage(damage_amount, damage_type, damage_flag, sound_effect, get_dir(src, user), armor_penetration)
+	return take_damage(damage_amount, damage_type, sound_effect, get_dir(src, user), armor_penetration)
 
 /obj/attack_alien(mob/living/carbon/alien/humanoid/user)
 	if(attack_generic(user, 60, BRUTE, MELEE, 0))

--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -77,7 +77,7 @@
 	if(P.suppressed != SUPPRESSED_VERY)
 		visible_message("<span class='danger'>[src] is hit by \a [P]!</span>", null, null, COMBAT_MESSAGE_RANGE)
 	if(!QDELETED(src)) //Bullet on_hit effect might have already destroyed this object
-		take_damage(P.damage, P.damage_type, P.flag, 0, turn(P.dir, 180), P.armour_penetration)
+		take_damage(P.damage, P.damage_type, 0, turn(P.dir, 180), P.armour_penetration)
 
 ///Called to get the damage that hulks will deal to the obj.
 /obj/proc/hulk_damage()

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -6,7 +6,6 @@
 	var/set_obj_flags // ONLY FOR MAPPING: Sets flags from a string list, handled in Initialize. Usage: set_obj_flags = "EMAGGED;!CAN_BE_HIT" to set EMAGGED and clear CAN_BE_HIT.
 
 	var/damtype = RED_DAMAGE
-	var/armortype = RED_DAMAGE
 	var/force = 0
 
 	/// How good a given object is at causing wounds on carbons. Higher values equal better shots at creating serious wounds.
@@ -378,7 +377,7 @@
 /obj/handle_ricochet(obj/projectile/P)
 	. = ..()
 	if(. && receive_ricochet_damage_coeff)
-		take_damage(P.damage * receive_ricochet_damage_coeff, P.damage_type, P.flag, 0, turn(P.dir, 180), P.armour_penetration) // pass along receive_ricochet_damage_coeff damage to the structure for the ricochet
+		take_damage(P.damage * receive_ricochet_damage_coeff, P.damage_type, 0, turn(P.dir, 180), P.armour_penetration) // pass along receive_ricochet_damage_coeff damage to the structure for the ricochet
 
 /obj/update_overlays()
 	. = ..()

--- a/code/game/objects/structures/aliens.dm
+++ b/code/game/objects/structures/aliens.dm
@@ -11,16 +11,15 @@
 	icon = 'icons/mob/alien.dmi'
 	max_integrity = 100
 
-/obj/structure/alien/run_obj_armor(damage_amount, damage_type, damage_flag = 0, attack_dir)
-	if(damage_flag == MELEE)
-		switch(damage_type)
-			if(BRUTE)
-				damage_amount *= 0.25
-			if(BURN)
-				damage_amount *= 2
+/obj/structure/alien/run_obj_armor(damage_amount, damage_type, attack_dir)
+	switch(damage_type)
+		if(BRUTE)
+			damage_amount *= 0.25
+		if(BURN)
+			damage_amount *= 2
 	. = ..()
 
-/obj/structure/alien/play_attack_sound(damage_amount, damage_type = BRUTE, damage_flag = 0)
+/obj/structure/alien/play_attack_sound(damage_amount, damage_type = BRUTE)
 	switch(damage_type)
 		if(BRUTE)
 			if(damage_amount)

--- a/code/game/objects/structures/barsigns.dm
+++ b/code/game/objects/structures/barsigns.dm
@@ -51,7 +51,7 @@
 	new /obj/item/stack/cable_coil(drop_location(), 2)
 	qdel(src)
 
-/obj/structure/sign/barsign/play_attack_sound(damage_amount, damage_type = BRUTE, damage_flag = 0)
+/obj/structure/sign/barsign/play_attack_sound(damage_amount, damage_type = BRUTE)
 	switch(damage_type)
 		if(BRUTE)
 			playsound(src.loc, 'sound/effects/glasshit.ogg', 75, TRUE)

--- a/code/game/objects/structures/beds_chairs/alien_nest.dm
+++ b/code/game/objects/structures/beds_chairs/alien_nest.dm
@@ -76,7 +76,7 @@
 	M.layer = initial(M.layer)
 	cut_overlay(nest_overlay)
 
-/obj/structure/bed/nest/play_attack_sound(damage_amount, damage_type = BRUTE, damage_flag = 0)
+/obj/structure/bed/nest/play_attack_sound(damage_amount, damage_type = BRUTE)
 	switch(damage_type)
 		if(BRUTE)
 			playsound(loc, 'sound/effects/attackblob.ogg', 100, TRUE)

--- a/code/game/objects/structures/crates_lockers/crates/secure.dm
+++ b/code/game/objects/structures/crates_lockers/crates/secure.dm
@@ -18,7 +18,7 @@
 	else
 		. += "securecrateg"
 
-/obj/structure/closet/crate/secure/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1)
+/obj/structure/closet/crate/secure/take_damage(damage_amount, damage_type = BRUTE, sound_effect = 1)
 	if(prob(tamperproof) && damage_amount >= DAMAGE_PRECISION)
 		boom()
 	else

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -67,7 +67,7 @@
 	showpiece = null
 	update_icon()
 
-/obj/structure/displaycase/play_attack_sound(damage_amount, damage_type = BRUTE, damage_flag = 0)
+/obj/structure/displaycase/play_attack_sound(damage_amount, damage_type = BRUTE)
 	switch(damage_type)
 		if(BRUTE)
 			playsound(src, 'sound/effects/glasshit.ogg', 75, TRUE)

--- a/code/game/objects/structures/fireaxe.dm
+++ b/code/game/objects/structures/fireaxe.dm
@@ -65,7 +65,7 @@
 	else
 		return ..()
 
-/obj/structure/fireaxecabinet/play_attack_sound(damage_amount, damage_type = BRUTE, damage_flag = 0)
+/obj/structure/fireaxecabinet/play_attack_sound(damage_amount, damage_type = BRUTE)
 	switch(damage_type)
 		if(BRUTE)
 			if(broken)
@@ -75,7 +75,7 @@
 		if(BURN)
 			playsound(src.loc, 'sound/items/welder.ogg', 100, TRUE)
 
-/obj/structure/fireaxecabinet/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = TRUE, attack_dir)
+/obj/structure/fireaxecabinet/take_damage(damage_amount, damage_type = BRUTE, sound_effect = TRUE, attack_dir)
 	if(open)
 		return
 	. = ..()

--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -43,7 +43,7 @@
 	max_integrity = 80
 	var/obj/effect/mob_spawn/human/ash_walker/egg
 
-/obj/structure/ash_walker_eggshell/play_attack_sound(damage_amount, damage_type = BRUTE, damage_flag = 0) //lifted from xeno eggs
+/obj/structure/ash_walker_eggshell/play_attack_sound(damage_amount, damage_type = BRUTE) //lifted from xeno eggs
 	switch(damage_type)
 		if(BRUTE)
 			if(damage_amount)

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -25,7 +25,7 @@
 	update_cable_icons_on_turf(get_turf(src))
 	return ..()
 
-/obj/structure/grille/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir)
+/obj/structure/grille/take_damage(damage_amount, damage_type = BRUTE, sound_effect = 1, attack_dir)
 	. = ..()
 	update_icon()
 
@@ -204,7 +204,7 @@
 	else if(istype(W, /obj/item/shard) || !shock(user, 70))
 		return ..()
 
-/obj/structure/grille/play_attack_sound(damage_amount, damage_type = BRUTE, damage_flag = 0)
+/obj/structure/grille/play_attack_sound(damage_amount, damage_type = BRUTE)
 	switch(damage_type)
 		if(BRUTE, RED_DAMAGE, WHITE_DAMAGE, BLACK_DAMAGE, PALE_DAMAGE)
 			if(damage_amount)

--- a/code/game/objects/structures/holosign.dm
+++ b/code/game/objects/structures/holosign.dm
@@ -31,7 +31,7 @@
 	user.changeNext_move(CLICK_CD_MELEE)
 	take_damage(5 , BRUTE, MELEE, 1)
 
-/obj/structure/holosign/play_attack_sound(damage_amount, damage_type = BRUTE, damage_flag = 0)
+/obj/structure/holosign/play_attack_sound(damage_amount, damage_type = BRUTE)
 	switch(damage_type)
 		if(BRUTE)
 			playsound(loc, 'sound/weapons/egloves.ogg', 80, TRUE)

--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -88,7 +88,7 @@
 
 	return TRUE
 
-/obj/structure/mirror/play_attack_sound(damage_amount, damage_type = BRUTE, damage_flag = 0)
+/obj/structure/mirror/play_attack_sound(damage_amount, damage_type = BRUTE)
 	playsound(src, 'sound/effects/hit_on_shattered_glass.ogg', 70, TRUE)
 
 

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -656,7 +656,7 @@
 	user.visible_message("<span class='danger'>[user] kicks [src].</span>", null, null, COMBAT_MESSAGE_RANGE)
 	take_damage(rand(4,8), BRUTE, MELEE, 1)
 
-/obj/structure/rack/play_attack_sound(damage_amount, damage_type = BRUTE, damage_flag = 0)
+/obj/structure/rack/play_attack_sound(damage_amount, damage_type = BRUTE)
 	switch(damage_type)
 		if(BRUTE, RED_DAMAGE, WHITE_DAMAGE, BLACK_DAMAGE, PALE_DAMAGE)
 			if(damage_amount)

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -692,7 +692,7 @@
 	new /obj/item/stack/rods (loc, 1)
 	qdel(src)
 
-/obj/structure/curtain/play_attack_sound(damage_amount, damage_type = BRUTE, damage_flag = 0)
+/obj/structure/curtain/play_attack_sound(damage_amount, damage_type = BRUTE)
 	switch(damage_type)
 		if(BRUTE)
 			if(damage_amount)

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -158,7 +158,7 @@
 /obj/structure/window/attack_paw(mob/user)
 	return attack_hand(user)
 
-/obj/structure/window/attack_generic(mob/user, damage_amount = 0, damage_type = BRUTE, damage_flag = 0, sound_effect = 1)	//used by attack_alien, attack_animal, and attack_slime
+/obj/structure/window/attack_generic(mob/user, damage_amount = 0, damage_type = BRUTE, sound_effect = 1)	//used by attack_alien, attack_animal, and attack_slime
 	if(!can_be_reached(user))
 		return
 	..()
@@ -232,12 +232,12 @@
 					return FALSE
 	return TRUE
 
-/obj/structure/window/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1)
+/obj/structure/window/take_damage(damage_amount, damage_type = BRUTE, sound_effect = 1)
 	. = ..()
 	if(.) //received damage
 		update_nearby_icons()
 
-/obj/structure/window/play_attack_sound(damage_amount, damage_type = BRUTE, damage_flag = 0)
+/obj/structure/window/play_attack_sound(damage_amount, damage_type = BRUTE)
 	switch(damage_type)
 		if(BRUTE, RED_DAMAGE, WHITE_DAMAGE, BLACK_DAMAGE, PALE_DAMAGE)
 			if(damage_amount)

--- a/code/modules/antagonists/blob/blobstrains/blazing_oil.dm
+++ b/code/modules/antagonists/blob/blobstrains/blazing_oil.dm
@@ -17,13 +17,13 @@
 /datum/blobstrain/reagent/blazing_oil/extinguish_reaction(obj/structure/blob/B)
 	B.take_damage(1.5, BURN, ENERGY)
 
-/datum/blobstrain/reagent/blazing_oil/damage_reaction(obj/structure/blob/B, damage, damage_type, damage_flag)
-	if(damage_type == BURN && damage_flag != ENERGY)
+/datum/blobstrain/reagent/blazing_oil/damage_reaction(obj/structure/blob/B, damage, damage_type)
+	if(damage_type == BURN)
 		for(var/turf/open/T in range(1, B))
 			var/obj/structure/blob/C = locate() in T
 			if(!(C && C.overmind && C.overmind.blobstrain.type == B.overmind.blobstrain.type) && prob(80))
 				new /obj/effect/hotspot(T)
-	if(damage_flag == FIRE)
+	if(damage_type == FIRE)
 		return 0
 	return ..()
 

--- a/code/modules/antagonists/blob/blobstrains/distributed_neurons.dm
+++ b/code/modules/antagonists/blob/blobstrains/distributed_neurons.dm
@@ -12,7 +12,7 @@
 	reagent = /datum/reagent/blob/distributed_neurons
 
 /datum/blobstrain/reagent/distributed_neurons/damage_reaction(obj/structure/blob/B, damage, damage_type, damage_flag)
-	if((damage_flag == MELEE || damage_flag == BULLET || damage_flag == LASER) && damage <= 20 && B.obj_integrity - damage <= 0 && prob(15)) //if the cause isn't fire or a bomb, the damage is less than 21, we're going to die from that damage, 15% chance of a shitty spore.
+	if((damage_type in list(MELEE, BULLET, LASER)) && damage <= 20 && B.obj_integrity - damage <= 0 && prob(15)) //if the cause isn't fire or a bomb, the damage is less than 21, we're going to die from that damage, 15% chance of a shitty spore.
 		B.visible_message("<span class='warning'><b>A spore floats free of the blob!</b></span>")
 		var/mob/living/simple_animal/hostile/blob/blobspore/weak/BS = new/mob/living/simple_animal/hostile/blob/blobspore/weak(B.loc)
 		BS.overmind = B.overmind

--- a/code/modules/antagonists/blob/blobstrains/electromagnetic_web.dm
+++ b/code/modules/antagonists/blob/blobstrains/electromagnetic_web.dm
@@ -9,13 +9,13 @@
 	analyzerdesceffect = "Is fragile to all types of damage, but takes massive damage from brute. In addition, releases a small EMP when killed."
 	reagent = /datum/reagent/blob/electromagnetic_web
 
-/datum/blobstrain/reagent/electromagnetic_web/damage_reaction(obj/structure/blob/B, damage, damage_type, damage_flag)
+/datum/blobstrain/reagent/electromagnetic_web/damage_reaction(obj/structure/blob/B, damage, damage_type)
 	if(damage_type == BRUTE) // take full brute, divide by the multiplier to get full value
 		return damage / B.brute_resist
 	return damage * 1.25 //a laser will do 25 damage, which will kill any normal blob
 
-/datum/blobstrain/reagent/electromagnetic_web/death_reaction(obj/structure/blob/B, damage_flag)
-	if(damage_flag == MELEE || damage_flag == BULLET || damage_flag == LASER)
+/datum/blobstrain/reagent/electromagnetic_web/death_reaction(obj/structure/blob/B, damage_type)
+	if(damage_type in list(MELEE, BULLET, LASER))
 		empulse(B.loc, 1, 3) //less than screen range, so you can stand out of range to avoid it
 
 /datum/reagent/blob/electromagnetic_web

--- a/code/modules/antagonists/blob/blobstrains/energized_jelly.dm
+++ b/code/modules/antagonists/blob/blobstrains/energized_jelly.dm
@@ -10,7 +10,7 @@
 	reagent = /datum/reagent/blob/energized_jelly
 
 /datum/blobstrain/reagent/energized_jelly/damage_reaction(obj/structure/blob/B, damage, damage_type, damage_flag)
-	if((damage_flag == MELEE || damage_flag == BULLET || damage_flag == LASER) && B.obj_integrity - damage <= 0 && prob(10))
+	if((damage_type in list(MELEE, BULLET, LASER)) && B.obj_integrity - damage <= 0 && prob(10))
 		do_sparks(rand(2, 4), FALSE, B)
 	return ..()
 

--- a/code/modules/antagonists/blob/blobstrains/explosive_lattice.dm
+++ b/code/modules/antagonists/blob/blobstrains/explosive_lattice.dm
@@ -11,10 +11,10 @@
 	message = "The blob blasts you"
 	reagent = /datum/reagent/blob/explosive_lattice
 
-/datum/blobstrain/reagent/explosive_lattice/damage_reaction(obj/structure/blob/B, damage, damage_type, damage_flag)
-	if(damage_flag == BOMB)
+/datum/blobstrain/reagent/explosive_lattice/damage_reaction(obj/structure/blob/B, damage, damage_type)
+	if(damage_type == BOMB)
 		return 0
-	else if(damage_flag != MELEE && damage_flag != BULLET && damage_flag != LASER)
+	else if(!(damage_type in list(MELEE, BULLET, LASER)))
 		return damage * 1.5
 	return ..()
 

--- a/code/modules/antagonists/blob/blobstrains/pressurized_slime.dm
+++ b/code/modules/antagonists/blob/blobstrains/pressurized_slime.dm
@@ -12,15 +12,15 @@
 	message_living = ", and you gasp for breath"
 	reagent = /datum/reagent/blob/pressurized_slime
 
-/datum/blobstrain/reagent/pressurized_slime/damage_reaction(obj/structure/blob/B, damage, damage_type, damage_flag)
-	if((damage_flag == MELEE || damage_flag == BULLET || damage_flag == LASER) || damage_type != BURN)
+/datum/blobstrain/reagent/pressurized_slime/damage_reaction(obj/structure/blob/B, damage, damage_type)
+	if((damage_type in list(MELEE, BULLET, LASER)) || damage_type != BURN)
 		extinguisharea(B, damage)
 	if(damage_type == BRUTE)
 		return damage * 0.5
 	return ..()
 
-/datum/blobstrain/reagent/pressurized_slime/death_reaction(obj/structure/blob/B, damage_flag)
-	if(damage_flag == MELEE || damage_flag == BULLET || damage_flag == LASER)
+/datum/blobstrain/reagent/pressurized_slime/death_reaction(obj/structure/blob/B, damage_type)
+	if(damage_type in list(MELEE, BULLET, LASER))
 		B.visible_message("<span class='boldwarning'>The blob ruptures, spraying the area with liquid!</span>")
 		extinguisharea(B, 50)
 

--- a/code/modules/antagonists/blob/blobstrains/reactive_spines.dm
+++ b/code/modules/antagonists/blob/blobstrains/reactive_spines.dm
@@ -11,10 +11,9 @@
 	message = "The blob stabs you"
 	reagent = /datum/reagent/blob/reactive_spines
 
-/datum/blobstrain/reagent/reactive_spines/damage_reaction(obj/structure/blob/B, damage, damage_type, damage_flag)
+/datum/blobstrain/reagent/reactive_spines/damage_reaction(obj/structure/blob/B, damage, damage_type)
 	if(damage && ((damage_type == BRUTE) || (damage_type == BURN)) && B.obj_integrity - damage > 0) //is there any damage, is it burn or brute, and will we be alive
-		if(damage_flag == MELEE)
-			B.visible_message("<span class='boldwarning'>The blob retaliates, lashing out!</span>")
+		B.visible_message("<span class='boldwarning'>The blob retaliates, lashing out!</span>")
 		for(var/atom/A in range(1, B))
 			A.blob_act(B)
 	return ..()

--- a/code/modules/antagonists/blob/blobstrains/shifting_fragments.dm
+++ b/code/modules/antagonists/blob/blobstrains/shifting_fragments.dm
@@ -14,8 +14,8 @@
 		newB.forceMove(get_turf(B))
 		B.forceMove(T)
 
-/datum/blobstrain/reagent/shifting_fragments/damage_reaction(obj/structure/blob/B, damage, damage_type, damage_flag)
-	if((damage_flag == MELEE || damage_flag == BULLET || damage_flag == LASER) && damage > 0 && B.obj_integrity - damage > 0 && prob(60-damage))
+/datum/blobstrain/reagent/shifting_fragments/damage_reaction(obj/structure/blob/B, damage, damage_type)
+	if((damage_type in list(MELEE, BULLET, LASER)) && damage > 0 && B.obj_integrity - damage > 0 && prob(60-damage))
 		var/list/blobstopick = list()
 		for(var/obj/structure/blob/OB in orange(1, B))
 			if((istype(OB, /obj/structure/blob/normal) || (istype(OB, /obj/structure/blob/shield) && prob(25))) && OB.overmind && OB.overmind.blobstrain.type == B.overmind.blobstrain.type)

--- a/code/modules/antagonists/blob/blobstrains/synchronous_mesh.dm
+++ b/code/modules/antagonists/blob/blobstrains/synchronous_mesh.dm
@@ -11,8 +11,8 @@
 	message = "The blobs strike you"
 	reagent = /datum/reagent/blob/synchronous_mesh
 
-/datum/blobstrain/reagent/synchronous_mesh/damage_reaction(obj/structure/blob/B, damage, damage_type, damage_flag)
-	if(damage_flag == MELEE || damage_flag == BULLET || damage_flag == LASER) //the cause isn't fire or bombs, so split the damage
+/datum/blobstrain/reagent/synchronous_mesh/damage_reaction(obj/structure/blob/B, damage, damage_type)
+	if(damage_type in list(MELEE, BULLET, LASER)) //the cause isn't fire or bombs, so split the damage
 		var/damagesplit = 1 //maximum split is 9, reducing the damage each blob takes to 11% but doing that damage to 9 blobs
 		for(var/obj/structure/blob/C in orange(1, B))
 			if(!C.ignore_syncmesh_share && C.overmind && C.overmind.blobstrain.type == B.overmind.blobstrain.type) //if it doesn't have the same chemical or is a core or node, don't split damage to it

--- a/code/modules/antagonists/blob/structures/_blob.dm
+++ b/code/modules/antagonists/blob/structures/_blob.dm
@@ -11,7 +11,7 @@
 	pass_flags_self = PASSBLOB
 	CanAtmosPass = ATMOS_PASS_PROC
 	/// How many points the blob gets back when it removes a blob of that type. If less than 0, blob cannot be removed.
-	var/point_return = 0 
+	var/point_return = 0
 	max_integrity = 30
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 80, ACID = 70)
 	/// how much health this blob regens when pulsed
@@ -22,12 +22,12 @@
 	COOLDOWN_DECLARE(heal_timestamp)
 	/// Multiplies brute damage by this
 	var/brute_resist = BLOB_BRUTE_RESIST
-	/// Multiplies burn damage by this 
-	var/fire_resist = BLOB_FIRE_RESIST 
+	/// Multiplies burn damage by this
+	var/fire_resist = BLOB_FIRE_RESIST
 	/// Only used by the synchronous mesh strain. If set to true, these blobs won't share or receive damage taken with others.
 	var/ignore_syncmesh_share = 0
 	/// If the blob blocks atmos and heat spread
-	var/atmosblock = FALSE 
+	var/atmosblock = FALSE
 	var/mob/camera/blob/overmind
 
 
@@ -231,7 +231,7 @@
 		return
 	..()
 
-/obj/structure/blob/play_attack_sound(damage_amount, damage_type = BRUTE, damage_flag = 0)
+/obj/structure/blob/play_attack_sound(damage_amount, damage_type = BRUTE)
 	switch(damage_type)
 		if(BRUTE)
 			if(damage_amount)
@@ -241,7 +241,7 @@
 		if(BURN)
 			playsound(src.loc, 'sound/items/welder.ogg', 100, TRUE)
 
-/obj/structure/blob/run_obj_armor(damage_amount, damage_type, damage_flag = 0, attack_dir)
+/obj/structure/blob/run_obj_armor(damage_amount, damage_type, attack_dir)
 	switch(damage_type)
 		if(BRUTE)
 			damage_amount *= brute_resist
@@ -251,14 +251,14 @@
 		else
 			return 0
 	var/armor_protection = 0
-	if(damage_flag)
-		armor_protection = armor.getRating(damage_flag)
+	if(damage_type)
+		armor_protection = armor.getRating(damage_type)
 	damage_amount = round(damage_amount * (100 - armor_protection)*0.01, 0.1)
-	if(overmind && damage_flag)
-		damage_amount = overmind.blobstrain.damage_reaction(src, damage_amount, damage_type, damage_flag)
+	if(overmind && damage_type)
+		damage_amount = overmind.blobstrain.damage_reaction(src, damage_amount, damage_type)
 	return damage_amount
 
-/obj/structure/blob/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir)
+/obj/structure/blob/take_damage(damage_amount, damage_type = BRUTE, sound_effect = 1, attack_dir)
 	. = ..()
 	if(. && obj_integrity > 0)
 		update_icon()
@@ -344,14 +344,14 @@
 
 	// Spore production vars: for core, factories, and nodes (with strains)
 	var/mob/living/simple_animal/hostile/blob/blobbernaut/naut = null
-	var/max_spores = 0 
+	var/max_spores = 0
 	var/list/spores	= list()
 	COOLDOWN_DECLARE(spore_delay)
 	var/spore_cooldown = BLOBMOB_SPORE_SPAWN_COOLDOWN
 
 	// Area reinforcement vars: used by cores and nodes, for strains to modify
 	/// Range this blob free upgrades to strong blobs at: for the core, and for strains
-	var/strong_reinforce_range = 0 
+	var/strong_reinforce_range = 0
 	/// Range this blob free upgrades to reflector blobs at: for the core, and for strains
 	var/reflector_reinforce_range = 0
 

--- a/code/modules/antagonists/blob/structures/core.dm
+++ b/code/modules/antagonists/blob/structures/core.dm
@@ -53,7 +53,7 @@
 	var/damage = 50 - 10 * severity //remember, the core takes half brute damage, so this is 20/15/10 damage based on severity
 	take_damage(damage, BRUTE, BOMB, 0)
 
-/obj/structure/blob/special/core/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir, overmind_reagent_trigger = 1)
+/obj/structure/blob/special/core/take_damage(damage_amount, damage_type = BRUTE, sound_effect = 1, attack_dir, overmind_reagent_trigger = 1)
 	. = ..()
 	if(obj_integrity > 0)
 		if(overmind) //we should have an overmind, but...

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -299,7 +299,6 @@
 	pass_flags = PASSTABLE
 	damage = 0
 	damage_type = RED_DAMAGE
-	flag = RED_DAMAGE
 	range = 8
 	hitsound = 'sound/weapons/thudswoosh.ogg'
 	var/chain

--- a/code/modules/events/crystal_event.dm
+++ b/code/modules/events/crystal_event.dm
@@ -792,7 +792,6 @@ This section is for the crystal monsters variations
 	damage = 0
 	damage_type = BURN
 	nodamage = TRUE
-	flag = ENERGY
 	temperature = -75
 
 /mob/living/simple_animal/hostile/crystal_monster/killer/Bump(atom/clong)

--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -388,7 +388,7 @@
 		damage_dealt = SM.on_hit(src, user, I, damage_dealt) //on_hit now takes override damage as arg and returns new value for other mutations to permutate further
 	take_damage(damage_dealt, I.damtype, MELEE, 1)
 
-/obj/structure/spacevine/play_attack_sound(damage_amount, damage_type = BRUTE, damage_flag = 0)
+/obj/structure/spacevine/play_attack_sound(damage_amount, damage_type = BRUTE)
 	switch(damage_type)
 		if(BRUTE)
 			if(damage_amount)

--- a/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher.dm
@@ -172,7 +172,6 @@
 	nodamage = TRUE
 	damage = 0 //We're just here to mark people. This is still a melee weapon.
 	damage_type = BRUTE
-	flag = BOMB
 	range = 6
 	log_override = TRUE
 	var/obj/item/kinetic_crusher/hammer_synced

--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -50,7 +50,7 @@
 	worn_icon_state = "facehugger_dead"
 	stat = DEAD
 
-/obj/item/clothing/mask/facehugger/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir)
+/obj/item/clothing/mask/facehugger/take_damage(damage_amount, damage_type = BRUTE, sound_effect = 1, attack_dir)
 	..()
 	if(obj_integrity < 90)
 		Die()

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -320,7 +320,7 @@
 			target.visible_message("<span class='danger'>[name] shoves [target.name], knocking [target.p_them()] down!</span>",
 							"<span class='userdanger'>You're knocked down from a shove by [name]!</span>", "<span class='hear'>You hear aggressive shuffling followed by a loud thud!</span>", COMBAT_MESSAGE_RANGE, src)
 			to_chat(src, "<span class='danger'>You shove [target.name], knocking [target.p_them()] down!</span>")
-			
+
 		else if(target_table)
 			target.Knockdown(SHOVE_KNOCKDOWN_TABLE)
 			target.visible_message("<span class='danger'>[name] shoves [target.name] onto \the [target_table]!</span>",
@@ -603,7 +603,7 @@
 		return effect_amount //how soundbanged we are
 
 
-/mob/living/carbon/damage_clothes(damage_amount, damage_type = BRUTE, damage_flag = 0, def_zone)
+/mob/living/carbon/damage_clothes(damage_amount, damage_type = BRUTE, def_zone)
 	if(damage_type != BRUTE && damage_type != BURN)
 		return
 	damage_amount *= 0.5 //0.5 multiplier for balance reason, we don't want clothes to be too easily destroyed
@@ -616,7 +616,7 @@
 		if(head)
 			hit_clothes = head
 		if(hit_clothes)
-			hit_clothes.take_damage(damage_amount, damage_type, damage_flag, 0)
+			hit_clothes.take_damage(damage_amount, damage_type, 0)
 
 /mob/living/carbon/can_hear()
 	. = FALSE

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -338,7 +338,7 @@
 	var/obj/item/bodypart/affecting = get_bodypart(ran_zone(dam_zone))
 	if(!affecting)
 		affecting = get_bodypart(BODY_ZONE_CHEST)
-	var/armor = run_armor_check(affecting, M.armortype, armour_penetration = M.armour_penetration)
+	var/armor = run_armor_check(affecting, M.melee_damage_type, armour_penetration = M.armour_penetration)
 	apply_damage(damage, M.melee_damage_type, affecting, armor, wound_bonus = M.wound_bonus, bare_wound_bonus = M.bare_wound_bonus, sharpness = M.sharpness, forced = FALSE)
 
 
@@ -364,7 +364,7 @@
 	var/obj/item/bodypart/affecting = get_bodypart(ran_zone(dam_zone))
 	if(!affecting)
 		affecting = get_bodypart(BODY_ZONE_CHEST)
-	var/armor_block = run_armor_check(affecting, M.armortype)
+	var/armor_block = run_armor_check(affecting, M.melee_damage_type)
 	apply_damage(damage, BRUTE, affecting, armor_block, wound_bonus=wound_mod)
 
 

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -859,7 +859,7 @@
 
 	to_chat(src, combined_msg.Join("\n"))
 
-/mob/living/carbon/human/damage_clothes(damage_amount, damage_type = BRUTE, damage_flag = 0, def_zone)
+/mob/living/carbon/human/damage_clothes(damage_amount, damage_type = BRUTE, def_zone)
 	if(damage_type != BRUTE && damage_type != BURN)
 		return
 	damage_amount *= 0.5 //0.5 multiplier for balance reason, we don't want clothes to be too easily destroyed
@@ -916,4 +916,4 @@
 			torn_items |= leg_clothes
 
 	for(var/obj/item/I in torn_items)
-		I.take_damage(damage_amount, damage_type, damage_flag, 0)
+		I.take_damage(damage_amount, damage_type, 0)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1489,7 +1489,12 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 	hit_area = affecting.name
 	var/def_zone = affecting.body_zone
 
-	var/armor_block = H.run_armor_check(affecting, I.armortype, "<span class='notice'>Your armor has protected your [hit_area]!</span>", "<span class='warning'>Your armor has softened a hit to your [hit_area]!</span>",I.armour_penetration)
+	var/armor_block
+	switch(I.damtype)
+		if(RED_DAMAGE, WHITE_DAMAGE, BLACK_DAMAGE, PALE_DAMAGE, MELEE, BULLET, LASER, ENERGY, BOMB, BIO, RAD, FIRE, ACID)
+			armor_block = H.run_armor_check(affecting, I.damtype, "<span class='notice'>Your armor has protected your [hit_area]!</span>", "<span class='warning'>Your armor has softened a hit to your [hit_area]!</span>",I.armour_penetration)
+		else
+			armor_block = 0
 	var/Iwound_bonus = I.wound_bonus
 
 	// this way, you can't wound with a surgical tool on help intent if they have a surgery active and are lying down, so a misclick with a circular saw on the wrong limb doesn't bleed them dry (they still get hit tho)
@@ -1584,9 +1589,8 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 			BP = H.get_bodypart(check_zone(def_zone))
 			if(!BP)
 				BP = H.bodyparts[1]
-
 	switch(damagetype)
-		if(BRUTE)
+		if(BRUTE, MELEE, BULLET, BOMB, ACID)
 			H.damageoverlaytemp = 20
 			var/damage_amount = forced ? damage : damage * hit_percent * brutemod * H.physiology.brute_mod
 			if(BP)
@@ -1594,7 +1598,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 					H.update_damage_overlays()
 			else//no bodypart, we deal damage with a more general method.
 				H.adjustBruteLoss(damage_amount)
-		if(BURN)
+		if(BURN, FIRE, LASER, ENERGY, RAD)
 			H.damageoverlaytemp = 20
 			var/damage_amount = forced ? damage : damage * hit_percent * burnmod * H.physiology.burn_mod
 			if(BP)
@@ -1602,7 +1606,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 					H.update_damage_overlays()
 			else
 				H.adjustFireLoss(damage_amount)
-		if(TOX)
+		if(TOX, BIO)
 			var/damage_amount = forced ? damage : damage * hit_percent * H.physiology.tox_mod
 			H.adjustToxLoss(damage_amount)
 		if(OXY)

--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -383,7 +383,7 @@
 
 /datum/species/golem/sand/bullet_act(obj/projectile/P, mob/living/carbon/human/H)
 	if(!(P.original == H && P.firer == H))
-		if(P.flag == BULLET || P.flag == BOMB)
+		if(P.damage_type in list(BULLET, BOMB))
 			playsound(H, 'sound/effects/shovel_dig.ogg', 70, TRUE)
 			H.visible_message("<span class='danger'>The [P.name] sinks harmlessly in [H]'s sandy body!</span>", \
 			"<span class='userdanger'>The [P.name] sinks harmlessly in [H]'s sandy body!</span>")
@@ -415,7 +415,7 @@
 
 /datum/species/golem/glass/bullet_act(obj/projectile/P, mob/living/carbon/human/H)
 	if(!(P.original == H && P.firer == H)) //self-shots don't reflect
-		if(P.flag == LASER || P.flag == ENERGY)
+		if(P.damage_type in list(LASER, ENERGY))
 			H.visible_message("<span class='danger'>The [P.name] gets reflected by [H]'s glass skin!</span>", \
 			"<span class='userdanger'>The [P.name] gets reflected by [H]'s glass skin!</span>")
 			if(P.starting)
@@ -823,7 +823,7 @@
 /datum/species/golem/bronze/bullet_act(obj/projectile/P, mob/living/carbon/human/H)
 	if(!(world.time > last_gong_time + gong_cooldown))
 		return ..()
-	if(P.flag == BULLET || P.flag == BOMB)
+	if(P.damage_type in list(BULLET, BOMB))
 		gong(H)
 		return ..()
 

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -48,7 +48,7 @@
 	return BULLET_ACT_HIT
 
 /mob/living/bullet_act(obj/projectile/P, def_zone, piercing_hit = FALSE)
-	var/armor = run_armor_check(def_zone, P.flag, "","",P.armour_penetration)
+	var/armor = run_armor_check(def_zone, P.damage_type, "","",P.armour_penetration)
 	var/on_hit_state = P.on_hit(src, armor, piercing_hit)
 	if(!P.nodamage && on_hit_state != BULLET_ACT_BLOCK)
 		apply_damage(P.damage, P.damage_type, def_zone, armor, wound_bonus=P.wound_bonus, bare_wound_bonus=P.bare_wound_bonus, sharpness = P.sharpness, white_healable = P.white_healing)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -89,7 +89,7 @@
 						"<span class='userdanger'>You're hit by [thrown_item]!</span>")
 		if(!thrown_item.throwforce)
 			return
-		var/armor = run_armor_check(zone, thrown_item.armortype, "Your armor has protected your [parse_zone(zone)].", "Your armor has softened hit to your [parse_zone(zone)].", thrown_item.armour_penetration)
+		var/armor = run_armor_check(zone, thrown_item.damtype, "Your armor has protected your [parse_zone(zone)].", "Your armor has softened hit to your [parse_zone(zone)].", thrown_item.armour_penetration)
 		var/justice_mod = 1
 		if(ishuman(thrown_item.thrownby))
 			var/mob/living/carbon/human/H = thrown_item.thrownby
@@ -416,7 +416,7 @@
 	return FALSE
 
 //to damage the clothes worn by a mob
-/mob/living/proc/damage_clothes(damage_amount, damage_type = BRUTE, damage_flag = 0, def_zone)
+/mob/living/proc/damage_clothes(damage_amount, damage_type = BRUTE, def_zone)
 	return
 
 

--- a/code/modules/mob/living/simple_animal/abnormality/!tutorial/bill.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/!tutorial/bill.dm
@@ -17,7 +17,6 @@
 	melee_damage_lower = 4
 	melee_damage_upper = 6
 	melee_damage_type = RED_DAMAGE
-
 	work_damage_amount = 4
 	work_damage_type = RED_DAMAGE
 	damage_coeff = list(BRUTE = 1, RED_DAMAGE = 0.5, WHITE_DAMAGE = 1.5, BLACK_DAMAGE = 1, PALE_DAMAGE = 1)

--- a/code/modules/mob/living/simple_animal/abnormality/!tutorial/fairies.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/!tutorial/fairies.dm
@@ -19,7 +19,6 @@
 	melee_damage_lower = 3
 	melee_damage_upper = 5
 	melee_damage_type = PALE_DAMAGE
-
 	work_damage_amount = 2
 	work_damage_type = PALE_DAMAGE
 	damage_coeff = list(BRUTE = 1, RED_DAMAGE = 1.5, WHITE_DAMAGE = 1, BLACK_DAMAGE = 1, PALE_DAMAGE = 0.5)

--- a/code/modules/mob/living/simple_animal/abnormality/!tutorial/shadow.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/!tutorial/shadow.dm
@@ -18,7 +18,6 @@
 	melee_damage_lower = 4
 	melee_damage_upper = 6
 	melee_damage_type = BLACK_DAMAGE
-
 	work_damage_amount = 4
 	work_damage_type = BLACK_DAMAGE
 	damage_coeff = list(BRUTE = 1, RED_DAMAGE = 1, WHITE_DAMAGE = 1, BLACK_DAMAGE = 0.5, PALE_DAMAGE = 1.5)

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/censored.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/censored.dm
@@ -17,7 +17,6 @@
 	maxHealth = 4000
 	obj_damage = 600
 	damage_coeff = list(BRUTE = 1, RED_DAMAGE = 0.6, WHITE_DAMAGE = 0.8, BLACK_DAMAGE = 0.4, PALE_DAMAGE = 1)
-	armortype = BLACK_DAMAGE
 	melee_damage_type = BLACK_DAMAGE
 	melee_damage_lower = 75
 	melee_damage_upper = 80

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/crying_children.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/crying_children.dm
@@ -238,7 +238,7 @@
 		base_pixel_y = 0
 		animate(src, alpha = 0, time = 10 SECONDS)
 		charge = 0
-		can_charge = FALSE 
+		can_charge = FALSE
 		QDEL_IN(src, 10 SECONDS)
 		return ..()
 
@@ -267,10 +267,10 @@
 			return Combusting_Courage()
 		if(sorrow_cooldown <= world.time && prob(25))
 			return Wounds_Of_Sorrow(target)
-	
+
 	if(prob(35))
 		return Bygone_Illusion(target)
-	
+
 	// Distorted Illusion
 	can_act = FALSE
 	icon_state = "[icon_phase]_salvador"
@@ -524,7 +524,7 @@
 		H.update_blindness()
 		H.update_sight()
 		blinded += H
-	
+
 /mob/living/simple_animal/hostile/child/unseeing/death(gibbed)
 	for(var/mob/living/carbon/human/H in blinded)
 		REMOVE_TRAIT(H, TRAIT_BLIND, GENETIC_MUTATION)
@@ -584,7 +584,7 @@
 	icon_state = "heavylaser"
 	damage = 100
 	damage_type = RED_DAMAGE
-	flag = RED_DAMAGE
+
 	hitscan = TRUE
 	projectile_piercing = PASSMOB
 	projectile_phasing = (ALL & (~PASSMOB) & (~PASSCLOSEDTURF))

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/last_shot.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/last_shot.dm
@@ -109,7 +109,7 @@ GLOBAL_LIST_EMPTY(meat_list)
 	health = 500
 	maxHealth = 500
 	melee_damage_type = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	damage_coeff = list(RED_DAMAGE = 1, WHITE_DAMAGE = 1, BLACK_DAMAGE = 1.5, PALE_DAMAGE = 2)
 	melee_damage_lower = 15
 	melee_damage_upper = 20

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/last_shot.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/last_shot.dm
@@ -109,7 +109,6 @@ GLOBAL_LIST_EMPTY(meat_list)
 	health = 500
 	maxHealth = 500
 	melee_damage_type = RED_DAMAGE
-
 	damage_coeff = list(RED_DAMAGE = 1, WHITE_DAMAGE = 1, BLACK_DAMAGE = 1.5, PALE_DAMAGE = 2)
 	melee_damage_lower = 15
 	melee_damage_upper = 20

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/mountain.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/mountain.dm
@@ -13,7 +13,6 @@
 	melee_damage_lower = 25
 	melee_damage_upper = 35
 	melee_damage_type = RED_DAMAGE
-	armortype = RED_DAMAGE
 	rapid_melee = 2
 	stat_attack = DEAD
 	ranged = TRUE

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/nihil.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/nihil.dm
@@ -23,7 +23,6 @@
 	melee_damage_lower = 55
 	melee_damage_upper = 65
 	melee_damage_type = RED_DAMAGE
-
 	stat_attack = HARD_CRIT
 	work_damage_amount = 16
 	work_damage_type = RED_DAMAGE

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/nihil.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/nihil.dm
@@ -23,7 +23,7 @@
 	melee_damage_lower = 55
 	melee_damage_upper = 65
 	melee_damage_type = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	stat_attack = HARD_CRIT
 	work_damage_amount = 16
 	work_damage_type = RED_DAMAGE

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/nothing_there.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/nothing_there.dm
@@ -13,7 +13,6 @@
 	icon_living = "nothing"
 	icon_dead = "nothing_dead"
 	melee_damage_type = RED_DAMAGE
-	armortype = RED_DAMAGE
 	damage_coeff = list(BRUTE = 1, RED_DAMAGE = 0.3, WHITE_DAMAGE = 0.8, BLACK_DAMAGE = 0.8, PALE_DAMAGE = 1.2)
 	melee_damage_lower = 55
 	melee_damage_upper = 65

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/seasons.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/seasons.dm
@@ -24,7 +24,7 @@
 	maxHealth = 4000
 	obj_damage = 600
 	damage_coeff = list(BRUTE = 1, RED_DAMAGE = 1.1, WHITE_DAMAGE = -1, BLACK_DAMAGE = 1.1, PALE_DAMAGE = 1.1)
-	armortype = WHITE_DAMAGE
+
 	melee_damage_type = WHITE_DAMAGE
 	melee_damage_lower = 35
 	melee_damage_upper = 45
@@ -209,7 +209,6 @@
 	datum_reference.available_work = work_chances
 	damage_coeff = new_damage_coeff.Copy()
 	work_damage_type = season_stats[current_season][2]
-	armortype = season_stats[current_season][2]
 	melee_damage_type = season_stats[current_season][2]
 	icon_state = current_season
 	name = season_stats[current_season][4]

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/seasons.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/seasons.dm
@@ -24,7 +24,6 @@
 	maxHealth = 4000
 	obj_damage = 600
 	damage_coeff = list(BRUTE = 1, RED_DAMAGE = 1.1, WHITE_DAMAGE = -1, BLACK_DAMAGE = 1.1, PALE_DAMAGE = 1.1)
-
 	melee_damage_type = WHITE_DAMAGE
 	melee_damage_lower = 35
 	melee_damage_upper = 45

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/titania.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/titania.dm
@@ -24,7 +24,6 @@
 
 	melee_damage_lower = 92
 	melee_damage_upper = 99		//Will never one shot you.
-	armortype = RED_DAMAGE
 	melee_damage_type = RED_DAMAGE
 	damage_coeff = list(BRUTE = 1, RED_DAMAGE = 1.2, WHITE_DAMAGE = 0.3, BLACK_DAMAGE = 0.5, PALE_DAMAGE = 1)
 	stat_attack = HARD_CRIT
@@ -67,16 +66,13 @@
 		return
 
 	if(target == nemesis)	//Deals pale damage to Oberon, fuck you.
-		armortype = PALE_DAMAGE
 		melee_damage_type = PALE_DAMAGE
 		melee_damage_lower = 61
 		melee_damage_upper = 72
 	else if(nemesis)		//If there's still a nemesis, you need to reset the damage
-		armortype = initial(armortype)
 		melee_damage_type = initial(melee_damage_type)
 		melee_damage_lower = initial(melee_damage_lower)
 		melee_damage_upper = initial(melee_damage_upper)
-
 	. = ..()
 
 	if(H.stat == DEAD && target == nemesis)		//Does she slay Oberon personally? If so, get buffed.
@@ -262,7 +258,6 @@
 	maxHealth = 80
 	melee_damage_lower = 12
 	melee_damage_upper = 15
-	armortype = RED_DAMAGE
 	melee_damage_type = RED_DAMAGE
 	obj_damage = 0
 	environment_smash = ENVIRONMENT_SMASH_NONE

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/white_night.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/white_night.dm
@@ -233,7 +233,6 @@ GLOBAL_LIST_EMPTY(apostles)
 	friendly_verb_simple = "stare down"
 	speak_emote = list("says")
 	melee_damage_type = RED_DAMAGE
-	armortype = RED_DAMAGE
 	melee_damage_lower = 35
 	melee_damage_upper = 45
 	obj_damage = 400
@@ -333,7 +332,6 @@ GLOBAL_LIST_EMPTY(apostles)
 	maxHealth = 3000
 	move_to_delay = 7
 	melee_damage_type = PALE_DAMAGE
-	armortype = PALE_DAMAGE
 	damage_coeff = list(BRUTE = 1, RED_DAMAGE = 0.5, WHITE_DAMAGE = 0.5, BLACK_DAMAGE = 0.5, PALE_DAMAGE = 1.5)
 	vision_range = 12
 	aggro_vision_range = 12
@@ -392,7 +390,6 @@ GLOBAL_LIST_EMPTY(apostles)
 	icon_state = "apostle_spear"
 	icon_living = "apostle_spear"
 	melee_damage_type = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
 	damage_coeff = list(BRUTE = 1, RED_DAMAGE = 0.5, WHITE_DAMAGE = 0.5, BLACK_DAMAGE = 1.5, PALE_DAMAGE = 0.5)
 	var/spear_cooldown
 	var/spear_cooldown_time = 10 SECONDS
@@ -474,7 +471,6 @@ GLOBAL_LIST_EMPTY(apostles)
 	melee_damage_lower = 25
 	melee_damage_upper = 35
 	melee_damage_type = BLACK_DAMAGE // Okay, look, they aren't really meant to melee anyway
-	armortype = BLACK_DAMAGE
 	damage_coeff = list(BRUTE = 1, RED_DAMAGE = 0.5, WHITE_DAMAGE = 1.5, BLACK_DAMAGE = 0.5, PALE_DAMAGE = 0.5)
 	var/staff_cooldown
 	var/staff_cooldown_time = 20 SECONDS

--- a/code/modules/mob/living/simple_animal/abnormality/he/KQE.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/KQE.dm
@@ -12,7 +12,6 @@
 	icon_dead = "kqe_egg"
 	del_on_death = FALSE
 	melee_damage_type = BLACK_DAMAGE
-
 	damage_coeff = list(BRUTE = 1, RED_DAMAGE = 1.5, WHITE_DAMAGE = 0.8, BLACK_DAMAGE = 1, PALE_DAMAGE = 1.2)
 	melee_damage_lower = 20
 	melee_damage_upper = 25

--- a/code/modules/mob/living/simple_animal/abnormality/he/KQE.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/KQE.dm
@@ -12,7 +12,7 @@
 	icon_dead = "kqe_egg"
 	del_on_death = FALSE
 	melee_damage_type = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
+
 	damage_coeff = list(BRUTE = 1, RED_DAMAGE = 1.5, WHITE_DAMAGE = 0.8, BLACK_DAMAGE = 1, PALE_DAMAGE = 1.2)
 	melee_damage_lower = 20
 	melee_damage_upper = 25

--- a/code/modules/mob/living/simple_animal/abnormality/he/blue_shepherd.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/blue_shepherd.dm
@@ -30,7 +30,6 @@
 	melee_damage_lower = 22
 	melee_damage_upper = 30
 	melee_damage_type = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
 	stat_attack = HARD_CRIT
 	work_damage_amount = 10
 	work_damage_type = BLACK_DAMAGE

--- a/code/modules/mob/living/simple_animal/abnormality/he/headless_ichthys.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/headless_ichthys.dm
@@ -19,7 +19,7 @@
 	rapid_melee = 1
 	melee_queue_distance = 2
 	melee_damage_type = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
+
 	damage_coeff = list(BRUTE = 1, RED_DAMAGE = 1.2, WHITE_DAMAGE = 1.5, BLACK_DAMAGE = 0.5, PALE_DAMAGE = 2)
 	speak_emote = list("rasps", "growls", "gurgles")
 	can_breach = TRUE

--- a/code/modules/mob/living/simple_animal/abnormality/he/headless_ichthys.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/headless_ichthys.dm
@@ -19,7 +19,6 @@
 	rapid_melee = 1
 	melee_queue_distance = 2
 	melee_damage_type = BLACK_DAMAGE
-
 	damage_coeff = list(BRUTE = 1, RED_DAMAGE = 1.2, WHITE_DAMAGE = 1.5, BLACK_DAMAGE = 0.5, PALE_DAMAGE = 2)
 	speak_emote = list("rasps", "growls", "gurgles")
 	can_breach = TRUE

--- a/code/modules/mob/living/simple_animal/abnormality/he/helper.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/helper.dm
@@ -158,7 +158,7 @@
 				var/mob/living/carbon/human/H = L
 				// Ugly code
 				var/affecting = get_bodypart(ran_zone(pick(BODY_ZONE_CHEST, BODY_ZONE_PRECISE_L_HAND, BODY_ZONE_PRECISE_R_HAND, BODY_ZONE_L_LEG, BODY_ZONE_R_LEG)))
-				var/armor = H.run_armor_check(affecting, armortype, armour_penetration = src.armour_penetration)
+				var/armor = H.run_armor_check(affecting, melee_damage_type, armour_penetration = src.armour_penetration)
 				H.apply_damage(60, src.melee_damage_type, affecting, armor, wound_bonus = src.wound_bonus, bare_wound_bonus = src.bare_wound_bonus, sharpness = src.sharpness)
 			else
 				L.adjustRedLoss(120)

--- a/code/modules/mob/living/simple_animal/abnormality/he/jangsan.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/jangsan.dm
@@ -31,7 +31,6 @@
 //Only done to non-humans, objects, and strong(er) agents
 	attack_sound = 'sound/abnormalities/jangsan/tigerbite.ogg'
 	melee_damage_type = RED_DAMAGE
-	armortype = RED_DAMAGE
 	melee_damage_lower = 40
 	melee_damage_upper = 60
 

--- a/code/modules/mob/living/simple_animal/abnormality/he/laetitia.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/laetitia.dm
@@ -63,7 +63,6 @@
 	pixel_x = -16
 	damage_coeff = list(BRUTE = 1, RED_DAMAGE = 0.8, WHITE_DAMAGE = 0.8, BLACK_DAMAGE = 1.2, PALE_DAMAGE = 1)
 	melee_damage_type = RED_DAMAGE
-	armortype = RED_DAMAGE
 	stat_attack = HARD_CRIT
 	melee_damage_lower = 20
 	melee_damage_upper = 30

--- a/code/modules/mob/living/simple_animal/abnormality/he/missed_reaper.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/missed_reaper.dm
@@ -9,7 +9,7 @@
 	melee_damage_lower = 35
 	melee_damage_upper = 45
 	melee_damage_type = PALE_DAMAGE
-	armortype = PALE_DAMAGE
+
 	attack_verb_continuous = "pierces"
 	attack_verb_simple = "pierce"
 	faction = list("hostile")

--- a/code/modules/mob/living/simple_animal/abnormality/he/missed_reaper.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/missed_reaper.dm
@@ -9,7 +9,6 @@
 	melee_damage_lower = 35
 	melee_damage_upper = 45
 	melee_damage_type = PALE_DAMAGE
-
 	attack_verb_continuous = "pierces"
 	attack_verb_simple = "pierce"
 	faction = list("hostile")

--- a/code/modules/mob/living/simple_animal/abnormality/he/norinori.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/norinori.dm
@@ -12,7 +12,6 @@
 	health = 1200
 	attack_sound = 'sound/weapons/slashmiss.ogg'
 	melee_damage_type = RED_DAMAGE
-
 	melee_damage_lower = 20
 	melee_damage_upper = 25
 	rapid_melee = 1 //we change this later

--- a/code/modules/mob/living/simple_animal/abnormality/he/norinori.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/norinori.dm
@@ -12,7 +12,7 @@
 	health = 1200
 	attack_sound = 'sound/weapons/slashmiss.ogg'
 	melee_damage_type = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	melee_damage_lower = 20
 	melee_damage_upper = 25
 	rapid_melee = 1 //we change this later

--- a/code/modules/mob/living/simple_animal/abnormality/he/pinocchio.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/pinocchio.dm
@@ -161,7 +161,7 @@
 	name = "liar's lyre"
 	desc = "A wooden axe, somehow wickedly sharp. Looks fragile."
 	damtype = WHITE_DAMAGE
-	armortype = WHITE_DAMAGE
+
 	item_flags = ABSTRACT
 	var/delete_timer
 

--- a/code/modules/mob/living/simple_animal/abnormality/he/pisc_mermaid.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/pisc_mermaid.dm
@@ -34,7 +34,6 @@
 	work_damage_amount = 10
 	work_damage_type = WHITE_DAMAGE
 	melee_damage_type = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
 
 	ego_list = list(
 		/datum/ego_datum/weapon/unrequited,

--- a/code/modules/mob/living/simple_animal/abnormality/he/porccubus.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/porccubus.dm
@@ -28,7 +28,6 @@
 	stat_attack = HARD_CRIT
 	work_damage_type = BLACK_DAMAGE
 	melee_damage_type = WHITE_DAMAGE
-	armortype = WHITE_DAMAGE
 	start_qliphoth = 2
 	can_breach = TRUE
 	deathsound = 'sound/abnormalities/porccubus/porccu_death.ogg'

--- a/code/modules/mob/living/simple_animal/abnormality/he/puss_in_boots.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/puss_in_boots.dm
@@ -15,7 +15,7 @@
 	del_on_death = FALSE
 	attack_sound = 'sound/weapons/ego/rapier1.ogg'
 	melee_damage_type = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	melee_damage_lower = 5
 	melee_damage_upper = 15
 	attack_verb_continuous = "slashes"

--- a/code/modules/mob/living/simple_animal/abnormality/he/puss_in_boots.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/puss_in_boots.dm
@@ -15,7 +15,6 @@
 	del_on_death = FALSE
 	attack_sound = 'sound/weapons/ego/rapier1.ogg'
 	melee_damage_type = RED_DAMAGE
-
 	melee_damage_lower = 5
 	melee_damage_upper = 15
 	attack_verb_continuous = "slashes"

--- a/code/modules/mob/living/simple_animal/abnormality/he/red_buddy.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/red_buddy.dm
@@ -26,7 +26,6 @@
 	melee_damage_lower = 35
 	melee_damage_upper = 70 //has a wide range, he can critically hit you
 	melee_damage_type = RED_DAMAGE
-	armortype = RED_DAMAGE
 	stat_attack = HARD_CRIT
 	work_damage_amount = 0 //his work damage now is entirely related to suffering
 	work_damage_type = RED_DAMAGE

--- a/code/modules/mob/living/simple_animal/abnormality/he/road_home.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/road_home.dm
@@ -13,7 +13,6 @@
 	melee_damage_upper = 1 //Irrelevant, she does not attack of her own volition
 	generic_canpass = FALSE
 	melee_damage_type = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
 	can_breach = TRUE
 	threat_level = HE_LEVEL
 	start_qliphoth = 2

--- a/code/modules/mob/living/simple_animal/abnormality/he/scarecrow.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/scarecrow.dm
@@ -14,7 +14,6 @@
 	melee_damage_lower = 20
 	melee_damage_upper = 24
 	melee_damage_type = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
 	stat_attack = HARD_CRIT
 	attack_sound = 'sound/abnormalities/scarecrow/attack.ogg'
 	attack_verb_continuous = "stabs"

--- a/code/modules/mob/living/simple_animal/abnormality/he/scaredy_cat.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/scaredy_cat.dm
@@ -14,7 +14,6 @@
 	melee_damage_lower = 1
 	melee_damage_upper = 1
 	melee_damage_type = RED_DAMAGE
-	armortype = RED_DAMAGE
 	vision_range = 7 //nerfed vision range so he doesn't go 2 continents away from his friend
 	stat_attack = CONSCIOUS
 	attack_sound = 'sound/abnormalities/scaredycat/catattack.ogg'

--- a/code/modules/mob/living/simple_animal/abnormality/he/schadenfreude.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/schadenfreude.dm
@@ -14,7 +14,6 @@
 	melee_damage_lower = 40		//Yeah it's super slow, and you're not gonna get hit by it too often
 	melee_damage_upper = 48
 	melee_damage_type = RED_DAMAGE
-	armortype = RED_DAMAGE
 	stat_attack = HARD_CRIT
 	attack_sound = 'sound/abnormalities/scarecrow/attack.ogg'
 	attack_verb_continuous = "bashes"

--- a/code/modules/mob/living/simple_animal/abnormality/he/watchman.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/watchman.dm
@@ -13,7 +13,6 @@
 	melee_damage_lower = 16
 	melee_damage_upper = 20			//He doesn't really attack but I guess if he does he would deal this kind of damage
 	melee_damage_type = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
 	stat_attack = HARD_CRIT
 	attack_sound = "swing_hit"
 	attack_verb_continuous = "bashes"

--- a/code/modules/mob/living/simple_animal/abnormality/he/wayward_passenger.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/wayward_passenger.dm
@@ -17,7 +17,6 @@
 	melee_damage_lower = 20
 	melee_damage_upper = 24
 	melee_damage_type = RED_DAMAGE
-
 	attack_sound = 'sound/abnormalities/wayward_passenger/attack2.ogg'
 	can_breach = TRUE
 	can_buckle = FALSE

--- a/code/modules/mob/living/simple_animal/abnormality/he/wayward_passenger.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/wayward_passenger.dm
@@ -17,7 +17,7 @@
 	melee_damage_lower = 20
 	melee_damage_upper = 24
 	melee_damage_type = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	attack_sound = 'sound/abnormalities/wayward_passenger/attack2.ogg'
 	can_breach = TRUE
 	can_buckle = FALSE

--- a/code/modules/mob/living/simple_animal/abnormality/he/white_lake.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/white_lake.dm
@@ -111,7 +111,6 @@
 	icon_state = "flower_waltz"
 	force = 22
 	damtype = PALE_DAMAGE
-	armortype = PALE_DAMAGE
 	attack_verb_continuous = list("slices", "cuts")
 	attack_verb_simple = list("slices", "cuts")
 	hitsound = 'sound/weapons/bladeslice.ogg'

--- a/code/modules/mob/living/simple_animal/abnormality/he/you_strong.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/you_strong.dm
@@ -220,7 +220,7 @@
 	melee_damage_lower = 3
 	melee_damage_upper = 5
 	melee_damage_type = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 
 	attack_sound = "swing_hit"
 	attack_verb_continuous = "bashes"

--- a/code/modules/mob/living/simple_animal/abnormality/he/you_strong.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/you_strong.dm
@@ -221,7 +221,6 @@
 	melee_damage_upper = 5
 	melee_damage_type = RED_DAMAGE
 
-
 	attack_sound = "swing_hit"
 	attack_verb_continuous = "bashes"
 	attack_verb_simple = "bash"

--- a/code/modules/mob/living/simple_animal/abnormality/teth/fairy_long_legs.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/fairy_long_legs.dm
@@ -16,7 +16,6 @@
 	melee_damage_lower = 12
 	melee_damage_upper = 16
 	melee_damage_type = RED_DAMAGE
-
 	stat_attack = HARD_CRIT
 	attack_sound = 'sound/abnormalities/fairy_longlegs/attack.ogg'
 	attack_verb_continuous = "stabs"

--- a/code/modules/mob/living/simple_animal/abnormality/teth/fairy_long_legs.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/fairy_long_legs.dm
@@ -16,7 +16,7 @@
 	melee_damage_lower = 12
 	melee_damage_upper = 16
 	melee_damage_type = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	stat_attack = HARD_CRIT
 	attack_sound = 'sound/abnormalities/fairy_longlegs/attack.ogg'
 	attack_verb_continuous = "stabs"

--- a/code/modules/mob/living/simple_animal/abnormality/teth/forsaken_murderer.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/forsaken_murderer.dm
@@ -29,7 +29,7 @@
 	melee_damage_upper = 18
 	melee_damage_type = RED_DAMAGE
 	//Is the second half of melee damage type. This the armor type checked when attacking someone.
-	armortype = RED_DAMAGE
+
 	//Used chrome to listen to the sound effects. In the chrome link was the file name i could copy paste in.
 	attack_sound = 'sound/effects/hit_kick.ogg'
 	attack_verb_continuous = "smashes"

--- a/code/modules/mob/living/simple_animal/abnormality/teth/forsaken_murderer.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/forsaken_murderer.dm
@@ -28,8 +28,6 @@
 		Unsure if i should be comparing Forsaken Murderer to Fragment of the Universe. Most HE level abnormalities do 20+ damange.*/
 	melee_damage_upper = 18
 	melee_damage_type = RED_DAMAGE
-	//Is the second half of melee damage type. This the armor type checked when attacking someone.
-
 	//Used chrome to listen to the sound effects. In the chrome link was the file name i could copy paste in.
 	attack_sound = 'sound/effects/hit_kick.ogg'
 	attack_verb_continuous = "smashes"

--- a/code/modules/mob/living/simple_animal/abnormality/teth/fragment.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/fragment.dm
@@ -14,7 +14,6 @@
 	melee_damage_upper = 12
 	rapid_melee = 2
 	melee_damage_type = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
 	stat_attack = HARD_CRIT
 	attack_sound = 'sound/abnormalities/fragment/attack.ogg'
 	attack_verb_continuous = "stabs"

--- a/code/modules/mob/living/simple_animal/abnormality/teth/my_sweet_home.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/my_sweet_home.dm
@@ -17,7 +17,6 @@
 	melee_damage_lower = 15
 	melee_damage_upper = 20
 	melee_damage_type = RED_DAMAGE
-	armortype = RED_DAMAGE
 	melee_queue_distance = 1
 	retreat_distance = 0
 	minimum_distance = 0

--- a/code/modules/mob/living/simple_animal/abnormality/teth/redblooded.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/redblooded.dm
@@ -130,5 +130,5 @@
 	name = "american pellet"
 	desc = "100% real, surplus military ammo."
 	damage_type = RED_DAMAGE
-	flag = RED_DAMAGE
+
 	damage = 5

--- a/code/modules/mob/living/simple_animal/abnormality/teth/simple_smile.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/simple_smile.dm
@@ -15,7 +15,6 @@
 	melee_damage_upper = 5
 	is_flying_animal = TRUE
 	melee_damage_type = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
 	stat_attack = HARD_CRIT
 	attack_verb_continuous = "bumps"
 	attack_verb_simple = "bumps"

--- a/code/modules/mob/living/simple_animal/abnormality/waw/apex_predator.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/apex_predator.dm
@@ -18,7 +18,6 @@
 	move_to_delay = 3
 
 	melee_damage_type = RED_DAMAGE
-
 	stat_attack = HARD_CRIT
 
 	fear_level = 0	//You should never notice it

--- a/code/modules/mob/living/simple_animal/abnormality/waw/apex_predator.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/apex_predator.dm
@@ -18,7 +18,7 @@
 	move_to_delay = 3
 
 	melee_damage_type = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	stat_attack = HARD_CRIT
 
 	fear_level = 0	//You should never notice it

--- a/code/modules/mob/living/simple_animal/abnormality/waw/babayaga.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/babayaga.dm
@@ -13,7 +13,6 @@
 	melee_damage_lower = 40
 	melee_damage_upper = 50
 	melee_damage_type = RED_DAMAGE
-
 	stat_attack = HARD_CRIT
 	health = 2500
 	maxHealth = 2500
@@ -178,7 +177,6 @@
 	health = 300
 	maxHealth = 300
 	melee_damage_type = RED_DAMAGE
-
 	damage_coeff = list(BRUTE = 1, RED_DAMAGE = 1.3, WHITE_DAMAGE = 0.6, BLACK_DAMAGE = 1, PALE_DAMAGE = 2)
 	melee_damage_lower = 15
 	melee_damage_upper = 27

--- a/code/modules/mob/living/simple_animal/abnormality/waw/babayaga.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/babayaga.dm
@@ -13,7 +13,7 @@
 	melee_damage_lower = 40
 	melee_damage_upper = 50
 	melee_damage_type = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	stat_attack = HARD_CRIT
 	health = 2500
 	maxHealth = 2500
@@ -178,7 +178,7 @@
 	health = 300
 	maxHealth = 300
 	melee_damage_type = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	damage_coeff = list(BRUTE = 1, RED_DAMAGE = 1.3, WHITE_DAMAGE = 0.6, BLACK_DAMAGE = 1, PALE_DAMAGE = 2)
 	melee_damage_lower = 15
 	melee_damage_upper = 27

--- a/code/modules/mob/living/simple_animal/abnormality/waw/big_bird.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/big_bird.dm
@@ -39,7 +39,6 @@
 
 	// This stuff is only done to non-humans and objects
 	melee_damage_type = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
 	melee_damage_lower = 100
 	melee_damage_upper = 100
 

--- a/code/modules/mob/living/simple_animal/abnormality/waw/big_wolf.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/big_wolf.dm
@@ -40,7 +40,7 @@
 	work_damage_amount = 16
 	work_damage_type = RED_DAMAGE
 	melee_damage_type = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	melee_damage_lower = 20
 	melee_damage_upper = 40
 	attack_sound = 'sound/abnormalities/big_wolf/Wolf_Scratch.ogg'

--- a/code/modules/mob/living/simple_animal/abnormality/waw/big_wolf.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/big_wolf.dm
@@ -40,7 +40,6 @@
 	work_damage_amount = 16
 	work_damage_type = RED_DAMAGE
 	melee_damage_type = RED_DAMAGE
-
 	melee_damage_lower = 20
 	melee_damage_upper = 40
 	attack_sound = 'sound/abnormalities/big_wolf/Wolf_Scratch.ogg'

--- a/code/modules/mob/living/simple_animal/abnormality/waw/black_swan.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/black_swan.dm
@@ -26,7 +26,6 @@
 	vision_range = 14
 	aggro_vision_range = 20
 	melee_damage_type = RED_DAMAGE
-
 	melee_damage_lower = 20
 	melee_damage_upper = 40
 	threat_level = WAW_LEVEL

--- a/code/modules/mob/living/simple_animal/abnormality/waw/black_swan.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/black_swan.dm
@@ -26,7 +26,7 @@
 	vision_range = 14
 	aggro_vision_range = 20
 	melee_damage_type = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	melee_damage_lower = 20
 	melee_damage_upper = 40
 	threat_level = WAW_LEVEL

--- a/code/modules/mob/living/simple_animal/abnormality/waw/ebony_queen.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/ebony_queen.dm
@@ -12,12 +12,10 @@
 	pixel_x = -16
 	base_pixel_x = -16
 	melee_damage_type = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
 	melee_damage_lower = 35
 	melee_damage_upper = 45
 	damage_coeff = list(BRUTE = 1.0, RED_DAMAGE = 1.0, WHITE_DAMAGE = 1.3, BLACK_DAMAGE = 0, PALE_DAMAGE = 0.7)
 	ranged = TRUE
-	armortype = BLACK_DAMAGE
 	stat_attack = HARD_CRIT
 	attack_sound = 'sound/abnormalities/ebonyqueen/attack.ogg'
 	attack_verb_continuous = "claws"

--- a/code/modules/mob/living/simple_animal/abnormality/waw/generalb.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/generalb.dm
@@ -31,7 +31,6 @@
 	melee_damage_lower = 40
 	melee_damage_upper = 52
 	melee_damage_type = RED_DAMAGE
-	armortype = RED_DAMAGE
 	stat_attack = HARD_CRIT
 	//She has a Quad Artillery Cannon
 
@@ -124,7 +123,6 @@
 	health = 450
 	maxHealth = 450
 	melee_damage_type = RED_DAMAGE
-	armortype = RED_DAMAGE
 	damage_coeff = list(RED_DAMAGE = 1, WHITE_DAMAGE = 1.5, BLACK_DAMAGE = 0.8, PALE_DAMAGE = 2)
 	melee_damage_lower = 14
 	melee_damage_upper = 18

--- a/code/modules/mob/living/simple_animal/abnormality/waw/judgement_bird.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/judgement_bird.dm
@@ -154,7 +154,7 @@
 	maxHealth = 100
 	melee_damage_lower = 5
 	melee_damage_upper = 8
-	armortype = PALE_DAMAGE
+
 	melee_damage_type = PALE_DAMAGE
 	obj_damage = 0
 	environment_smash = ENVIRONMENT_SMASH_NONE

--- a/code/modules/mob/living/simple_animal/abnormality/waw/judgement_bird.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/judgement_bird.dm
@@ -154,7 +154,6 @@
 	maxHealth = 100
 	melee_damage_lower = 5
 	melee_damage_upper = 8
-
 	melee_damage_type = PALE_DAMAGE
 	obj_damage = 0
 	environment_smash = ENVIRONMENT_SMASH_NONE

--- a/code/modules/mob/living/simple_animal/abnormality/waw/little_prince.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/little_prince.dm
@@ -178,7 +178,6 @@
 	maxHealth = 1500
 	move_to_delay = 3
 	melee_damage_type = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
 	damage_coeff = list(RED_DAMAGE = 1.2, WHITE_DAMAGE = 1.3, BLACK_DAMAGE = 0.8, PALE_DAMAGE = 2)
 	melee_damage_lower = 40
 	melee_damage_upper = 50		//slow melee and has nothing else.

--- a/code/modules/mob/living/simple_animal/abnormality/waw/luna.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/luna.dm
@@ -110,7 +110,6 @@
 	health = 2600
 	maxHealth = 2600
 	melee_damage_type = RED_DAMAGE
-	armortype = RED_DAMAGE
 	damage_coeff = list(RED_DAMAGE = 1.2, WHITE_DAMAGE = 0, BLACK_DAMAGE = 1, PALE_DAMAGE = 2)
 	melee_damage_lower = 32
 	melee_damage_upper = 41

--- a/code/modules/mob/living/simple_animal/abnormality/waw/naked_nest.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/naked_nest.dm
@@ -259,7 +259,6 @@
 	melee_damage_lower = 10
 	melee_damage_upper = 30
 	melee_damage_type = RED_DAMAGE
-	armortype = RED_DAMAGE
 	maxHealth = 300
 	health = 300
 	stat_attack = CONSCIOUS //When you are put into crit the nested will continue to transform into a nest. I thought about having the nested infest you if your in crit but that seemed a bit too cruel.

--- a/code/modules/mob/living/simple_animal/abnormality/waw/nosferatu.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/nosferatu.dm
@@ -24,7 +24,6 @@
 	melee_damage_lower = 35
 	melee_damage_upper = 45 //has a wide range, he can critically hit you
 	melee_damage_type = RED_DAMAGE
-
 	stat_attack = HARD_CRIT
 	work_damage_amount = 8
 	work_damage_type = RED_DAMAGE

--- a/code/modules/mob/living/simple_animal/abnormality/waw/nosferatu.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/nosferatu.dm
@@ -24,7 +24,7 @@
 	melee_damage_lower = 35
 	melee_damage_upper = 45 //has a wide range, he can critically hit you
 	melee_damage_type = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	stat_attack = HARD_CRIT
 	work_damage_amount = 8
 	work_damage_type = RED_DAMAGE

--- a/code/modules/mob/living/simple_animal/abnormality/waw/queen_bee.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/queen_bee.dm
@@ -83,7 +83,6 @@
 	health = 450
 	maxHealth = 450
 	melee_damage_type = RED_DAMAGE
-	armortype = RED_DAMAGE
 	damage_coeff = list(RED_DAMAGE = 1.2, WHITE_DAMAGE = 1.5, BLACK_DAMAGE = 0.8, PALE_DAMAGE = 2)
 	melee_damage_lower = 14
 	melee_damage_upper = 18

--- a/code/modules/mob/living/simple_animal/abnormality/waw/screenwriter.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/screenwriter.dm
@@ -239,7 +239,6 @@ Defeating the murderer also surpresses the abnormality.
 	maxHealth = 1400
 	health = 1400
 	melee_damage_type = WHITE_DAMAGE
-
 	melee_damage_lower = 10
 	melee_damage_upper = 20
 	rapid_melee = 3

--- a/code/modules/mob/living/simple_animal/abnormality/waw/screenwriter.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/screenwriter.dm
@@ -239,7 +239,7 @@ Defeating the murderer also surpresses the abnormality.
 	maxHealth = 1400
 	health = 1400
 	melee_damage_type = WHITE_DAMAGE
-	armortype = WHITE_DAMAGE
+
 	melee_damage_lower = 10
 	melee_damage_upper = 20
 	rapid_melee = 3

--- a/code/modules/mob/living/simple_animal/abnormality/waw/shrimp.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/shrimp.dm
@@ -142,7 +142,6 @@
 	health = 400
 	maxHealth = 400
 	melee_damage_type = RED_DAMAGE
-	armortype = RED_DAMAGE
 	damage_coeff = list(RED_DAMAGE = 0.8, WHITE_DAMAGE = 1.5, BLACK_DAMAGE = 1.2, PALE_DAMAGE = 2)
 	melee_damage_lower = 24
 	melee_damage_upper = 27
@@ -165,7 +164,6 @@
 	health = 500	//They're here to help
 	maxHealth = 500
 	melee_damage_type = RED_DAMAGE
-	armortype = RED_DAMAGE
 	damage_coeff = list(RED_DAMAGE = 0.6, WHITE_DAMAGE = 0.7, BLACK_DAMAGE = 1.2, PALE_DAMAGE = 2)
 	melee_damage_lower = 14
 	melee_damage_upper = 18

--- a/code/modules/mob/living/simple_animal/abnormality/waw/snow_whites_apple.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/snow_whites_apple.dm
@@ -14,7 +14,6 @@ GLOBAL_LIST_EMPTY(vine_list)
 	ranged = TRUE
 	ranged_cooldown_time = 4 SECONDS
 	melee_damage_type = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
 	stat_attack = HARD_CRIT
 	projectilesound = 'sound/creatures/venus_trap_hit.ogg'
 	ranged_message = null

--- a/code/modules/mob/living/simple_animal/abnormality/waw/snow_whites_apple.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/snow_whites_apple.dm
@@ -221,7 +221,7 @@ GLOBAL_LIST_EMPTY(vine_list)
 	if(isliving(AM))
 		vine_effect(AM)
 
-/obj/structure/spreading/apple_vine/play_attack_sound(damage_amount, damage_type = BRUTE, damage_flag = 0)
+/obj/structure/spreading/apple_vine/play_attack_sound(damage_amount, damage_type = BRUTE)
 	playsound(loc, 'sound/creatures/venus_trap_hurt.ogg', 60, TRUE)
 
 /obj/structure/spreading/apple_vine/proc/vine_effect(mob/living/L)

--- a/code/modules/mob/living/simple_animal/abnormality/waw/sphinx.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/sphinx.dm
@@ -24,7 +24,7 @@
 	can_breach = TRUE
 	threat_level = WAW_LEVEL
 	melee_damage_type = WHITE_DAMAGE
-	armortype = WHITE_DAMAGE
+
 	start_qliphoth = 3
 	work_chances = list(
 		ABNORMALITY_WORK_INSTINCT = list(0, 0, 35, 35, 40),

--- a/code/modules/mob/living/simple_animal/abnormality/waw/sphinx.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/sphinx.dm
@@ -24,7 +24,6 @@
 	can_breach = TRUE
 	threat_level = WAW_LEVEL
 	melee_damage_type = WHITE_DAMAGE
-
 	start_qliphoth = 3
 	work_chances = list(
 		ABNORMALITY_WORK_INSTINCT = list(0, 0, 35, 35, 40),

--- a/code/modules/mob/living/simple_animal/abnormality/waw/warden.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/warden.dm
@@ -15,7 +15,6 @@
 	melee_damage_lower = 70
 	melee_damage_upper = 70
 	melee_damage_type = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
 	stat_attack = HARD_CRIT
 	attack_sound = 'sound/weapons/slashmiss.ogg'
 	attack_verb_continuous = "claws"

--- a/code/modules/mob/living/simple_animal/abnormality/waw/wrath_servant.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/wrath_servant.dm
@@ -33,7 +33,6 @@
 	work_damage_amount = 12
 	work_damage_type = BLACK_DAMAGE
 
-
 	melee_damage_type = RED_DAMAGE
 	melee_damage_lower = 30
 	melee_damage_upper = 45
@@ -576,7 +575,6 @@
 	melee_damage_upper = 30
 	rapid_melee = 2
 	melee_damage_type = WHITE_DAMAGE
-
 	attack_sound = 'sound/abnormalities/wrath_servant/hermit_attack.ogg'
 
 	COOLDOWN_DECLARE(conjure)
@@ -756,7 +754,6 @@
 	melee_damage_lower = 10
 	melee_damage_upper = 20
 	melee_damage_type = RED_DAMAGE
-
 	rapid_melee = 2
 	stat_attack = HARD_CRIT
 

--- a/code/modules/mob/living/simple_animal/abnormality/waw/wrath_servant.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/wrath_servant.dm
@@ -33,7 +33,7 @@
 	work_damage_amount = 12
 	work_damage_type = BLACK_DAMAGE
 
-	armortype = RED_DAMAGE
+
 	melee_damage_type = RED_DAMAGE
 	melee_damage_lower = 30
 	melee_damage_upper = 45
@@ -576,7 +576,7 @@
 	melee_damage_upper = 30
 	rapid_melee = 2
 	melee_damage_type = WHITE_DAMAGE
-	armortype = WHITE_DAMAGE
+
 	attack_sound = 'sound/abnormalities/wrath_servant/hermit_attack.ogg'
 
 	COOLDOWN_DECLARE(conjure)
@@ -756,7 +756,7 @@
 	melee_damage_lower = 10
 	melee_damage_upper = 20
 	melee_damage_type = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	rapid_melee = 2
 	stat_attack = HARD_CRIT
 

--- a/code/modules/mob/living/simple_animal/abnormality/waw/yang.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/yang.dm
@@ -192,7 +192,6 @@
 	hitscan = TRUE
 	damage = 70
 	damage_type = WHITE_DAMAGE
-	flag = WHITE_DAMAGE
 	muzzle_type = /obj/effect/projectile/muzzle/laser/white
 	tracer_type = /obj/effect/projectile/tracer/laser/white
 	impact_type = /obj/effect/projectile/impact/laser/white

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/blubbering_toad.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/blubbering_toad.dm
@@ -16,7 +16,6 @@
 	health = 1400
 	can_breach = TRUE
 	melee_damage_type = BLACK_DAMAGE
-
 	stat_attack = DEAD
 	damage_coeff = list(BRUTE = 1.0, RED_DAMAGE = 0.7, WHITE_DAMAGE = 0.7, BLACK_DAMAGE = 0.3, PALE_DAMAGE = 2)
 	move_to_delay = 3
@@ -223,7 +222,6 @@
 			icon_tongue = "blubbering_egg_tongue"
 			icon_state = icon_living
 			melee_damage_type = WHITE_DAMAGE
-
 			broken = TRUE
 			playsound(src, 'sound/abnormalities/doomsdaycalendar/Limbus_Dead_Generic.ogg', 40, 0, 1)
 		return
@@ -234,7 +232,6 @@
 			melee_damage_upper = 35
 		else
 			melee_damage_type = RED_DAMAGE
-
 		transformed = TRUE
 		icon_living = "blubbering_[state]"
 		icon_tongue = "blubbering_tongue_[state]"

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/blubbering_toad.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/blubbering_toad.dm
@@ -16,7 +16,7 @@
 	health = 1400
 	can_breach = TRUE
 	melee_damage_type = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
+
 	stat_attack = DEAD
 	damage_coeff = list(BRUTE = 1.0, RED_DAMAGE = 0.7, WHITE_DAMAGE = 0.7, BLACK_DAMAGE = 0.3, PALE_DAMAGE = 2)
 	move_to_delay = 3
@@ -223,7 +223,7 @@
 			icon_tongue = "blubbering_egg_tongue"
 			icon_state = icon_living
 			melee_damage_type = WHITE_DAMAGE
-			armortype = WHITE_DAMAGE
+
 			broken = TRUE
 			playsound(src, 'sound/abnormalities/doomsdaycalendar/Limbus_Dead_Generic.ogg', 40, 0, 1)
 		return
@@ -234,7 +234,7 @@
 			melee_damage_upper = 35
 		else
 			melee_damage_type = RED_DAMAGE
-			armortype = RED_DAMAGE
+
 		transformed = TRUE
 		icon_living = "blubbering_[state]"
 		icon_tongue = "blubbering_tongue_[state]"

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/hammer_light.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/hammer_light.dm
@@ -204,8 +204,7 @@
 	inhand_x_dimension = 64
 	inhand_y_dimension = 64
 	force = 40
-	damtype = BRUTE
-	armortype = MELEE //Ignores armor for our intents and purposes.
+	damtype = BRUTE //Ignores armor for our intents and purposes.
 	attack_verb_continuous = list("slams", "strikes", "smashes")
 	attack_verb_simple = list("slam", "strike", "smash")
 	hitsound = 'sound/abnormalities/lighthammer/hammer_filter.ogg'

--- a/code/modules/mob/living/simple_animal/animal_defense.dm
+++ b/code/modules/mob/living/simple_animal/animal_defense.dm
@@ -111,7 +111,7 @@
 	. = ..()
 	if(.)
 		var/damage = rand(M.melee_damage_lower, M.melee_damage_upper)
-		return attack_threshold_check(damage, M.melee_damage_type, M.armortype)
+		return attack_threshold_check(damage, M.melee_damage_type)
 
 /mob/living/simple_animal/attack_slime(mob/living/simple_animal/slime/M)
 	if(..()) //successful slime attack
@@ -125,7 +125,7 @@
 		return
 	return ..()
 
-/mob/living/simple_animal/proc/attack_threshold_check(damage, damagetype = BRUTE, armorcheck = MELEE, actuallydamage = TRUE)
+/mob/living/simple_animal/proc/attack_threshold_check(damage, damagetype = BRUTE, actuallydamage = TRUE)
 	var/temp_damage = damage
 	if(!damage_coeff[damagetype])
 		temp_damage = 0
@@ -137,7 +137,7 @@
 		return FALSE
 	else
 		if(actuallydamage)
-			apply_damage(damage, damagetype, null, getarmor(null, armorcheck))
+			apply_damage(damage, damagetype, null, getarmor(null, damagetype))
 		return TRUE
 
 /mob/living/simple_animal/bullet_act(obj/projectile/Proj, def_zone, piercing_hit = FALSE)

--- a/code/modules/mob/living/simple_animal/distortion/myth/another_day_work.dm
+++ b/code/modules/mob/living/simple_animal/distortion/myth/another_day_work.dm
@@ -16,7 +16,7 @@
 	melee_damage_lower = 10
 	melee_damage_upper = 14
 	melee_damage_type = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
+
 	stat_attack = HARD_CRIT
 	attack_sound = 'sound/abnormalities/censored/attack.ogg'
 	attack_verb_continuous = "whips"
@@ -91,7 +91,7 @@
 	name = "stretchy tie"
 	damage = 15
 	damage_type = BLACK_DAMAGE
-	flag = BLACK_DAMAGE
+
 	hitscan = TRUE
 	muzzle_type = /obj/effect/projectile/tracer/laser/tie
 	tracer_type = /obj/effect/projectile/tracer/laser/tie
@@ -136,7 +136,7 @@
 	force = 32
 	reach = 2		//Has 2 Square Reach.
 	damtype = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
+
 	attack_speed = 1.6
 	attack_verb_continuous = list("cuts", "slices")
 	attack_verb_simple = list("cuts", "slices")

--- a/code/modules/mob/living/simple_animal/distortion/myth/another_day_work.dm
+++ b/code/modules/mob/living/simple_animal/distortion/myth/another_day_work.dm
@@ -16,7 +16,6 @@
 	melee_damage_lower = 10
 	melee_damage_upper = 14
 	melee_damage_type = BLACK_DAMAGE
-
 	stat_attack = HARD_CRIT
 	attack_sound = 'sound/abnormalities/censored/attack.ogg'
 	attack_verb_continuous = "whips"

--- a/code/modules/mob/living/simple_animal/distortion/nightmare/black_hole_sun.dm
+++ b/code/modules/mob/living/simple_animal/distortion/nightmare/black_hole_sun.dm
@@ -13,7 +13,6 @@
 	melee_damage_lower = 25
 	melee_damage_upper = 30
 	melee_damage_type = BLACK_DAMAGE
-
 	stat_attack = HARD_CRIT
 	attack_sound = 'sound/weapons/ego/axe2.ogg'
 	attack_verb_continuous = "bashes"

--- a/code/modules/mob/living/simple_animal/distortion/nightmare/black_hole_sun.dm
+++ b/code/modules/mob/living/simple_animal/distortion/nightmare/black_hole_sun.dm
@@ -13,7 +13,7 @@
 	melee_damage_lower = 25
 	melee_damage_upper = 30
 	melee_damage_type = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
+
 	stat_attack = HARD_CRIT
 	attack_sound = 'sound/weapons/ego/axe2.ogg'
 	attack_verb_continuous = "bashes"

--- a/code/modules/mob/living/simple_animal/distortion/plague/bunnyman.dm
+++ b/code/modules/mob/living/simple_animal/distortion/plague/bunnyman.dm
@@ -17,7 +17,7 @@
 	melee_damage_lower = 25
 	melee_damage_upper = 30
 	melee_damage_type = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	stat_attack = HARD_CRIT
 	attack_sound = 'sound/weapons/ego/axe2.ogg'
 	attack_verb_continuous = "chops"

--- a/code/modules/mob/living/simple_animal/distortion/plague/bunnyman.dm
+++ b/code/modules/mob/living/simple_animal/distortion/plague/bunnyman.dm
@@ -17,7 +17,6 @@
 	melee_damage_lower = 25
 	melee_damage_upper = 30
 	melee_damage_type = RED_DAMAGE
-
 	stat_attack = HARD_CRIT
 	attack_sound = 'sound/weapons/ego/axe2.ogg'
 	attack_verb_continuous = "chops"

--- a/code/modules/mob/living/simple_animal/distortion/plague/lantern.dm
+++ b/code/modules/mob/living/simple_animal/distortion/plague/lantern.dm
@@ -13,7 +13,6 @@
 	melee_damage_lower = 25
 	melee_damage_upper = 30
 	melee_damage_type = BLACK_DAMAGE
-
 	stat_attack = HARD_CRIT
 	attack_sound = 'sound/weapons/ego/axe2.ogg'
 	attack_verb_continuous = "bashes"

--- a/code/modules/mob/living/simple_animal/distortion/plague/lantern.dm
+++ b/code/modules/mob/living/simple_animal/distortion/plague/lantern.dm
@@ -13,7 +13,7 @@
 	melee_damage_lower = 25
 	melee_damage_upper = 30
 	melee_damage_type = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
+
 	stat_attack = HARD_CRIT
 	attack_sound = 'sound/weapons/ego/axe2.ogg'
 	attack_verb_continuous = "bashes"

--- a/code/modules/mob/living/simple_animal/distortion/star/shrimp.dm
+++ b/code/modules/mob/living/simple_animal/distortion/star/shrimp.dm
@@ -14,7 +14,7 @@
 	melee_damage_lower = 45
 	melee_damage_upper = 80
 	melee_damage_type = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	stat_attack = HARD_CRIT
 	rapid_melee = 2
 	retreat_distance = 2

--- a/code/modules/mob/living/simple_animal/distortion/star/shrimp.dm
+++ b/code/modules/mob/living/simple_animal/distortion/star/shrimp.dm
@@ -14,7 +14,6 @@
 	melee_damage_lower = 45
 	melee_damage_upper = 80
 	melee_damage_type = RED_DAMAGE
-
 	stat_attack = HARD_CRIT
 	rapid_melee = 2
 	retreat_distance = 2

--- a/code/modules/mob/living/simple_animal/hostile/dark_wizard.dm
+++ b/code/modules/mob/living/simple_animal/hostile/dark_wizard.dm
@@ -37,5 +37,4 @@
 	icon_state = "declone"
 	damage = 4
 	damage_type = BURN
-	flag = ENERGY
 	temperature = -100 // closer to the old temp loss

--- a/code/modules/mob/living/simple_animal/hostile/jungle/seedling.dm
+++ b/code/modules/mob/living/simple_animal/hostile/jungle/seedling.dm
@@ -43,7 +43,6 @@
 	damage = 10
 	damage_type = BURN
 	light_range = 2
-	flag = ENERGY
 	light_color = LIGHT_COLOR_YELLOW
 	hitsound = 'sound/weapons/sear.ogg'
 	hitsound_wall = 'sound/weapons/effects/searwall.ogg'

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -447,7 +447,7 @@
 	if(istype(P, /obj/projectile/magic))
 		ActivationReaction(P.firer, ACTIVATE_MAGIC, P.damage_type)
 		return
-	ActivationReaction(P.firer, P.flag, P.damage_type)
+	ActivationReaction(P.firer, P.damage_type, P.damage_type)
 
 /obj/machinery/anomalous_crystal/proc/ActivationReaction(mob/user, method, damtype)
 	if(world.time < last_use_timer)

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/basilisk.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/basilisk.dm
@@ -42,7 +42,6 @@
 	damage = 0
 	damage_type = BURN
 	nodamage = TRUE
-	flag = ENERGY
 	temperature = -50 // Cools you down! per hit!
 
 /obj/projectile/temp/basilisk/heated

--- a/code/modules/mob/living/simple_animal/hostile/ordeal/gold.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/gold.dm
@@ -10,7 +10,6 @@
 	maxHealth = 400
 	health = 400
 	melee_damage_type = BLACK_DAMAGE
-
 	melee_damage_lower = 14
 	melee_damage_upper = 14
 	pixel_x = -8
@@ -41,7 +40,6 @@
 	maxHealth = 100
 	health = 100
 	melee_damage_type = RED_DAMAGE
-
 	melee_damage_lower = 14
 	melee_damage_upper = 24
 	attack_verb_continuous = "bashes"
@@ -204,7 +202,6 @@
 	maxHealth = 250
 	health = 250
 	melee_damage_type = RED_DAMAGE
-
 	rapid_melee = 3
 	melee_damage_lower = 4
 	melee_damage_upper = 6
@@ -259,7 +256,6 @@
 	maxHealth = 3000 //it's a boss, more or less
 	health = 3000
 	melee_damage_type = PALE_DAMAGE
-
 	melee_damage_lower = 14
 	melee_damage_upper = 18
 	pixel_x = -8
@@ -462,7 +458,6 @@
 	maxHealth = 400
 	health = 400
 	melee_damage_type = RED_DAMAGE
-
 	rapid_melee = 2
 	melee_damage_lower = 14
 	melee_damage_upper = 14
@@ -582,7 +577,6 @@
 	maxHealth = 900
 	health = 900
 	melee_damage_type = BLACK_DAMAGE
-
 	melee_damage_lower = 26
 	melee_damage_upper = 36
 	attack_verb_continuous = "chops"
@@ -646,7 +640,6 @@
 	maxHealth = 1500
 	health = 1500
 	melee_damage_type = BLACK_DAMAGE
-
 	melee_damage_lower = 10 //they're support, so they deal low damage
 	melee_damage_upper = 15
 	attack_verb_continuous = "shocks"
@@ -708,7 +701,6 @@
 	maxHealth = 800
 	health = 800
 	melee_damage_type = RED_DAMAGE
-
 	rapid_melee = 3
 	melee_damage_lower = 15
 	melee_damage_upper = 20
@@ -785,7 +777,6 @@
 	maxHealth = 1000
 	health = 1000
 	melee_damage_type = BLACK_DAMAGE
-
 	melee_damage_lower = 15
 	melee_damage_upper = 30
 	attack_verb_continuous = "bashes"

--- a/code/modules/mob/living/simple_animal/hostile/ordeal/gold.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/gold.dm
@@ -10,7 +10,7 @@
 	maxHealth = 400
 	health = 400
 	melee_damage_type = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
+
 	melee_damage_lower = 14
 	melee_damage_upper = 14
 	pixel_x = -8
@@ -41,7 +41,7 @@
 	maxHealth = 100
 	health = 100
 	melee_damage_type = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	melee_damage_lower = 14
 	melee_damage_upper = 24
 	attack_verb_continuous = "bashes"
@@ -204,7 +204,7 @@
 	maxHealth = 250
 	health = 250
 	melee_damage_type = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	rapid_melee = 3
 	melee_damage_lower = 4
 	melee_damage_upper = 6
@@ -259,7 +259,7 @@
 	maxHealth = 3000 //it's a boss, more or less
 	health = 3000
 	melee_damage_type = PALE_DAMAGE
-	armortype = PALE_DAMAGE
+
 	melee_damage_lower = 14
 	melee_damage_upper = 18
 	pixel_x = -8
@@ -415,7 +415,7 @@
 	maxHealth = 300
 	health = 300
 	melee_damage_type = WHITE_DAMAGE
-	armortype = WHITE_DAMAGE
+
 	rapid_melee = 2
 	melee_damage_lower = 14
 	melee_damage_upper = 14
@@ -462,7 +462,7 @@
 	maxHealth = 400
 	health = 400
 	melee_damage_type = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	rapid_melee = 2
 	melee_damage_lower = 14
 	melee_damage_upper = 14
@@ -582,7 +582,7 @@
 	maxHealth = 900
 	health = 900
 	melee_damage_type = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
+
 	melee_damage_lower = 26
 	melee_damage_upper = 36
 	attack_verb_continuous = "chops"
@@ -646,7 +646,7 @@
 	maxHealth = 1500
 	health = 1500
 	melee_damage_type = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
+
 	melee_damage_lower = 10 //they're support, so they deal low damage
 	melee_damage_upper = 15
 	attack_verb_continuous = "shocks"
@@ -708,7 +708,7 @@
 	maxHealth = 800
 	health = 800
 	melee_damage_type = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	rapid_melee = 3
 	melee_damage_lower = 15
 	melee_damage_upper = 20
@@ -785,7 +785,7 @@
 	maxHealth = 1000
 	health = 1000
 	melee_damage_type = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
+
 	melee_damage_lower = 15
 	melee_damage_upper = 30
 	attack_verb_continuous = "bashes"

--- a/code/modules/mob/living/simple_animal/hostile/ordeal/indigo.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/indigo.dm
@@ -13,7 +13,6 @@
 	move_to_delay = 1.3	//Super fast, but squishy and weak.
 	stat_attack = DEAD
 	melee_damage_type = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
 	melee_damage_lower = 10
 	melee_damage_upper = 12
 	butcher_results = list(/obj/item/food/meat/slab/sweeper = 1)
@@ -61,7 +60,6 @@
 	move_to_delay = 4
 	stat_attack = DEAD
 	melee_damage_type = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
 	melee_damage_lower = 20
 	melee_damage_upper = 24
 	butcher_results = list(/obj/item/food/meat/slab/sweeper = 2)
@@ -143,7 +141,6 @@
 	health = 1500
 	stat_attack = DEAD
 	melee_damage_type = RED_DAMAGE
-	armortype = RED_DAMAGE
 	rapid_melee = 1
 	melee_damage_lower = 13
 	melee_damage_upper = 17
@@ -165,7 +162,6 @@
 	icon_state = "adelheide"
 	icon_living = "adelheide"
 	melee_damage_type = WHITE_DAMAGE
-	armortype = WHITE_DAMAGE
 	melee_damage_lower = 42
 	melee_damage_upper = 55
 	damage_coeff = list(BRUTE = 1, RED_DAMAGE = 0.7, WHITE_DAMAGE = 0.5, BLACK_DAMAGE = 1.5, PALE_DAMAGE = 0.7)
@@ -183,7 +179,6 @@
 	icon_state = "maria"
 	icon_living = "maria"
 	melee_damage_type = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
 	melee_damage_lower = 42
 	melee_damage_upper = 55
 	damage_coeff = list(BRUTE = 1, RED_DAMAGE = 0.7, WHITE_DAMAGE = 0.7, BLACK_DAMAGE = 0.5, PALE_DAMAGE = 1.5)
@@ -195,7 +190,6 @@
 	icon_living = "jacques"
 	rapid_melee = 4
 	melee_damage_type = RED_DAMAGE
-	armortype = RED_DAMAGE
 	damage_coeff = list(BRUTE = 1, RED_DAMAGE = 0.5, WHITE_DAMAGE = 1.5, BLACK_DAMAGE = 0.7, PALE_DAMAGE = 0.7)
 
 /mob/living/simple_animal/hostile/ordeal/indigo_dusk/pale
@@ -205,7 +199,6 @@
 	icon_living = "silvina"
 	rapid_melee = 2
 	melee_damage_type = PALE_DAMAGE
-	armortype = PALE_DAMAGE
 	damage_coeff = list(BRUTE = 1, RED_DAMAGE = 1.5, WHITE_DAMAGE = 0.7, BLACK_DAMAGE = 0.7, PALE_DAMAGE = 0.5)
 
 
@@ -294,7 +287,6 @@
 	pixel_x = -16
 	base_pixel_x = -16
 	melee_damage_type = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
 	move_to_delay = 3
 	speed = 3
 	rapid_melee = 2
@@ -615,7 +607,6 @@
 	move_to_delay = 1.3	//Super fast, but squishy and weak.
 	stat_attack = HARD_CRIT
 	melee_damage_type = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
 	melee_damage_lower = 21
 	melee_damage_upper = 24
 	attack_verb_continuous = "stabs"

--- a/code/modules/mob/living/simple_animal/hostile/ordeal/misc.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/misc.dm
@@ -11,7 +11,6 @@
 	maxHealth = 2000
 	health = 2000
 	melee_damage_type = PALE_DAMAGE
-	armortype = PALE_DAMAGE
 	rapid_melee = 2
 	melee_damage_lower = 14
 	melee_damage_upper = 14

--- a/code/modules/mob/living/simple_animal/hostile/ordeal/steel.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/steel.dm
@@ -12,7 +12,6 @@
 	maxHealth = 220
 	health = 220
 	melee_damage_type = RED_DAMAGE
-
 	vision_range = 8
 	move_to_delay = 2.2
 	melee_damage_lower = 10

--- a/code/modules/mob/living/simple_animal/hostile/ordeal/steel.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/steel.dm
@@ -12,7 +12,7 @@
 	maxHealth = 220
 	health = 220
 	melee_damage_type = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 	vision_range = 8
 	move_to_delay = 2.2
 	melee_damage_lower = 10

--- a/code/modules/mob/living/simple_animal/hostile/ordeal/white.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/white.dm
@@ -10,7 +10,6 @@
 	maxHealth = 3000
 	health = 3000
 	melee_damage_type = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
 	rapid_melee = 2
 	melee_damage_lower = 30
 	melee_damage_upper = 40
@@ -130,7 +129,6 @@
 	hitsound = 'sound/effects/ordeals/white/black_kunai.ogg'
 	damage = 30
 	damage_type = BLACK_DAMAGE
-	flag = BLACK_DAMAGE
 
 // White Fixer
 /mob/living/simple_animal/hostile/ordeal/white_fixer
@@ -349,7 +347,6 @@
 	maxHealth = 3000
 	health = 3000
 	melee_damage_type = RED_DAMAGE
-	armortype = RED_DAMAGE
 	rapid_melee = 2
 	melee_damage_lower = 35
 	melee_damage_upper = 45
@@ -486,7 +483,6 @@
 	maxHealth = 4000
 	health = 4000
 	melee_damage_type = PALE_DAMAGE
-	armortype = PALE_DAMAGE
 	melee_damage_lower = 35
 	melee_damage_upper = 45
 	rapid_melee = 2
@@ -712,4 +708,3 @@
 	icon_state = "palebullet"
 	damage = 16
 	damage_type = PALE_DAMAGE
-	flag = PALE_DAMAGE

--- a/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/space_dragon.dm
@@ -541,7 +541,7 @@
 	if(isobserver(user))
 		. += "<span class='notice'>It has [carp_stored] carp available to spawn as.</span>"
 
-/obj/structure/carp_rift/play_attack_sound(damage_amount, damage_type = BRUTE, damage_flag = 0)
+/obj/structure/carp_rift/play_attack_sound(damage_amount, damage_type = BRUTE)
 	playsound(src, 'sound/magic/lightningshock.ogg', 50, TRUE)
 
 /obj/structure/carp_rift/Destroy()

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -82,8 +82,6 @@
 	var/armour_penetration = 0
 	///Damage type of a simple mob's melee attack, should it do damage.
 	var/melee_damage_type = RED_DAMAGE
-	///Armor type that is checked when attacking someone
-	var/armortype = RED_DAMAGE
 	/// 1 for full damage , 0 for none , -1 for 1:1 heal from that source.
 	var/list/damage_coeff = list(BRUTE = 1, RED_DAMAGE = 1, WHITE_DAMAGE = 1, BLACK_DAMAGE = 1, PALE_DAMAGE = 1)
 	///Attacking verb in present continuous tense.

--- a/code/modules/modular_computers/computers/item/computer_damage.dm
+++ b/code/modules/modular_computers/computers/item/computer_damage.dm
@@ -1,7 +1,7 @@
-/obj/item/modular_computer/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1)
+/obj/item/modular_computer/take_damage(damage_amount, damage_type = BRUTE, sound_effect = 1)
 	. = ..()
 	var/component_probability = min(50, max(damage_amount*0.1, 1 - obj_integrity/max_integrity))
-	switch(damage_flag)
+	switch(damage_type)
 		if(BULLET)
 			component_probability = damage_amount * 0.5
 		if(LASER)
@@ -10,7 +10,7 @@
 		for(var/I in all_components)
 			var/obj/item/computer_hardware/H = all_components[I]
 			if(prob(component_probability))
-				H.take_damage(round(damage_amount*0.5), damage_type, damage_flag, 0)
+				H.take_damage(round(damage_amount*0.5), damage_type, 0)
 
 
 /obj/item/modular_computer/deconstruct(disassembled = TRUE)

--- a/code/modules/ninja/suit/ninja_equipment_actions/energy_net_nets.dm
+++ b/code/modules/ninja/suit/ninja_equipment_actions/energy_net_nets.dm
@@ -25,7 +25,7 @@
 	///The creature currently caught in the net
 	var/mob/living/affecting
 
-/obj/structure/energy_net/play_attack_sound(damage, damage_type = BRUTE, damage_flag = 0)
+/obj/structure/energy_net/play_attack_sound(damage, damage_type = BRUTE)
 	if(damage_type == BRUTE || damage_type == BURN)
 		playsound(src, 'sound/weapons/slash.ogg', 80, TRUE)
 

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -760,7 +760,7 @@
 	last_nightshift_switch = world.time
 	set_nightshift(!nightshift_lights)
 
-/obj/machinery/power/apc/run_obj_armor(damage_amount, damage_type, damage_flag = 0, attack_dir)
+/obj/machinery/power/apc/run_obj_armor(damage_amount, damage_type, attack_dir)
 	if(machine_stat & BROKEN)
 		return damage_amount
 	. = ..()

--- a/code/modules/power/floodlight.dm
+++ b/code/modules/power/floodlight.dm
@@ -139,5 +139,5 @@
 	new /obj/item/light/tube/broken(loc)
 	qdel(src)
 
-/obj/machinery/power/floodlight/play_attack_sound(damage_amount, damage_type = BRUTE, damage_flag = 0)
+/obj/machinery/power/floodlight/play_attack_sound(damage_amount, damage_type = BRUTE)
 	playsound(src, 'sound/effects/glasshit.ogg', 75, TRUE)

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -609,7 +609,7 @@
 			if(prob(12))
 				electrocute_mob(user, get_area(src), src, 0.3, TRUE)
 
-/obj/machinery/light/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1)
+/obj/machinery/light/take_damage(damage_amount, damage_type = BRUTE, sound_effect = 1)
 	. = ..()
 	if(. && !QDELETED(src))
 		if(prob(damage_amount * 5))
@@ -618,7 +618,7 @@
 
 
 
-/obj/machinery/light/play_attack_sound(damage_amount, damage_type = BRUTE, damage_flag = 0)
+/obj/machinery/light/play_attack_sound(damage_amount, damage_type = BRUTE)
 	switch(damage_type)
 		if(BRUTE)
 			switch(status)

--- a/code/modules/power/singularity/containment_field.dm
+++ b/code/modules/power/singularity/containment_field.dm
@@ -41,7 +41,7 @@
 	shock(user)
 	return TRUE
 
-/obj/machinery/field/containment/play_attack_sound(damage_amount, damage_type = BRUTE, damage_flag = 0)
+/obj/machinery/field/containment/play_attack_sound(damage_amount, damage_type = BRUTE)
 	switch(damage_type)
 		if(BURN)
 			playsound(loc, 'sound/effects/empulse.ogg', 75, TRUE)

--- a/code/modules/power/singularity/field_generator.dm
+++ b/code/modules/power/singularity/field_generator.dm
@@ -164,7 +164,7 @@ no power level overlay is currently in the overlays list.
 		return ..()
 
 /obj/machinery/field/generator/bullet_act(obj/projectile/Proj)
-	if(Proj.flag != BULLET)
+	if(Proj.damage_type != BULLET)
 		power = min(power + Proj.damage, field_generator_max_power)
 		check_power_level()
 	. = ..()

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -79,7 +79,7 @@
 		deconstruct(TRUE)
 	return TRUE
 
-/obj/machinery/power/solar/play_attack_sound(damage_amount, damage_type = BRUTE, damage_flag = 0)
+/obj/machinery/power/solar/play_attack_sound(damage_amount, damage_type = BRUTE)
 	switch(damage_type)
 		if(BRUTE)
 			if(machine_stat & BROKEN)
@@ -437,7 +437,7 @@
 	else
 		return ..()
 
-/obj/machinery/power/solar_control/play_attack_sound(damage_amount, damage_type = BRUTE, damage_flag = 0)
+/obj/machinery/power/solar_control/play_attack_sound(damage_amount, damage_type = BRUTE)
 	switch(damage_type)
 		if(BRUTE)
 			if(machine_stat & BROKEN)

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -824,7 +824,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 		return FALSE
 	if(!istype(Proj.firer, /obj/machinery/power/emitter) && power_changes)
 		investigate_log("has been hit by [Proj] fired by [key_name(Proj.firer)]", INVESTIGATE_SUPERMATTER)
-	if(Proj.flag != BULLET)
+	if(Proj.damage_type != BULLET)
 		if(power_changes) //This needs to be here I swear
 			power += Proj.damage * bullet_energy
 			if(!has_been_powered)

--- a/code/modules/projectiles/guns/ego_gun/he.dm
+++ b/code/modules/projectiles/guns/ego_gun/he.dm
@@ -8,7 +8,6 @@
 	weapon_weight = WEAPON_HEAVY
 	fire_delay = 10
 	damtype = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
 	fire_sound = 'sound/weapons/gun/rifle/shot_alt.ogg'
 	attribute_requirements = list(
 							TEMPERANCE_ATTRIBUTE = 40

--- a/code/modules/projectiles/guns/ego_gun/teth.dm
+++ b/code/modules/projectiles/guns/ego_gun/teth.dm
@@ -91,7 +91,6 @@
 	weapon_weight = WEAPON_HEAVY
 	fire_delay = 10
 	damtype = BLACK_DAMAGE
-
 	fire_sound = 'sound/weapons/gun/rifle/shot_alt.ogg'
 
 /obj/item/gun/ego_gun/snapshot
@@ -116,7 +115,6 @@
 	fire_delay = 3
 	burst_size = 2
 	damtype = BLACK_DAMAGE
-
 	fire_sound = 'sound/abnormalities/pagoda/throw.ogg'
 	var/ammo2 = /obj/item/ammo_casing/caseless/ego_wishing2
 

--- a/code/modules/projectiles/guns/ego_gun/teth.dm
+++ b/code/modules/projectiles/guns/ego_gun/teth.dm
@@ -91,7 +91,7 @@
 	weapon_weight = WEAPON_HEAVY
 	fire_delay = 10
 	damtype = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
+
 	fire_sound = 'sound/weapons/gun/rifle/shot_alt.ogg'
 
 /obj/item/gun/ego_gun/snapshot
@@ -116,7 +116,7 @@
 	fire_delay = 3
 	burst_size = 2
 	damtype = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
+
 	fire_sound = 'sound/abnormalities/pagoda/throw.ogg'
 	var/ammo2 = /obj/item/ammo_casing/caseless/ego_wishing2
 

--- a/code/modules/projectiles/guns/ego_gun/waw.dm
+++ b/code/modules/projectiles/guns/ego_gun/waw.dm
@@ -25,7 +25,6 @@
 	fire_sound = 'sound/weapons/gun/rifle/leveraction.ogg'
 	fire_delay = 5
 	damtype = RED_DAMAGE
-
 	attribute_requirements = list(
 							FORTITUDE_ATTRIBUTE = 80
 							)

--- a/code/modules/projectiles/guns/ego_gun/waw.dm
+++ b/code/modules/projectiles/guns/ego_gun/waw.dm
@@ -25,7 +25,6 @@
 	fire_sound = 'sound/weapons/gun/rifle/leveraction.ogg'
 	fire_delay = 5
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
 
 	attribute_requirements = list(
 							FORTITUDE_ATTRIBUTE = 80
@@ -315,7 +314,6 @@
 	special = "This weapon deals 35 white in melee."
 	force = 35
 	damtype = WHITE_DAMAGE
-	armortype = WHITE_DAMAGE
 	fire_delay = 25
 	attribute_requirements = list(
 							FORTITUDE_ATTRIBUTE = 60,
@@ -331,7 +329,6 @@
 	weapon_weight = WEAPON_HEAVY
 	special = "Upon hit the targets RED vulnerability is increased by 0.2."
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
 	fire_delay = 30 //5 less than the Rend Armor status effect
 	fire_sound = 'sound/misc/moist_impact.ogg'
 	attribute_requirements = list(

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -174,7 +174,6 @@
 	icon_state = null
 	damage = 40
 	damage_type = BRUTE
-	flag = BOMB
 	range = 3
 	log_override = TRUE
 
@@ -400,7 +399,7 @@
 				M.gets_drilled(K.firer, TRUE)
 	if(modifier)
 		for(var/mob/living/L in range(1, target_turf) - K.firer - target)
-			var/armor = L.run_armor_check(K.def_zone, K.flag, "", "", K.armour_penetration)
+			var/armor = L.run_armor_check(K.def_zone, K.damage_type, "", "", K.armour_penetration)
 			L.apply_damage(K.damage*modifier, K.damage_type, K.def_zone, armor)
 			to_chat(L, "<span class='userdanger'>You're struck by a [K.name]!</span>")
 
@@ -506,7 +505,7 @@
 			var/kill_modifier = 1
 			if(K.pressure_decrease_active)
 				kill_modifier *= K.pressure_decrease
-			var/armor = L.run_armor_check(K.def_zone, K.flag, "", "", K.armour_penetration)
+			var/armor = L.run_armor_check(K.def_zone, K.damage_type, "", "", K.armour_penetration)
 			L.apply_damage(bounties_reaped[L.type]*kill_modifier, K.damage_type, K.def_zone, armor)
 
 /obj/item/borg/upgrade/modkit/bounty/proc/get_kill(mob/living/L)

--- a/code/modules/projectiles/guns/misc/beam_rifle.dm
+++ b/code/modules/projectiles/guns/misc/beam_rifle.dm
@@ -411,7 +411,6 @@
 	hitsound = 'sound/effects/explosion3.ogg'
 	damage = 0				//Handled manually.
 	damage_type = BURN
-	flag = ENERGY
 	range = 150
 	jitter = 10
 	var/obj/item/gun/energy/beam_rifle/gun

--- a/code/modules/projectiles/guns/misc/reindeer.dm
+++ b/code/modules/projectiles/guns/misc/reindeer.dm
@@ -47,7 +47,6 @@
 			damtype = BLACK_DAMAGE
 		if(BLACK_DAMAGE)
 			damtype = RED_DAMAGE
-	armortype = damtype
 	to_chat(user, "<span class='notice'>[src] will now deal [force] [damtype] damage.</span>")
 	playsound(src, 'sound/items/screwdriver2.ogg', 50, TRUE)
 

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -128,7 +128,6 @@
 	var/damage = 10
 	var/damage_type = RED_DAMAGE
 	var/nodamage = FALSE //Determines if the projectile will skip any damage inflictions
-	var/flag = RED_DAMAGE //Defines what armor to use when it hits things.  Must be set to bullet, laser, energy,or bomb
 	///How much armor this projectile pierces.
 	var/armour_penetration = 0
 	var/projectile_type = /obj/projectile
@@ -612,10 +611,10 @@
 	return FALSE
 
 /obj/projectile/proc/check_ricochet_flag(atom/A)
-	if((flag in list(ENERGY, LASER)) && (A.flags_ricochet & RICOCHET_SHINY))
+	if((damage_type in list(ENERGY, LASER)) && (A.flags_ricochet & RICOCHET_SHINY))
 		return TRUE
 
-	if((flag in list(BOMB, BULLET)) && (A.flags_ricochet & RICOCHET_HARD))
+	if((damage_type in list(BOMB, BULLET)) && (A.flags_ricochet & RICOCHET_HARD))
 		return TRUE
 
 	return FALSE

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -6,7 +6,6 @@
 	damage_type = BLACK_DAMAGE
 	hitsound = 'sound/weapons/sear.ogg'
 	hitsound_wall = 'sound/weapons/effects/searwall.ogg'
-	flag = BLACK_DAMAGE
 	eyeblur = 0
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/red_laser
 	light_system = MOVABLE_LIGHT
@@ -37,26 +36,22 @@
 
 /obj/projectile/beam/laser/red
 	damage_type = RED_DAMAGE
-	flag = RED_DAMAGE
 	light_color = COLOR_RED
 
 /obj/projectile/beam/laser/white
 	damage_type = WHITE_DAMAGE
-	flag = WHITE_DAMAGE
 	light_color = COLOR_WHITE
 	icon_state = "whitelaser"
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/white_laser
 
 /obj/projectile/beam/laser/black
 	damage_type = BLACK_DAMAGE
-	flag = BLACK_DAMAGE
 	light_color = COLOR_PURPLE
 	icon_state = "purplelaser"
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/purple_laser
 
 /obj/projectile/beam/laser/pale
 	damage_type = PALE_DAMAGE
-	flag = PALE_DAMAGE
 	light_color = COLOR_PALE_BLUE_GRAY
 	icon_state = "omnilaser"
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/blue_laser
@@ -82,12 +77,10 @@
 
 /obj/projectile/beam/laser/heavylaser/red
 	damage_type = RED_DAMAGE
-	flag = RED_DAMAGE
 	light_color = COLOR_RED
 
 /obj/projectile/beam/laser/heavylaser/white
 	damage_type = WHITE_DAMAGE
-	flag = WHITE_DAMAGE
 	light_color = COLOR_WHITE
 	icon_state = "whiteheavylaser"
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/white_laser
@@ -95,7 +88,6 @@
 /obj/projectile/beam/laser/heavylaser/black
 	damage = 40
 	damage_type = BLACK_DAMAGE
-	flag = BLACK_DAMAGE
 	light_color = COLOR_PURPLE
 	icon_state = "purpleheavylaser"
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/purple_laser
@@ -103,7 +95,6 @@
 /obj/projectile/beam/laser/heavylaser/pale
 	damage = 20
 	damage_type = PALE_DAMAGE
-	flag = PALE_DAMAGE
 	light_color = COLOR_PALE_BLUE_GRAY
 	icon_state = "blueheavylaser"
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/blue_laser
@@ -127,7 +118,6 @@
 /obj/projectile/beam/xray
 	name = "\improper X-ray beam"
 	icon_state = "xray"
-	flag = RAD
 	damage = 15
 	irradiate = 300
 	range = 15
@@ -144,7 +134,6 @@
 	icon_state = "omnilaser"
 	damage = 30
 	damage_type = WHITE_DAMAGE
-	flag = ENERGY
 	hitsound = 'sound/weapons/tap.ogg'
 	eyeblur = 0
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/blue_laser
@@ -220,7 +209,6 @@
 	hitsound = null
 	damage = 0
 	damage_type = STAMINA
-	flag = LASER
 	var/suit_types = list(/obj/item/clothing/suit/redtag, /obj/item/clothing/suit/bluetag)
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/blue_laser
 	light_color = LIGHT_COLOR_BLUE
@@ -287,7 +275,6 @@
 	hitsound = 'sound/weapons/shrink_hit.ogg'
 	damage = 0
 	damage_type = STAMINA
-	flag = ENERGY
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/shrink
 	light_color = LIGHT_COLOR_BLUE
 	var/shrink_time = 90
@@ -303,7 +290,6 @@
 	icon_state = "fairy"
 	damage = 50
 	damage_type = BLACK_DAMAGE
-	flag = BLACK_DAMAGE
 	hit_stunned_targets = TRUE
 	white_healing = FALSE
 	projectile_piercing = PASSMOB

--- a/code/modules/projectiles/projectile/bullets/_incendiary.dm
+++ b/code/modules/projectiles/projectile/bullets/_incendiary.dm
@@ -29,8 +29,7 @@
 	ricochets_max = 4
 	ricochet_incidence_leeway = 0
 	suppressed = SUPPRESSED_VERY
-	damage_type = BURN
-	flag = BOMB
+	damage_type = BOMB
 	speed = 1.2
 	wound_bonus = 30
 	bare_wound_bonus = 30

--- a/code/modules/projectiles/projectile/ego_bullets/aleph.dm
+++ b/code/modules/projectiles/projectile/ego_bullets/aleph.dm
@@ -3,7 +3,6 @@
 	icon_state = "star"
 	damage = 28 // Multiplied by 1.5x when at high SP
 	damage_type = WHITE_DAMAGE
-	flag = WHITE_DAMAGE
 
 /obj/projectile/ego_bullet/melting_blob
 	name = "slime projectile"
@@ -12,7 +11,6 @@
 	damage = 40	//Fires 3
 	speed = 0.8
 	damage_type = BLACK_DAMAGE
-	flag = BLACK_DAMAGE
 	hitsound = "sound/effects/footstep/slime1.ogg"
 
 /obj/projectile/ego_bullet/melting_blob/dot

--- a/code/modules/projectiles/projectile/ego_bullets/aleph.dm
+++ b/code/modules/projectiles/projectile/ego_bullets/aleph.dm
@@ -42,7 +42,7 @@
 	damage = 35	//Fires 4 +10 damage per upgrade, up to 75
 	speed = 0.7
 	damage_type = WHITE_DAMAGE
-	flag = WHITE_DAMAGE
+
 	hitsound = 'sound/abnormalities/nihil/filter.ogg'
 	var/damage_list = list(WHITE_DAMAGE)
 	var/icon_list = list()
@@ -98,13 +98,12 @@
 	else
 		color = pick("#36454F", "#818589")
 	damage_type = pick(damage_list)
-	flag = damage_type
 
 /obj/projectile/ego_bullet/pink
 	name = "heart-piercing bullet"
 	damage = 130
 	damage_type = WHITE_DAMAGE
-	flag = WHITE_DAMAGE
+
 	hitscan = TRUE
 	damage_falloff_tile = 5//the damage ramps up; 5 extra damage per tile. Maximum range is about 32 tiles, dealing 290 damage
 

--- a/code/modules/projectiles/projectile/ego_bullets/he.dm
+++ b/code/modules/projectiles/projectile/ego_bullets/he.dm
@@ -2,19 +2,16 @@
 	name = "prank"
 	damage = 30
 	damage_type = BLACK_DAMAGE
-	flag = BLACK_DAMAGE
 
 /obj/projectile/ego_bullet/ego_transmission
 	name = "transmission"
 	damage = 30
 	damage_type = RED_DAMAGE
-	flag = RED_DAMAGE
 
 /obj/projectile/ego_bullet/ego_gaze
 	name = "gaze"
 	damage = 70 //Slow as balls
 	damage_type = RED_DAMAGE
-	flag = RED_DAMAGE
 
 //Homing weapon with no homing
 /obj/projectile/ego_bullet/ego_galaxy
@@ -22,7 +19,6 @@
 	icon_state = "magicm"
 	damage = 45
 	damage_type = BLACK_DAMAGE
-	flag = BLACK_DAMAGE
 	speed = 1.5
 
 //Homing weapon (Galaxy)
@@ -55,7 +51,6 @@
 	name = "unrequited"
 	damage = 11
 	damage_type = WHITE_DAMAGE
-	flag = WHITE_DAMAGE
 
 /obj/projectile/ego_bullet/ego_harmony
 	name = "harmony"
@@ -63,7 +58,6 @@
 	nondirectional_sprite = TRUE
 	damage = 16
 	damage_type = WHITE_DAMAGE
-	flag = WHITE_DAMAGE
 	speed = 1.3
 	projectile_piercing = PASSMOB
 	ricochets_max = 3
@@ -85,25 +79,21 @@
 	name = "song"
 	damage = 6
 	damage_type = WHITE_DAMAGE
-	flag = WHITE_DAMAGE
 
 /obj/projectile/ego_bullet/ego_songmini
 	name = "song"
 	damage = 2 //4 pellets
 	damage_type = WHITE_DAMAGE
-	flag = WHITE_DAMAGE
 
 /obj/projectile/ego_bullet/ego_wedge
 	name = "screaming"
 	damage = 30
 	damage_type = WHITE_DAMAGE
-	flag = WHITE_DAMAGE
 
 /obj/projectile/ego_bullet/replica
 	name = "sinewy claw"
 	damage = 30
 	damage_type = BLACK_DAMAGE
-	flag = BLACK_DAMAGE
 	hitscan = TRUE
 	muzzle_type = /obj/effect/projectile/tracer/laser/replica
 	tracer_type = /obj/effect/projectile/tracer/laser/replica
@@ -129,7 +119,6 @@
 	name = "swindle"
 	damage = 1
 	damage_type = RED_DAMAGE
-	flag = RED_DAMAGE
 
 /obj/projectile/ego_bullet/ego_swindle/Initialize()
 	. = ..()
@@ -140,13 +129,11 @@
 	icon_state = "energy2"
 	damage = 7
 	damage_type = BLACK_DAMAGE
-	flag = BLACK_DAMAGE
 
 /obj/projectile/ego_bullet/ego_syrinx
 	name = "syrinx"
 	icon_state = "ecstasy"
 	damage_type = WHITE_DAMAGE
-	flag = WHITE_DAMAGE
 	color = COLOR_GREEN
 	damage = 7
 	speed = 1.3

--- a/code/modules/projectiles/projectile/ego_bullets/teth.dm
+++ b/code/modules/projectiles/projectile/ego_bullets/teth.dm
@@ -42,13 +42,13 @@
 	damage = 6
 	speed = 1.5
 	damage_type = WHITE_DAMAGE
-	flag = WHITE_DAMAGE
+
 
 /obj/projectile/ego_bullet/ego_page
 	name = "page"
 	damage = 20
 	damage_type = BLACK_DAMAGE
-	flag = BLACK_DAMAGE
+
 
 //Snapshot, hitscan laser
 /obj/projectile/beam/snapshot
@@ -57,7 +57,7 @@
 	hitsound = null
 	damage = 18
 	damage_type = WHITE_DAMAGE
-	flag = WHITE_DAMAGE
+
 	hitscan = TRUE
 	muzzle_type = /obj/effect/projectile/muzzle/laser/snapshot
 	tracer_type = /obj/effect/projectile/tracer/laser/snapshot
@@ -82,7 +82,7 @@
 	icon_state = "wishing_rock"
 	damage = 5
 	damage_type = BLACK_DAMAGE
-	flag = BLACK_DAMAGE
+
 
 /obj/projectile/ego_bullet/ego_wishing/on_hit(atom/target, blocked = FALSE)
 	. = ..()
@@ -95,14 +95,14 @@
 	icon_state = "wishing_kunai"
 	damage = 10
 	damage_type = BLACK_DAMAGE
-	flag = BLACK_DAMAGE
+
 
 /obj/projectile/ego_bullet/ego_aspiration
 	name = "aspiration"
 	icon_state = "lava"
 	damage = 25
 	damage_type = RED_DAMAGE
-	flag = RED_DAMAGE
+
 	hitscan = TRUE
 	tracer_type = /obj/effect/projectile/tracer/laser/aspiration
 
@@ -124,4 +124,4 @@
 	name = "patriot"
 	damage = 15
 	damage_type = RED_DAMAGE
-	flag = RED_DAMAGE
+

--- a/code/modules/projectiles/projectile/ego_bullets/teth.dm
+++ b/code/modules/projectiles/projectile/ego_bullets/teth.dm
@@ -3,7 +3,6 @@
 	icon_state = "pulse0"
 	damage = 35 // Direct hit
 	damage_type = RED_DAMAGE
-	flag = RED_DAMAGE
 
 /obj/projectile/ego_bullet/ego_match/on_hit(atom/target, blocked = FALSE)
 	..()
@@ -16,31 +15,26 @@
 	name = "beak"
 	damage = 4
 	damage_type = RED_DAMAGE
-	flag = RED_DAMAGE
 
 /obj/projectile/ego_bullet/ego_noise
 	name = "noise"
 	damage = 10
 	damage_type = WHITE_DAMAGE
-	flag = WHITE_DAMAGE
 
 /obj/projectile/ego_bullet/ego_solitude
 	name = "solitude"
 	damage = 40	//Slow as balls
 	damage_type = WHITE_DAMAGE
-	flag = WHITE_DAMAGE
 
 /obj/projectile/ego_bullet/ego_beakmagnum
 	name = "beak"
 	damage = 30	//entirely accurate. should have 32 DPS, it suffers.
 	damage_type = RED_DAMAGE
-	flag = RED_DAMAGE
 
 /obj/projectile/ego_bullet/ego_shy
 	name = "today's expression"
 	damage = 4 //Can dual wield, full auto
 	damage_type = BLACK_DAMAGE
-	flag = BLACK_DAMAGE
 
 /obj/projectile/ego_bullet/ego_dream
 	name = "dream"

--- a/code/modules/projectiles/projectile/ego_bullets/waw.dm
+++ b/code/modules/projectiles/projectile/ego_bullets/waw.dm
@@ -298,7 +298,7 @@
 	icon_state = "pulse0"
 	damage = 120
 	damage_type = BLACK_DAMAGE
-	flag = BLACK_DAMAGE
+
 
 /obj/projectile/ego_bullet/ego_blind_rage
 	name = "blind rage"
@@ -326,7 +326,7 @@
 	icon_state = "energy"
 	damage = 7 //Can dual wield, full auto
 	damage_type = WHITE_DAMAGE
-	flag = WHITE_DAMAGE
+
 
 /obj/projectile/ego_bullet/ego_hypocrisy
 	name = "hypocrisy"
@@ -334,11 +334,11 @@
 	color = "#AAFF00"
 	damage = 90 //50 damage is transfered to the spawnable trap
 	damage_type = RED_DAMAGE
-	flag = RED_DAMAGE
+
 
 /obj/projectile/ego_bullet/ego_bride
 	name = "bride"
 	icon_state = "bride"
 	damage = 25
 	damage_type = WHITE_DAMAGE
-	flag = WHITE_DAMAGE
+

--- a/code/modules/projectiles/projectile/ego_bullets/waw.dm
+++ b/code/modules/projectiles/projectile/ego_bullets/waw.dm
@@ -12,7 +12,6 @@
 	name = "magic beam"
 	icon_state = "qoh1"
 	damage_type = BLACK_DAMAGE
-	flag = BLACK_DAMAGE
 	damage = 50
 	spread = 10
 
@@ -44,7 +43,6 @@
 	. = ..()
 	icon_state = "qoh[pick(1,2,3)]"
 	damage_type = pick(RED_DAMAGE, WHITE_DAMAGE, BLACK_DAMAGE, PALE_DAMAGE)
-	flag = damage_type
 
 /obj/projectile/ego_bullet/ego_magicbullet
 	name = "magic bullet"
@@ -52,7 +50,6 @@
 	damage = 80
 	speed = 0.1
 	damage_type = BLACK_DAMAGE
-	flag = BLACK_DAMAGE
 	projectile_piercing = PASSMOB
 	range = 18 // Don't want people shooting it through the entire facility
 	hit_nondense_targets = TRUE
@@ -78,7 +75,6 @@
 	damage = 4
 	speed = 0.2
 	damage_type = RED_DAMAGE
-	flag = RED_DAMAGE
 
 /obj/projectile/ego_bullet/ego_loyalty/iff
 	name = "loyalty IFF"
@@ -110,7 +106,6 @@
 	name = "ecstasy"
 	icon_state = "ecstasy"
 	damage_type = WHITE_DAMAGE
-	flag = WHITE_DAMAGE
 	damage = 7
 	speed = 1.3
 	range = 6
@@ -126,7 +121,6 @@
 	damage = 3
 	nodamage = TRUE	//Damage is calculated later
 	damage_type = RED_DAMAGE
-	flag = RED_DAMAGE
 	projectile_piercing = PASSMOB
 	homing = TRUE
 	homing_turn_speed = 30		//Angle per tick.
@@ -165,7 +159,6 @@
 	damage = 40
 	speed = 0.1
 	damage_type = BLACK_DAMAGE
-	flag = BLACK_DAMAGE
 	projectile_piercing = PASSMOB
 
 //tommygun
@@ -174,21 +167,18 @@
 	damage = 5
 	speed = 0.2
 	damage_type = RED_DAMAGE
-	flag = RED_DAMAGE
 
 //laststop
 /obj/projectile/ego_bullet/ego_laststop
 	name = "laststop"
 	damage = 145
 	damage_type = RED_DAMAGE
-	flag = RED_DAMAGE
 
 /obj/projectile/ego_bullet/ego_aroma
 	name = "aroma"
 	icon_state = "arrow_aroma"
 	damage = 140
 	damage_type = WHITE_DAMAGE
-	flag = WHITE_DAMAGE
 
 //Assonance, our one hitscan laser
 /obj/projectile/beam/assonance
@@ -197,7 +187,6 @@
 	hitsound = null
 	damage = 50
 	damage_type = WHITE_DAMAGE
-	flag = WHITE_DAMAGE
 	hitscan = TRUE
 	muzzle_type = /obj/effect/projectile/muzzle/laser/white
 	tracer_type = /obj/effect/projectile/tracer/laser/white
@@ -231,7 +220,6 @@
 	icon_state = "lava"
 	damage = 40
 	damage_type = WHITE_DAMAGE
-	flag = WHITE_DAMAGE
 	homing = TRUE
 	speed = 1.5
 
@@ -243,7 +231,6 @@
 	desc = "A sterile naked nest serpent"
 	damage = 120
 	damage_type = RED_DAMAGE
-	flag = RED_DAMAGE
 	hitsound = "sound/effects/wounds/pierce1.ogg"
 
 /obj/projectile/ego_bullet/ego_exuviae/on_hit(target)
@@ -260,7 +247,6 @@
 	icon_state = "arrow"
 	damage = 75
 	damage_type = BLACK_DAMAGE
-	flag = BLACK_DAMAGE
 
 /obj/projectile/ego_bullet/ego_warring/on_hit(atom/target, blocked = FALSE)
 	. = ..()
@@ -281,7 +267,6 @@
 	hitsound = null
 	damage = 125
 	damage_type = BLACK_DAMAGE
-	flag = BLACK_DAMAGE
 	hitscan = TRUE
 	muzzle_type = /obj/effect/projectile/muzzle/laser/warring
 	tracer_type = /obj/effect/projectile/tracer/warring

--- a/code/modules/projectiles/projectile/ego_bullets/zayin.dm
+++ b/code/modules/projectiles/projectile/ego_bullets/zayin.dm
@@ -2,7 +2,6 @@
 	name = "9mm tough bullet"
 	damage = 12 // Being bald is the optimal gameplay choice!
 	damage_type = WHITE_DAMAGE
-	flag = WHITE_DAMAGE
 
 /obj/projectile/ego_bullet/ego_soda
 	name = "9mm soda bullet"

--- a/code/modules/projectiles/projectile/ego_bullets/zayin.dm
+++ b/code/modules/projectiles/projectile/ego_bullets/zayin.dm
@@ -52,10 +52,10 @@
 	icon_state = "wishing_rock"
 	damage = 20
 	damage_type = RED_DAMAGE
-	flag = RED_DAMAGE
+
 
 /obj/projectile/ego_bullet/ego_oceanic
 	name = "oceanic"
 	damage = 11		//Worse than tough lol
 	damage_type = WHITE_DAMAGE
-	flag = WHITE_DAMAGE
+

--- a/code/modules/projectiles/projectile/energy/_energy.dm
+++ b/code/modules/projectiles/projectile/energy/_energy.dm
@@ -2,7 +2,6 @@
 	name = "energy"
 	icon_state = "spark"
 	damage = 0
-	damage_type = BURN
-	flag = ENERGY
+	damage_type = ENERGY
 	reflectable = REFLECT_NORMAL
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/energy

--- a/code/modules/projectiles/projectile/energy/nuclear_particle.dm
+++ b/code/modules/projectiles/projectile/energy/nuclear_particle.dm
@@ -3,7 +3,7 @@
 	name = "nuclear particle"
 	icon_state = "nuclear_particle"
 	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE
-	flag = RAD
+	damage_type = RAD
 	irradiate = 5000
 	speed = 0.4
 	hitsound = 'sound/weapons/emitter2.ogg'

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -5,7 +5,6 @@
 	damage_type = OXY
 	nodamage = TRUE
 	armour_penetration = 100
-	flag = MAGIC
 
 /obj/projectile/magic/death
 	name = "bolt of death"
@@ -354,7 +353,6 @@
 	icon_state = "lavastaff"
 	damage = 15
 	damage_type = BURN
-	flag = MAGIC
 	dismemberment = 50
 	nodamage = FALSE
 
@@ -374,7 +372,6 @@
 	damage_type = BURN
 	nodamage = FALSE
 	armour_penetration = 0
-	flag = MAGIC
 	hitsound = 'sound/weapons/barragespellhit.ogg'
 
 /obj/projectile/magic/arcane_barrage/on_hit(target)
@@ -391,7 +388,6 @@
 	name = "locker bolt"
 	icon_state = "locker"
 	nodamage = TRUE
-	flag = MAGIC
 	var/weld = TRUE
 	var/created = FALSE //prevents creation of more then one locker if it has multiple hits
 	var/locker_suck = TRUE
@@ -619,7 +615,6 @@
 	damage_type = BURN
 	nodamage = FALSE
 	speed = 0.3
-	flag = MAGIC
 
 	var/zap_power = 20000
 	var/zap_range = 15
@@ -684,7 +679,6 @@
 
 	damage = 350
 	damage_type = BLACK_DAMAGE
-	flag = BLACK_DAMAGE
 	armour_penetration = 0
 	speed = 1.5 // Slow
 	damage_falloff_tile = -5 // Loses a bit of damage so you don't get jumpscared out of nowhere
@@ -717,19 +711,16 @@
 /obj/projectile/magic/aoe/pillar/red
 	icon_state = "pillar_red"
 	damage_type = RED_DAMAGE
-	flag = RED_DAMAGE
 	trail_type = /obj/effect/temp_visual/cult/sparks
 
 /obj/projectile/magic/aoe/pillar/white
 	icon_state = "pillar_white"
 	damage_type = WHITE_DAMAGE
-	flag = WHITE_DAMAGE
 
 /obj/projectile/magic/aoe/pillar/pale
 	icon_state = "pillar_pale"
 	damage = 250
 	damage_type = PALE_DAMAGE
-	flag = PALE_DAMAGE
 
 //still magic related, but a different path
 
@@ -741,7 +732,6 @@
 	nodamage = FALSE
 	armour_penetration = 100
 	temperature = -200 // Cools you down greatly per hit
-	flag = MAGIC
 
 /obj/projectile/magic/nothing
 	name = "bolt of nothing"

--- a/code/modules/projectiles/projectile/magic/abnormality.dm
+++ b/code/modules/projectiles/projectile/magic/abnormality.dm
@@ -48,7 +48,7 @@
 	icon_state = "slime"
 	hitsound = 'sound/abnormalities/meltinglove/ranged_hit.ogg'
 	damage_type = BLACK_DAMAGE
-	flag = BLACK_DAMAGE
+
 	damage = 30 // Mainly a disabling tool, to pursue escaping opponents
 	spread = 5
 	slur = 5
@@ -133,7 +133,7 @@
 	desc = "A magic white bolt, enchanted to protect or to avenge the sculptor."
 	icon_state = "bride_bolt"
 	damage_type = WHITE_DAMAGE
-	flag = WHITE_DAMAGE
+
 	damage = 25
 	spread = 10
 
@@ -142,7 +142,7 @@
 	desc = "A magic white bolt, enchanted to protect or to avenge the sculptor."
 	icon_state = "bride_bolt_enraged"
 	damage_type = WHITE_DAMAGE
-	flag = WHITE_DAMAGE
+
 	damage = 50
 	spread = 5
 
@@ -151,7 +151,7 @@
 	desc = "Report this to a dev"
 	icon_state = "mountain"
 	damage_type = RED_DAMAGE
-	flag = RED_DAMAGE
+
 	damage = 45
 
 /obj/projectile/season_projectile/Moved(atom/OldLoc, Dir)
@@ -167,28 +167,28 @@
 	desc = "A spiky burr"
 	icon_state = "toxin"
 	damage_type = WHITE_DAMAGE
-	flag = WHITE_DAMAGE
+
 
 /obj/projectile/season_projectile/summer
 	name = "fireball"
 	desc = "A ball of heated plasma"
 	icon_state = "fireball"
 	damage_type = RED_DAMAGE
-	flag = RED_DAMAGE
+
 
 /obj/projectile/season_projectile/fall
 	name = "wisp"
 	desc = "A glowing ember"
 	icon_state = "pulse1"
 	damage_type = BLACK_DAMAGE
-	flag = BLACK_DAMAGE
+
 
 /obj/projectile/season_projectile/winter
 	name = "ice spear"
 	desc = "A sharp-looking icicle"
 	icon_state = "ice_2"
 	damage_type = PALE_DAMAGE
-	flag = PALE_DAMAGE
+
 	damage = 35
 
 //slow, dodgable, and make it hard to see and talk
@@ -196,7 +196,7 @@
 	name = "blood blob"
 	icon_state = "mini_leaper"
 	damage_type = RED_DAMAGE
-	flag = RED_DAMAGE
+
 	damage = 30
 	spread = 15
 	eyeblur = 10
@@ -208,7 +208,7 @@
 	icon_state = "bullet"
 	desc = "causes a lot of pain"
 	damage_type = WHITE_DAMAGE
-	flag = WHITE_DAMAGE
+
 	damage = 10
 
 /obj/projectile/actor/on_hit(target)
@@ -229,7 +229,7 @@
 	desc = "Look out!"
 	icon_state = "thunder_tomahawk"
 	damage_type = BLACK_DAMAGE
-	flag = BLACK_DAMAGE
+
 	damage = 45
 
 /obj/projectile/thunder_tomahawk/Initialize()
@@ -242,7 +242,7 @@
 	hitsound = null
 	damage = 10
 	damage_type = WHITE_DAMAGE
-	flag = WHITE_DAMAGE
+
 	hitscan = TRUE
 	muzzle_type = /obj/effect/projectile/muzzle/laser/snapshot
 	tracer_type = /obj/effect/projectile/tracer/laser/snapshot

--- a/code/modules/projectiles/projectile/magic/abnormality.dm
+++ b/code/modules/projectiles/projectile/magic/abnormality.dm
@@ -3,7 +3,6 @@
 	desc = "A magic rapier, enchanted by the sheer despair and suffering the knight has been through."
 	icon_state = "despair"
 	damage_type = PALE_DAMAGE
-	flag = PALE_DAMAGE
 	damage = 40
 	alpha = 0
 	spread = 20
@@ -27,7 +26,6 @@
 	name = "light"
 	icon_state = "apocalypse"
 	damage_type = BLACK_DAMAGE
-	flag = BLACK_DAMAGE
 	damage = 30
 	alpha = 0
 	spread = 45
@@ -41,7 +39,6 @@
 	name = "magic beam"
 	icon_state = "qoh1"
 	damage_type = BLACK_DAMAGE
-	flag = BLACK_DAMAGE
 	damage = 25
 	spread = 15
 
@@ -92,7 +89,6 @@
 	desc = "Gross, disgusting spit."
 	icon_state = "mountain"
 	damage_type = BLACK_DAMAGE
-	flag = BLACK_DAMAGE
 	damage = 15 // Launches 16(48) of those, for a whooping 240(720) black damage
 	spread = 60
 	slur = 3
@@ -114,7 +110,6 @@
 	desc = "A blade thrown maliciously"
 	icon_state = "clown"
 	damage_type = RED_DAMAGE
-	flag = RED_DAMAGE
 	damage = 5
 
 /obj/projectile/clown_throw/Initialize()

--- a/code/modules/projectiles/projectile/special/floral.dm
+++ b/code/modules/projectiles/projectile/special/floral.dm
@@ -4,7 +4,6 @@
 	damage = 0
 	damage_type = TOX
 	nodamage = TRUE
-	flag = ENERGY
 
 /obj/projectile/energy/florayield
 	name = "beta somatoray"
@@ -12,7 +11,6 @@
 	damage = 0
 	damage_type = TOX
 	nodamage = TRUE
-	flag = ENERGY
 
 /obj/projectile/energy/florarevolution
 	name = "gamma somatoray"
@@ -20,4 +18,3 @@
 	damage = 0
 	damage_type = TOX
 	nodamage = TRUE
-	flag = ENERGY

--- a/code/modules/projectiles/projectile/special/ion.dm
+++ b/code/modules/projectiles/projectile/special/ion.dm
@@ -2,9 +2,8 @@
 	name = "ion bolt"
 	icon_state = "ion"
 	damage = 0
-	damage_type = BURN
+	damage_type = ENERGY
 	nodamage = TRUE
-	flag = ENERGY
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/ion
 	var/emp_radius = 1
 

--- a/code/modules/projectiles/projectile/special/meteor.dm
+++ b/code/modules/projectiles/projectile/special/meteor.dm
@@ -3,9 +3,8 @@
 	icon = 'icons/obj/meteor.dmi'
 	icon_state = "small1"
 	damage = 0
-	damage_type = BRUTE
+	damage_type = BULLET
 	nodamage = TRUE
-	flag = BULLET
 
 /obj/projectile/meteor/Bump(atom/A)
 	if(A == firer)

--- a/code/modules/projectiles/projectile/special/neurotoxin.dm
+++ b/code/modules/projectiles/projectile/special/neurotoxin.dm
@@ -5,7 +5,6 @@
 	damage_type = TOX
 	nodamage = FALSE
 	paralyze = 100
-	flag = BIO
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/neurotoxin
 
 /obj/projectile/neurotoxin/on_hit(atom/target, blocked = FALSE)

--- a/code/modules/projectiles/projectile/special/temperature.dm
+++ b/code/modules/projectiles/projectile/special/temperature.dm
@@ -2,9 +2,8 @@
 	name = "freeze beam"
 	icon_state = "ice_2"
 	damage = 0
-	damage_type = BURN
+	damage_type = ENERGY
 	nodamage = FALSE
-	flag = ENERGY
 	var/temperature = -50 // reduce the body temperature by 50 points
 
 /obj/projectile/temp/on_hit(atom/target, blocked = 0)

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -21,10 +21,10 @@
 	if(can_be_tanked)
 		. += "<span class='notice'>Use a sheet of metal to convert this into a plumbing-compatible tank.</span>"
 
-/obj/structure/reagent_dispensers/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir)
+/obj/structure/reagent_dispensers/take_damage(damage_amount, damage_type = BRUTE, sound_effect = 1, attack_dir)
 	. = ..()
 	if(. && obj_integrity > 0)
-		if(tank_volume && (damage_flag == BULLET || damage_flag == LASER))
+		if(tank_volume && (damage_type in list(BULLET, LASER)))
 			boom()
 
 /obj/structure/reagent_dispensers/attackby(obj/item/W, mob/user, params)

--- a/code/modules/spells/ability_types/realized_aimed.dm
+++ b/code/modules/spells/ability_types/realized_aimed.dm
@@ -430,7 +430,7 @@
 	speed = 0
 	damage = 30
 	damage_type = BLACK_DAMAGE
-	flag = BLACK_DAMAGE
+
 	projectile_piercing = PASSMOB
 	hit_nondense_targets = TRUE
 	var/damage_amount = 200 // Amount of black damage dealt to enemies in the epicenter.

--- a/code/modules/swarmers/swarmer_objs.dm
+++ b/code/modules/swarmers/swarmer_objs.dm
@@ -16,7 +16,7 @@
 	. = ..()
 	set_light(glow_range)
 
-/obj/structure/swarmer/play_attack_sound(damage_amount, damage_type = BRUTE, damage_flag = 0)
+/obj/structure/swarmer/play_attack_sound(damage_amount, damage_type = BRUTE)
 	switch(damage_type)
 		if(BRUTE)
 			playsound(src, 'sound/weapons/egloves.ogg', 80, TRUE)

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -51,7 +51,6 @@
 #include "heretic_knowledge.dm"
 #include "holidays.dm"
 #include "initialize_sanity.dm"
-#include "item_damage.dm"
 #include "keybinding_init.dm"
 #include "machine_disassembly.dm"
 #include "medical_wounds.dm"

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -51,6 +51,7 @@
 #include "heretic_knowledge.dm"
 #include "holidays.dm"
 #include "initialize_sanity.dm"
+#include "item_damage.dm"
 #include "keybinding_init.dm"
 #include "machine_disassembly.dm"
 #include "medical_wounds.dm"

--- a/code/modules/vehicles/cars/clowncar.dm
+++ b/code/modules/vehicles/cars/clowncar.dm
@@ -50,7 +50,7 @@
 	. = ..()
 	UnregisterSignal(M, COMSIG_MOB_CLICKON)
 
-/obj/vehicle/sealed/car/clowncar/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir)
+/obj/vehicle/sealed/car/clowncar/take_damage(damage_amount, damage_type = BRUTE, sound_effect = 1, attack_dir)
 	. = ..()
 	if(prob(33))
 		visible_message("<span class='danger'>[src] spews out a ton of space lube!</span>")

--- a/code/modules/vehicles/mecha/combat/durand.dm
+++ b/code/modules/vehicles/mecha/combat/durand.dm
@@ -96,10 +96,10 @@ Expects a turf. Returns true if the attack should be blocked, false if not.*/
 				. = TRUE
 	return
 
-/obj/vehicle/sealed/mecha/combat/durand/attack_generic(mob/user, damage_amount = 0, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, armor_penetration = 0)
+/obj/vehicle/sealed/mecha/combat/durand/attack_generic(mob/user, damage_amount = 0, damage_type = BRUTE, sound_effect = 1, armor_penetration = 0)
 	if(defense_check(user.loc))
 		log_message("Attack absorbed by defense field. Attacker - [user].", LOG_MECHA, color="orange")
-		shield.attack_generic(user, damage_amount, damage_type, damage_flag, sound_effect, armor_penetration)
+		shield.attack_generic(user, damage_amount, damage_type, sound_effect, armor_penetration)
 	else
 		. = ..()
 

--- a/code/modules/vehicles/mecha/equipment/weapons/mecha_melee.dm
+++ b/code/modules/vehicles/mecha/equipment/weapons/mecha_melee.dm
@@ -9,7 +9,7 @@
 	range = MECHA_MELEE
 	mech_flags = EXOSUIT_MODULE_COMBAT
 	damtype = RED_DAMAGE
-	armortype = RED_DAMAGE
+
 
 /obj/item/mecha_parts/mecha_equipment/hammer/rhinoblade
 	name = "Rhino Hammer (Black)"
@@ -22,7 +22,7 @@
 	range = MECHA_MELEE
 	mech_flags = EXOSUIT_MODULE_COMBAT
 	damtype = BLACK_DAMAGE
-	armortype = BLACK_DAMAGE
+
 
 /obj/item/mecha_parts/mecha_equipment/hammer/action(mob/source, atom/target, params)
 	// Check if we can even use the equipment to begin with.
@@ -31,7 +31,7 @@
 
 	if(isliving(target))
 		var/mob/living/L = target
-		L.apply_damage(force, damtype, null, L.run_armor_check(null, armortype), spread_damage = TRUE)
+		L.apply_damage(force, damtype, null, L.run_armor_check(null, damtype), spread_damage = TRUE)
 		playsound(src,'sound/weapons/fixer/generic/club2.ogg',40,TRUE)
 
 	new /obj/effect/temp_visual/smash_effect(get_turf(target))

--- a/code/modules/vehicles/mecha/mecha_defense.dm
+++ b/code/modules/vehicles/mecha/mecha_defense.dm
@@ -114,7 +114,7 @@
 			var/mob/living/hitmob = m
 			hitmob.bullet_act(Proj) //If the sides are open, the occupant can be hit
 		return BULLET_ACT_HIT
-	log_message("Hit by projectile. Type: [Proj.name]([Proj.flag]).", LOG_MECHA, color="red")
+	log_message("Hit by projectile. Type: [Proj.name]([Proj.damage_type]).", LOG_MECHA, color="red")
 	. = ..()
 
 /obj/vehicle/sealed/mecha/ex_act(severity, target)

--- a/code/modules/vehicles/mecha/mecha_defense.dm
+++ b/code/modules/vehicles/mecha/mecha_defense.dm
@@ -6,11 +6,11 @@
 			return facing_modifiers[MECHA_FRONT_ARMOUR]
 	return facing_modifiers[MECHA_SIDE_ARMOUR] //if its not a front hit or back hit then assume its from the side
 
-/obj/vehicle/sealed/mecha/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir)
+/obj/vehicle/sealed/mecha/take_damage(damage_amount, damage_type = BRUTE, sound_effect = 1, attack_dir)
 	. = ..()
 	if(. && obj_integrity > 0)
 		spark_system.start()
-		switch(damage_flag)
+		switch(damage_type)
 			if(FIRE)
 				check_for_internal_damage(list(MECHA_INT_FIRE,MECHA_INT_TEMP_CONTROL))
 			if(MELEE)
@@ -21,19 +21,19 @@
 			to_chat(occupants, "[icon2html(src, occupants)]<span class='userdanger'>Taking damage!</span>")
 		log_message("Took [damage_amount] points of damage. Damage type: [damage_type]", LOG_MECHA)
 
-/obj/vehicle/sealed/mecha/run_obj_armor(damage_amount, damage_type, damage_flag = 0, attack_dir)
+/obj/vehicle/sealed/mecha/run_obj_armor(damage_amount, damage_type, attack_dir)
 	. = ..()
 	if(!damage_amount)
 		return 0
 	var/booster_deflection_modifier = 1
 	var/booster_damage_modifier = 1
-	if(damage_flag == BULLET || damage_flag == LASER || damage_flag == ENERGY)
+	if(damage_type in list(BULLET, LASER, ENERGY))
 		for(var/obj/item/mecha_parts/mecha_equipment/antiproj_armor_booster/B in equipment)
 			if(B.projectile_react())
 				booster_deflection_modifier = B.deflect_coeff
 				booster_damage_modifier = B.damage_coeff
 				break
-	else if(damage_flag == MELEE)
+	else if(damage_type == MELEE)
 		for(var/obj/item/mecha_parts/mecha_equipment/anticcw_armor_booster/B in equipment)
 			if(B.attack_react())
 				booster_deflection_modifier *= B.deflect_coeff


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
It was useful for if we wanted to do stuff like have Red damage hit White Armor but we've never once considered doing this intentionally and it's a gimmick that would be a pain to play against.

Removes most usage of `damage_flag` and converts it to `damage_type` checks. Most are ugly *yet functional*. 
Converts a lot of `if(damage_type == BRUTE || damage_type == MELEE || ...)` with `if(damage_type in list(BRUTE, MELEE, ...))` instead.
Removes all usage of `flag` for projectiles and `armortype` for items. We don't need it.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Redundant Code Removal makes coding things easier.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
