### PR TITLE
Adjustable EGO Example

### DIFF
--- a/code/modules/clothing/suits/ego_gear/_ego_gear.dm
+++ b/code/modules/clothing/suits/ego_gear/_ego_gear.dm
@@ -67,3 +67,37 @@
 		display_text += SpecialGearRequirements()
 		to_chat(usr, display_text)
 
+
+/obj/item/clothing/suit/armor/ego_gear/adjustable
+	var/list/alternative_styles = list()
+	var/index = 0
+
+/obj/item/clothing/suit/armor/ego_gear/adjustable/Initialize()
+	. = ..()
+	alternative_styles |= icon_state
+	index = alternative_styles.len
+
+/obj/item/clothing/suit/armor/ego_gear/adjustable/examine(mob/user)
+	. = ..()
+	. += "<span class='notice'>It can be adjusted by right-clicking the armor.</span>"
+
+/obj/item/clothing/suit/armor/ego_gear/adjustable/verb/AdjustStyle()
+	set name = "Adjust EGO Style"
+	set category = null
+	set src in usr
+	Adjust()
+
+/obj/item/clothing/suit/armor/ego_gear/adjustable/proc/Adjust()
+	if(!ishuman(usr))
+		return
+	if(alternative_styles.len <= 1)
+		to_chat(usr, "<span class='notice'>Has no other styles!</span>")
+		return
+	index++
+	if(index > alternative_styles.len)
+		index = 1
+	icon_state = alternative_styles[index]
+	to_chat(usr, "<span class='notice'>You adjust [src] to a new style~!</span>")
+	var/mob/living/carbon/human/H = usr
+	H.update_inv_wear_suit()
+	H.update_body()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Example of adjustable EGO Armor. This example shifts In the Name of Love and Hate into it's Nihil version. It's a new subtype which should be easily addible to any existing armor with 2 edits, adding the type and adding to the "alternative_styles" list.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It's a cool change that opens up opportunities in the future, which I also want to see used in Jester of Nihil.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
![image](https://user-images.githubusercontent.com/61567407/232972536-a4dc2b54-dfed-4b04-8c48-aae47927a5fc.png)
![image](https://user-images.githubusercontent.com/61567407/232972632-ae205961-2887-4e1a-9da9-c579c9fcf041.png)
![image](https://user-images.githubusercontent.com/61567407/232972658-4a909dc2-e0e3-4ec9-aa3e-b14c4e82efe9.png)
