### PR TITLE
Updates all damage resistances to be more faithful to how the original game portrays them

### DIFF
--- a/code/__HELPERS/abnormalities.dm
+++ b/code/__HELPERS/abnormalities.dm
@@ -7,16 +7,16 @@
 			return "Normal"
 		if(-INFINITY to 0)
 			return "Absorbed"
-		if(0 to 0.5)
-			return "Resistant"
 		if(0.5 to 1)
 			return "Endured"
+		if(0 to 0.5)
+			return "Resistant"
 		if(1 to 1.5)
 			return "Weak"
-		if(2 to INFINITY)
-			return "Fatal"
 		if(1.5 to 2)
 			return "Vulnerable"
+		if(2 to INFINITY)
+			return "Fatal"
 	return "Unknown ([resist])"
 
 /// Returns text description for combat damage


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

It fixes the other stat calculations to work like the original game. Sorry to not put it in one PR, but it was only later brought to my attention.

## Why It's Good For The Game

Here is WhiteNight's damage resistances before:
![image](https://github.com/vlggms/lobotomy-corp13/assets/37984520/5a2bf022-3dd3-4dfc-9ab3-ca19e635c994)

Here is WhiteNight's damage resistances after:
![image](https://github.com/vlggms/lobotomy-corp13/assets/37984520/c394c207-b340-43c1-aac4-4a349c6a8807)

We can actually tell what abnormalities like WhiteNight are weakest against.
Sure, we also run into the inverse issue of Thunderbird having 3 Endured and 1 Normal, but due to how much more noticable resistances get the lower or higher you go, it's really important to highlight the really high/low ones. 

## Changelog
:cl:
fix: fixed record resistance calculations
/:cl:
