### PR TITLE
Status Effect Cleanup and related PascalCasing

### DIFF
--- a/ModularTegustation/tegu_items/lc13unique_items.dm
+++ b/ModularTegustation/tegu_items/lc13unique_items.dm
@@ -34,7 +34,7 @@
 	to_chat(user, "<span class='notice'>You got a prize!</span>")
 	new reward(get_turf(src))
 	qdel(src)
-	
+
 	//Pet Whistle
 /obj/item/pet_whistle
 	name = "Galtons whistle"
@@ -201,6 +201,8 @@
 
 /datum/status_effect/interventionshield/be_replaced()
 	var/mob/living/carbon/human/L = owner
+	if(!istype(L))
+		return ..()
 	switch(respectivedamage)
 		if(RED_DAMAGE)
 			L.physiology.red_mod /= 0.0001
@@ -211,7 +213,7 @@
 		if(PALE_DAMAGE)
 			L.physiology.pale_mod /= 0.0001
 	playsound(get_turf(owner), 'sound/effects/glassbr1.ogg', 50, 0, 10)
-	..()
+	return ..()
 
 /datum/status_effect/interventionshield/on_remove()
 	var/mob/living/carbon/human/L = owner

--- a/code/datums/status_effects/panic.dm
+++ b/code/datums/status_effects/panic.dm
@@ -16,7 +16,6 @@
 	. = ..()
 	owner.cut_overlay(mutable_appearance('icons/effects/32x64.dmi', "panicked", -ABOVE_MOB_LAYER))
 
-
 /datum/status_effect/panicked_lvl_0
 	id = "calm"
 	status_type = STATUS_EFFECT_UNIQUE
@@ -30,7 +29,6 @@
 /datum/status_effect/panicked_lvl_0/on_remove()
 	. = ..()
 	owner.cut_overlay(mutable_appearance('icons/effects/32x64.dmi', "calm", -ABOVE_MOB_LAYER))
-
 
 /datum/status_effect/panicked_lvl_1
 	id = "nervous"
@@ -46,7 +44,6 @@
 	. = ..()
 	owner.cut_overlay(mutable_appearance('icons/effects/32x64.dmi', "nervous", -ABOVE_MOB_LAYER))
 
-
 /datum/status_effect/panicked_lvl_2
 	id = "terrified"
 	status_type = STATUS_EFFECT_UNIQUE
@@ -60,7 +57,6 @@
 /datum/status_effect/panicked_lvl_2/on_remove()
 	. = ..()
 	owner.cut_overlay(mutable_appearance('icons/effects/32x64.dmi', "terrified", -ABOVE_MOB_LAYER))
-
 
 /datum/status_effect/panicked_lvl_3
 	id = "hopeless"
@@ -76,7 +72,6 @@
 	. = ..()
 	owner.cut_overlay(mutable_appearance('icons/effects/32x64.dmi', "hopeless", -ABOVE_MOB_LAYER))
 
-
 /datum/status_effect/panicked_lvl_4
 	id = "overwhelmed"
 	status_type = STATUS_EFFECT_UNIQUE
@@ -91,7 +86,6 @@
 	. = ..()
 	owner.cut_overlay(mutable_appearance('icons/effects/32x64.dmi', "overwhelmed", -ABOVE_MOB_LAYER))
 
-
 /datum/status_effect/panicked_lvl_5
 	id = "reverence"
 	status_type = STATUS_EFFECT_UNIQUE
@@ -105,7 +99,6 @@
 /datum/status_effect/panicked_lvl_5/on_remove()
 	. = ..()
 	owner.cut_overlay(mutable_appearance('icons/effects/32x64.dmi', "reverence", -ABOVE_MOB_LAYER))
-
 
 /datum/status_effect/panicked_type
 	id = "panic_state_base"
@@ -122,8 +115,8 @@
 	owner.cut_overlay(mutable_appearance('icons/effects/effects.dmi', icon, -ABOVE_MOB_LAYER))
 
 /datum/status_effect/panicked_type/be_replaced()
-	. = ..()
 	owner.cut_overlay(mutable_appearance('icons/effects/effects.dmi', icon, -ABOVE_MOB_LAYER))
+	return ..()
 
 /datum/status_effect/panicked_type/murder
 	icon = "murder"

