### PR TITLE
EGO Rebalance April

### DIFF
--- a/code/game/objects/items/ego_weapons/aleph.dm
+++ b/code/game/objects/items/ego_weapons/aleph.dm
@@ -248,7 +248,7 @@
 /obj/item/ego_weapon/goldrush/attack(mob/living/target, mob/living/user)
 	if(!CanUseEgo(user))
 		return
-	if(do_after(user, 6, target))
+	if(do_after(user, 5, target))
 
 		target.visible_message("<span class='danger'>[user] rears up and slams into [target]!</span>", \
 						"<span class='userdanger'>[user] punches you with everything you got!!</span>", COMBAT_MESSAGE_RANGE, user)

--- a/code/game/objects/items/ego_weapons/he.dm
+++ b/code/game/objects/items/ego_weapons/he.dm
@@ -43,7 +43,7 @@
 	attack_verb_simple = list("attack", "bash", "till")
 	hitsound = 'sound/weapons/ego/harvest.ogg'
 	attribute_requirements = list(
-							TEMPERANCE_ATTRIBUTE = 20		//It's 20 to keep clerks from using it
+							PRUDENCE_ATTRIBUTE = 40
 							)
 	var/can_spin = TRUE
 	var/spinning = FALSE
@@ -244,7 +244,7 @@
 	attack_verb_simple = "chop"
 	hitsound = 'sound/abnormalities/woodsman/woodsman_attack.ogg'
 	attribute_requirements = list(
-							TEMPERANCE_ATTRIBUTE = 40
+							JUSTICE_ATTRIBUTE = 40
 							)
 	var/ramping = 1.5
 	var/smashing = FALSE
@@ -457,7 +457,7 @@
 	attack_verb_simple = "slash"
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attribute_requirements = list(
-							TEMPERANCE_ATTRIBUTE = 40
+							PRUDENCE_ATTRIBUTE = 40
 							)
 	var/happy = FALSE
 
@@ -602,7 +602,7 @@
 	hit_message = "parries the attack!"
 	block_cooldown_message = "You rearm your E.G.O."
 	attribute_requirements = list(
-							TEMPERANCE_ATTRIBUTE = 40
+							FORTITUDE_ATTRIBUTE = 40
 							)
 
 /obj/item/ego_weapon/revelation

--- a/code/game/objects/items/ego_weapons/waw.dm
+++ b/code/game/objects/items/ego_weapons/waw.dm
@@ -124,7 +124,7 @@
 	attack_verb_simple = list("cleaves", "cuts")
 	hitsound = 'sound/weapons/slash.ogg'
 	attribute_requirements = list(
-							TEMPERANCE_ATTRIBUTE = 80
+							PRUDENCE_ATTRIBUTE = 80
 							)
 	var/charged = FALSE
 	var/meter = 0
@@ -415,7 +415,7 @@
 							JUSTICE_ATTRIBUTE = 60
 							)
 	var/ranged_cooldown
-	var/ranged_cooldown_time = 1.5 SECONDS
+	var/ranged_cooldown_time = 1.2 SECONDS
 	var/ranged_damage = 60
 
 /obj/effect/temp_visual/thornspike
@@ -436,7 +436,7 @@
 		return
 	..()
 	ranged_cooldown = world.time + ranged_cooldown_time
-	if(do_after(user, 6))
+	if(do_after(user, 5))
 		playsound(target_turf, 'sound/abnormalities/ebonyqueen/attack.ogg', 50, TRUE)
 		for(var/turf/open/T in range(target_turf, 1))
 			new /obj/effect/temp_visual/thornspike(T)
@@ -727,8 +727,7 @@
 	projectile_block_message = "You swat the projectile out of the air!"
 	block_cooldown_message = "You rearm your E.G.O."
 	attribute_requirements = list(
-							PRUDENCE_ATTRIBUTE = 60,
-							TEMPERANCE_ATTRIBUTE = 60
+							PRUDENCE_ATTRIBUTE = 80
 							)
 	var/close_cooldown
 	var/close_cooldown_time = 3 SECONDS
@@ -811,7 +810,7 @@
 
 
 /obj/item/ego_weapon/spore
-	name = "Spore"
+	name = "spore"
 	desc = "A spear covered in spores and affection. \
 	It lights the employee's heart, shines like a star, and steadily tames them."
 	special = "Upon hit the targets WHITE vulnerability is increased by 0.2."
