### PR TITLE
Max understanding counter & PE on yellow roll

### DIFF
--- a/code/controllers/subsystem/lobotomy_corp.dm
+++ b/code/controllers/subsystem/lobotomy_corp.dm
@@ -64,6 +64,8 @@ SUBSYSTEM_DEF(lobotomy_corp)
 	//possession conditions
 	var/enable_possession = FALSE
 
+	var/understood_abnos = 0
+
 /datum/controller/subsystem/lobotomy_corp/Initialize(timeofday)
 	. = ..()
 	addtimer(CALLBACK(src, .proc/SetGoal), 5 MINUTES)

--- a/code/datums/abnormality/datum/abnormality.dm
+++ b/code/datums/abnormality/datum/abnormality.dm
@@ -149,6 +149,7 @@
 				understanding = clamp((understanding + (max_understanding/20)), 0, max_understanding)
 		if (understanding == max_understanding) // Checks for max understanding after the fact
 			current.gift_chance *= 1.5
+			SSlobotomy_corp.understood_abnos++
 	stored_boxes += pe
 	if(overload_chance > overload_chance_limit)
 		overload_chance += overload_chance_amount

--- a/code/game/machinery/computer/abnormality_queue.dm
+++ b/code/game/machinery/computer/abnormality_queue.dm
@@ -96,6 +96,9 @@
 	if(lock_after)
 		message_admins("[usr] has [logstring] the anomaly to [initial(target_type.name)].")
 		locked = TRUE
+		// PE awarded for yellow roll - just as kirie had wanted.
+		SSlobotomy_corp.current_box += 250
+		to_chat(usr, "<span class='notice'>The headquarters reimbursed you the costs of extracting a specific abnormality. You will receive a random one.</span>")
 		SSabnormality_queue.AnnounceLock()
 		SSabnormality_queue.ClearChoices()
 		SStgui.close_uis(src) // Hacky solution but I don't care

--- a/code/modules/jobs/job_types/agent.dm
+++ b/code/modules/jobs/job_types/agent.dm
@@ -78,6 +78,7 @@
 		to_chat(M, "<b>You have not been assigned to any department.</b>")
 
 	var/set_attribute = normal_attribute_level
+
 	if(world.time >= 75 MINUTES) // Full facility expected
 		set_attribute *= 4
 	else if(world.time >= 60 MINUTES) // More than one ALEPH
@@ -88,6 +89,22 @@
 		set_attribute *= 2
 	else if(world.time >= 15 MINUTES) // Usual time for HEs
 		set_attribute *= 1.5
+
+	//if(SSlobotomy_corp.understood_abnos.len && SSlobotomy_corp.understood_abnos.len > 0)
+	//	var/numberlol = SSlobotomy_corp.understood_abnos.len
+	//	var/totalcells = SSabnormality_queue.rooms_start
+	//	var/percentageofunderstanding = numberlol / totalcells
+	//	if(percentageofunderstanding == 0.5)
+	//		set_attribute *= 5
+	//	else if (percentageofunderstanding >= 0.4)
+	//		set_attribute *= 4
+	//	else if (percentageofunderstanding >= 0.3)
+	//		set_attribute *= 3
+	//	else if (percentageofunderstanding >= 0.2)
+	//		set_attribute *= 2
+	//	else if (percentageofunderstanding >= 0.1)
+	//		set_attribute *= 1.5
+
 
 	for(var/A in roundstart_attributes)
 		roundstart_attributes[A] = round(set_attribute)


### PR DESCRIPTION
This pull request is some changes kirie said i could do.

This includes changes that are supposed to promote yellow rolling as well as picking less-liked abnos and also promotes maxing out understanding.

CHANGES:
-Game time no longer gives you respawn stats, instead each 5 fully understood abnos give you increased stats (this might need to be adjusted, waiting on feedback!!)
-Yellow rolling / red rolling awards 250 PE boxes

SCRATCH ALL THAT: REVISED
-Yellow rolling awards 250 PE boxes
-Max understanding abnos increase a variable that counts all max understanding abnos

TO BE DONE:
Abnormality pick and 100% understanding count is saved in a persistent file, for both developer analysis and later use Abnormalities that are picked less will automatically reward you somehow for picking them.