### PR TITLE
Fix invalid initialize hints in LC13 code

### DIFF
--- a/ModularTegustation/lc13_machinery.dm
+++ b/ModularTegustation/lc13_machinery.dm
@@ -11,7 +11,7 @@
 	var/relative_location
 
 /obj/machinery/containment_panel/Initialize()
-	..()
+	. = ..()
 	var/turf/closest_department
 	for(var/turf/T in GLOB.department_centers)
 		if(T.z != z)

--- a/ModularTegustation/tegu_items/lc13/refinery/_spawners.dm
+++ b/ModularTegustation/tegu_items/lc13/refinery/_spawners.dm
@@ -20,9 +20,8 @@ GLOBAL_LIST_INIT(unspawned_sales, list(
 /obj/effect/landmark/salesspawn/Initialize()
 	..()
 	if(!LAZYLEN(GLOB.unspawned_sales)) // You shouldn't ever need this but I mean go on I guess
-		return
-	var/obj/structure/pe_sales/spawning = pick(GLOB.unspawned_sales)
-	GLOB.unspawned_sales -= spawning
+		return INITIALIZE_HINT_QDEL
+	var/obj/structure/pe_sales/spawning = pick_n_take(GLOB.unspawned_sales)
 	new spawning(get_turf(src))
-
+	return INITIALIZE_HINT_QDEL
 

--- a/ModularTegustation/tegu_items/lc13/refinery/sales.dm
+++ b/ModularTegustation/tegu_items/lc13/refinery/sales.dm
@@ -16,7 +16,7 @@
 	var/icon_full = "machinelcb_full"
 
 /obj/structure/pe_sales/Initialize()
-	..()
+	. = ..()
 	crates_per_box = crate_timer/power_timer
 
 /obj/structure/pe_sales/examine(mob/user)

--- a/ModularTegustation/tegu_items/lc13unique_items.dm
+++ b/ModularTegustation/tegu_items/lc13unique_items.dm
@@ -601,7 +601,7 @@
 	charges = 1
 
 /obj/structure/trap/slowingmk1/Initialize()
-	..()
+	. = ..()
 	playsound(src, 'sound/machines/terminal_processing.ogg', 20, TRUE)
 
 /obj/structure/trap/slowingmk1/Crossed(atom/movable/AM)
@@ -775,7 +775,7 @@
 	default_icon = "gadget2r" //roundabout way of making update item easily changed. Used in updateicon proc.
 
 /obj/item/powered_gadget/detector_gadget/ordeal/Initialize()
-	..()
+	. = ..()
 	if(prob(2))
 		name = "R-corp Peen Sense Rangefinder"
 
@@ -950,7 +950,7 @@
 
 
 /mob/living/simple_animal/hostile/clerkbot/Initialize()
-	..()
+	. = ..()
 	icon = 'ModularTegustation/Teguicons/32x32.dmi'
 	icon_state = "clerkbot2"
 	icon_living = "clerkbot2"
@@ -980,7 +980,7 @@
 	attack_sound = 'sound/weapons/bite.ogg'
 
 /mob/living/simple_animal/hostile/clerkbot/Initialize()
-	..()
+	. = ..()
 	QDEL_IN(src, (120 SECONDS))
 
 /obj/item/powered_gadget/handheld_taser

--- a/ModularTegustation/tegu_mobs/lc13_outskirtdwellers.dm
+++ b/ModularTegustation/tegu_mobs/lc13_outskirtdwellers.dm
@@ -32,7 +32,7 @@
 	var/current_size = RESIZE_DEFAULT_SIZE
 
 /mob/living/simple_animal/hostile/ordeal/amber_bug/morsel/Initialize()
-	..()
+	. = ..()
 	base_pixel_x = 0
 	pixel_x = base_pixel_x
 	base_pixel_y = 0

--- a/code/game/objects/effects/abnormality.dm
+++ b/code/game/objects/effects/abnormality.dm
@@ -8,7 +8,7 @@
 	alpha = 0
 
 /obj/effect/silent_orchestra_singer/Initialize()
-	..()
+	. = ..()
 	animate(src, alpha = 225, time = 10)
 
 /obj/effect/silent_orchestra_singer/proc/fade_out()
@@ -31,7 +31,7 @@
 	alpha = 0
 
 /obj/effect/qoh_sygil/Initialize()
-	..()
+	. = ..()
 	animate(src, alpha = 255, time = 15)
 
 /obj/effect/qoh_sygil/proc/fade_out()
@@ -49,7 +49,7 @@
 	movement_type = PHASING | FLYING
 
 /obj/effect/magic_bullet/Initialize()
-	..()
+	. = ..()
 	playsound(get_turf(src), 'sound/abnormalities/freischutz/shoot.ogg', 100, 1)
 
 /obj/effect/magic_bullet/proc/moveBullet() // Shamelessly stolen code from immovable rod and paradise lost, GO!
@@ -94,7 +94,7 @@
 	alpha = 0
 
 /obj/effect/frei_magic/Initialize()
-	..()
+	. = ..()
 	animate(src, alpha = 255, time = 6)
 	playsound(get_turf(src), 'sound/abnormalities/freischutz/portal.ogg', 100, 0, 10)
 
@@ -109,7 +109,7 @@
 	alpha = 0
 
 /obj/effect/frei_trail/Initialize()
-	..()
+	. = ..()
 	animate(src, alpha = 255, time = 1, easing = JUMP_EASING)
 	QDEL_IN(src, 33)
 
@@ -124,7 +124,7 @@
 	base_pixel_y = 25
 
 /obj/effect/scaredy_stun/Initialize()
-	..()
+	. = ..()
 	animate(src, alpha = 0, time = 20 SECONDS)
 	QDEL_IN(src, 20 SECONDS)
 
@@ -199,5 +199,5 @@
 	base_pixel_x = -48
 
 /obj/effect/greenmidnight_laser/Initialize()
-	..()
+	. = ..()
 	animate(src, alpha = 255, time = 5)

--- a/code/game/objects/effects/temporary_visuals/miscellaneous.dm
+++ b/code/game/objects/effects/temporary_visuals/miscellaneous.dm
@@ -564,7 +564,7 @@
 	duration = 50
 
 /obj/effect/temp_visual/bee_gas/Initialize()
-	..()
+	. = ..()
 	animate(src, alpha = rand(125,200), time = 5)
 	addtimer(CALLBACK(src, .proc/fade_out), 5)
 
@@ -591,7 +591,7 @@
 	duration = 20
 
 /obj/effect/temp_visual/judgement/Initialize()
-	..()
+	. = ..()
 	addtimer(CALLBACK(src, .proc/fade_out), 10)
 
 /obj/effect/temp_visual/judgement/proc/fade_out()
@@ -614,7 +614,7 @@
 	duration = 10
 
 /obj/effect/temp_visual/paradise_attack/Initialize()
-	..()
+	. = ..()
 	animate(src, alpha = 0, time = duration)
 
 /obj/effect/temp_visual/water_waves
@@ -627,7 +627,7 @@
 	alpha = 0
 
 /obj/effect/temp_visual/water_waves/Initialize()
-	..()
+	. = ..()
 	animate(src, alpha = 255, time = 10)
 	addtimer(CALLBACK(src, .proc/fade_out), 10 SECONDS)
 
@@ -640,7 +640,7 @@
 	duration = 5
 
 /obj/effect/temp_visual/justitia_effect/Initialize()
-	..()
+	. = ..()
 	animate(src, alpha = 0, transform = transform*2, time = 5)
 
 /obj/effect/temp_visual/fragment_song
@@ -651,7 +651,7 @@
 	base_pixel_y = 16
 
 /obj/effect/temp_visual/fragment_song/Initialize()
-	..()
+	. = ..()
 	animate(src, alpha = 0, transform = transform*3, time = 5)
 
 /obj/effect/temp_visual/saw_effect
@@ -674,7 +674,7 @@
 	duration = 8
 
 /obj/effect/temp_visual/green_noon_reload/Initialize()
-	..()
+	. = ..()
 	animate(src, alpha = 0, transform = transform*1.5, time = duration)
 
 /obj/effect/temp_visual/slice
@@ -694,7 +694,7 @@
 	duration = 3 SECONDS
 
 /obj/effect/temp_visual/hatred/Initialize()
-	..()
+	. = ..()
 	pixel_x = rand(-16, 16)
 	animate(src, alpha = 0, pixel_z = rand(16, 48), time = duration)
 
@@ -708,7 +708,7 @@
 	alpha = 0
 
 /obj/effect/temp_visual/flesh/Initialize()
-	..()
+	. = ..()
 	icon_state = "flesh[rand(0,3)]"
 	animate(src, alpha = 255, time = 5)
 	addtimer(CALLBACK(src, .proc/fade_out), 4 SECONDS)
@@ -726,7 +726,7 @@
 	alpha = 175
 
 /obj/effect/temp_visual/black_fixer_ability/Initialize()
-	..()
+	. = ..()
 	animate(src, alpha = 0, transform = transform*4, time = 4)
 
 /obj/effect/temp_visual/censored
@@ -741,7 +741,7 @@
 	base_pixel_y = -48
 
 /obj/effect/temp_visual/censored/Initialize()
-	..()
+	. = ..()
 	animate(src, alpha = 255, time = 2)
 	addtimer(CALLBACK(src, .proc/fade_out), 17)
 	for(var/i = 1 to 9)
@@ -775,7 +775,7 @@
 	base_pixel_y = -16
 
 /obj/effect/temp_visual/ambermidnight_hole/Initialize()
-	..()
+	. = ..()
 	animate(src, alpha = 0, time = duration)
 
 /obj/effect/temp_visual/cross
@@ -789,7 +789,7 @@
 	duration = 8 SECONDS
 
 /obj/effect/temp_visual/cross/fall/Initialize()
-	..()
+	. = ..()
 	addtimer(CALLBACK(src, .proc/FadeOut), 6 SECONDS)
 
 /obj/effect/temp_visual/cross/fall/proc/FadeOut()
@@ -807,7 +807,7 @@
 	duration = 0.5 SECONDS
 
 /obj/effect/temp_visual/mermaid_drowning/Initialize()
-	..()
+	. = ..()
 	animate(src, alpha = 0, pixel_y = pixel_y + 5 , time = duration)
 
 /obj/effect/temp_visual/alriune_attack
@@ -822,7 +822,7 @@
 	duration = 2 SECONDS
 
 /obj/effect/temp_visual/alriune_curtain/Initialize()
-	..()
+	. = ..()
 	animate(src, alpha = 255, time = 5)
 	addtimer(CALLBACK(src, .proc/FadeOut), 5)
 
@@ -848,7 +848,7 @@
 	duration = 5
 
 /obj/effect/temp_visual/pale_eye_attack/Initialize()
-	..()
+	. = ..()
 	animate(src, alpha = 0, time = 5)
 
 /obj/effect/temp_visual/screech
@@ -857,7 +857,7 @@
 	duration = 5
 
 /obj/effect/temp_visual/screech/Initialize()
-	..()
+	. = ..()
 	animate(src, alpha = 0, transform = transform*4, time = 5)
 
 /obj/effect/temp_visual/human_fire

--- a/code/game/objects/items/ego_weapons/waw.dm
+++ b/code/game/objects/items/ego_weapons/waw.dm
@@ -1155,7 +1155,7 @@
 	layer = ABOVE_ALL_MOB_LAYER
 
 /obj/effect/infinity/Initialize()
-	..()
+	. = ..()
 	animate(src, alpha = 0, time = 1 SECONDS)
 	QDEL_IN(src, 1 SECONDS)
 

--- a/code/modules/clothing/suits/ego_gear/non_abnormality/zwei.dm
+++ b/code/modules/clothing/suits/ego_gear/non_abnormality/zwei.dm
@@ -23,7 +23,7 @@
 							)
 
 /obj/item/clothing/suit/armor/ego_gear/city/zweivet/Initialize()
-	..()
+	. = ..()
 	if(prob(50))
 		icon_state = "zweishort"
 		worn_icon_state = icon_state

--- a/code/modules/mob/living/simple_animal/abnormality/_tools/he/treesap.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_tools/he/treesap.dm
@@ -7,7 +7,7 @@
 	var/list/used = list()
 
 /obj/structure/toolabnormality/treesap/Initialize()
-	..()
+	. = ..()
 	addtimer(CALLBACK(src, .proc/reset), 20 MINUTES)
 
 /obj/structure/toolabnormality/treesap/proc/reset()

--- a/code/modules/mob/living/simple_animal/abnormality/_tools/tool_abnormality.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_tools/tool_abnormality.dm
@@ -31,10 +31,8 @@ GLOBAL_LIST_INIT(unspawned_tools, list(
 /obj/effect/landmark/toolspawn/Initialize()
 	..()
 	if(!LAZYLEN(GLOB.unspawned_tools)) // You shouldn't ever need this but I mean go on I guess
-		return
-	var/spawning
-	spawning = pick(GLOB.unspawned_tools)
-	GLOB.unspawned_tools -= spawning
+		return INITIALIZE_HINT_QDEL
+	var/spawning = pick_n_take(GLOB.unspawned_tools)
 	new spawning(get_turf(src))
-
+	return INITIALIZE_HINT_QDEL
 

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/censored.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/censored.dm
@@ -181,7 +181,7 @@
 	var/list/breach_affected = list()
 
 /mob/living/simple_animal/hostile/mini_censored/Initialize()
-	..()
+	. = ..()
 	playsound(get_turf(src), 'sound/abnormalities/censored/mini_born.ogg', 50, 1, 4)
 	base_pixel_x = rand(-6,6)
 	pixel_x = base_pixel_x

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/staining_rose.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/staining_rose.dm
@@ -42,7 +42,7 @@
 
 
 /mob/living/simple_animal/hostile/abnormality/staining_rose/Initialize()
-	..()
+	. = ..()
 	meltdown_cooldown = world.time + meltdown_cooldown_time
 
 /mob/living/simple_animal/hostile/abnormality/staining_rose/PostWorkEffect(mob/living/carbon/human/user, work_type, pe)

--- a/code/modules/mob/living/simple_animal/abnormality/he/doomsday_calendar.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/doomsday_calendar.dm
@@ -337,7 +337,7 @@
 	var/can_act = TRUE
 
 /mob/living/simple_animal/hostile/doomsday_doll/Initialize()
-	..()
+	. = ..()
 	base_pixel_x = rand(-6,6)
 	pixel_x = base_pixel_x
 	base_pixel_y = rand(-6,6)

--- a/code/modules/mob/living/simple_animal/abnormality/he/jangsan.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/jangsan.dm
@@ -286,6 +286,6 @@
 	layer = POINT_LAYER	//High enough that you can see it if you look up.
 
 /obj/effect/halo/Initialize()
-	..()
+	. = ..()
 	animate(src, pixel_x = 0, pixel_z = 16, time = 3 SECONDS)
 	QDEL_IN(src, 30 SECONDS)

--- a/code/modules/mob/living/simple_animal/abnormality/he/road_home.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/road_home.dm
@@ -336,7 +336,7 @@
 	var/brick_number //The index of this brick in the brick list
 
 /obj/effect/golden_road/Initialize()
-	..()
+	. = ..()
 	animate(src, alpha = 255, time = 0.5 SECONDS)
 
 //This will make those people try to reach the house, they will be slowed to be easier to intercept, and are generally rather harmless.

--- a/code/modules/mob/living/simple_animal/abnormality/teth/old_lady.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/old_lady.dm
@@ -63,7 +63,7 @@
 	layer = ABOVE_MOB_LAYER
 
 /obj/effect/solitude/Initialize()
-	..()
+	. = ..()
 	icon_state = "solitude[pick(1,2,3,4)]"
 	animate(src, alpha = 0, time = 3 SECONDS)
 	QDEL_IN(src, 3 SECONDS)

--- a/code/modules/mob/living/simple_animal/abnormality/teth/void_dream.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/void_dream.dm
@@ -150,7 +150,7 @@
 	var/homing_range = 9
 
 /obj/projectile/sleepdart/Initialize()
-	..()
+	. = ..()
 	var/list/targetslist = list()
 	for(var/mob/living/carbon/human/H in view(homing_range, src))
 		if(H.IsSleeping())

--- a/code/modules/mob/living/simple_animal/abnormality/waw/ebony_queen.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/ebony_queen.dm
@@ -135,7 +135,7 @@
 	layer = POINT_LAYER	//We want this HIGH. SUPER HIGH. We want it so that you can absolutely, guaranteed, see exactly what is about to hit you.
 
 /obj/effect/root/Initialize()
-	..()
+	. = ..()
 	addtimer(CALLBACK(src, .proc/explode), 0.5 SECONDS)
 
 /obj/effect/root/proc/explode() //repurposed code from artillary bees, a delayed attack

--- a/code/modules/mob/living/simple_animal/abnormality/waw/generalb.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/generalb.dm
@@ -204,7 +204,7 @@
 	layer = POINT_LAYER	//We want this HIGH. SUPER HIGH. We want it so that you can absolutely, guaranteed, see exactly what is about to hit you.
 
 /obj/effect/beeshell/Initialize()
-	..()
+	. = ..()
 	addtimer(CALLBACK(src, .proc/explode), 3.5 SECONDS)
 
 /obj/effect/beeshell/New(loc, ...)

--- a/code/modules/mob/living/simple_animal/abnormality/waw/sphinx.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/sphinx.dm
@@ -450,7 +450,7 @@
 	duration = 2 SECONDS
 
 /obj/effect/temp_visual/stone_gaze/Initialize()
-	..()
+	. = ..()
 	alpha = rand(75,255)
 	animate(src, alpha = 0, time = 20)
 

--- a/code/modules/mob/living/simple_animal/abnormality/waw/thunder_bird.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/thunder_bird.dm
@@ -265,7 +265,7 @@ GLOBAL_LIST_EMPTY(zombies)
 	layer = POINT_LAYER	//Sprite should always be visible
 
 /obj/effect/thunderbolt/Initialize()
-	..()
+	. = ..()
 	addtimer(CALLBACK(src, .proc/explode), 3 SECONDS)
 
 //Zombie conversion through lightning bombs
@@ -370,7 +370,7 @@ GLOBAL_LIST_EMPTY(zombies)
 		Convert(H)
 
 /mob/living/simple_animal/hostile/thunder_zombie/Initialize()
-	..()
+	. = ..()
 	GLOB.zombies += src
 	playsound(get_turf(src), 'sound/abnormalities/thunderbird/tbird_charge.ogg', 50, 1, 4)
 	base_pixel_x = rand(-6,6)

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/herald.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/herald.dm
@@ -207,7 +207,7 @@
 	var/mob/living/simple_animal/hostile/asteroid/elite/herald/my_master = null
 
 /mob/living/simple_animal/hostile/asteroid/elite/herald/mirror/Initialize()
-	..()
+	. = ..()
 	toggle_ai(AI_OFF)
 
 /mob/living/simple_animal/hostile/asteroid/elite/herald/mirror/Destroy()

--- a/code/modules/mob/living/simple_animal/hostile/ordeal/amber.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/amber.dm
@@ -24,7 +24,7 @@
 	guaranteed_butcher_results = list(/obj/item/food/meat/slab/worm = 1)
 
 /mob/living/simple_animal/hostile/ordeal/amber_bug/Initialize()
-	..()
+	. = ..()
 	base_pixel_x = rand(-6,6)
 	pixel_x = base_pixel_x
 	base_pixel_y = rand(-6,6)
@@ -115,7 +115,7 @@
 	return ..()
 
 /mob/living/simple_animal/hostile/ordeal/amber_dusk/Initialize()
-	..()
+	. = ..()
 	addtimer(CALLBACK(src, .proc/BurrowOut, get_turf(src)))
 	soundloop = new(list(src), TRUE)
 
@@ -230,7 +230,7 @@
 	var/datum/looping_sound/ambermidnight/soundloop
 
 /mob/living/simple_animal/hostile/ordeal/amber_midnight/Initialize()
-	..()
+	. = ..()
 	burrow_cooldown = world.time + 20 SECONDS
 	soundloop = new(list(src), TRUE)
 	addtimer(CALLBACK(src, .proc/BurrowOut))

--- a/code/modules/mob/living/simple_animal/hostile/ordeal/green.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/green.dm
@@ -201,7 +201,7 @@
 	var/list/spawned_mobs = list()
 
 /mob/living/simple_animal/hostile/ordeal/green_dusk/Initialize()
-	..()
+	. = ..()
 	update_icon()
 
 /mob/living/simple_animal/hostile/ordeal/green_dusk/CanAttack(atom/the_target)
@@ -303,7 +303,7 @@
 	var/next_health_mark = 0 // Initialize below
 
 /mob/living/simple_animal/hostile/ordeal/green_midnight/Initialize()
-	..()
+	. = ..()
 	left_shell = new(get_turf(src))
 	right_shell = new(get_turf(src))
 	laser_cooldown = world.time + 6 SECONDS

--- a/code/modules/mob/living/simple_animal/hostile/ordeal/indigo.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/indigo.dm
@@ -68,7 +68,7 @@
 	var/leader //used by indigo dusk to recruit sweepers
 
 /mob/living/simple_animal/hostile/ordeal/indigo_noon/Initialize()
-	..()
+	. = ..()
 	attack_sound = "sound/effects/ordeals/indigo/stab_[pick(1,2)].ogg"
 	icon_living = "sweeper_[pick(1,2)]"
 	icon_state = icon_living
@@ -464,7 +464,7 @@
 	layer = POINT_LAYER	//We want this HIGH. SUPER HIGH. We want it so that you can absolutely, guaranteed, see exactly what is about to hit you.
 
 /obj/effect/sweeperspawn/Initialize()
-	..()
+	. = ..()
 	addtimer(CALLBACK(src, .proc/spawnscout), 6)
 
 /obj/effect/sweeperspawn/proc/spawnscout()

--- a/code/modules/mob/living/simple_animal/hostile/ordeal/misc.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/misc.dm
@@ -24,7 +24,7 @@
 				/mob/living/simple_animal/hostile/abnormality/hatred_queen)
 
 /mob/living/simple_animal/hostile/ordeal/pink_midnight/Initialize()
-	..()
+	. = ..()
 	addtimer(CALLBACK(src, .proc/Breach_All), 5 SECONDS)
 
 /mob/living/simple_animal/hostile/ordeal/pink_midnight/death(gibbed)

--- a/code/modules/mob/living/simple_animal/hostile/ordeal/violet.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/violet.dm
@@ -20,7 +20,7 @@
 	var/list/enemies = list() //copying retaliate code cause i dont know how else to inherit it
 
 /mob/living/simple_animal/hostile/ordeal/violet_fruit/Initialize()
-	..()
+	. = ..()
 	addtimer(CALLBACK(src, .proc/ReleaseDeathGas), rand(60 SECONDS, 65 SECONDS))
 
 /mob/living/simple_animal/hostile/ordeal/violet_fruit/Found(atom/A)
@@ -112,7 +112,7 @@
 	var/next_pulse = INFINITY
 
 /mob/living/simple_animal/hostile/ordeal/violet_monolith/Initialize()
-	..()
+	. = ..()
 	next_pulse = world.time + 30 SECONDS
 	addtimer(CALLBACK(src, .proc/FallDown))
 

--- a/code/modules/mob/living/simple_animal/hostile/ordeal/white.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/white.dm
@@ -33,7 +33,7 @@
 	var/list/been_hit = list()
 
 /mob/living/simple_animal/hostile/ordeal/black_fixer/Initialize()
-	..()
+	. = ..()
 	pulse_cooldown = world.time + (pulse_cooldown_time * 1.5)
 
 /mob/living/simple_animal/hostile/ordeal/black_fixer/Life()
@@ -170,7 +170,7 @@
 	var/circle_overtime_damage = 70
 
 /mob/living/simple_animal/hostile/ordeal/white_fixer/Initialize()
-	..()
+	. = ..()
 	circle_cooldown = world.time + 10 SECONDS
 
 /mob/living/simple_animal/hostile/ordeal/white_fixer/Life()

--- a/code/modules/projectiles/guns/ego_gun/he.dm
+++ b/code/modules/projectiles/guns/ego_gun/he.dm
@@ -83,7 +83,7 @@
 	var/jam_noticed = FALSE
 
 /obj/item/gun/ego_gun/unrequited/Initialize()
-	..()
+	. = ..()
 	jam_cooldown_time = rand(1, 5) MINUTES
 	jam_cooldown = jam_cooldown_time + world.time
 	START_PROCESSING(SSobj, src)

--- a/code/modules/projectiles/projectile/ego_bullets/he.dm
+++ b/code/modules/projectiles/projectile/ego_bullets/he.dm
@@ -32,7 +32,7 @@
 	var/homing_range = 9
 
 /obj/projectile/ego_bullet/ego_galaxy/homing/Initialize()
-	..()
+	. = ..()
 	addtimer(CALLBACK(src, .proc/fireback), 3)
 
 /obj/projectile/ego_bullet/ego_galaxy/homing/proc/fireback()

--- a/code/modules/projectiles/projectile/ego_bullets/special.dm
+++ b/code/modules/projectiles/projectile/ego_bullets/special.dm
@@ -11,7 +11,7 @@
 	icon_state = "kcorp_nade"
 
 /obj/projectile/ego_bullet/ego_knade/Initialize()
-	..()
+	. = ..()
 	addtimer(CALLBACK(src, .proc/fireback), 5)
 
 /obj/projectile/ego_bullet/ego_knade/proc/fireback()

--- a/code/modules/projectiles/projectile/ego_bullets/waw.dm
+++ b/code/modules/projectiles/projectile/ego_bullets/waw.dm
@@ -142,7 +142,7 @@
 		qdel(src)
 
 /obj/projectile/ego_bullet/ego_praetorian/Initialize()
-	..()
+	. = ..()
 	addtimer(CALLBACK(src, .proc/fireback), 3)
 
 /obj/projectile/ego_bullet/ego_praetorian/proc/fireback()


### PR DESCRIPTION
## About The Pull Request
Fixes a bunch of invalid initialize hints in LC13 code.
Cleans up the tool/sales spawner code *very* slightly.

## Why It's Good For The Game
Fixes only two actual bugs (issues with tool/sales spawners not deleting), but this also makes it easier to find actual issues with the `Display Initialize() Log` verb.