@@ -825,7 +824,7 @@
 	attack_verb_simple = list("poke", "jab", "tear", "lacerate", "gore")
 	hitsound = 'sound/weapons/ego/spear1.ogg'
 	attribute_requirements = list(
-							TEMPERANCE_ATTRIBUTE = 80
+							PRUDENCE_ATTRIBUTE = 80
 							)
 
 /obj/item/ego_weapon/spore/attack(mob/living/target, mob/living/user)
@@ -1017,7 +1016,7 @@
 	attack_verb_continuous = list("slices", "cuts")
 	attack_verb_simple = list("slice", "cut")
 	hitsound = 'sound/weapons/blade1.ogg'
-	attribute_requirements = list(TEMPERANCE_ATTRIBUTE = 80)
+	attribute_requirements = list(FORTITUDE_ATTRIBUTE = 80)
 
 /obj/item/ego_weapon/diffraction/attack(mob/living/target, mob/living/user)
 	if((target.health<=target.maxHealth *0.2) && !(GODMODE in target.status_flags))

--- a/code/game/objects/items/ego_weapons/waw.dm
+++ b/code/game/objects/items/ego_weapons/waw.dm
@@ -21,7 +21,7 @@
 	if(!CanUseEgo(user))
 		return FALSE
 	. = ..()
-	for(var/mob/living/L in livinginrange(1, M))
+	for(var/mob/living/L in view(1, M))
 		var/aoe = 25
 		var/userjust = (get_attribute_level(user, JUSTICE_ATTRIBUTE))
 		var/justicemod = 1 + userjust/100

--- a/code/modules/clothing/suits/ego_gear/aleph.dm
+++ b/code/modules/clothing/suits/ego_gear/aleph.dm
@@ -55,7 +55,7 @@
 	name = "mimicry"
 	desc = "It takes human hide to protect human flesh. To protect humans, you need something made out of humans."
 	icon_state = "mimicry"