--- a/code/game/machinery/computer/extraction_cargo.dm
+++ b/code/game/machinery/computer/extraction_cargo.dm
@@ -55,7 +55,7 @@
 		new /datum/data/extraction_cargo("Sal-Acid Medi-Pen ",			/obj/item/reagent_containers/hypospray/medipen/salacid,				50, CAT_MEDICAL) = 1,
 		new /datum/data/extraction_cargo("Mental-Stabilizer Medi-Pen ",	/obj/item/reagent_containers/hypospray/medipen/mental,				50, CAT_MEDICAL) = 1,
 		new /datum/data/extraction_cargo("Standard First-Aid Kit ",		/obj/item/storage/firstaid/regular,									250, CAT_MEDICAL) = 1,
-		new /datum/data/extraction_cargo("Naked Nest Cure Vial ",		/obj/item/serpentspoision,											400, CAT_MEDICAL) = 1,
+		new /datum/data/extraction_cargo("Naked Nest Cure Vial ",		/obj/item/serpentspoison,											400, CAT_MEDICAL) = 1,
 		new /datum/data/extraction_cargo("Prosthetic Limb Crate ",		/obj/structure/closet/crate/freezer/surplus_limbs,					500, CAT_MEDICAL) = 1,
 		new /datum/data/extraction_cargo("Assorted Medi-Pen Kit ",		/obj/item/storage/firstaid/revival,									500, CAT_MEDICAL) = 1,
 

--- a/code/modules/mob/living/simple_animal/abnormality/he/laetitia.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/laetitia.dm
@@ -31,7 +31,7 @@
 		if(prob(15)) //15% chance to remove prank
 			user.remove_status_effect(STATUS_EFFECT_PRANKED)
 		else if(prob(15)) //15% chance to trigger explosion
-			P.triggerprank()
+			P.TriggerPrank()
 	else
 		if(prob(70)) //not 100% of the time to be funny
 			var/datum/status_effect/pranked/SE = user.apply_status_effect(STATUS_EFFECT_PRANKED)
@@ -47,7 +47,7 @@
 /mob/living/simple_animal/hostile/abnormality/laetitia/FailureEffect(mob/living/carbon/human/user, work_type, pe)
 	var/datum/status_effect/pranked/P = user.has_status_effect(STATUS_EFFECT_PRANKED)
 	if(P && prob(70)) //70% to trigger explosion
-		P.triggerprank()
+		P.TriggerPrank()
 	return
 
 //Her friend
@@ -137,7 +137,7 @@
 			L.apply_damage(200, RED_DAMAGE, null, L.run_armor_check(null, RED_DAMAGE), spread_damage = TRUE)//Usually a kill, you can block it if you're good
 	return ..()
 
-/datum/status_effect/pranked/proc/triggerprank()
+/datum/status_effect/pranked/proc/TriggerPrank()
 	//immediately set to 10 seconds, don't shorten if less than 10 seconds remaining
 	var/newduration = duration - world.time
 	newduration = clamp(newduration, 0, 100)

--- a/code/modules/mob/living/simple_animal/abnormality/he/laetitia.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/laetitia.dm
@@ -135,7 +135,6 @@
 			if(!L.anchored)
 				L.throw_at(throw_target, rand(1, 3), 7, L)
 			L.apply_damage(200, RED_DAMAGE, null, L.run_armor_check(null, RED_DAMAGE), spread_damage = TRUE)//Usually a kill, you can block it if you're good
-	return ..()
 
 /datum/status_effect/pranked/proc/TriggerPrank()
 	//immediately set to 10 seconds, don't shorten if less than 10 seconds remaining

--- a/code/modules/mob/living/simple_animal/abnormality/he/laetitia.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/laetitia.dm
@@ -135,6 +135,7 @@
 			if(!L.anchored)
 				L.throw_at(throw_target, rand(1, 3), 7, L)
 			L.apply_damage(200, RED_DAMAGE, null, L.run_armor_check(null, RED_DAMAGE), spread_damage = TRUE)//Usually a kill, you can block it if you're good
+	return ..()
 
 /datum/status_effect/pranked/proc/triggerprank()
 	//immediately set to 10 seconds, don't shorten if less than 10 seconds remaining

