### PR TITLE
Fixes beer not dispensing from booze dispenser, fixes reagent names and adds unit test

### DIFF
--- a/code/modules/antagonists/blob/blobstrains/energized_jelly.dm
+++ b/code/modules/antagonists/blob/blobstrains/energized_jelly.dm
@@ -22,7 +22,7 @@
 	B.take_damage(damage, BURN, ENERGY)
 
 /datum/reagent/blob/energized_jelly
-	name = "Energized Jelly"
+	name = "Energized Blob Jelly"
 	taste_description = "gelatin"
 	color = "#EFD65A"
 

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/wellcheers.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/wellcheers.dm
@@ -64,7 +64,7 @@
 
 /obj/item/reagent_containers/food/drinks/soda_cans/wellcheers_white
 	name = "can of 'Wellcheers' soda"
-	desc = "A can of soda."
+	desc = "A can of regular soda."
 	icon_state = "wellcheers_white"
 	inhand_icon_state = "monkey_energy"
 	list_reagents = list(/datum/reagent/consumable/wellcheers_white = 10)

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -521,25 +521,26 @@
 	icon_state = "booze_dispenser"
 	circuit = /obj/item/circuitboard/machine/chem_dispenser/drinks/beer
 	dispensable_reagents = list(
-		/datum/reagent/consumable/ethanol/beer,
-		/datum/reagent/consumable/ethanol/kahlua,
-		/datum/reagent/consumable/ethanol/whiskey,
-		/datum/reagent/consumable/ethanol/wine,
-		/datum/reagent/consumable/ethanol/vodka,
-		/datum/reagent/consumable/ethanol/gin,
-		/datum/reagent/consumable/ethanol/rum,
-		/datum/reagent/consumable/ethanol/tequila,
-		/datum/reagent/consumable/ethanol/vermouth,
-		/datum/reagent/consumable/ethanol/cognac,
-		/datum/reagent/consumable/ethanol/ale,
 		/datum/reagent/consumable/ethanol/absinthe,
-		/datum/reagent/consumable/ethanol/hcider,
-		/datum/reagent/consumable/ethanol/creme_de_menthe,
+		/datum/reagent/consumable/ethanol/ale,
+		/datum/reagent/consumable/ethanol/applejack,
+		/datum/reagent/consumable/ethanol/beer,
+		/datum/reagent/consumable/ethanol/cognac,
 		/datum/reagent/consumable/ethanol/creme_de_cacao,
 		/datum/reagent/consumable/ethanol/creme_de_coconut,
-		/datum/reagent/consumable/ethanol/triple_sec,
+		/datum/reagent/consumable/ethanol/creme_de_menthe,
+		/datum/reagent/consumable/ethanol/gin,
+		/datum/reagent/consumable/ethanol/hcider,
+		/datum/reagent/consumable/ethanol/kahlua,
+		/datum/reagent/consumable/ethanol/beer/maltliquor,
+		/datum/reagent/consumable/ethanol/rum,
 		/datum/reagent/consumable/ethanol/sake,
-		/datum/reagent/consumable/ethanol/applejack
+		/datum/reagent/consumable/ethanol/tequila,
+		/datum/reagent/consumable/ethanol/triple_sec,
+		/datum/reagent/consumable/ethanol/vermouth,
+		/datum/reagent/consumable/ethanol/vodka,
+		/datum/reagent/consumable/ethanol/whiskey,
+		/datum/reagent/consumable/ethanol/wine,
 	)
 	upgrade_reagents = null
 	emagged_reagents = list(

--- a/code/modules/reagents/chemistry/reagents.dm
+++ b/code/modules/reagents/chemistry/reagents.dm
@@ -17,7 +17,7 @@ GLOBAL_LIST_INIT(name2reagent, build_name2reagent())
 /// A single reagent
 /datum/reagent
 	/// datums don't have names by default
-	var/name = "Reagent"
+	var/name = ""
 	/// nor do they have descriptions
 	var/description = ""
 	///J/(K*mol)

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -961,7 +961,7 @@
 // Wellcheers
 /datum/reagent/consumable/wellcheers_red
 	name = "Cherry Soda"
-	description = "A can of cherry-flavored soda."
+	description = "It tastes like cherry-flavored soda."
 	color = "#FC2403"
 	taste_description = "cherry soda"
 	glass_icon_state = "dr_gibb_glass"
@@ -973,13 +973,13 @@
 	return ..()
 
 /datum/reagent/consumable/wellcheers_white
-	name = "Soda"
-	description = "A can of normal soda."
+	name = "Regular Soda"
+	description = "It tastes like regular soda."
 	color = "#03FCD3"
 	taste_description = "soda"
 	glass_icon_state = "glass_clear"
-	glass_name = "glass of soda"
-	glass_desc = "A glass of normal soda."
+	glass_name = "glass of regular soda"
+	glass_desc = "A glass of regular soda."
 
 /datum/reagent/consumable/wellcheers_white/on_mob_life(mob/living/M)
 	if(!ishuman(M))
@@ -989,8 +989,8 @@
 	return ..()
 
 /datum/reagent/consumable/wellcheers_purple
-	name = "Soda"
-	description = "A can of grape-flavored soda."
+	name = "Purple Soda"
+	description = "It tastes like grape-flavored soda."
 	color = "#DB03FC"
 	taste_description = "grape soda"
 	glass_icon_state = "lean"

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -7,7 +7,6 @@
 // where all the reagents related to medicine go.
 
 /datum/reagent/medicine
-	name = "Medicine"
 	taste_description = "bitterness"
 
 /datum/reagent/medicine/on_mob_life(mob/living/M)

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -125,6 +125,7 @@
 		src.data |= data.Copy()
 
 /datum/reagent/vaccine/fungal_tb
+	name = "Vaccine (Fungal Tuberculosis)"
 
 /datum/reagent/vaccine/fungal_tb/New(data)
 	. = ..()

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -403,7 +403,7 @@
 	..()
 
 /datum/reagent/toxin/fakebeer	//disguised as normal beer for use by emagged brobots
-	name = "Beer"
+	name = "Bear" //Netzach approved
 	description = "A specially-engineered sedative disguised as beer. It induces instant sleep in its target."
 	color = "#664300" // rgb: 102, 67, 0
 	metabolization_rate = 1.5 * REAGENTS_METABOLISM
@@ -675,11 +675,11 @@
 	metabolization_rate = 0.75 * REAGENTS_METABOLISM
 	toxpwr = 0
 
-/datum/reagent/medicine/sodium_thiopental/on_mob_add(mob/living/L, amount)
+/datum/reagent/toxin/sodium_thiopental/on_mob_add(mob/living/L, amount)
 	. = ..()
 	ADD_TRAIT(L, TRAIT_ANTICONVULSANT, name)
 
-/datum/reagent/medicine/sodium_thiopental/on_mob_delete(mob/living/L)
+/datum/reagent/toxin/sodium_thiopental/on_mob_delete(mob/living/L)
 	. = ..()
 	REMOVE_TRAIT(L, TRAIT_ANTICONVULSANT, name)
 

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -65,6 +65,7 @@
 #include "reagent_id_typos.dm"
 #include "reagent_mod_expose.dm"
 #include "reagent_mod_procs.dm"
+#include "reagent_names.dm"
 #include "reagent_recipe_collisions.dm"
 #include "resist.dm"
 #include "say.dm"

--- a/code/modules/unit_tests/reagent_names.dm
+++ b/code/modules/unit_tests/reagent_names.dm
@@ -1,0 +1,27 @@
+/// Test that all reagent names are different in order to prevent #65231 and tests that searching for that reagent by name gives the correct one
+/datum/unit_test/reagent_names
+
+/datum/unit_test/reagent_names/Run()
+	var/used_names = list()
+
+	for (var/datum/reagent/reagent as anything in subtypesof(/datum/reagent))
+		// Make sure names are different
+		var/name = initial(reagent.name)
+		if (!name)
+			continue
+
+		if (name in used_names)
+			Fail("[used_names[name]] shares a name with [reagent] ([name])")
+		else
+			used_names[name] = reagent
+
+		// Now make sure searching for that name gets us the right reagent
+		var/datum/reagent/found_reagent = get_chem_id(name)
+
+		if (!found_reagent)
+			Fail("Searching for [reagent] ([name]) returned nothing")
+
+		var/found_name = initial(found_reagent.name)
+
+		if (found_reagent != reagent)
+			Fail("Searching for [reagent] ([name]) returned [found_reagent] ([found_name]) instead")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
**Ports:**
1. [[COOL BUG READ FOR MORE INFO] Fix vaccines not working in chem masters by giving Fungal TB's vaccine (and others) a name + Add unit test for duplicate chem names + Rename fake beer + Ratio #65241](https://github.com/tgstation/tgstation/pull/65241)
2. [Updates the Reagent Name unit test to also ensure searching by reagent name returns the correct reagent #70223](https://github.com/tgstation/tgstation/pull/70223)

**Changes**
- Fixes booze dispenser not being able to dispense beer
- Fakebeer renamed from "Beer" to "Bear"
- Adds unit test for reagent names
- Adds some more beers to the booze dispenser
- Changes Wellcheer soda names and descriptions
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The issue came from the fact fakebeer and beer had the same name. This addresses that as well as all the other chems fixed in the original PR. The unit test seems useful for any future chem-related updates.
Changes wellcheers soda chems to have unique names.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: reagents sharing names, typepath issues
fix: fakebeer name changed to "Bear"
fix: wellcheers reagents renamed
add: reagent name unit test
add: more beers to booze dispenser
:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
