### PR TITLE
Fix harddels from abno effect/minion spawning

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/aleph/silent_orchestra.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/silent_orchestra.dm
@@ -56,6 +56,7 @@
 /mob/living/simple_animal/hostile/abnormality/silentorchestra/Destroy()
 	for(var/obj/effect/silent_orchestra_singer/O in performers)
 		O.fade_out()
+	performers.Cut()
 	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/silentorchestra/CanAttack(atom/the_target)

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/titania.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/titania.dm
@@ -96,7 +96,8 @@
 	listclearnulls(spawned_mobs)
 	for(var/mob/living/L in spawned_mobs)
 		if(L.stat == DEAD)
-			QDEL_NULL(L)
+			qdel(L)
+			spawned_mobs -= L
 	if(length(spawned_mobs) >= fairy_spawn_limit)
 		return
 

--- a/code/modules/mob/living/simple_animal/abnormality/waw/hatred_queen.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/hatred_queen.dm
@@ -133,6 +133,7 @@
 	addtimer(CALLBACK(S, .obj/effect/qoh_sygil/proc/fade_out), 5 SECONDS)
 	for(var/obj/effect/qoh_sygil/QS in spawned_effects)
 		QS.fade_out()
+	spawned_effects.Cut()
 	UnregisterSignal(SSdcs, COMSIG_GLOB_MOB_DEATH)
 	QDEL_NULL(beamloop)
 	QDEL_NULL(current_beam)
@@ -280,6 +281,7 @@
 	SLEEP_CHECK_DEATH(1 SECONDS)
 	for(var/obj/effect/qoh_sygil/SE in spawned_effects)
 		SE.fade_out()
+	spawned_effects.Cut()
 	icon_state = icon_living
 	can_act = TRUE
 	beats_cooldown = world.time + beats_cooldown_time
@@ -420,6 +422,7 @@
 	QDEL_NULL(current_beam)
 	for(var/obj/effect/qoh_sygil/S in spawned_effects)
 		S.fade_out()
+	spawned_effects.Cut()
 	beamloop.stop()
 	SLEEP_CHECK_DEATH(4 SECONDS) //Rest after laser beam
 	can_act = TRUE

--- a/code/modules/mob/living/simple_animal/abnormality/waw/snow_whites_apple.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/snow_whites_apple.dm
@@ -89,7 +89,7 @@ GLOBAL_LIST_EMPTY(vine_list)
 		var/del_time = rand(4,10) //all the vines dissapear at different interval so it looks more organic.
 		animate(vine, alpha = 0, time = del_time SECONDS)
 		QDEL_IN(vine, del_time SECONDS)
-		GLOB.vine_list -= vine
+	GLOB.vine_list.Cut()
 	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/snow_whites_apple/Login()
@@ -203,6 +203,10 @@ GLOBAL_LIST_EMPTY(vine_list)
 			/obj/effect,
 			/mob/dead,
 			/mob/living/simple_animal/hostile/abnormality/snow_whites_apple))
+
+/obj/structure/spreading/apple_vine/Destroy()
+	GLOB.vine_list -= src
+	return ..()
 
 /obj/structure/spreading/apple_vine/Crossed(atom/movable/AM)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
Fixes some harddels (which can lead to lag spikes) caused by minions spawning effects (Silent Orchestra, Queen of Hatred, Snow White's Apple) or minions (Titania).
Also fixes a potential issue where dead fairies aren't properly removed from Titania's spawned mobs list.

## Why It's Good For The Game
![image](https://cdn.discordapp.com/attachments/982658750747926610/1105522200955600997/image.png)
Fifteen seconds total of lag created from only two breaches of Snow White's Apple.