### PR TITLE
Removes the recipe for large cardboard boxes

### DIFF
--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -420,7 +420,6 @@ GLOBAL_LIST_INIT(cardboard_recipes, list (														\
 	new/datum/stack_recipe("box", /obj/item/storage/box),										\
 	new/datum/stack_recipe("cardborg suit", /obj/item/clothing/suit/cardborg, 3),				\
 	new/datum/stack_recipe("cardborg helmet", /obj/item/clothing/head/cardborg),				\
-	new/datum/stack_recipe("large box", /obj/structure/closet/cardboard, 4, one_per_turf = TRUE, on_floor = TRUE), \
 	new/datum/stack_recipe("cardboard cutout", /obj/item/cardboard_cutout, 5),					\
 	null,																						\
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

What it says on the tin

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This is the single most abused bug in the entire server. I cannot play a single round without seeing one of the stupid boxes, and a clerk on their high horse thinking they actually have a right to survive. It is stupid, immersion-breaking, and has been abused to hell and back. I am apalled by the fact that I am one of the few people who even have a problem with this. Furthermore, it has been abused to clear the backstreets without fighting a single enemy or taking any damage, due to the fact that simple mobs do not attack people in this container. Good riddance.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Removes the "large box" recipe from cardboard sheets
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
