### PR TITLE
Green Noon Rebalance (Alternate of 855)

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/ordeal/green.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/green.dm
@@ -92,18 +92,20 @@
 	base_pixel_x = -8
 	gender = NEUTER
 	mob_biotypes = MOB_ROBOTIC
-	maxHealth = 900
-	health = 900
+	maxHealth = 1100
+	health = 1100
 	speed = 3
 	move_to_delay = 6
-	melee_damage_lower = 22 // Full damage is done on the entire turf of target
-	melee_damage_upper = 26
+	rapid_melee = 4
+	melee_damage_lower = 5 // Full damage is done on the entire turf of target
+	melee_damage_upper = 6
 	attack_verb_continuous = "slices"
 	attack_verb_simple = "slice"
 	attack_sound = 'sound/effects/ordeals/green/saw.ogg'
 	ranged = 1
-	rapid = 8
+	rapid = 6
 	rapid_fire_delay = 3
+	check_friendly_fire = 1
 	projectiletype = /obj/projectile/bullet/c9x19mm
 	projectilesound = 'sound/effects/ordeals/green/fire.ogg'
 	deathsound = 'sound/effects/ordeals/green/noon_dead.ogg'
@@ -113,7 +115,7 @@
 
 	/// Can't move/attack when it's TRUE
 	var/reloading = FALSE
-	/// When at 10 - it will start "reloading"
+	/// When at 3 - it will start "reloading"
 	var/fire_count = 0
 
 /mob/living/simple_animal/hostile/ordeal/green_bot_big/CanAttack(atom/the_target)
@@ -129,8 +131,11 @@
 /mob/living/simple_animal/hostile/ordeal/green_bot_big/OpenFire(atom/A)
 	if(reloading)
 		return FALSE
+	if(target in range(2, src))	//Doesn't shoot you if you're within range for too long
+		return FALSE
+
 	fire_count += 1
-	if(fire_count >= 6)
+	if(fire_count >= 3)
 		StartReloading()
 		return FALSE
 	return ..()
@@ -148,7 +153,7 @@
 			for(var/mob/living/L in T.contents)
 				if(faction_check_mob(L))
 					continue
-				L.apply_damage(8, RED_DAMAGE, null, L.run_armor_check(null, RED_DAMAGE), spread_damage = TRUE)
+				L.apply_damage(2, RED_DAMAGE, null, L.run_armor_check(null, RED_DAMAGE), spread_damage = TRUE)
 			SLEEP_CHECK_DEATH(1)
 
 /mob/living/simple_animal/hostile/ordeal/green_bot_big/spawn_gibs()
@@ -172,6 +177,7 @@
 /mob/living/simple_animal/hostile/ordeal/green_bot_big/factory
 	butcher_results = list()
 	guaranteed_butcher_results = list()
+	can_patrol = TRUE
 
 /mob/living/simple_animal/hostile/ordeal/green_bot_big/factory/death(gibbed)
 		density = FALSE
@@ -229,7 +235,10 @@
 	visible_message("<span class='danger'>\The [src] produces a new set of robots!</span>")
 	for(var/i = 1 to 3)
 		var/turf/T = get_step(get_turf(src), pick(0, EAST))
-		var/picked_mob = pick(/mob/living/simple_animal/hostile/ordeal/green_bot/factory, /mob/living/simple_animal/hostile/ordeal/green_bot_big/factory)
+		var/picked_mob = /mob/living/simple_animal/hostile/ordeal/green_bot/factory
+		if(prob(30))
+			picked_mob = /mob/living/simple_animal/hostile/ordeal/green_bot_big/factory
+
 		var/mob/living/simple_animal/hostile/ordeal/nb = new picked_mob(T)
 		spawned_mobs += nb
 		if(ordeal_reference)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
- It reloads more often, every 3 volleys.
- Volley reduced to 6 from 8
- Damage has been changed to be many fast attacks (with proportionally less damage) - This change isn't really necessary, I just like it better as a chainsaw.
- Green Noons from the Dusk have now patrol to not clog up halls around the factory
- Green Noons now check friendly fire.
- Green Noons no longer shoot at you when you are within spear range
- Green Dusks spawn Noons at 1/3rd rate rather than 50%

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I am really not a fan of #855 and would rather it not be merged; This is my alternative PR that should make it a more engaging fight.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Green Noon rebalance
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
