### PR TITLE
Fixes head of god ability

### DIFF
--- a/code/modules/spells/ability_types/realized.dm
+++ b/code/modules/spells/ability_types/realized.dm
@@ -43,6 +43,7 @@
 	var/damage_range = 9
 
 /obj/effect/proc_holder/ability/judgement/Perform(target, mob/user)
+	cooldown = world.time + (2 SECONDS)
 	playsound(get_turf(user), 'sound/abnormalities/judgementbird/pre_ability.ogg', 50, 0)
 	var/obj/effect/temp_visual/judgement/still/J = new (get_turf(user))
 	animate(J, pixel_y = 24, time = 1.5 SECONDS)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Adds short cooldown to the ability before the do_after is called.

## Why It's Good For The Game

- Prevents people from spamming the ability.
