### PR TITLE
Silent Girl Rework

### DIFF
--- a/code/modules/mob/living/carbon/human/physiology.dm
+++ b/code/modules/mob/living/carbon/human/physiology.dm
@@ -28,7 +28,7 @@
 
 	var/hunger_mod = 1		//% of hunger rate taken per tick.
 
-	var/work_success_mod = 1 // %dditive Modifier to the success rate of works
+	var/work_success_mod = 1 // % Modifier to the success rate of works
 	var/instinct_success_mod = 0 // Additive Modifier to the success rate of Instinct works
 	var/insight_success_mod = 0 // Additive Modifier to the success rate of Insight works
 	var/attachment_success_mod = 0 // Additive Modifier to the success rate of Attachment works

--- a/code/modules/mob/living/simple_animal/abnormality/he/silent_girl.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/silent_girl.dm
@@ -31,7 +31,7 @@
 		/datum/ego_datum/armor/remorse
 		)
 	gift_type = /datum/ego_gifts/remorse
-	abnormality_origin = "Artbook"
+	abnormality_origin = ABNORMALITY_ORIGIN_ARTBOOK
 
 /mob/living/simple_animal/hostile/abnormality/silent_girl/proc/GuiltEffect(mob/living/carbon/human/user, enable_qliphoth = TRUE, stack_count = 1)
 	if (user.stat == DEAD)
@@ -50,7 +50,7 @@
 
 /mob/living/simple_animal/hostile/abnormality/silent_girl/AttemptWork(mob/living/carbon/human/user, work_type)
 	if (user.has_status_effect(STATUS_EFFECT_SG_GUILTY))
-		user.adjustSanityLoss(user.getMaxSanity()*2) // Suffer.
+		user.adjustSanityLoss(user.getMaxSanity()) // Suffer.
 		user.remove_status_effect(STATUS_EFFECT_SG_GUILTY) // but Cleanse!
 		return FALSE
 	return ..()

--- a/code/modules/mob/living/simple_animal/abnormality/he/silent_girl.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/silent_girl.dm
@@ -102,7 +102,7 @@
 		works_required = args[3]
 	guilt_icon = mutable_appearance('ModularTegustation/Teguicons/tegu_effects.dmi', "guilt", -MUTATIONS_LAYER)
 	. = ..()
-	linked_alert.desc = initial(linked_alert.desc)+" Complete [works_required] more Attachment works attone."
+	linked_alert.desc = initial(linked_alert.desc)+" Complete [works_required] more Attachment works to attone."
 	return
 
 /datum/status_effect/sg_guilty/on_apply()
@@ -130,7 +130,7 @@
 /datum/status_effect/sg_guilty/refresh()
 	playsound(get_turf(owner), 'sound/abnormalities/silentgirl/Guilt_Apply.ogg', 50, 0, 2)
 	works_required++
-	linked_alert.desc = initial(linked_alert.desc)+" Complete [works_required] more Attachment works attone."
+	linked_alert.desc = initial(linked_alert.desc)+" Complete [works_required] more Attachment works to attone."
 
 /datum/status_effect/sg_guilty/proc/OnWorkComplete(datum/source, datum/abnormality/abno_reference, mob/living/carbon/human/user, work_type)
 	SIGNAL_HANDLER

--- a/code/modules/paperwork/records/info/he.dm
+++ b/code/modules/paperwork/records/info/he.dm
@@ -48,12 +48,15 @@
 	abno_code = "T-01-01"
 	abno_info = list(
 		"When an employee with Prudence Level 2 or lower worked on Silent Girl, the Qliphoth Counter lowered regardless of the work result.",
+		"When the Work Result was Normal, the Qliphoth Counter lowered with a normal probability.",
 		"When the Work Result was Bad, the Qliphoth Counter lowered.",
-		" the Qliphoth Counter lowered, the employee was found to have significant psychological instability. We have designated this state as \"Guilt\".",
+		"When the Qliphoth Counter lowered, the employee was found to have possess significant psychological instability. We have designated this state as \"Guilt\".",
 		"Employees under the effects of Guilt have significantly decreased work success rate with any Abnormality.",
-		"When an employee with Guilt performed work with Silent Girl, they reported feeling a splitting headache before contact was lost. The employee was later found dead from self-inflicted injuries. This state has been termed \"Atonement\".",
-		"When an employee with Guilt or Atonement completed Attachment Work, the affliction seemed to be removed from the employee. Then, the Qliphoth Counter increased.",
-		"When Silent Girl’s Qliphoth Counter reached 0, all employees with Guilt immediately transitioned into Atonement. If no employees in the facility had Guilt, a random employee was afflicted with Atonement.")
+		"After an employee with Guilt attempted to work on Silent Girl, connection with them was lost and they were later found insane.",
+		"After an afflicted employee completed Attachment Work several times, they were cleansed of Guilt. Then, the Qliphoth Counter raised.",
+		"When the Insight Work Result was Good, the Qliphoth Counter raised with a normal probability.",
+		"When Silent Girl’s Qliphoth Counter reached 0, all agents are afflicted with Guilt. An Agent with Guilt had their affliction prolonged."
+		)
 
 //Blue Shep
 /obj/item/paper/fluff/info/he/blue_shep


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Silent Girl no longer has a primarily panic based gimmick, instead leaning full-force into the Work Rate Penalty.

Guilt no longer drives you insane, merely tanks your work rate for 1+ works, the number of which stacks with every application.
Silent Girl, upon reaching 0 Qliphoth, will simply give ALL Agents Guilt. Removal of this Guilt does not raise nor lower the Qliphoth Counter.
Silent Girl's counter will increase at a normal (40%) probability upon completing Good Insight Work.
Silent Girl's counter will lower (and thus, apply Guilt), at a normal (40%) probability upon getting a Normal work result.
Guilt's work-rate penalty was upped from 0.75x to 0.70x.
Guilt's alert informs you of how many works remaining you need to complete to resolve the debuff.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes Silent Girl a more passive threat that greatly disadvantages the facility if blatantly ignored, but doesn't outright cause deaths/strip control away.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

