### PR TITLE
Randomize vine spread directions

### DIFF
--- a/ModularTegustation/lc13_machinery.dm
+++ b/ModularTegustation/lc13_machinery.dm
@@ -168,7 +168,9 @@
 		qdel(src)
 		return FALSE
 
-	for(var/turf/T in U.GetAtmosAdjacentTurfs())
+	var/list/spread_turfs = U.GetAtmosAdjacentTurfs()
+	shuffle_inplace(spread_turfs)
+	for(var/turf/T in spread_turfs)
 		if(locate(/obj/structure/spreading) in T)
 			var/obj/structure/spreading/S = locate(/obj/structure/spreading) in T
 			if(S.type != type) //if it is not another of the same spreading structure.


### PR DESCRIPTION
## About The Pull Request
Vines will now spread in random directions rather than using a fixed (atmos-dependent) order.

## Why It's Good For The Game
Fixes some weirdness with how vines and other spreading structures spread, which made it create strange patterns that were easy to fight.

## Changelog
:cl:
tweak: Vine spread directions are now truly random instead of biased towards certain directions.
/:cl:
