### PR TITLE
Remove unused vars/procs in LC13 code

### DIFF
--- a/ModularTegustation/lc13_machinery.dm
+++ b/ModularTegustation/lc13_machinery.dm
@@ -7,7 +7,6 @@
 	density = FALSE
 	use_power = 0
 	var/obj/machinery/computer/abnormality/linked_console
-	var/work
 	var/relative_location
 
 /obj/machinery/containment_panel/Initialize()

--- a/ModularTegustation/tegu_items/lc13/refinery/sales.dm
+++ b/ModularTegustation/tegu_items/lc13/refinery/sales.dm
@@ -13,6 +13,7 @@
 	var/crates_per_box		//Just used to calculate examine text
 
 	var/generating
+	var/icon_full = "full"
 
 /obj/structure/pe_sales/Initialize()
 	. = ..()
@@ -31,9 +32,13 @@
 		to_chat(user, "<span class='notice'>You load PE into the machine.</span>")
 		qdel(I)
 		counter()
-		add_overlay("full")
 	else if(generating)
 		to_chat(user, "<span class='notice'>This is already sending power!</span>")
+
+/obj/structure/pe_sales/update_overlays()
+	. = ..()
+	if(generating)
+		LAZYADD(., icon_full)
 
 /obj/structure/pe_sales/proc/counter()
 	power_timer--
@@ -44,10 +49,8 @@
 		power_timer = initial(power_timer)
 		generating = FALSE
 		visible_message("<span class='notice'>Payment has arrived from [src]</span>")
-		cut_overlays()
-		var/obj/item/holochip/C = new (get_turf(src))
-		C.credits = rand(ahn_amount/4,ahn_amount)
-
+		new /obj/item/holochip (get_turf(src), rand(ahn_amount/4,ahn_amount))
+	update_icon()
 	//gacha time
 	if(crate_timer  <= 0)
 		crate_timer = initial(crate_timer)

--- a/ModularTegustation/tegu_items/lc13/refinery/sales.dm
+++ b/ModularTegustation/tegu_items/lc13/refinery/sales.dm
@@ -13,7 +13,6 @@
 	var/crates_per_box		//Just used to calculate examine text
 
 	var/generating
-	var/icon_full = "machinelcb_full"
 
 /obj/structure/pe_sales/Initialize()
 	. = ..()

--- a/ModularTegustation/tegu_items/lc13unique_items.dm
+++ b/ModularTegustation/tegu_items/lc13unique_items.dm
@@ -113,7 +113,6 @@
 	desc = "Welfare put out a notice that they lost a bunch of manager bullets. This must be one of them."
 	icon = 'icons/obj/ammo.dmi'
 	icon_state = "sleeper-live"
-	var/bullettype = 1
 
 /obj/item/managerbullet/attack(mob/living/M, mob/user)
 	M.visible_message("<span class='notice'>[user] smashes [src] against [M].</span>")
@@ -479,6 +478,7 @@
 
 	return ..()
 
+// Currently unused, TODO: Remove or use
 /obj/item/powered_gadget/proc/toggle_on(mob/user)
 	if(cell && cell.charge >= batterycost)
 		turned_on = !turned_on
@@ -679,7 +679,6 @@
 	default_icon = "gadget2" //roundabout way of making update item easily changed. Used in updateicon proc.
 	batterycost = 40 // 1 minute
 	var/on = 0
-	var/entitydistance
 	var/nearestentity
 	var/their_loc
 	var/distance
@@ -716,22 +715,19 @@
 /obj/item/powered_gadget/detector_gadget/process(delta_time)
 	if(cell && cell.charge >= batterycost)
 		cell.charge = cell.charge - batterycost
-		var/turf/my_loc = get_turf(src)
 		detectthing()
-		var/target_loc = get_turf(nearestentity)
-		var/entitydistance = get_dist_euclidian(my_loc, target_loc)
-		calcdistance(entitydistance)
+		calcdistance(get_dist_euclidian(get_turf(src), get_turf(nearestentity)))
 		return
 	on = 0
 	icon_state = "[default_icon]-nobat"
 	STOP_PROCESSING(SSobj, src)
 
 /obj/item/powered_gadget/detector_gadget/proc/detectthing(mob/user)
