### PR TITLE
Eyeball Scooper Rework

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/zayin/bottle.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/bottle.dm
@@ -61,18 +61,55 @@
 			//Drowns you like Wellcheers does, so I mean the code checks out
 			for(var/turf/open/T in view(7, src))
 				new /obj/effect/temp_visual/water_waves(T)
-			to_chat(user, "<span class='userdanger'>The room is filling with water! You're going to drown!</span>")
 			playsound(get_turf(user), 'sound/abnormalities/bottle/bottledrown.ogg', 80, 0)
 			icon_state = "bottle3" //cake all gone
 
+			/* "I get it now. There's no reason to have any emotions or a heart."
+			"Abandon reason and protect Catt! That's how you survive in this wonderland!"
+			Catt was a low level agent with temperance and fortitude. She sought to abandon that temperance in exchange for justice.
+			Thus, bottle will check for those. Overall low level, high temperance, high fortitude.
+			Keep in mind that this event can happen ONCE PER ROUND. The spoon is already jokingly called the protagonist weapon, so it can bend the rules a bit, right?*/
+
 			new /obj/item/ego_weapon/eyeball(get_turf(user))
 
+			var/fortitude = get_attribute_level(user, FORTITUDE_ATTRIBUTE)
+			var/prudence = get_attribute_level(user, PRUDENCE_ATTRIBUTE)
+			var/temperance = get_attribute_level(user, TEMPERANCE_ATTRIBUTE)
+			var/justice = get_attribute_level(user, JUSTICE_ATTRIBUTE)
+			var/goal_damage = 0
+			if(temperance >= (fortitude + prudence + justice) / 1.5) // If your temperance is at least twice your average stat, you aren't hurt, but lose temperance.
+				to_chat(user, "<span class='userdanger'>The room is filling with water... but you feel oddly unconcerned.</span>")
+				user.adjust_attribute_level(TEMPERANCE_ATTRIBUTE, 20 - temperance)
+				// This is a PERMANENT stat change, VERY significant. But it can happen only once per round. You're The Protagonist, after all.
+				var/stat_change = 0
+				stat_change = temperance - 20
+				user.adjust_attribute_buff(JUSTICE_ATTRIBUTE, stat_change) // Gain benefit from what you lost.
+				addtimer(CALLBACK(src, .proc/DecayProtagonistBuff, user, stat_change), 20 SECONDS) // Short grace period. 10s of this happens while you're asleep.
+			else
+				to_chat(user, "<span class='userdanger'>The room is filling with water! Are you going to drown?!</span>")
+				goal_damage = 99999 // DIE.
+				if(fortitude >= (prudence + justice)) // Like the temperance calculation, but high temperance doesn't actively hurt your odds.
+					goal_damage = 120 + fortitude // Hurt bad, but never lethally.
+
 			user.AdjustSleeping(10 SECONDS)
-			user.adjustBruteLoss(200) //You have 100 health + 40 crit health, you need 60 fort to live at all.
+			user.adjustBruteLoss(goal_damage)
 			if(user.stat == DEAD)
 				animate(user, alpha = 0, time = 2 SECONDS)
 				QDEL_IN(user, 3.5 SECONDS)
+			else
+				user.adjustBruteLoss(-(goal_damage * 0.25)) // If you didn't die instantly, heal up some.
 	return
+
+/mob/living/simple_animal/hostile/abnormality/bottle/proc/DecayProtagonistBuff(mob/living/carbon/human/buffed, justice = 0)
+	// Goes faster when the buff is higher, so you don't have an overwhelming buff for an overwhelming length of time.
+	if(justice == 0 || !buffed)
+		return FALSE
+	var/factor = justice / 10
+	var/timing = 10 + max(0, (100 - factor * factor))
+	buffed.adjust_attribute_buff(JUSTICE_ATTRIBUTE, -1)
+	if(prob(10))
+		buffed.adjust_attribute_level(JUSTICE_ATTRIBUTE, 1) // 10% chance for justice buff to become real justice as it decays.
+	addtimer(CALLBACK(src, .proc/DecayProtagonistBuff, buffed, justice - 1), timing)
 
 /datum/status_effect/tears
 	id = "tears"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Alters the Eyeball Scooper EGO weapon to allow it to fulfill its original niche: A unique EGO that, at its best, is as powerful as its user, enabling its use for an entire round.

It now scales off of fortitude by default, with a mostly predictable, linear growth. It also has an additional scaling factor, only active at 80 fortitude and above, that helps it bridge the gap between Waw and Aleph.

Its DPS almost exactly matches that of a regular EGO one could wield at each stat threshold: It has 22 force at 40 fortitude, 33 force at 60 fortitude, 44 force at 80 fortitude, and (if the extra scaling factor is active) 80 force at 100 fortitude.

To compensate for its additional strength, the extra scaling factor only applies when Eyeball Scooper is the only EGO weapon on your person. To make this slightly less punishing within the context of LC13, the weapon will detect enemies that are black immune or that absorb black damage, and instead deal brute damage (with significantly reduced force).

Beyond 100 fortitude, Eyeball Scooper continues gaining force, but as there is only one copy of it and the weapon still requires its wielder to use no other EGO for it to exceed Aleph-tier base force, this is hopefully balanced.

The conditions under which Eyeball Scooper is acquired have also been changed; it is easier to acquire nonlethally in the early half of a round, and near impossible in the latter half, assuming you're keeping up.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The protagonist weapon deserves to actually be usable.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Eyeball Scooper is worthwhile for an entire round
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
