### PR TITLE
Updates timelocks for Agent Captain and Records Officer.

### DIFF
--- a/code/modules/jobs/job_types/agent.dm
+++ b/code/modules/jobs/job_types/agent.dm
@@ -139,7 +139,7 @@
 	normal_attribute_level = 21 // :)
 
 	access = list(ACCESS_COMMAND) // LC13:To-Do
-	exp_requirements = 240
+	exp_requirements = 6000
 	exp_type = EXP_TYPE_CREW
 	exp_type_department = EXP_TYPE_SECURITY
 	mapexclude = list("wonderlabs", "mini")

--- a/code/modules/jobs/job_types/command.dm
+++ b/code/modules/jobs/job_types/command.dm
@@ -57,6 +57,7 @@
 /datum/job/command/records
 	title = "Records Officer"
 	outfit = /datum/outfit/job/command/records
+	exp_requirements = 600
 	job_important = "You are the Records Officer. Your job is to manage Records. You have filing cabinets in the back of your office filled with all sorts of information; make sure the agents know this information. \
 	Make sure that you assist Interns and new clerks in learning how to work at Lcorp. Help agents use tool abnormalities with proper warnings. \
 	As well as this, you have access to powerful handheld watches with various effects."


### PR DESCRIPTION
Update command.dm

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Agent Captain has it's timelock increased to 100 hours, as per a community poll.
Records officer has it's timelock increased from 3 hrs to 10 hours.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Agent captain and Records officer are both roles that require an extremely large amount of experience to actually play as intended. Thus, I put it to a poll on the discord.
Players polled said that 100 hours makes you a "Veteran" at the game, so I set the captain timelock to that, to require players to actually have played our game for a long amount of time.

Records officer actually has unique mechanics to it, and while it shouldn't require 100 hrs to play, they are a soft mentor role, and should require more than 3.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Command role timelocks increased by orders of magnitude.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
