### PR TITLE
Fix #859

### DIFF
--- a/code/modules/mob/living/carbon/carbon_update_icons.dm
+++ b/code/modules/mob/living/carbon/carbon_update_icons.dm
@@ -1,4 +1,4 @@
-sues//IMPORTANT: Multiple animate() calls do not stack well, so try to do them all at once if you can.
+//IMPORTANT: Multiple animate() calls do not stack well, so try to do them all at once if you can.
 /mob/living/carbon/update_transform()
 	var/matrix/ntransform = matrix(transform) //aka transform.Copy()
 	var/final_pixel_y = pixel_y

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/nothing_there.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/nothing_there.dm
@@ -195,6 +195,9 @@
 	new /obj/effect/gibspawner/generic(get_turf(M))
 	to_chat(M, "<span class='userdanger'>Oh no...</span>")
 	disguise = M
+	// The following code makes it so that even if a disguised mob is resting, Nothing There's shell will still be standing up.
+	M.set_lying_angle(0)
+	M.set_body_position(STANDING_UP)
 	appearance = M.appearance
 	M.death()
 	M.forceMove(src) // Hide them for examine message to work


### PR DESCRIPTION
## About The Pull Request
Fixes #859.
Nothing There shells will now be standing up even if the mob they disguise as is laying down.
Removes `sues`.

## Why It's Good For The Game
It's slightly harder to metagame Nothing There.
Removes an unused, functionless type that was created only because Egor made a typo.

## Changelog
:cl:
fix: Nothing There has learned to use its legs to stand back up again.
/:cl:
