### PR TITLE
Raises max PE on blubbering toad

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/zayin/blubbering_toad.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/blubbering_toad.dm
@@ -23,7 +23,7 @@
 	move_to_delay = 3
 	melee_damage_lower = 35
 	melee_damage_upper = 45
-
+	max_boxes = 10
 	ranged = TRUE
 	attack_sound = 'sound/abnormalities/blubbering_toad/attack.ogg'
 	attack_verb_continuous = "mauls"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I forgot to update this when making the abnormality, blubbering toad now has a maximum PE of 10 instead of 6.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It has no reason to have such a low amount of PE per work.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: blubbering toad now awards 10 PE instead of 6 maximum
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
