### PR TITLE
Ordeal Refraction Edits

### DIFF
--- a/code/modules/ordeals/amber_ordeals.dm
+++ b/code/modules/ordeals/amber_ordeals.dm
@@ -17,6 +17,9 @@
 	annonce_text = "To accustom oneself to the taste was an inevitable process."
 	level = 3
 	reward_percent = 0.2
+	annonce_sound = 'sound/effects/ordeals/amber_start.ogg'
+	end_sound = 'sound/effects/ordeals/amber_end.ogg'
+	color = "#FFBF00"
 	spawn_places = 3
 	spawn_amount = 1
 	spawn_type = /mob/living/simple_animal/hostile/ordeal/amber_dusk

--- a/code/modules/ordeals/green_ordeals.dm
+++ b/code/modules/ordeals/green_ordeals.dm
@@ -29,7 +29,7 @@
 	color = COLOR_DARK_LIME
 
 // Dusk
-/datum/ordeal/green_dusk
+/datum/ordeal/simplecommander/green_dusk
 	name = "Dusk of Green"
 	annonce_text = "We constructed a looming tower to return whence we came."
 	level = 3
@@ -37,27 +37,13 @@
 	annonce_sound = 'sound/effects/ordeals/green_start.ogg'
 	end_sound = 'sound/effects/ordeals/green_end.ogg'
 	color = COLOR_DARK_LIME
-	/// How many places are chosen for the spawn
-	var/spawn_places = 3
-
-/datum/ordeal/green_dusk/Run()
-	..()
-	var/list/availablespawns = GLOB.xeno_spawn.Copy()
-	for(var/i = 1 to spawn_places)
-		var/X = pick(availablespawns)
-		availablespawns -= X
-
-		var/turf/T = get_turf(X)
-		var/turf/NT = get_step(T, EAST) // It's a 2x1 object, after all
-		if(NT.density) // Retry
-			i -= 1
-			continue
-		var/mob/living/simple_animal/hostile/ordeal/green_dusk/GD = new(T)
-		ordeal_mobs += GD
-		GD.ordeal_reference = src
+	bosstype = list(/mob/living/simple_animal/hostile/ordeal/green_dusk)
+	grunttype = list(/mob/living/simple_animal/hostile/ordeal/green_bot)
+	bossnumber = 3
+	gruntnumber = 1
 
 // Midnight
-/datum/ordeal/green_midnight
+/datum/ordeal/boss/green_midnight
 	name = "Midnight of Green"
 	annonce_text = "The tower is touched by the sky, and it will leave nothing on the earth."
 	level = 4
@@ -65,12 +51,5 @@
 	annonce_sound = 'sound/effects/ordeals/green_start.ogg'
 	end_sound = 'sound/effects/ordeals/green_end.ogg'
 	color = COLOR_DARK_LIME
-
-/datum/ordeal/green_midnight/Run()
-	..()
-	for(var/turf/T in GLOB.department_centers)
-		if(!istype(get_area(T), /area/department_main/command))
-			continue
-		var/mob/living/simple_animal/hostile/ordeal/green_midnight/GM = new(T)
-		ordeal_mobs += GM
-		GM.ordeal_reference = src
+	bosstype = /mob/living/simple_animal/hostile/ordeal/green_midnight
+	bossspawnloc = /area/department_main/command

--- a/code/modules/ordeals/indigo_ordeals.dm
+++ b/code/modules/ordeals/indigo_ordeals.dm
@@ -43,7 +43,7 @@
 		/mob/living/simple_animal/hostile/ordeal/indigo_dusk/black,
 		/mob/living/simple_animal/hostile/ordeal/indigo_dusk/white
 		)
-	grunttype = /mob/living/simple_animal/hostile/ordeal/indigo_noon
+	grunttype = list(/mob/living/simple_animal/hostile/ordeal/indigo_noon)
 
 // Midnight
 /datum/ordeal/boss/indigo_midnight


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Used my knowelege of lists and oview to spread out ordeals upon spawning. Spawning them farther than 1 tile has resulted in them spawning inside windows so i put the turf requirements to be is floor and isnt dense.
Edited Boss Ordeal to have a "zone" variable for when a ordeal needs to spawn specifically in Central Command or any other department. For now the only one i applied this to is Green Midnight.
I tested this by casually spawning each ordeal in a map.

I also left alot of notes so that people can see where and why i made redundant checks.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
People have complained about ordeals standing on one spot ontop of eachother and then rapidly swarming out. This hopefully helps with that.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Ordeal Types
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