--- a/code/modules/mob/living/simple_animal/abnormality/he/road_home.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/road_home.dm
@@ -397,3 +397,7 @@
 
 	if(!valid_tile)
 		return COMPONENT_MOVABLE_BLOCK_PRE_MOVE
+
+/datum/status_effect/stay_home/on_remove()
+	UnregisterSignal(owner, COMSIG_MOVABLE_PRE_MOVE)
+	return ..()

--- a/code/modules/mob/living/simple_animal/abnormality/he/road_home.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/road_home.dm
@@ -380,10 +380,10 @@
 
 /datum/status_effect/stay_home/on_apply()
 	. = ..()
-	RegisterSignal(owner, COMSIG_MOVABLE_PRE_MOVE, .proc/moved)
+	RegisterSignal(owner, COMSIG_MOVABLE_PRE_MOVE, .proc/Moved)
 
 ///If someone has this status effect, they will be incapable of leaving the gold road if they ever step on it.
-/datum/status_effect/stay_home/proc/moved(datum/source, atom/new_location)
+/datum/status_effect/stay_home/proc/Moved(datum/source, atom/new_location)
 	SIGNAL_HANDLER
 	var/turf/newloc_turf = get_turf(new_location)
 	var/valid_tile = FALSE

--- a/code/modules/mob/living/simple_animal/abnormality/he/silent_girl.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/silent_girl.dm
@@ -47,7 +47,7 @@
 	else if(user.has_status_effect(STATUS_EFFECT_SG_ATTONEMENT))
 		user.remove_status_effect(STATUS_EFFECT_SG_ATTONEMENT)
 
-/mob/living/simple_animal/hostile/abnormality/silent_girl/proc/Guilt_Effect(mob/living/carbon/human/user)
+/mob/living/simple_animal/hostile/abnormality/silent_girl/proc/GuiltEffect(mob/living/carbon/human/user)
 	if ((user.stat == DEAD) || (user.has_status_effect(STATUS_EFFECT_SG_GUILTY)))
 		return
 	datum_reference.qliphoth_change(-1)
@@ -56,7 +56,7 @@
 
 /mob/living/simple_animal/hostile/abnormality/silent_girl/PostWorkEffect(mob/living/carbon/human/user, work_type, pe, work_time)
 	if(get_attribute_level(user, PRUDENCE_ATTRIBUTE) < 60 && !user.has_status_effect(STATUS_EFFECT_SG_GUILTY))
-		Guilt_Effect(user)
+		GuiltEffect(user)
 	return
 
 /mob/living/simple_animal/hostile/abnormality/silent_girl/AttemptWork(mob/living/carbon/human/user, work_type)
@@ -66,7 +66,7 @@
 	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/silent_girl/FailureEffect(mob/living/carbon/human/user, work_type, pe)
-	Guilt_Effect(user)
+	GuiltEffect(user)
 	return
 
 /mob/living/simple_animal/hostile/abnormality/silent_girl/ZeroQliphoth(mob/living/carbon/human/user)

--- a/code/modules/mob/living/simple_animal/abnormality/he/silent_girl.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/silent_girl.dm
@@ -146,12 +146,12 @@
 		UnregisterSignal(H, COMSIG_WORK_STARTED)
 
 /datum/status_effect/sg_guilty/be_replaced()
-	. = ..()
 	if(ishuman(owner))
 		var/mob/living/carbon/human/H = owner
 		H.cut_overlay(guilt_icon)
 		H.physiology.work_success_mod /= 0.75
 		UnregisterSignal(H, COMSIG_WORK_STARTED)
+	return ..()
 
 /datum/status_effect/sg_guilty/proc/OnWorkStart(datum/source, datum/abnormality/abno_reference, mob/living/carbon/human/user, work_type)
 	SIGNAL_HANDLER
@@ -230,11 +230,11 @@
 		UnregisterSignal(H, COMSIG_WORK_STARTED)
 
 /datum/status_effect/sg_atonement/be_replaced()
-	. = ..()
 	if(ishuman(owner))
 		var/mob/living/carbon/human/H = owner
 		H.cut_overlay(guilt_icon)
 		UnregisterSignal(H, COMSIG_WORK_COMPLETED)
+	return ..()
 
 /datum/status_effect/sg_atonement/proc/OnWorkStart(datum/source, datum/abnormality/abno_reference, mob/living/carbon/human/user, work_type)
 	SIGNAL_HANDLER

