### PR TITLE
Gamemode Vote Redux

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -207,7 +207,20 @@
 
 	to_chat(world, "<BR><BR><BR><span class='big bold'>The round has ended.</span>")
 	log_game("The round has ended.")
-	SSvote.initiate_vote("gamemode", "automatic gamemode selection vote")
+
+	var/rounds_since_vote = trim(file2text("data/rounds_since_vote.txt"))
+	rounds_since_vote = text2num(rounds_since_vote)
+	rounds_since_vote += 1
+	if(rounds_since_vote < 3)
+		if(GLOB.master_mode != "classic")
+			SSticker.save_mode("classic")
+	else
+		SSvote.initiate_vote("gamemode", "automatic gamemode selection vote")
+		rounds_since_vote = 0
+	var/F = file("data/rounds_since_vote.txt")
+	var/file_contents = num2text(rounds_since_vote)
+	fdel(F)
+	WRITE_FILE(F, file_contents)
 
 	for(var/I in round_end_events)
 		var/datum/callback/cb = I

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -64,10 +64,14 @@ SUBSYSTEM_DEF(vote)
 				if(choices["Continue Playing"] >= greatest_votes)
 					greatest_votes = choices["Continue Playing"]
 			else if(mode == "gamemode")
+				/*
 				var/random_gamemode = pick(choices)
 				choices[random_gamemode] += non_voters.len
 				if(choices[random_gamemode] >= greatest_votes)
 					greatest_votes = choices[random_gamemode]
+				*/
+				// Nothing happens! Absolutely nothing.
+				non_voters = list() // Clear out that list.
 			else if(mode == "map")
 				for (var/non_voter_ckey in non_voters)
 					var/client/C = non_voters[non_voter_ckey]

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -256,7 +256,7 @@ SUBSYSTEM_DEF(vote)
 			text += "\n[question]"
 		log_vote(text)
 		var/vp = CONFIG_GET(number/vote_period)
-		to_chat(world, "\n<font color='purple'><b>[text]</b>\nType <b>vote</b> or click <a href='byond://winset?command=vote'>here</a> to place your votes.\nYou have [DisplayTimeText(vp)] to vote.</font>")
+		to_chat(world, "\n<span class='userdanger'><font color='purple'><b>[text]</b>\nType <b>vote</b> or click <a href='byond://winset?command=vote'>here</a> to place your votes.\nYou have [DisplayTimeText(vp)] to vote.</font></span>")
 		time_remaining = round(vp/10)
 		for(var/c in GLOB.clients)
 			var/client/C = c

--- a/data/mode.txt
+++ b/data/mode.txt
@@ -1,0 +1,1 @@
+classic


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Gamemode votes now occur once every three rounds, and a non-Classic gamemode will only ever last one round. Two guaranteed rounds of Classic for every one time Pure might be selected!

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Allows for an upcoming change to core suppressions that makes them a round-long gamemode-based thing. Also slightly less annoying to the apparently significant portion of our playerbase who doesn't notice nor care about such subtle cues as _text in chat telling them a gamemode vote has started_ or _a new verb button appearing in the top left_, and to those who get dragged into undesirable situations in spite of their due digilence thanks to them.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Gamemode votes occur less and gamemode defaults to Classic when no vote occurs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
