### PR TITLE
Snow White Apple vine removal and immunity list updates

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/waw/snow_whites_apple.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/snow_whites_apple.dm
@@ -196,13 +196,18 @@ GLOBAL_LIST_EMPTY(vine_list)
 	if(!atom_remove_condition)
 		atom_remove_condition = typecacheof(list(
 			/obj/projectile/ego_bullet/ego_match,
-			/mob/living/simple_animal/hostile/abnormality/helper,))
+			/mob/living/simple_animal/hostile/abnormality/helper,
+			/mob/living/simple_animal/hostile/abnormality/greed_king,
+			/mob/living/simple_animal/hostile/abnormality/dimensional_refraction,
+			/obj/vehicle/sealed/mecha))
 
 	if(!ignore_typecache)
 		ignore_typecache = typecacheof(list(
 			/obj/effect,
 			/mob/dead,
-			/mob/living/simple_animal/hostile/abnormality/snow_whites_apple))
+			/mob/living/simple_animal/hostile/abnormality/snow_whites_apple,
+			/mob/living/simple_animal/hostile/abnormality/golden_apple,
+			/mob/living/simple_animal/hostile/abnormality/ebony_queen))
 
 /obj/structure/spreading/apple_vine/Destroy()
 	GLOB.vine_list -= src


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Added Snow Whites Apple Abberations to the immunity list of Snow Whites Apple
Added DRV and Mecha like Rhinos to the Atom Removal list.

## Why It's Good For The Game
Makes vines less cancerous to deal with and possibly helpful in locating DRV. 

## Changelog
:cl:
tweak: Snow Whites Apple Vines
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