-	src.visible_message("<span class='notice'>The [src] falls apart.</span>", "<span class='notice'>You press a button and the [src] starts whirring before falling apart.</span>")
+	src.visible_message("<span class='notice'>The [src] falls apart.</span>", null, "<span class='notice'>You press a button and the [src] starts whirring before falling apart.</span>")
 	qdel(src)
 	return
 
-	//Abnormality Detector
+//Abnormality Detector
 /obj/item/powered_gadget/detector_gadget/abnormality
 	name = "Enkaphlin Drain Monitor"
 	desc = "This device detects abnormalities by taking advantage of their siphon of Enkaphlin. Use in hand to activate."

--- a/ModularTegustation/tegu_mobs/lc13_outskirtdwellers.dm
+++ b/ModularTegustation/tegu_mobs/lc13_outskirtdwellers.dm
@@ -162,7 +162,6 @@
 	melee_damage_upper = 4
 	mob_size = MOB_SIZE_LARGE
 	vision_range = 4
-	var/weapon
 
 /mob/living/simple_animal/hostile/ordeal/green_bot/price/Login()
 	. = ..()

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -848,6 +848,9 @@
 
 //Gibs
 
+///from /obj/effect/gibspawner/Initialize(): (list/directions, mapload)
+#define COMSIG_GIBS_TRY_STREAK "gibs_try_streak"
+
 ///from base of /obj/effect/decal/cleanable/blood/gibs/streak(): (list/directions, list/diseases)
 #define COMSIG_GIBS_STREAK "gibs_streak"
 

--- a/code/game/machinery/computer/abnormality_archive.dm
+++ b/code/game/machinery/computer/abnormality_archive.dm
@@ -6,8 +6,6 @@
 	icon_keyboard = "tech_key"
 	icon_screen = "forensic"
 	var/printfile
-	var/printing_status
-	var/notehtml
 	var/note
 	var/linecount
 	var/paper = 1 //You get one paper

--- a/code/game/objects/effects/abnormality.dm
+++ b/code/game/objects/effects/abnormality.dm
@@ -139,9 +139,7 @@
 	movement_type = PHASING | FLYING
 	pixel_y = -32
 	pixel_x = -32
-	var/list/damaged = list()
 	animate_movement = SLIDE_STEPS
-	var/datum/looping_sound/expresstrain/soundloop
 	var/clickety = 0
 	var/noise = 0
 

--- a/code/game/objects/effects/decals/cleanable/aliens.dm
+++ b/code/game/objects/effects/decals/cleanable/aliens.dm
@@ -30,6 +30,11 @@
 /obj/effect/decal/cleanable/xenoblood/xgibs/Initialize()
 	. = ..()
 	RegisterSignal(src, COMSIG_MOVABLE_PIPE_EJECTING, .proc/on_pipe_eject)
+	RegisterSignal(src, COMSIG_GIBS_TRY_STREAK, .proc/try_streak)
+
+/obj/effect/decal/cleanable/xenoblood/xgibs/proc/try_streak(datum/source, list/directions, mapload = FALSE)
+	SIGNAL_HANDLER
+	streak(directions, mapload)
 
 /obj/effect/decal/cleanable/xenoblood/xgibs/proc/streak(list/directions, mapload=FALSE)
 	set waitfor = FALSE

--- a/code/game/objects/effects/decals/cleanable/humans.dm
+++ b/code/game/objects/effects/decals/cleanable/humans.dm
@@ -96,8 +96,7 @@
 	. = ..()
 	reagents.add_reagent(/datum/reagent/liquidgibs, 5)
 	RegisterSignal(src, COMSIG_MOVABLE_PIPE_EJECTING, .proc/on_pipe_eject)
-	if(mapload) //Don't rot at roundstart for the love of god
-		return
+	RegisterSignal(src, COMSIG_GIBS_TRY_STREAK, .proc/try_streak)
 
 /obj/effect/decal/cleanable/blood/gibs/dry()
 	. = ..()
@@ -121,6 +120,10 @@
 		dirs = GLOB.alldirs.Copy()
 
 	streak(dirs)
+
+/obj/effect/decal/cleanable/blood/gibs/proc/try_streak(datum/source, list/directions, mapload = FALSE)
+	SIGNAL_HANDLER
+	streak(directions, mapload)
 
 /obj/effect/decal/cleanable/blood/gibs/proc/streak(list/directions, mapload=FALSE)
 	set waitfor = FALSE

