### PR TITLE
Fix IDs disappearing upon becoming a box sephirah

### DIFF
--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -194,7 +194,7 @@
 				update_inv_w_uniform()
 			update_inv_wear_suit()
 	else if(I == w_uniform)
-		if(invdrop)
+		if(invdrop && !dna?.species.nojumpsuit)
 			if(r_store)
 				dropItemToGround(r_store, TRUE) //Again, makes sense for pockets to drop.
 			if(l_store)


### PR DESCRIPTION
## About The Pull Request
Even if you had `nojumpsuit = TRUE` on your species, taking off your jumpsuit would cause stuff to drop. When spawning in, it would drop into nullspace. That's bad! This fixes that.

## Why It's Good For The Game
Necessary for #976.