### PR TITLE
road home no longer leaves the status effect after death

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/he/road_home.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/road_home.dm
@@ -84,7 +84,7 @@
 		retaliation = 3
 	attacker.apply_damage(retaliation, BLACK_DAMAGE, null, attacker.run_armor_check(null, BLACK_DAMAGE), spread_damage = TRUE)
 	to_chat(attacker, "<span class='userdanger'>[src] counter attacks!</span>")
-	if(attacker.has_status_effect(/datum/status_effect/stay_home) || !ishuman(attacker) || health <= 0)
+	if(attacker.has_status_effect(/datum/status_effect/stay_home) || !ishuman(attacker) || stat == DEAD)
 		return
 	attacker.apply_status_effect(/datum/status_effect/stay_home)
 	agent_friends += attacker
@@ -125,7 +125,7 @@
 		addtimer(CALLBACK(src, .proc/FlipAttack), 2 SECONDS)
 		return
 
-/mob/living/simple_animal/hostile/abnormality/road_home/death(gibbed)
+/mob/living/simple_animal/hostile/abnormality/road_home/Destroy(gibbed)
 	for(var/obj/effect/golden_road/GR in brick_list)
 		brick_list -= GR
 		qdel(GR)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes a bug where road home would leave her status effect should someone kill her without her health going to 0 (such as the execute move of mountain's weapon). This was pretty bad as someone would literally be unable to move should that happen

## Why It's Good For The Game

Road stuck.

## Changelog
:cl:
fix: road home now properly removes her status effect when executed by smile.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
