### PR TITLE
Spreading Structure Type

### DIFF
--- a/ModularTegustation/lc13_machinery.dm
+++ b/ModularTegustation/lc13_machinery.dm
@@ -129,3 +129,57 @@
 		if(C.linked_console)
 			LAZYADD(abnormalities, "[C.AbnormalityInfo()]: [C.relative_location]")
 	sortList(abnormalities)
+
+	//Spreading Structures Code
+	//Stolen and edited from alien weed code. I wanted a spreading structure that doesnt have the atmospheric element attached to its root.
+/obj/structure/spreading
+	name = "spreading structure"
+	desc = "This thing seems to spread when supplied with a outside signal."
+	max_integrity = 15
+	anchored = TRUE
+	density = FALSE
+	layer = TURF_LAYER
+	plane = FLOOR_PLANE
+	var/conflict_damage = 10
+	var/last_expand = 0 //last world.time this weed expanded
+	var/expand_cooldown = 1.5 SECONDS
+	var/can_expand = TRUE
+	var/static/list/blacklisted_turfs
+
+/obj/structure/spreading/Initialize()
+	. = ..()
+
+	if(!blacklisted_turfs)
+		blacklisted_turfs = typecacheof(list(
+			/turf/open/space,
+			/turf/open/chasm,
+			/turf/open/lava,
+			/turf/open/openspace))
+
+/obj/structure/spreading/proc/expand(bypasscooldown = FALSE)
+	if(!can_expand)
+		return
+
+	if(!bypasscooldown)
+		last_expand = world.time + expand_cooldown
+
+	var/turf/U = get_turf(src)
+	if(is_type_in_typecache(U, blacklisted_turfs))
+		qdel(src)
+		return FALSE
+
+	for(var/turf/T in U.GetAtmosAdjacentTurfs())
+		if(locate(/obj/structure/spreading) in T)
+			var/obj/structure/spreading/S = locate(/obj/structure/spreading) in T
+			if(S.type != type) //if it is not another of the same spreading structure.
+				S.take_damage(conflict_damage, BRUTE, "melee", 1)
+				break
+			last_expand += (0.6 SECONDS) //if you encounter another of the same then the delay increases
+			continue
+
+		if(is_type_in_typecache(T, blacklisted_turfs))
+			continue
+
+		new type(T)
+		break
+	return TRUE

--- a/code/game/objects/items/ego_weapons/waw.dm
+++ b/code/game/objects/items/ego_weapons/waw.dm
@@ -374,9 +374,9 @@
 		user.visible_message("<span class='notice'>[user] stabs [src] into the ground.</span>", "<span class='nicegreen'>You stab your [src] into the ground.</span>")
 		var/mob/living/carbon/human/L = user
 		L.adjustSanityLoss(30)
-		if(!locate(/obj/structure/apple_vine) in get_turf(user))
+		if(!locate(/obj/structure/spreading/apple_vine) in get_turf(user))
 			L.visible_message("<span class='notice'>Wilted stems grow from [src].</span>")
-			new /obj/structure/apple_vine(get_turf(user))
+			new /obj/structure/spreading/apple_vine(get_turf(user))
 			return
 
 		var/affected_mobs = 0

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -291,7 +291,7 @@
 
 /datum/reagent/toxin/plantbgone/expose_obj(obj/exposed_obj, reac_volume)
 	. = ..()
-	if(istype(exposed_obj, /obj/structure/alien/weeds) || istype(exposed_obj, /obj/structure/apple_vine))
+	if(istype(exposed_obj, /obj/structure/alien/weeds) || istype(exposed_obj, /obj/structure/spreading/apple_vine))
 		var/obj/structure/alien/weeds/alien_weeds = exposed_obj
 		alien_weeds.take_damage(rand(15,35), BRUTE, 0) // Kills alien weeds pretty fast
 	else if(istype(exposed_obj, /obj/structure/glowshroom)) //even a small amount is enough to kill it


### PR DESCRIPTION
## About The Pull Request
In order to modularize code and make it so that snow whites vines wont grow ontop of another spreading structure i am making a structure type for all spreading structures. 
I also added code for spreading structures to fight eachother and even though i like the concept of it i may need to remove it.

## Why It's Good For The Game
Modularization, prevents overlaping spreading structures.

## Changelog
:cl:
add: spreading structures
tweak: some of snow whites apple's procs that rely on spreading structures.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