--- a/code/modules/mob/living/simple_animal/abnormality/waw/fire_bird.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/fire_bird.dm
@@ -91,7 +91,7 @@
 	light_range = 20
 	light_power = 20
 	update_light()
-	addtimer(CALLBACK(src, .proc/kill_otherbird), 90 SECONDS)
+	addtimer(CALLBACK(src, .proc/KillOtherBird), 90 SECONDS)
 
 /mob/living/simple_animal/hostile/abnormality/fire_bird/Life()
 	. = ..()
@@ -100,7 +100,7 @@
 	if((pulse_cooldown < world.time) && !(status_flags & GODMODE))
 		crispynugget()
 
-/mob/living/simple_animal/hostile/abnormality/fire_bird/proc/kill_otherbird()
+/mob/living/simple_animal/hostile/abnormality/fire_bird/proc/KillOtherBird()
 	loot = null
 	light_range = 0
 	light_power = 0
@@ -130,9 +130,9 @@
 		SLEEP_CHECK_DEATH(11)
 		been_hit = list()
 		playsound(get_turf(src), 'sound/abnormalities/firebird/Firebird_Hit.ogg', 100, 0, 20) //TEMPORARY
-		do_dash(dir_to_target, 0)
+		DoDash(dir_to_target, 0)
 
-/mob/living/simple_animal/hostile/abnormality/fire_bird/proc/do_dash(move_dir, times_ran)
+/mob/living/simple_animal/hostile/abnormality/fire_bird/proc/DoDash(move_dir, times_ran)
 	var/stop_charge = FALSE
 	if(times_ran >= dash_max)
 		stop_charge = TRUE
@@ -165,7 +165,7 @@
 				been_hit += L
 
 
-	addtimer(CALLBACK(src, .proc/do_dash, move_dir, (times_ran + 1)), 0.5) // SPEED
+	addtimer(CALLBACK(src, .proc/DoDash, move_dir, (times_ran + 1)), 0.5) // SPEED
 
 /mob/living/simple_animal/hostile/abnormality/fire_bird/attackby(obj/item/I, mob/living/user, params)
 	..()

--- a/code/modules/mob/living/simple_animal/abnormality/waw/fire_bird.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/fire_bird.dm
@@ -182,7 +182,7 @@
 		carbon_firer.apply_status_effect(STATUS_EFFECT_BLINDED)
 	retaliatedash()
 
-/mob/living/simple_animal/hostile/abnormality/fire_bird/proc/Blinded_Work(datum/source, datum/abnormality/datum_sent, mob/living/carbon/human/user)
+/mob/living/simple_animal/hostile/abnormality/fire_bird/proc/BlindedWork(datum/source, datum/abnormality/datum_sent, mob/living/carbon/human/user)
 	SIGNAL_HANDLER
 	user.remove_status_effect(STATUS_EFFECT_BLINDED)
 
@@ -249,7 +249,7 @@
 		cantsee[L] = get_attribute_level(L, TEMPERANCE_ATTRIBUTE)/2
 		L.adjust_attribute_level(TEMPERANCE_ATTRIBUTE, -cantsee[L])
 		to_chat(L, "<span class='userdanger'>The light of the bird burns your eyes!")
-		RegisterSignal(L, COMSIG_WORK_COMPLETED, .proc/Blinded_Work)
+		RegisterSignal(L, COMSIG_WORK_COMPLETED, .proc/BlindedWork)
 
 /datum/status_effect/blinded/on_remove()
 	. = ..()
@@ -258,9 +258,10 @@
 		L.adjust_attribute_level(TEMPERANCE_ATTRIBUTE, cantsee[L])
 		cantsee -= L
 		to_chat(L, "<span class='nicegreen'>The blinding light fades...")
-		UnregisterSignal(L, COMSIG_WORK_COMPLETED, .proc/Blinded_Work)
+		UnregisterSignal(L, COMSIG_WORK_COMPLETED, .proc/BlindedWork)
 
-/datum/status_effect/blinded/proc/Blinded_Work(datum/source, datum/abnormality/datum_sent, mob/living/carbon/human/user)
+/datum/status_effect/blinded/proc/BlindedWork(datum/source, datum/abnormality/datum_sent, mob/living/carbon/human/user)
 	SIGNAL_HANDLER
 	user.remove_status_effect(STATUS_EFFECT_BLINDED)