--- a/code/game/objects/effects/decals/cleanable/robots.dm
+++ b/code/game/objects/effects/decals/cleanable/robots.dm
@@ -16,6 +16,11 @@
 /obj/effect/decal/cleanable/robot_debris/Initialize()
 	. = ..()
 	RegisterSignal(src, COMSIG_MOVABLE_PIPE_EJECTING, .proc/on_pipe_eject)
+	RegisterSignal(src, COMSIG_GIBS_TRY_STREAK, .proc/try_streak)
+
+/obj/effect/decal/cleanable/robot_debris/proc/try_streak(datum/source, list/directions, mapload = FALSE)
+	SIGNAL_HANDLER
+	streak(directions, mapload)
 
 /obj/effect/decal/cleanable/robot_debris/proc/streak(list/directions, mapload=FALSE)
 	set waitfor = FALSE

--- a/code/game/objects/effects/spawners/gibspawner.dm
+++ b/code/game/objects/effects/spawners/gibspawner.dm
@@ -20,7 +20,8 @@
 		stack_trace("Gib list dir length mismatch!")
 		return
 
-	var/obj/effect/decal/cleanable/blood/gibs/gib = null
+	var/obj/gib = null // this is the bare minimum typecast needed for this
+	// note it will still pass diseases to Initialize
 
 	if(sound_to_play && isnum(sound_vol))
 		playsound(src, sound_to_play, sound_vol, TRUE)
@@ -51,9 +52,8 @@
 				gib.add_blood_DNA(dna_to_add)
 
 				var/list/directions = gibdirections[i]
-				if(isturf(loc))
-					if(directions.len)
-						gib.streak(directions, mapload)
+				if(isturf(loc) && length(directions))
+					SEND_SIGNAL(gib, COMSIG_GIBS_TRY_STREAK, directions, mapload)
 
 	return INITIALIZE_HINT_QDEL
 

--- a/code/game/objects/items/clerks/hypo/hypo.dm
+++ b/code/game/objects/items/clerks/hypo/hypo.dm
@@ -10,8 +10,6 @@
 	var/list/modes = list()
 	var/mode = 1
 	var/bypass_protection = FALSE
-	var/recharge_time = 10
-	var/charge_timer = 0
 	var/locked = TRUE //clerks only
 
 /obj/item/reagent_containers/hypospray/emais/Initialize()
@@ -67,7 +65,7 @@
 			RG.add_reagent(reagent_ids[i], 5)		//And fill hypo with reagent.
 
 /obj/item/reagent_containers/hypospray/emais/attack(mob/living/carbon/M, mob/user)
-	if(!clerk_check(user))
+	if(locked && !clerk_check(user))
 		to_chat(user,"<span class='warning'>You don't know how to use this.</span>")
 		return
 	if(istype(SSlobotomy_corp.core_suppression, /datum/suppression/safety))

--- a/code/game/objects/items/ego_weapons/he.dm
+++ b/code/game/objects/items/ego_weapons/he.dm
@@ -649,18 +649,12 @@
 	var/combo_time
 	var/combo_wait = 10
 	var/combo_on = TRUE
-	var/finisher = FALSE
 
 /obj/item/ego_weapon/inheritance/attack_self(mob/user)
-	..()
-	if(combo_on)
-		to_chat(user,"<span class='warning'>You change your stance, and will no longer perform a finisher.</span>")
-		combo_on = FALSE
+	if((. = ..()))
 		return
-	if(!combo_on)
-		to_chat(user,"<span class='warning'>You change your stance, and will now perform a finisher.</span>")
-		combo_on =TRUE
-		return
+	combo_on = !combo_on
+	to_chat(user,"<span class='warning'>You change your stance, and will [combo_on ? "now" : "no longer"] perform a finisher.</span>")
 
 /obj/item/ego_weapon/inheritance/attack(mob/living/M, mob/living/user)
 	if(!CanUseEgo(user))

--- a/code/game/objects/items/ego_weapons/non_abnormality/cane.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/cane.dm
@@ -12,6 +12,8 @@
 	var/charge_effect = "deal an extra attack in damage."
 	var/charge_cost = 2
 	var/charge
