### PR TITLE
Ppodae Damage Up

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/teth/ppodae.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/ppodae.dm
@@ -19,7 +19,7 @@
 						ABNORMALITY_WORK_ATTACHMENT = 40,
 						ABNORMALITY_WORK_REPRESSION = list(40, 40, 30, 30, 30),
 						)
-	work_damage_amount = 4
+	work_damage_amount = 6
 	work_damage_type = RED_DAMAGE
 	damage_coeff = list(BRUTE = 1, RED_DAMAGE = 1.5, WHITE_DAMAGE = 0.8, BLACK_DAMAGE = 1, PALE_DAMAGE = 2)
 	can_breach = TRUE
@@ -152,7 +152,7 @@
 		return
 	can_act = FALSE
 	dir = dir_to_target
-	var/smash_damage = rand(8, 14)
+	var/smash_damage = rand(16, 28)
 	for(var/turf/T in area_of_effect)
 		new /obj/effect/temp_visual/smash_effect(T)
 		for(var/mob/living/L in T)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Increases Ppodae's work damage by 2, only equivalents were Crumbling (Who deals pale) and Training Dummy (Self-explanatory). Double's PPodae's AoE damage, Fragment has Rapid Melee 2 and roughly the same DPS, this brings PPodae up to speed.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Ppodae was free real-estate.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
