### PR TITLE
Make Jangsan Make sense

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/he/jangsan.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/jangsan.dm
@@ -96,10 +96,10 @@
 	return chance * chance_modifier
 
 /mob/living/simple_animal/hostile/abnormality/jangsan/proc/StatCheck(mob/living/carbon/human/user)
-	strong_counter = 0 //Counts how many stats are above 40
-	weak_counter = 0
+	strong_counter = 0 //Counts how many stats are at or above 60 AKA level 3 or higher
+	weak_counter = 0 //Counts how many stats are below 40 AKA level 1
 	for(var/attribute in stats)
-		if(get_attribute_level(user, attribute)<= 40)
+		if(get_attribute_level(user, attribute)< 40)
 			weak_counter += 1
 		if(get_attribute_level(user, attribute)>= 60)
 			strong_counter += 1


### PR DESCRIPTION





## About The Pull Request

Jangsan now does not kill employees with exactly 40s in every stat

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: No longer misleaded by the belief that level two join stats saves you.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
