### PR TITLE
Registers Normal resistances

### DIFF
--- a/code/__HELPERS/abnormalities.dm
+++ b/code/__HELPERS/abnormalities.dm
@@ -3,6 +3,8 @@
 	switch(resist)
 		if(0 to 0) //Just putting 0 doesn't work.
 			return "Immune"
+		if(1 to 1) 
+			return "Normal"
 		if(-INFINITY to 0)
 			return "Absorbed"
 		if(0 to 0.5)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

It fixes the calculation so that a flat 1 is registered as Normal, as it should.

## Why It's Good For The Game

Finally, people can actually properly tell what's the best option against an abno whose resistances all are 1 or lower.

## Changelog
:cl:
fix: fixed record resistance calculations
/:cl:
