### PR TITLE
Added Weapons, Edited Verbs, et cetera

### DIFF
--- a/code/game/objects/items/ego_weapons/aleph.dm
+++ b/code/game/objects/items/ego_weapons/aleph.dm
@@ -7,8 +7,8 @@
 	force = 70
 	damtype = PALE_DAMAGE
 	armortype = PALE_DAMAGE
-	attack_verb_continuous = list("purges", "purifies")
-	attack_verb_simple = list("purge", "purify")
+	attack_verb_continuous = list("purges", "purifies", "abjures")
+	attack_verb_simple = list("purge", "purify", "abjure")
 	hitsound = 'sound/weapons/ego/paradise.ogg'
 	attribute_requirements = list(
 							FORTITUDE_ATTRIBUTE = 100,
@@ -117,8 +117,8 @@
 	attack_speed = 0.5
 	damtype = WHITE_DAMAGE
 	armortype = WHITE_DAMAGE
-	attack_verb_continuous = list("slashes", "slices", "rips", "cuts")
-	attack_verb_simple = list("slash", "slice", "rip", "cut")
+	attack_verb_continuous = list("slashes", "slices", "cuts", "conducts")
+	attack_verb_simple = list("slash", "slice", "cut", "conduct")
 	hitsound = 'sound/weapons/ego/da_capo1.ogg'
 	attribute_requirements = list(
 							FORTITUDE_ATTRIBUTE = 80,
@@ -230,7 +230,7 @@
 
 /obj/item/ego_weapon/goldrush
 	name = "gold rush"
-	desc = "The weapon of someone who can swing their weight around like a truck"
+	desc = "The weapon of the Magical Girl whose desire for happiness twisted into greed."
 	special = "This weapon deals it's damage after a short windup."
 	icon_state = "gold_rush"
 	force = 140
@@ -345,8 +345,8 @@
 	force = 70	//there's a focus on the ranged attack here.
 	damtype = BLACK_DAMAGE
 	armortype = BLACK_DAMAGE
-	attack_verb_continuous = list("attacks")
-	attack_verb_simple = list("attack")
+	attack_verb_continuous = list("CENSOREDs")
+	attack_verb_simple = list("CENSORED")
 	hitsound = 'sound/weapons/ego/censored1.ogg'
 	attribute_requirements = list(
 							FORTITUDE_ATTRIBUTE = 100,

--- a/code/game/objects/items/ego_weapons/non_abnormality/wcorp.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/wcorp.dm
@@ -51,8 +51,8 @@
 	icon_state = "wcorp_fist"
 	inhand_icon_state = "wcorp_fist"
 	force = 40
-	attack_verb_continuous = list("bashes", "crushes")
-	attack_verb_simple = list("bash", "crush")
+	attack_verb_continuous = list("bashes", "crushes", "decks", "pummels")
+	attack_verb_simple = list("bash", "crush", "deck", "pummel")
 	release_message = "You release your charge, slamming your whole weight into your opponent!"
 	charge_effect = "knock your opponent backwards."
 	charge_cost = 3
@@ -177,12 +177,12 @@
 	attack_verb_simple = list("cleave", "slash", "carve")
 	release_message = "You release your charge, attempting to cripple your enemy!"
 	charge_effect = "deliver a crippling blow, slowing your target."
-	attribute_requirements = list{
+	attribute_requirements = list(
 							FORTITUDE_ATTRIBUTE = 100,
 							PRUDENCE_ATTRIBUTE = 80,
 							TEMPERANCE_ATTRIBUTE = 80,
 							JUSTICE_ATTRIBUTE = 80
-							}
+	)
 	/obj/item/ego_weapon/city/wcorp/modifiedhatchet/release_charge(mob/living/target, mob/living/user)
 		to_chat(user, "<span class='notice'>[release_message].</span>")
 		sleep(2)
@@ -204,12 +204,12 @@
 	charge_cost = 8
 	release_message = "You release your charge, shattering the will of your foe!"
 	charge_effect = "increase the BLACK damage your target takes for a short time."
-	attribute_requirements = list{
+	attribute_requirements = list(
 							FORTITUDE_ATTRIBUTE = 80,
 							PRUDENCE_ATTRIBUTE = 80,
 							TEMPERANCE_ATTRIBUTE = 80,
 							JUSTICE_ATTRIBUTE = 100
-							}
+							)
 	/obj/item/ego_weapon/city/wcorp/modhammer/release_charge(mob/living/target, mob/living/user)
 		to_chat(user, "<span class='notice'>[release_message].</span>")
 		sleep(5)

--- a/code/game/objects/items/ego_weapons/non_abnormality/wcorp.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/wcorp.dm
@@ -46,7 +46,7 @@
 
 //Non-baton Wcorp is Grade 5
 /obj/item/ego_weapon/city/wcorp/fist
-	name = "w-corp gauntlet"
+	name = "W-Corp gauntlet"
 	desc = "A glowing blue fist used by senior W corp staff."
 	icon_state = "wcorp_fist"
 	inhand_icon_state = "wcorp_fist"
@@ -72,7 +72,7 @@
 
 
 /obj/item/ego_weapon/city/wcorp/axe
-	name = "w-corp axe"
+	name = "W-Corp axe"
 	desc = "A glowing blue axe used by senior W corp staff."
 	icon_state = "wcorp_axe"
 	inhand_icon_state = "wcorp_fist"
@@ -100,7 +100,7 @@
 	user.changeNext_move(CLICK_CD_MELEE * 6)
 
 /obj/item/ego_weapon/city/wcorp/spear
-	name = "w-corp spear"
+	name = "W-Corp spear"
 	desc = "A glowing blue spear used by senior W corp staff."
 	icon_state = "wcorp_spear"
 	inhand_icon_state = "wcorp_spear"
@@ -137,8 +137,8 @@
 
 
 /obj/item/ego_weapon/city/wcorp/dagger
-	name = "w-corp dagger"
-	desc = "A glowing blue dagger used by senior W corp staff."
+	name = "W-Corp dagger"
+	desc = "A glowing blue dagger used by senior W-Corp staff."
 	icon_state = "wcorp_dagger"
 	inhand_icon_state = "wcorp_dagger"
 	force = 24
@@ -164,3 +164,77 @@
 		var/turf/T = get_turf(target)
 		new /obj/effect/temp_visual/justitia_effect(T)
 
+//Modified W-Corp weapons are above Grade 5, usually stopping at the higher end of Grade 3. Alongside the burst damage, they usually include a minor side-effect. Custom-made by ValerieSteel!
+/obj/item/ego_weapon/city/wcorp/modifiedhatchet
+	name = "modified W-Corp hatchet"
+	desc = "A glowing blue W-Corp handaxe once used by senior W-Corp staff. This one's seen some after-market modifications."
+	icon_state = "wcorp_axe"
+	inhand_icon_state = "wcorp_fist"
+	force = 65
+	attack_speed = 1
+	charge_cost = 5
+	attack_verb_continuous = list("cleaves", "slashes", "carves")
+	attack_verb_simple = list("cleave", "slash", "carve")
+	release_message = "You release your charge, attempting to cripple your enemy!"
+	charge_effect = "deliver a crippling blow, slowing your target."
+	attribute_requirements = list(
+							FORTITUDE_ATTRIBUTE = 100
+							PRUDENCE_ATTRIBUTE = 80
+							TEMPERANCE_ATTRIBUTE = 80
+							JUSTICE_ATTRIBUTE = 80
+							)
+	/obj/item/ego_weapon/city/wcorp/modifiedhatchet/release_charge(mob/living/target, mob/living/user)
+		to_chat(user, "<span class='notice'>[release_message].</span>")
+		sleep(2)
+		target.apply_damage(force*2, damtype, null, target.run_armor_check(null, damtype), spread_damage = TRUE)
+		target.apply_status_effect(/datum/status_effect/qliphothoverload/)
+		playsound(src, 'sound/abnormalities/thunderbird/tbird_bolt.ogg', 50, TRUE)
+		var/turf/T = get_turf(target)
+		new /obj/effect/temp_visual/justitia_effect(T)
+
+/obj/item/ego_weapon/city/wcorp/modhammer
+	name = "modified W-Corp warhammer"
+	desc = "A glowing blue W-Corp warhammer once used by senior W-Corp staff. This one's seen some after-market modifications."
+	icon_state = "wcorp_spear"
+	inhand_icon_state = "wcorp_fist"
+	force = 140
+	attack_speed = 2
+	attack_verb_continuous = list("smashes", "crushes", "shatters")
+	attack_verb_simple = list("smash", "crush", "shatter")
+	charge_cost = 8
+	release_message = "You release your charge, shattering the will of your foe!"
+	charge_effect = "increase the BLACK damage your target takes for a short time."
+	attribute_requirements = list(
+							FORTITUDE_ATTRIBUTE = 80
+							PRUDENCE_ATTRIBUTE = 80
+							TEMPERANCE_ATTRIBUTE = 80
+							JUSTICE_ATTRIBUTE = 100
+							)
+	/obj/item/ego_weapon/city/wcorp/modhammer/release_charge(mob/living/target, mob/living/user)
+		to_chat(user, "<span class='notice'>[release_message].</span>")
+		sleep(5)
+		target.apply_damage(force*2, damtype, null, target.run_armor_check(null, damtype), spread_damage = TRUE)
+		target.apply_status_effect(/datum/status_effect/rendBlackArmor)
+		playsound(src, 'sound/abnormalities/thunderbird/tbird_bolt.ogg', 50, TRUE)
+		var/turf/T = get_turf(target)
+		new /obj/effect/temp_visual/justitia_effect(T)
+
+	/datum/status_effect/rendBlackArmor
+		id = "rend Black armor"
+		status_type = STATUS_EFFECT_UNIQUE
+		duration = 50 //5 seconds since it's melee-ish
+		alert_type = null
+		var/original_armor
+
+	/datum/status_effect/rendBlackArmor/on_apply()
+		. = ..()
+		var/mob/living/simple_animal/M = owner
+		original_armor = M.damage_coeff[BLACK_DAMAGE]
+		if(original_armor > 0)
+		M.damage_coeff[BLACK_DAMAGE] = original_armor + 0.2
+
+	/datum/status_effect/rendBlackArmor/on_remove()
+		. = ..()
+		var/mob/living/simple_animal/M = owner
+		if(M.damage_coeff[BLACK_DAMAGE] == original_armor + 0.2)
+		M.damage_coeff[BLACK_DAMAGE] = original_armor

--- a/code/game/objects/items/ego_weapons/non_abnormality/wcorp.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/wcorp.dm
@@ -231,10 +231,10 @@
 		var/mob/living/simple_animal/M = owner
 		original_armor = M.damage_coeff[BLACK_DAMAGE]
 		if(original_armor > 0)
-		M.damage_coeff[BLACK_DAMAGE] = original_armor + 0.2
+			M.damage_coeff[BLACK_DAMAGE] = original_armor + 0.2
 
 	/datum/status_effect/rendBlackArmor/on_remove()
 		. = ..()
 		var/mob/living/simple_animal/M = owner
 		if(M.damage_coeff[BLACK_DAMAGE] == original_armor + 0.2)
-		M.damage_coeff[BLACK_DAMAGE] = original_armor
+			M.damage_coeff[BLACK_DAMAGE] = original_armor

--- a/code/game/objects/items/ego_weapons/non_abnormality/wcorp.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/wcorp.dm
@@ -177,12 +177,12 @@
 	attack_verb_simple = list("cleave", "slash", "carve")
 	release_message = "You release your charge, attempting to cripple your enemy!"
 	charge_effect = "deliver a crippling blow, slowing your target."
-	attribute_requirements = list(
-							FORTITUDE_ATTRIBUTE = 100
-							PRUDENCE_ATTRIBUTE = 80
-							TEMPERANCE_ATTRIBUTE = 80
+	attribute_requirements = list{
+							FORTITUDE_ATTRIBUTE = 100,
+							PRUDENCE_ATTRIBUTE = 80,
+							TEMPERANCE_ATTRIBUTE = 80,
 							JUSTICE_ATTRIBUTE = 80
-							)
+							}
 	/obj/item/ego_weapon/city/wcorp/modifiedhatchet/release_charge(mob/living/target, mob/living/user)
 		to_chat(user, "<span class='notice'>[release_message].</span>")
 		sleep(2)
@@ -204,12 +204,12 @@
 	charge_cost = 8
 	release_message = "You release your charge, shattering the will of your foe!"
 	charge_effect = "increase the BLACK damage your target takes for a short time."
-	attribute_requirements = list(
-							FORTITUDE_ATTRIBUTE = 80
-							PRUDENCE_ATTRIBUTE = 80
-							TEMPERANCE_ATTRIBUTE = 80
+	attribute_requirements = list{
+							FORTITUDE_ATTRIBUTE = 80,
+							PRUDENCE_ATTRIBUTE = 80,
+							TEMPERANCE_ATTRIBUTE = 80,
 							JUSTICE_ATTRIBUTE = 100
-							)
+							}
 	/obj/item/ego_weapon/city/wcorp/modhammer/release_charge(mob/living/target, mob/living/user)
 		to_chat(user, "<span class='notice'>[release_message].</span>")
 		sleep(5)

--- a/code/game/objects/items/ego_weapons/waw.dm
+++ b/code/game/objects/items/ego_weapons/waw.dm
@@ -113,7 +113,7 @@
 
 /obj/item/ego_weapon/oppression
 	name = "oppression"
-	desc = "Even light forms of contraint can be considered totalitarianism"
+	desc = "Even light forms of constraint can be considered totalitarianism"
 	special = "This weapon builds up charge on every hit. Use the weapon in hand to charge the blade."
 	icon_state = "oppression"
 	force = 13
@@ -870,8 +870,8 @@
 	attack_speed = 1.2
 	damtype = RED_DAMAGE
 	armortype = RED_DAMAGE
-	attack_verb_continuous = list("pokes", "jabs", "tears", "lacerates", "gores")
-	attack_verb_simple = list("poke", "jab", "tear", "lacerate", "gore")
+	attack_verb_continuous = list("pokes", "jabs", "tears", "lacerates", "gores", "gazes upon")
+	attack_verb_simple = list("poke", "jab", "tear", "lacerate", "gore", "gaze upon")
 	hitsound = 'sound/weapons/ego/spear1.ogg'
 	attribute_requirements = list(
 							FORTITUDE_ATTRIBUTE = 80


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Added two new W-Corp gacha weapons: the Modified W-Corp Hatchet, which can spend charge to cripple the targeted enemy, and the Modified W-Corp Warhammer, which spends charge on lowering their BLACK resist. Also, I edited some verbs to make some EGO weapons a tad more flavorful.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
More W-Corp stuff is good! Also, the verbs I chose are neat, I think. They'd really add some minor flavor to the game.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added 2 new weapons to the W-Corp refinery gacha. Icons/sprites are currently placeholders.
tweak: Edited several verbs for some EGO weapons to make things more flavorful.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
