### PR TITLE
Abnos Can Return Home

### DIFF
--- a/code/datums/abnormality/datum/abnormality.dm
+++ b/code/datums/abnormality/datum/abnormality.dm
@@ -91,6 +91,7 @@
 	current.toggle_ai(AI_OFF)
 	current.status_flags |= GODMODE
 	current.setDir(EAST)
+	current.home = get_turf(landmark)
 	threat_level = current.threat_level
 	qliphoth_meter_max = current.start_qliphoth
 	qliphoth_meter = qliphoth_meter_max

--- a/code/modules/mob/living/simple_animal/abnormality/_abnormality.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_abnormality.dm
@@ -59,6 +59,9 @@
 	var/datum/ego_gifts/gift_type = null
 	var/gift_chance = null
 	var/gift_message = null
+
+	/// Abno Landmark Location
+	var/turf/home = null
 	var/abnormality_origin = ABNORMALITY_ORIGIN_ORIGINAL
 
 /mob/living/simple_animal/hostile/abnormality/Initialize(mapload)
@@ -317,6 +320,8 @@
 
 /mob/living/simple_animal/hostile/abnormality/proc/IsContained() //Are you in a cell and currently contained?? If so stop.
 //Contained checks for: If the abnorm is godmoded AND one of the following: It does not have a qliphoth meter OR It has qliphoth remaining
+	if(!(src in home) && !isnull(home))
+		return FALSE
 	if((status_flags & GODMODE) && (!datum_reference.qliphoth_meter_max || datum_reference.qliphoth_meter))
 		return TRUE
 	return FALSE

--- a/code/modules/mob/living/simple_animal/abnormality/teth/ppodae.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/ppodae.dm
@@ -30,6 +30,7 @@
 	var/smash_length = 2
 	var/smash_width = 1
 	var/can_act = TRUE
+	var/returning = FALSE
 
 	ego_list = list(
 		/datum/ego_datum/weapon/cute,
@@ -37,6 +38,13 @@
 		)
 	gift_type =  /datum/ego_gifts/cute
 	abnormality_origin = ABNORMALITY_ORIGIN_LOBOTOMY
+
+/mob/living/simple_animal/hostile/abnormality/ppodae/Life()
+	. = ..()
+	if(!returning)
+		return
+	if(!patrol_to(home))
+		QDEL_NULL(src)
 
 /mob/living/simple_animal/hostile/abnormality/ppodae/Move()
 	if(!can_act)
@@ -60,7 +68,15 @@
 			var/obj/item/bodypart/bp = pick(parts)
 			bp.dismember()
 			bp.forceMove(get_turf(datum_reference.landmark)) // Teleports limb to containment
-			QDEL_NULL(src)
+			if(!client)
+				LoseTarget()
+				if(patrol_to(datum_reference?.landmark))
+					density = FALSE
+					toggle_ai(AI_OFF)
+					status_flags |= GODMODE
+					returning = TRUE
+				else
+					QDEL_NULL(src)
 			// Taken from eldritch_demons.dm
 	return Smash(target)
 
@@ -179,3 +195,11 @@
 	..()
 	icon_state = "ppodae_active"
 	GiveTarget(user)
+
+/mob/living/simple_animal/hostile/abnormality/ppodae/patrol_finish()
+	if((src in home) && returning)
+		setDir(EAST)
+		density = TRUE
+		datum_reference.qliphoth_change(datum_reference.qliphoth_meter_max)
+		returning = FALSE
+	return

--- a/code/modules/mob/living/simple_animal/abnormality/teth/ppodae.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/ppodae.dm
@@ -198,6 +198,7 @@
 
 /mob/living/simple_animal/hostile/abnormality/ppodae/patrol_finish()
 	if((src in home) && returning)
+		adjustBruteLoss(-maxHealth, TRUE, TRUE)
 		setDir(EAST)
 		density = TRUE
 		datum_reference.qliphoth_change(datum_reference.qliphoth_meter_max)

