### PR TITLE
Fix runtime in abno cell template loading

### DIFF
--- a/code/game/objects/effects/spawners/abnormality_room.dm
+++ b/code/game/objects/effects/spawners/abnormality_room.dm
@@ -63,6 +63,7 @@ GLOBAL_LIST_EMPTY(abnormality_room_spawners)
 
 /obj/effect/spawner/abnormality_room/LateInitialize()
 	if(!template)
+		template = TRUE // to avoid generating it multiple times, since new() isn't instant
 		template = new(cache = TRUE)
 	GLOB.abnormality_room_spawners += src
 


### PR DESCRIPTION
## About The Pull Request
Fixes a runtime in abno cell template loading, where a bajillion copies of the template would be queued up because `new` takes time to complete.

## Why It's Good For The Game
Fewer runtimes = better. I was tired of dealing with it when testing locally.