+	// TODO: Implement this for activatable buffs
+	var/activated
 	attribute_requirements = list(
 							FORTITUDE_ATTRIBUTE = 80,
 							PRUDENCE_ATTRIBUTE = 100,

--- a/code/game/objects/items/ego_weapons/non_abnormality/cane.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/cane.dm
@@ -12,7 +12,6 @@
 	var/charge_effect = "deal an extra attack in damage."
 	var/charge_cost = 2
 	var/charge
-	var/activated
 	attribute_requirements = list(
 							FORTITUDE_ATTRIBUTE = 80,
 							PRUDENCE_ATTRIBUTE = 100,

--- a/code/game/objects/items/ego_weapons/non_abnormality/limbus_sinner.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/limbus_sinner.dm
@@ -236,8 +236,6 @@
 	hitsound = 'sound/weapons/ego/sword2.ogg'
 
 	var/gun_cooldown
-	var/blademark_cooldown
-	var/gunmark_cooldown
 	var/gun_cooldown_time = 1.2 SECONDS
 
 /obj/item/ego_weapon/nobody/Initialize()

--- a/code/game/objects/items/ego_weapons/teth.dm
+++ b/code/game/objects/items/ego_weapons/teth.dm
@@ -373,7 +373,6 @@
 	layer = ABOVE_ALL_MOB_LAYER
 	duration = 30 SECONDS
 	var/resonance_damage = 35
-	var/damage_multiplier = 1
 	var/mob/creator
 	var/obj/item/ego_weapon/lantern/res
 	var/rupturing = FALSE //So it won't recurse

--- a/code/game/objects/items/ego_weapons/waw.dm
+++ b/code/game/objects/items/ego_weapons/waw.dm
@@ -1183,7 +1183,6 @@
 							FORTITUDE_ATTRIBUTE = 80
 							)
 	var/can_spin = TRUE
-	var/spinning = FALSE
 
 /obj/item/ego_weapon/amrita/attack(mob/living/target, mob/living/user)
 	if(!can_spin)

--- a/code/modules/mob/living/simple_animal/abnormality/_tools/teth/theresia.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_tools/teth/theresia.dm
@@ -15,7 +15,7 @@
 	var/activation_cooldown_time = 45 SECONDS
 	var/max_winds = 6
 	var/current_winds = 1
-	var/pulse_heal = 10
+	var/pulse_heal = 20
 	var/pulse_damage = 20
 
 /obj/structure/toolabnormality/theresia/attack_hand(mob/user) //defines activator as user.
@@ -55,7 +55,7 @@
 	for(var/mob/living/carbon/human/L in view(8, src))
 		if(L.stat == DEAD)
 			continue
-		L.adjustSanityLoss(-pulse_damage)
+		L.adjustSanityLoss(-pulse_heal)
 		if(prob(10))
 			to_chat(L, "<span class='notice'>Despite the challenge, something reassures you that things will be okay.</span>")
 

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/staining_rose.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/staining_rose.dm
@@ -38,7 +38,6 @@
 	var/meltdown_cooldown_time = 15 MINUTES
 	var/meltdown_cooldown
 	var/safe = FALSE //work on it and you're safe for 15 minutes
-	var/reset_time = 3 MINUTES //Qliphoth resets after this time
 
 
 /mob/living/simple_animal/hostile/abnormality/staining_rose/Initialize()

--- a/code/modules/mob/living/simple_animal/abnormality/he/der_freischutz.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/der_freischutz.dm
@@ -71,7 +71,7 @@
 	datum_reference.qliphoth_change(3)
 	return ..()
 
-// currently unused, TODO: use or remove
+// currently admin-only
 /mob/living/simple_animal/hostile/abnormality/der_freischutz/proc/Machine_Gun(mob/living/target = null, shots = 7)
 	for(var/i = 0 to shots)
 		if(!isnull(target))

--- a/code/modules/mob/living/simple_animal/abnormality/he/der_freischutz.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/der_freischutz.dm
@@ -71,6 +71,7 @@
 	datum_reference.qliphoth_change(3)
 	return ..()
 
+// currently unused, TODO: use or remove
 /mob/living/simple_animal/hostile/abnormality/der_freischutz/proc/Machine_Gun(mob/living/target = null, shots = 7)
 	for(var/i = 0 to shots)
 		if(!isnull(target))

--- a/code/modules/mob/living/simple_animal/abnormality/he/doomsday_calendar.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/doomsday_calendar.dm
@@ -147,7 +147,7 @@
 	bonusRed = (5 - (datum_reference.qliphoth_meter))//It samples your blood if it's below the maximum counter, damage is RED instead of typeless
 	if(bonusRed)
 		to_chat(user,"<span class='warning'>A clay doll arrives with a bowl, demanding blood.</span>")
-		playsound(src, 'sound/abnormalities/doomsdaycalendar/Lor_Slash_Generic.ogg', 40, 0, 1)
+		playsound(src, 'sound/abnormalities/doomsdaycalendar/Lor_Slash_Generic.ogg', flavor_dist, 0, 1)
 	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/doomsday_calendar/Worktick(mob/living/carbon/human/user)
@@ -333,8 +333,6 @@
 	stat_attack = HARD_CRIT
 	del_on_death = FALSE
 	density = TRUE
-	var/list/breach_affected = list()
-	var/can_act = TRUE
 
 /mob/living/simple_animal/hostile/doomsday_doll/Initialize()
 	. = ..()

--- a/code/modules/mob/living/simple_animal/abnormality/he/golden_false_apple.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/golden_false_apple.dm
@@ -104,7 +104,6 @@
 	stacks = 1
 	on_remove_on_mob_delete = TRUE
 	alert_type = /atom/movable/screen/alert/status_effect/golden_sheen
-	var/glow
 	consumed_on_threshold = FALSE
 
 /atom/movable/screen/alert/status_effect/golden_sheen

--- a/code/modules/mob/living/simple_animal/abnormality/he/singing_machine.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/singing_machine.dm
@@ -39,7 +39,6 @@ Finally, an abnormality that DOESN'T have to do any fancy movement shit. It's a 
 	var/bonusRed = 0
 	var/grindRed = 4
 	var/minceRed = 8
-	var/playTiming = 5 SECONDS
 	var/playLength = 60 SECONDS
 	var/playStatus = 0
 	var/playRange = 20
@@ -191,7 +190,6 @@ Finally, an abnormality that DOESN'T have to do any fancy movement shit. It's a 
 	duration = 5 MINUTES // Just like WCCA
 	alert_type = /atom/movable/screen/alert/status_effect/singing_machine
 	var/addictionTick = 10 SECONDS
-	var/addictionTimer = 0
 	var/addictionSanityMin = 2
 	var/addictionSanityMax = 6
 

--- a/code/modules/mob/living/simple_animal/abnormality/he/siren.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/siren.dm
@@ -35,7 +35,6 @@
 	var/song_cooldown
 	var/meltdown_imminent = FALSE
 	pet_bonus = "beeps" //saves a few lines of code by allowing funpet() to be called by attack_hand()
-	var/meltdown = FALSE
 //Post-work effect
 	var/list/unsafe = list()
 //SFX

--- a/code/modules/mob/living/simple_animal/abnormality/teth/crumbling_armor.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/crumbling_armor.dm
@@ -24,8 +24,6 @@
 	gift_type = null
 	gift_chance = 100
 	abnormality_origin = ABNORMALITY_ORIGIN_LOBOTOMY
-	var/buff_icon = 'ModularTegustation/Teguicons/tegu_effects.dmi'
-	var/user_armored
 	var/numbermarked
 	var/meltdown_cooldown //no spamming the meltdown effect
 	var/meltdown_cooldown_time = 30 SECONDS

--- a/code/modules/mob/living/simple_animal/abnormality/teth/my_sweet_home.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/my_sweet_home.dm
@@ -6,7 +6,6 @@
 	icon_state = "sweet_home"
 	icon_living = "sweet_home"
 	icon_dead = "sweet_home_death"
-	var/can_act = TRUE
 	threat_level = TETH_LEVEL
 	can_breach = TRUE
 	del_on_death = FALSE

--- a/code/modules/mob/living/simple_animal/abnormality/waw/greed_king.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/greed_king.dm
@@ -33,7 +33,7 @@
 	work_damage_amount = 10
 	work_damage_type = RED_DAMAGE
 	//Some Variables cannibalized from helper
-	var/charge_check_time = 1 SECONDS
+	var/charge_check_time = 2 SECONDS
 	var/teleport_cooldown
 	var/dash_num = 50	//Mostly a safeguard
 	var/list/been_hit = list()
@@ -122,7 +122,7 @@
 		var/dir_to_target = get_cardinal_dir(get_turf(src), get_turf(target))
 		if(dir_to_target)
 			busy = TRUE
-			addtimer(CALLBACK(src, .proc/charge, dir_to_target, 0, target), 2 SECONDS)
+			addtimer(CALLBACK(src, .proc/charge, dir_to_target, 0, target), charge_check_time)
 			return
 	return
 

--- a/code/modules/mob/living/simple_animal/abnormality/waw/little_prince.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/little_prince.dm
@@ -51,7 +51,8 @@
 		to_chat(user, "<span class='userdanger'>You see mushrooms growing all over your body!</span>")
 		playsound(get_turf(user), 'sound/abnormalities/littleprince/Prince_Active.ogg', 50, 0, 2)
 		user.adjustSanityLoss(-500)
-	user.add_overlay(mutable_appearance('ModularTegustation/Teguicons/tegu_effects32x48.dmi', "spore_hypno", -HALO_LAYER))
+	spore_icon = mutable_appearance('ModularTegustation/Teguicons/tegu_effects32x48.dmi', "spore_hypno", -HALO_LAYER)
+	user.add_overlay(spore_icon)
 	QDEL_NULL(user.ai_controller)
 	user.ai_controller = /datum/ai_controller/insane/hypno
 	user.InitializeAIController()
@@ -81,7 +82,7 @@
 	once -= user
 	twice -= user
 	hypnotized -= user
-	user.cut_overlay(mutable_appearance('ModularTegustation/Teguicons/tegu_effects32x48.dmi', "spore_hypno", -HALO_LAYER))
+	user.cut_overlay(spore_icon)
 	var/turf/T = get_turf(user)
 	user.visible_message("<span class='danger'>Mushrooms rapidly grow all over [user]'s body, forming a giant mass!</span>")
 	user.emote("scream")

--- a/code/modules/mob/living/simple_animal/abnormality/waw/naked_nest.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/naked_nest.dm
@@ -146,10 +146,6 @@
 	else if(S.client)
 		to_chat(S, "<span class='notice'>This nest has no more room.</span>")
 
-/mob/living/simple_animal/hostile/abnormality/naked_nest/proc/Nest() //return to the nest
-	for(var/mob/living/simple_animal/hostile/naked_nest_serpent/M in range(0, src))
-		M.Nest(src)
-
 /mob/living/simple_animal/hostile/naked_nest_serpent
 	name = "naked serpent"
 	desc = "A sickly looking green-colored worm."

--- a/code/modules/mob/living/simple_animal/abnormality/waw/thunder_bird.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/thunder_bird.dm
@@ -330,7 +330,6 @@ GLOBAL_LIST_EMPTY(zombies)
 	stat_attack = HARD_CRIT
 	del_on_death = FALSE
 	density = TRUE
-	var/list/breach_affected = list()
 	var/can_act = TRUE
 
 //Zombie conversion from other zombies

--- a/code/modules/mob/living/simple_animal/abnormality/waw/wrath_servant.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/wrath_servant.dm
@@ -742,7 +742,7 @@
 
 	del_on_death = TRUE
 
-/obj/effect/decal/cleanable/wrath_acid/
+/obj/effect/decal/cleanable/wrath_acid
 	name = "Not-so Acidic Goo"
 	desc = "Ah, that kinda stings..."
 	icon = 'ModularTegustation/Teguicons/tegu_effects.dmi'
@@ -750,7 +750,6 @@
 	random_icon_states = list("wrath_acid")
 	mergeable_decal = TRUE
 	var/duration = 2 MINUTES
-	var/delling = FALSE
 
 /obj/effect/decal/cleanable/wrath_acid/Initialize(mapload, list/datum/disease/diseases)
 	. = ..()
@@ -765,15 +764,6 @@
 	STOP_PROCESSING(SSobj, src)
 	animate(src, time = (5 SECONDS), alpha = 0)
 	QDEL_IN(src, 5 SECONDS)
-
-/obj/effect/decal/cleanable/wrath_acid/proc/streak(list/directions, mapload=FALSE)
-	set waitfor = FALSE
-	var/direction = pick(directions)
-	for(var/i in 0 to pick(0, 200; 1, 150; 2, 50; 3, 17; 50)) //the 3% chance of 50 steps is intentional and played for laughs.
-		if (!mapload)
-			sleep(2)
-		if(!step_to(src, get_step(src, direction), 0))
-			break
 
 /obj/effect/decal/cleanable/wrath_acid/Crossed(atom/movable/AM)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
Removes a lot of unused vars and procs in LC13-specific code.

## Why It's Good For The Game
Like #948 but bigger. Specifically excludes the changes made in that PR. Shouldn't affect functionality because none of this is used. If you'd like me to change how I used or removed some vars please tell me.