--- a/code/modules/mob/living/simple_animal/abnormality/teth/punishing_bird.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/punishing_bird.dm
@@ -337,6 +337,7 @@
 			is_flying_animal = FALSE
 			update_icon()
 			REMOVE_TRAIT(src, TRAIT_MOVE_FLYING, INNATE_TRAIT)
+		adjustBruteLoss(-maxHealth, TRUE, TRUE)
 		setDir(EAST)
 		datum_reference.qliphoth_change(datum_reference.qliphoth_meter_max)
 		returning = FALSE

--- a/code/modules/mob/living/simple_animal/abnormality/teth/void_dream.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/void_dream.dm
@@ -151,6 +151,7 @@
 
 /mob/living/simple_animal/hostile/abnormality/voiddream/patrol_finish()
 	if((src in home) && returning)
+		adjustBruteLoss(-maxHealth, TRUE, TRUE)
 		setDir(EAST)
 		density = TRUE
 		datum_reference.qliphoth_change(datum_reference.qliphoth_meter_max)

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -721,9 +721,10 @@
 	patrol_tries = 0
 	stop_automated_movement = 0
 	patrol_cooldown = world.time + patrol_cooldown_time
+	patrol_finish()
 
 /mob/living/simple_animal/hostile/proc/patrol_move(dest)
-	if(client || target || status_flags & GODMODE)
+	if(client || target)
 		patrol_reset()
 		return FALSE
 	if(!dest || !patrol_path || !patrol_path.len) //A-star failed or a path/destination was not set.
@@ -734,6 +735,7 @@
 	dest = get_turf(dest) //We must always compare turfs, so get the turf of the dest var if dest was originally something else.
 	var/turf/last_node = get_turf(patrol_path[patrol_path.len]) //This is the turf at the end of the path, it should be equal to dest.
 	if(get_turf(src) == dest) //We have arrived, no need to move again.
+		patrol_finish()
 		return TRUE
 	else if(dest != last_node) //The path should lead us to our given destination. If this is not true, we must stop.
 		patrol_reset()
@@ -747,7 +749,7 @@
 	return TRUE
 
 /mob/living/simple_animal/hostile/proc/patrol_step(dest)
-	if(client || target  || status_flags & GODMODE || !patrol_path || !patrol_path.len)
+	if(client || target || !patrol_path || !patrol_path.len)
 		return FALSE
 	if(health <= 0) // No more moving corpses.
 		return FALSE
@@ -765,3 +767,7 @@
 		step_to(src, dest)
 		patrol_reset()
 	return TRUE
+
+/// Override for actions you want done once the creature stops patrolling.
+/mob/living/simple_animal/hostile/proc/patrol_finish()
+	return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Allows certain abnos (P-Bird, Ppodae, Void Dream) to return to containment instead of QDEL-ing. Does this by turning their AI off, turning GODMODE on, and telling them to go the heck home. Also adds a variable that tracks the location they spawn in so they can patrol there consistently. 

After completing whatever object they aim to do (Damage, kill, or just wandering), they'll godmode, have their AI turned off, lose density, and try and patrol home. If they *can't*, they'll QDEL like they used to. After arriving, they'll become Dense, reset their Qliphoth Counter, face East, and no longer be "returning". 

Code-wise this adds:
A proc that's called when a patrol stops, either by reaching it's destination or being stopped. By default it does nothing.
A variable to _abnormality.dm that tracks starting location for the abno.
Code to abnormality.dm to set home to the abno landmark location.
Adds a conditional to IsContained() to check if they are *on* their spawn location. If not, they aren't contained (Clearly). I'm down to edit this somehow if it's shitcode.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It looks cool. Might be more trouble than it's worth but I thought it'd be a nice addition, it's something patrol code HAS given us the power to do. Biggest issue would be scaredy cat but Im making a separate PR for that issue.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
