### PR TITLE
Pygmalion Prudence Fix

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/waw/pygmalion.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/pygmalion.dm
@@ -155,7 +155,10 @@
 		restorePrudence()
 
 /mob/living/simple_animal/hostile/abnormality/pygmalion/proc/restorePrudence()
-	sculptor.adjust_attribute_level(PRUDENCE_ATTRIBUTE, missing_prudence)
+	var/datum/attribute/user_attribute = sculptor.attributes[PRUDENCE_ATTRIBUTE]
+	var/user_attribute_level = max(1, user_attribute.level)
+	if (user_attribute_level < missing_prudence + PRUDENCE_CAP)
+		sculptor.adjust_attribute_level(PRUDENCE_ATTRIBUTE, missing_prudence + PRUDENCE_CAP - user_attribute_level)
 	missing_prudence = null
 	to_chat(sculptor, "<span class='nicegreen'> As soon as Pygmalion has fallen, You feel like your mind is back on track. </span>")
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I made a small fix to Pygmalion which makes it you can't restore your prudence to something higher then what it was before Pygmalion breaching.

## Why It's Good For The Game

Its a bug fix...


<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
