### PR TITLE
Naked nest fixes part2

### DIFF
--- a/code/modules/paperwork/records/info/waw.dm
+++ b/code/modules/paperwork/records/info/waw.dm
@@ -175,6 +175,7 @@
 	abno_info = list(
 		"Observations have concluded that The Naked Nest and its variants harbor serpents capable of infesting humans. These creatures have been given the designation O-02-74-1.",
 		"Employees with low HP are more susceptible to infestation by O-02-74-1. In particular, taking higher damage during work raises the probability of infestation.",
+		"Surgical removal of an incomplete O-02-74 resulted in the O-02-74-1 ejecting itself from the host.",
 		"Getting a Good work result prevented infestation from occurring, and a single-use cure was extracted.",
 		"Some employees suffering from infestation showed the following symptoms over time:<br>\
 		<ol type=1>\


### PR DESCRIPTION
## About The Pull Request
Edited targeting with what i learned from coding indigo leadership. Naked nest and its serpents will not bother themselves with nonhumans like cleanbots. This also lets me remove the Naked Nest faction since it only existed to prevent several worms from infecting the same host.
Added a goto proc on the spawned serpents so that they dont die instantly upon leaving the nest.
added a varient of the naked nest minion that will not metamorphizes into a nest until a hour has past.
Converts naked nest status effect into a removable organ

## Why It's Good For The Game
Fixes jankiness with naked nest and provides a combat subtype for special events.

## Changelog
:cl:
tweak: Naked Nest
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
