### PR TITLE
Better Gamemode Voting

### DIFF
--- a/code/controllers/configuration/configuration.dm
+++ b/code/controllers/configuration/configuration.dm
@@ -14,6 +14,7 @@
 	var/list/modes			// allowed modes
 	var/list/gamemode_cache
 	var/list/votable_modes		// votable modes
+	var/list/votable_mode_names // compound of mode_names and votable_modes
 	var/list/mode_names
 	var/list/mode_reports
 	var/list/mode_false_report_weight
@@ -228,6 +229,7 @@
 	mode_reports = list()
 	mode_false_report_weight = list()
 	votable_modes = list()
+	votable_mode_names = list()
 	var/list/probabilities = Get(/datum/config_entry/keyed_list/probability)
 	for(var/T in gamemode_cache)
 		// I wish I didn't have to instance the game modes in order to look up
@@ -247,6 +249,7 @@
 					mode_false_report_weight[M.report_type] = min(1, M.false_report_weight)
 				if(M.votable)
 					votable_modes += M.config_tag
+					votable_mode_names += M.name
 		qdel(M)
 
 /datum/controller/configuration/proc/LoadMOTD()

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -7,6 +7,7 @@ SUBSYSTEM_DEF(vote)
 	runlevels = RUNLEVEL_LOBBY | RUNLEVELS_DEFAULT
 
 	var/list/choices = list()
+	var/list/choice_tags = list() // If you want your votes to be named something comprehensible while their actual values may not be so useful
 	var/list/choice_by_ckey = list()
 	var/list/generated_actions = list()
 	var/initiator
@@ -29,6 +30,7 @@ SUBSYSTEM_DEF(vote)
 
 /datum/controller/subsystem/vote/proc/reset()
 	choices.Cut()
+	choice_tags.Cut()
 	choice_by_ckey.Cut()
 	initiator = null
 	mode = null
@@ -62,10 +64,10 @@ SUBSYSTEM_DEF(vote)
 				if(choices["Continue Playing"] >= greatest_votes)
 					greatest_votes = choices["Continue Playing"]
 			else if(mode == "gamemode")
-				if(GLOB.master_mode in choices)
-					choices[GLOB.master_mode] += non_voters.len
-					if(choices[GLOB.master_mode] >= greatest_votes)
-						greatest_votes = choices[GLOB.master_mode]
+				var/random_gamemode = pick(choices)
+				choices[random_gamemode] += non_voters.len
+				if(choices[random_gamemode] >= greatest_votes)
+					greatest_votes = choices[random_gamemode]
 			else if(mode == "map")
 				for (var/non_voter_ckey in non_voters)
 					var/client/C = non_voters[non_voter_ckey]
@@ -126,10 +128,11 @@ SUBSYSTEM_DEF(vote)
 				if(. == "Restart Round")
 					restart = TRUE
 			if("gamemode")
-				if(GLOB.master_mode != .)
-					SSticker.save_mode(.)
+				var/chosen_mode = choice_tags[choices[.]]
+				if(GLOB.master_mode != chosen_mode)
+					SSticker.save_mode(chosen_mode)
 					if(!SSticker.HasRoundStarted())
-						GLOB.master_mode = .
+						GLOB.master_mode = chosen_mode
 			if("map")
 				SSmapping.changemap(global.config.maplist[.])
 				SSmapping.map_voted = TRUE
@@ -201,7 +204,8 @@ SUBSYSTEM_DEF(vote)
 			if("restart")
 				choices.Add("Restart Round","Continue Playing")
 			if("gamemode")
-				choices.Add(config.votable_modes)
+				choice_tags.Add(config.votable_modes)
+				choices.Add(config.votable_mode_names)
 			if("map")
 				if(!lower_admin && SSmapping.map_voted)
 					to_chat(usr, "<span class='warning'>The next map has already been selected.</span>")

--- a/code/game/gamemodes/management/management.dm
+++ b/code/game/gamemodes/management/management.dm
@@ -32,7 +32,7 @@
 	return ..()
 
 /datum/game_mode/management/pure
-	name = "Pure"
+	name = "L Corp - Main Branch"
 	config_tag = "pure"
 	votable = 1
 
@@ -43,7 +43,7 @@
 		)
 
 /datum/game_mode/management/classic
-	name = "classic"
+	name = "L Corp - All Abnormalities"
 	config_tag = "classic"
 	votable = 1
 
@@ -60,7 +60,7 @@
 		)
 
 /datum/game_mode/management/branch
-	name = "Lobotomy Corporation - Side Branch"
+	name = "L Corp - Side Branch"
 	config_tag = "sidebranch"
 	votable = 0
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Three changes: 
First, gamemode votes actually display the names of the gamemodes you're voting for, and not their `config_tag` values.
Second, all players who didn't cast a vote in a gamemode vote will have their vote put towards a randomly selected mode out of all available options instead of the previous gamemode.
Thirdly, two gamemodes are renamed for consistency.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Gamemode votes are more readable.
The gamemode doesn't fall into constant reruns of the same mode. (WITHOUT touching persistence!)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: no gamemode vote is now random gamemode vote
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
