### PR TITLE
Dirt no longer spawns by zayin records bins

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/zayin/fallen_amurdad.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/fallen_amurdad.dm
@@ -46,7 +46,7 @@
 		)
 
 //Start us off with some soil trays and grass
-/mob/living/simple_animal/hostile/abnormality/fallen_amurdad/Initialize()
+/mob/living/simple_animal/hostile/abnormality/fallen_amurdad/PostSpawn()
 	..()
 	var/list/soil_area = range(1, src)
 	if((locate(/obj/machinery/hydroponics/soil/amurdad) in soil_area))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Today I learned a valuable lesson about PostSpawn() vs Initialize()
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Oh god its all broken
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: records bins are no longer filled with dirt
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
