### PR TITLE
Blind Rage fix

### DIFF
--- a/code/game/objects/items/ego_weapons/_ego_weapon.dm
+++ b/code/game/objects/items/ego_weapons/_ego_weapon.dm
@@ -18,7 +18,7 @@
 	. = ..()
 	if(attack_speed)
 		user.changeNext_move(CLICK_CD_MELEE * attack_speed)
-	return
+	return TRUE // If we want to do "if(!.)" checks, this has to exist.
 
 /obj/item/ego_weapon/examine(mob/user)
 	. = ..()

--- a/code/game/objects/items/ego_weapons/waw.dm
+++ b/code/game/objects/items/ego_weapons/waw.dm
@@ -979,6 +979,9 @@
 		if(prob(5))
 			new /obj/effect/gibspawner/generic/silent/wrath_acid(T) // The non-damaging one
 
+/obj/item/ego_weapon/blind_rage/get_clamped_volume()
+	return 50
+
 /obj/item/ego_weapon/mini/heart
 	name = "bleeding heart"
 	desc = "The supplicant will suffer various ordeals in a manner like being put through a trial."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Suggested change didn't work because parent method did not have a valid return. Fixes that and now allows for all EGO weapons that override Attack to use `if(!.)` to check for if the original attack can't be done.
Also curbs the volume of blind rage. I think all of our EGO need this honestly, right now they're basically guaranteed max due to "Weight Class". Seriously, volume is force x weight class, clamped between 30 and 100. That's basically ALWAYS 80-100 b/c weight class is like, 4.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Self Explanatory.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
