### PR TITLE
Removes the ability to heal working agents with love and hate

### DIFF
--- a/code/modules/projectiles/projectile/ego_bullets/waw.dm
+++ b/code/modules/projectiles/projectile/ego_bullets/waw.dm
@@ -23,6 +23,10 @@
 		if(firer==target)
 			return BULLET_ACT_BLOCK
 		if(user.faction_check_mob(H)) // Our faction
+			if(H.is_working)
+				H.visible_message("<span class='warning'>[src] vanishes on contact with [H]... but nothing happens!</span>")
+				qdel(src)
+				return BULLET_ACT_BLOCK
 			switch(damage_type)
 				if(WHITE_DAMAGE)
 					H.adjustSanityLoss(-damage*0.2)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Love and hate's healing projectile now checks if the target is working.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Preventing work cheese is pretty good for the game I'd say. This should be the standard for most healing abilities.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: love and hate no longer heals working agents
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