+
 #undef STATUS_EFFECT_BLINDED

--- a/code/modules/mob/living/simple_animal/abnormality/waw/naked_nest.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/naked_nest.dm
@@ -69,7 +69,7 @@
 		if(origin_cooldown <= world.time) //To prevent serpent flood there is a delay on how many serpents are brave enough to leave the safety of their nest.
 			var/turf/T = pick(GLOB.department_centers)
 			var/mob/living/simple_animal/hostile/naked_nest_serpent/serpent = new(get_turf(T))
-			serpent.hide()
+			serpent.Hide()
 			datum_reference.qliphoth_change(1)
 			origin_cooldown = world.time + origin_cooldown_delay
 		return
@@ -82,7 +82,7 @@
 		AM.forceMove(get_turf(src))
 	if(serpentsnested > 0)
 		var/mob/living/simple_animal/hostile/naked_nest_serpent/S = new(get_turf(src))
-		S.hide()
+		S.Hide()
 	..()
 
 /mob/living/simple_animal/hostile/abnormality/naked_nest/Move()
@@ -118,7 +118,7 @@
 	if(!target && istype(AM, /mob/living/simple_animal/hostile/naked_nest_serpent))
 		var/mob/living/simple_animal/hostile/naked_nest_serpent/S = AM
 		if(!S.target && !client)
-			S.nest(src)
+			S.Nest(src)
 
 /mob/living/simple_animal/hostile/abnormality/naked_nest/Life()
 	. = ..()
@@ -136,7 +136,7 @@
 	S.GiveTarget(target)
 	serpentsnested = serpentsnested - 1
 
-/mob/living/simple_animal/hostile/abnormality/naked_nest/proc/recover_serpent(mob/living/simple_animal/hostile/naked_nest_serpent/S) //destination of serpents nest proc
+/mob/living/simple_animal/hostile/abnormality/naked_nest/proc/RecoverSerpent(mob/living/simple_animal/hostile/naked_nest_serpent/S) //destination of serpents nest proc
 	if(serpentsnested <= 5)
 		if(S.client)
 			to_chat(src, "<span class='nicegreen'>You return to the safety of the nest.</span>")
@@ -146,9 +146,9 @@
 	else if(S.client)
 		to_chat(S, "<span class='notice'>This nest has no more room.</span>")
 
-/mob/living/simple_animal/hostile/abnormality/naked_nest/proc/nest() //return to the nest
+/mob/living/simple_animal/hostile/abnormality/naked_nest/proc/Nest() //return to the nest
 	for(var/mob/living/simple_animal/hostile/naked_nest_serpent/M in range(0, src))
-		M.nest(src)
+		M.Nest(src)
 
 /mob/living/simple_animal/hostile/naked_nest_serpent
 	name = "naked serpent"
@@ -189,11 +189,11 @@
 	if(iscarbon(target) && prob(80))
 		var/mob/living/carbon/human/C = target
 		if(C.stat != DEAD && !C.has_status_effect(/datum/status_effect/serpents_host) && a_intent == "harm")
-			enter_host(C)
+			EnterHost(C)
 			return
 	if(istype(target, /mob/living/simple_animal/hostile/abnormality/naked_nest))
 		var/mob/living/simple_animal/hostile/abnormality/naked_nest/nest = target
-		nest.recover_serpent(src)
+		nest.RecoverSerpent(src)
 	. = ..()
 
 /mob/living/simple_animal/hostile/naked_nest_serpent/PickTarget(list/Targets)
@@ -221,19 +221,19 @@
 				Goto(N, 5, 0)
 				return
 
-/mob/living/simple_animal/hostile/naked_nest_serpent/proc/enter_host(mob/living/carbon/host)
+/mob/living/simple_animal/hostile/naked_nest_serpent/proc/EnterHost(mob/living/carbon/host)
 	if(prob(50 * (host.health / host.maxHealth)))
 		to_chat(host, "<span class='warning'>You feel something cold touch the back of your leg!</span>")
 	to_chat(src, "<span class='nicegreen'>You’ve found a new nest!</span>")
 	host.apply_status_effect(/datum/status_effect/serpents_host)
 	QDEL_IN(src, 5)
 
