### PR TITLE
Add config option for qliphoth meltdown percentage

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -522,3 +522,9 @@
 	config_entry_value = 18000
 	integer = FALSE
 	min_val = 0
+
+/datum/config_entry/number/qliphoth_meltdown_percent // percentage of abnormalities to melt down per meltdown
+	config_entry_value = 0.35
+	integer = FALSE
+	min_val = 0.0
+	max_val = 1.0

--- a/code/controllers/subsystem/lobotomy_corp.dm
+++ b/code/controllers/subsystem/lobotomy_corp.dm
@@ -166,7 +166,7 @@ SUBSYSTEM_DEF(lobotomy_corp)
 	if(ran_ordeal)
 		return
 	InitiateMeltdown(qliphoth_meltdown_amount, FALSE)
-	qliphoth_meltdown_amount = max(1, round(abno_amount * 0.35))
+	qliphoth_meltdown_amount = max(1, round(abno_amount * CONFIG_GET(number/qliphoth_meltdown_percent)))
 
 /datum/controller/subsystem/lobotomy_corp/proc/InitiateMeltdown(meltdown_amount = 1, forced = TRUE, type = MELTDOWN_NORMAL, min_time = 60, max_time = 90, alert_text = "Qliphoth meltdown occured in containment zones of the following abnormalities:", alert_sound = 'sound/effects/meltdownAlert.ogg')
 	var/list/computer_list = list()

--- a/config/config.txt
+++ b/config/config.txt
@@ -558,3 +558,6 @@ VOTE_AUTOTRANSFER_ENABLED
 VOTE_AUTOTRANSFER_INITIAL 72000
 ## Time (in deciseconds) between subsequent transfer votes. Default: 30 minutes
 VOTE_AUTOTRANSFER_INTERVAL 18000
+
+## Percent of abnormalities to melt down per qliphoth meltdown event.
+QLIPHOTH_MELTDOWN_PERCENT 0.35


### PR DESCRIPTION
## About The Pull Request
The number of abnormalities that melt down per qliphoth meltdown event is now a config option.

## Why It's Good For The Game
As discussed in `#ask-mentors`, this would be useful for local servers where you want it to be harder/easier, and for adminbus.