-	armor = list(RED_DAMAGE = 90, WHITE_DAMAGE = 50, BLACK_DAMAGE = 50, PALE_DAMAGE = 50) // 240
+	armor = list(RED_DAMAGE = 90, WHITE_DAMAGE = 50, BLACK_DAMAGE = 30, PALE_DAMAGE = 50) // 220
 	attribute_requirements = list(
 							FORTITUDE_ATTRIBUTE = 100,
 							PRUDENCE_ATTRIBUTE = 80,
@@ -94,7 +94,7 @@
 	desc = "It is holding all of the laughter of those who cannot be seen here."
 	icon_state = "smile"
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT
-	armor = list(RED_DAMAGE = 50, WHITE_DAMAGE = 50, BLACK_DAMAGE = 90, PALE_DAMAGE = 50) // 240
+	armor = list(RED_DAMAGE = 30, WHITE_DAMAGE = 50, BLACK_DAMAGE = 90, PALE_DAMAGE = 50) // 220
 	attribute_requirements = list(
 							FORTITUDE_ATTRIBUTE = 80,
 							PRUDENCE_ATTRIBUTE = 80,

--- a/code/modules/clothing/suits/ego_gear/he.dm
+++ b/code/modules/clothing/suits/ego_gear/he.dm
@@ -76,7 +76,6 @@
 	// I kept it well-rounded, and lowered the requirements, It's now LIKE a waw with it's good, well-rounded defenses, but it was generally lowered.
 	armor = list(RED_DAMAGE = 20, WHITE_DAMAGE = 20, BLACK_DAMAGE = 20, PALE_DAMAGE = 20) // 80
 	attribute_requirements = list(
-							FORTITUDE_ATTRIBUTE = 40,
 							JUSTICE_ATTRIBUTE = 40
 							)
 
@@ -106,7 +105,7 @@
 	flags_inv = HIDESHOES
 	armor = list(RED_DAMAGE = 30, WHITE_DAMAGE = -20, BLACK_DAMAGE = 40, PALE_DAMAGE = 20) // 70
 	attribute_requirements = list(
-							TEMPERANCE_ATTRIBUTE = 40
+							PRUDENCE_ATTRIBUTE = 40
 							)
 
 /obj/item/clothing/suit/armor/ego_gear/harmony
@@ -125,7 +124,7 @@
 	flags_inv = HIDESHOES
 	armor = list(RED_DAMAGE = 0, WHITE_DAMAGE = 40, BLACK_DAMAGE = 20, PALE_DAMAGE = 10)
 	attribute_requirements = list(
-							TEMPERANCE_ATTRIBUTE = 40
+							PRUDENCE_ATTRIBUTE = 40
 							)
 
 /obj/item/clothing/suit/armor/ego_gear/frostsplinter
@@ -183,7 +182,7 @@
 	icon_state = "pleasure"
 	armor = list(RED_DAMAGE = -30, WHITE_DAMAGE = 40, BLACK_DAMAGE = 40, PALE_DAMAGE = 20) //70
 	attribute_requirements = list(
-							TEMPERANCE_ATTRIBUTE = 40)
+							PRUDENCE_ATTRIBUTE = 40)
 
 /obj/item/clothing/suit/armor/ego_gear/galaxy
 	name = "galaxy"
@@ -228,7 +227,7 @@
 	desc = "the coat itself is made from metal sheets"
 	icon_state = "metal"
 	armor = list(RED_DAMAGE = 50, WHITE_DAMAGE = 10, BLACK_DAMAGE = 10, PALE_DAMAGE = 0)
-	attribute_requirements = list(TEMPERANCE_ATTRIBUTE = 40)
+	attribute_requirements = list(FORTITUDE_ATTRIBUTE = 40)
 
 /obj/item/clothing/suit/armor/ego_gear/homing_instinct
 	name = "homing instinct"
@@ -245,7 +244,7 @@
 	icon_state = "maneater"
 	armor = list(RED_DAMAGE = 30, WHITE_DAMAGE = 20, BLACK_DAMAGE = 30, PALE_DAMAGE = -10) // 70
 	attribute_requirements = list(
-							TEMPERANCE_ATTRIBUTE = 40
+							FORTITUDE_ATTRIBUTE = 40
 							)
 
 /obj/item/clothing/suit/armor/ego_gear/inheritance

--- a/code/modules/clothing/suits/ego_gear/waw.dm
+++ b/code/modules/clothing/suits/ego_gear/waw.dm
@@ -15,7 +15,7 @@
 	icon_state = "lamp"
 	armor = list(RED_DAMAGE = 20, WHITE_DAMAGE = 30, BLACK_DAMAGE = 60, PALE_DAMAGE = 30) // 140
 	attribute_requirements = list(
-							TEMPERANCE_ATTRIBUTE = 60,
+							PRUDENCE_ATTRIBUTE = 60,
 							JUSTICE_ATTRIBUTE = 60
 							)
 
@@ -46,7 +46,7 @@
 	armor = list(RED_DAMAGE = 30, WHITE_DAMAGE = 20, BLACK_DAMAGE = 60, PALE_DAMAGE = 30) // 140
 	attribute_requirements = list(
 							PRUDENCE_ATTRIBUTE = 60,
-							TEMPERANCE_ATTRIBUTE = 60
+							JUSTICE_ATTRIBUTE = 60
 							)
 
 /obj/item/clothing/suit/armor/ego_gear/oppression
@@ -56,7 +56,7 @@
 	armor = list(RED_DAMAGE = 50, WHITE_DAMAGE = 20, BLACK_DAMAGE = 40, PALE_DAMAGE = 30) //140
 	attribute_requirements = list(
 							FORTITUDE_ATTRIBUTE = 60,
-							TEMPERANCE_ATTRIBUTE = 60
+							JUSTICE_ATTRIBUTE = 60
 							)
 
 /obj/item/clothing/suit/armor/ego_gear/totalitarianism
@@ -66,7 +66,7 @@
 	armor = list(RED_DAMAGE = 40, WHITE_DAMAGE = 20, BLACK_DAMAGE = 50, PALE_DAMAGE = 30) // 140
 	attribute_requirements = list(
 							JUSTICE_ATTRIBUTE = 60,
-							TEMPERANCE_ATTRIBUTE = 60
+							PRUDENCE_ATTRIBUTE = 60
 							)
 
 /obj/item/clothing/suit/armor/ego_gear/goldrush
@@ -84,7 +84,7 @@
 	icon_state = "tiara"
 	armor = list(RED_DAMAGE = 10, WHITE_DAMAGE = 50, BLACK_DAMAGE = 30, PALE_DAMAGE = 50)
 	attribute_requirements = list(
-							TEMPERANCE_ATTRIBUTE = 60,
+							PRUDENCE_ATTRIBUTE = 60,
 							JUSTICE_ATTRIBUTE = 60
 							)
 
@@ -113,7 +113,7 @@
 	armor = list(RED_DAMAGE = 10, WHITE_DAMAGE = 60, BLACK_DAMAGE = 30, PALE_DAMAGE = 40)
 	attribute_requirements = list(
 							FORTITUDE_ATTRIBUTE = 60,
-							TEMPERANCE_ATTRIBUTE = 60
+							PRUDENCE_ATTRIBUTE = 60
 							)
 
 /obj/item/clothing/suit/armor/ego_gear/stem
@@ -122,7 +122,7 @@
 	icon_state = "green_stem"
 	armor = list(RED_DAMAGE = 40, WHITE_DAMAGE = 10, BLACK_DAMAGE = 70, PALE_DAMAGE = 20)
 	attribute_requirements = list(
-							TEMPERANCE_ATTRIBUTE = 60,
+							JUSTICE_ATTRIBUTE = 60,
 							PRUDENCE_ATTRIBUTE = 60)
 
 /obj/item/clothing/suit/armor/ego_gear/loyalty
@@ -139,8 +139,7 @@
 	icon_state = "executive"
 	armor = list(RED_DAMAGE = 40, WHITE_DAMAGE = 40, BLACK_DAMAGE = 40, PALE_DAMAGE = 20) // 140
 	attribute_requirements = list(
-							TEMPERANCE_ATTRIBUTE = 60,
-							JUSTICE_ATTRIBUTE = 60
+							JUSTICE_ATTRIBUTE = 80
 							)
 
 /obj/item/clothing/suit/armor/ego_gear/ecstasy
@@ -165,9 +164,7 @@
 	desc = "All aboard!"
 	icon_state = "intentions"
 	armor = list(RED_DAMAGE = 40, WHITE_DAMAGE = 10, BLACK_DAMAGE = 60, PALE_DAMAGE = 30)
-	attribute_requirements = list(
-							TEMPERANCE_ATTRIBUTE = 60,
-							FORTITUDE_ATTRIBUTE = 60)
+	attribute_requirements = list(FORTITUDE_ATTRIBUTE = 80)
 
 /obj/item/clothing/suit/armor/ego_gear/aroma
 	name = "faint aroma"
@@ -204,8 +201,7 @@
 	icon_state = "exuviae"
 	armor = list(RED_DAMAGE = 60, WHITE_DAMAGE = 40, BLACK_DAMAGE = 20, PALE_DAMAGE = 20) // 140
 	attribute_requirements = list(
-							FORTITUDE_ATTRIBUTE = 60,
-							TEMPERANCE_ATTRIBUTE = 60
+							FORTITUDE_ATTRIBUTE = 80
 							)
 
 /obj/item/clothing/suit/armor/ego_gear/ebony_stem
@@ -245,8 +241,7 @@
 	icon_state = "dark_carnival"
 	armor = list(RED_DAMAGE = 60, WHITE_DAMAGE = 60, BLACK_DAMAGE = 10, PALE_DAMAGE = 10) // 140
 	attribute_requirements = list(
-							PRUDENCE_ATTRIBUTE = 60,
-							TEMPERANCE_ATTRIBUTE = 60
+							PRUDENCE_ATTRIBUTE = 80
 							)
 
 /obj/item/clothing/suit/armor/ego_gear/dipsia


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR does 3 main things.
1) Nerfs 9/5/5/5 Aleph armor to 9/5/5/3
2) Removes most temperance requirements on EGO. Now you need to level up your fort and prudence to equip most ego. 
3) Goldrush now takes half a second instead of 0.6, very minor buff

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Nerfs to mimicry and smile, and a soft-nerf to temperance.
Gold Rush got a slight buff, because it's been a little underperforming.

Temperance is significantly better than Prudence and fortitude, it's requirement has been made significantly more rare.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Smile and Mimicry nerfed.
balance: Temperance requirement replaced on most EGO gear.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