-/mob/living/simple_animal/hostile/naked_nest_serpent/proc/nest(mob/living/simple_animal/hostile/abnormality/naked_nest/nest)
+/mob/living/simple_animal/hostile/naked_nest_serpent/proc/Nest(mob/living/simple_animal/hostile/abnormality/naked_nest/nest)
 	for(var/mob/living/simple_animal/hostile/abnormality/naked_nest/N in range(1, src))
 		if(nest.serpentsnested <= 5 && origin_nest == N.tag || !origin_nest)
-			nest.recover_serpent(src)
+			nest.RecoverSerpent(src)
 
-/mob/living/simple_animal/hostile/naked_nest_serpent/proc/hide()
+/mob/living/simple_animal/hostile/naked_nest_serpent/proc/Hide()
 	Goto((locate(/obj/structure/table) in oview(get_turf(src), 9)), move_to_delay, 0)
 	wander = FALSE
 
@@ -266,7 +266,7 @@
 /mob/living/simple_animal/hostile/naked_nested/Initialize()
 	. = ..()
 	nestingtimer = world.time + (40 SECONDS)
-	updateArmor() //in order to fix damage coefficents
+	UpdateArmor() //in order to fix damage coefficents
 
 /mob/living/simple_animal/hostile/naked_nested/Life()
 	. = ..()
@@ -289,7 +289,7 @@
 	playsound(get_turf(src), 'sound/misc/moist_impact.ogg', 30, 1)
 	qdel(src)
 
-/mob/living/simple_animal/hostile/naked_nested/proc/updateArmor()
+/mob/living/simple_animal/hostile/naked_nested/proc/UpdateArmor()
 	damage_coeff = list(BRUTE = 1, RED_DAMAGE = 0.6, WHITE_DAMAGE = 0.8, BLACK_DAMAGE = 1.2, PALE_DAMAGE = 1.5)
 	var/obj/item/clothing/suit/armor/host_armor = locate(/obj/item/clothing/suit/armor) in contents
 	if(host_armor)
@@ -370,18 +370,18 @@
 			host.regenerate_icons()
 		if(B && cured != 1)
 			var/mob/living/simple_animal/hostile/naked_nested/N = new(owner.loc) //there was a issue with several converted naked nests getting the same damage coeffs so convert proc had to be moved here.
-			nested_items(N, host.get_item_by_slot(ITEM_SLOT_SUITSTORE))
-			nested_items(N, host.get_item_by_slot(ITEM_SLOT_BELT))
-			nested_items(N, host.get_item_by_slot(ITEM_SLOT_BACK))
+			NestedItems(N, host.get_item_by_slot(ITEM_SLOT_SUITSTORE))
+			NestedItems(N, host.get_item_by_slot(ITEM_SLOT_BELT))
+			NestedItems(N, host.get_item_by_slot(ITEM_SLOT_BACK))
 			if(host.get_item_by_slot(ITEM_SLOT_OCLOTHING))
-				nested_items(N, host.get_item_by_slot(ITEM_SLOT_OCLOTHING))
-				N.updateArmor() //moved to creature proc since changing armor values in the status effect resulted in all naked nested having their armor values changed. Even admin spawned ones.
+				NestedItems(N, host.get_item_by_slot(ITEM_SLOT_OCLOTHING))
+				N.UpdateArmor() //moved to creature proc since changing armor values in the status effect resulted in all naked nested having their armor values changed. Even admin spawned ones.
 			playsound(get_turf(owner), 'sound/misc/soggy.ogg', 20, 1)
 			qdel(owner)
 	owner.faction -= "Naked_Nest"
 	. = ..()
 
-/datum/status_effect/serpents_host/proc/nested_items(mob/living/simple_animal/hostile/naked_nested/nest, obj/item/nested_item)
+/datum/status_effect/serpents_host/proc/NestedItems(mob/living/simple_animal/hostile/naked_nested/nest, obj/item/nested_item)
 	if(nested_item)
 		nested_item.forceMove(nest)
 
@@ -397,15 +397,15 @@
 
 /obj/item/serpentspoison/attack(mob/living/M, mob/user)
 	user.visible_message("<span class='notice'>[user] injects [M] with [src].</span>")
