### PR TITLE
Fix patrol_reset messing with target chase AI

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -89,7 +89,7 @@
 		walk(src, 0) //stops walking
 	if(!can_patrol || client)
 		return
-	if(target && patrol_path) //if AI has acquired a target while on patrol, stop patrol
+	if(target && length(patrol_path)) //if AI has acquired a target while on patrol, stop patrol
 		patrol_reset()
 		return
 	if(CanStartPatrol())


### PR DESCRIPTION
## About The Pull Request
Checked `patrol_path` instead of `length(patrol_path)` and `patrol_reset()` set it to `list()` instead of `null`. Replaced it with a length check and it works now.

## Why It's Good For The Game
Fixes hostile mobs doing weird accidental strafing while chasing targets.