-	cure(M)
+	Cure(M)
 	qdel(src)
 
 /obj/item/serpentspoison/attack_self(mob/living/carbon/user)
 	user.visible_message("<span class='notice'>[user] injects themselves with [src].</span>")
-	cure(user)
+	Cure(user)
 	qdel(src)
 
-/obj/item/serpentspoison/proc/cure(mob/living/carbon/target)
+/obj/item/serpentspoison/proc/Cure(mob/living/carbon/target)
 	if(target.has_status_effect(/datum/status_effect/serpents_host))
 		var/datum/status_effect/serpents_host/C = target.has_status_effect(/datum/status_effect/serpents_host)
 		C.SerpentsPoison()

--- a/code/modules/mob/living/simple_animal/abnormality/waw/naked_nest.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/naked_nest.dm
@@ -51,7 +51,7 @@
 
 /mob/living/simple_animal/hostile/abnormality/naked_nest/SuccessEffect(mob/living/carbon/human/user, work_type, pe)
 	to_chat(user, "<span class='notice'>The serpents seem to avoid areas of their nest covered in this solution.</span>")
-	new /obj/item/serpentspoision(get_turf(user))
+	new /obj/item/serpentspoison(get_turf(user))
 	return
 
 /mob/living/simple_animal/hostile/abnormality/naked_nest/NeutralEffect(mob/living/carbon/human/user, work_type, pe)
@@ -340,7 +340,7 @@
 		H.adjustSanityLoss(0.1) //the serpents final destination is your frontal lobe
 		H.adjustOrganLoss(ORGAN_SLOT_BRAIN, 0.1)
 		if(H.bodytemperature <= INHOSPITABLE_FOR_NESTING) //cure conditions
-			serpentsPoision()
+			SerpentsPoison()
 		if(H.drunkenness >= 5 && H.stat != DEAD) //increases duration of infection.
 			duration = duration + extra_time
 			physical_symptoms = physical_symptoms + extra_time
@@ -355,7 +355,7 @@
 				H.skin_tone = "serpentgreen" //resulted in alteration to helpers.dm
 				H.regenerate_icons()
 
-/datum/status_effect/serpents_host/proc/serpentsPoision()
+/datum/status_effect/serpents_host/proc/SerpentsPoison()
 	cured = 1
 	qdel(src)
 
@@ -388,24 +388,24 @@
 #undef INHOSPITABLE_FOR_NESTING
 
 //Offical Cure
-/obj/item/serpentspoision
+/obj/item/serpentspoison
 	name = "serpent infestation cure"
 	desc = "A formula that removes O-02-74-1 infestation."
 	icon = 'icons/obj/chromosomes.dmi'
 	icon_state = ""
 	color = "gold"
 
-/obj/item/serpentspoision/attack(mob/living/M, mob/user)
+/obj/item/serpentspoison/attack(mob/living/M, mob/user)
 	user.visible_message("<span class='notice'>[user] injects [M] with [src].</span>")
 	cure(M)
 	qdel(src)
 
-/obj/item/serpentspoision/attack_self(mob/living/carbon/user)
+/obj/item/serpentspoison/attack_self(mob/living/carbon/user)
 	user.visible_message("<span class='notice'>[user] injects themselves with [src].</span>")
 	cure(user)
 	qdel(src)
 
-/obj/item/serpentspoision/proc/cure(mob/living/carbon/target)
+/obj/item/serpentspoison/proc/cure(mob/living/carbon/target)
 	if(target.has_status_effect(/datum/status_effect/serpents_host))
 		var/datum/status_effect/serpents_host/C = target.has_status_effect(/datum/status_effect/serpents_host)
-		C.serpentsPoision()
+		C.SerpentsPoison()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Some status effects were wacky:
Sanity didn't properly replace due to the order in which code executed (Parent -> Child), now it's inverse and works correctly.
Silent Girl's status did the same and has been fixed likewise.
Road Home's status now unregisters the signal `on_remove` which is really just cleanup.

Naked Nest got it's spelling issues fixed (see: Serpent's Poision -> Serpent's Poison)

Added an istype check for Intervention Shields being removed, just in case of severe admemery or unexpected issues arise.

All other changes are PascalCasing.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Cleans up a lot of code.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
code: 🧹 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
