### PR TITLE
Core Suppression time limit + some tweaks

### DIFF
--- a/_maps/map_files/Epsilon/epsiloncommand.dmm
+++ b/_maps/map_files/Epsilon/epsiloncommand.dmm
@@ -6154,9 +6154,7 @@
 /area/city/backstreets_room)
 "zC" = (
 /obj/structure/railing,
-/obj/machinery/computer/abnormality_auxiliary{
-	dir = 1
-	},
+/obj/structure/table/wood,
 /turf/open/floor/carpet/royalblack,
 /area/department_main/manager)
 "zE" = (

--- a/_maps/map_files/Epsilon/epsiloncommand.dmm
+++ b/_maps/map_files/Epsilon/epsiloncommand.dmm
@@ -6154,7 +6154,9 @@
 /area/city/backstreets_room)
 "zC" = (
 /obj/structure/railing,
-/obj/structure/table/wood,
+/obj/machinery/computer/abnormality_auxiliary{
+	dir = 1
+	},
 /turf/open/floor/carpet/royalblack,
 /area/department_main/manager)
 "zE" = (

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -12282,8 +12282,9 @@
 /turf/open/floor/plasteel/dark,
 /area/centcom/hub)
 "WE" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/coffee,
+/obj/machinery/computer/abnormality_auxiliary{
+	dir = 8
+	},
 /turf/open/floor/facility/dark,
 /area/department_main/manager)
 "WF" = (

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -528,3 +528,9 @@
 	integer = FALSE
 	min_val = 0.0
 	max_val = 1.0
+
+// If midnight has started by this time - upon finishing it, the core suppression will be available
+// In 1/10 of a second
+/datum/config_entry/number/suppression_time_limit
+	config_entry_value = 60 MINUTES
+	min_val = 0

--- a/code/modules/ordeals/_ordeal.dm
+++ b/code/modules/ordeals/_ordeal.dm
@@ -5,6 +5,8 @@
 	var/level = 0
 	/// Added meltdown delay. The higher it is - the longer it'll take for the ordeal to occur. If null - uses level.
 	var/delay = null
+	/// If TRUE - delay will always be adjusted by random number(1-2).
+	var/random_delay = TRUE
 	/// Announcement text. Self-explanatory
 	var/annonce_text = "Oh my god we're going to die!"
 	/// Sound to play on announcement, if any
@@ -19,14 +21,17 @@
 	var/color = COLOR_VERY_LIGHT_GRAY
 	/// If ordeal can be normally chosen
 	var/can_run = TRUE
+	/// World.time when ordeal started
+	var/start_time
 
 /datum/ordeal/New()
 	..()
 	if(delay == null)
-		delay = level
+		delay = level * 2
 
 // Runs the event itself
 /datum/ordeal/proc/Run()
+	start_time = world.time
 	priority_announce(annonce_text, name, sound='sound/effects/meltdownAlert.ogg')
 	if(annonce_sound)
 		for(var/mob/M in GLOB.player_list)
@@ -43,8 +48,11 @@
 		for(var/mob/M in GLOB.player_list)
 			if(M.client)
 				M.playsound_local(get_turf(M), end_sound, 35, 0)
-	if(level == 4 && !istype(SSlobotomy_corp.core_suppression) && !LAZYLEN(SSlobotomy_corp.available_core_suppressions))
-		addtimer(CALLBACK(SSlobotomy_corp, /datum/controller/subsystem/lobotomy_corp/proc/PickPotentialSuppressions), 5 SECONDS)
+	/// If it was a midnight and we got to it before time limit
+	if(level == 4 && !istype(SSlobotomy_corp.core_suppression) && \
+	!LAZYLEN(SSlobotomy_corp.available_core_suppressions) && \
+	start_time <= CONFIG_GET(number/suppression_time_limit))
+		addtimer(CALLBACK(SSlobotomy_corp, /datum/controller/subsystem/lobotomy_corp/proc/PickPotentialSuppressions), 10 SECONDS)
 	qdel(src)
 	return
 

--- a/code/modules/ordeals/white_ordeals.dm
+++ b/code/modules/ordeals/white_ordeals.dm
@@ -3,6 +3,7 @@
 	annonce_text = "This isn't supposed to happen, but they have come for you. Might want to report this to central command."
 	can_run = FALSE
 	delay = 2 // It will always give exactly 1 normal meltdown in-between ordeals
+	random_delay = FALSE
 	reward_percent = 0.1
 	annonce_sound = 'sound/effects/ordeals/white_start.ogg'
 	end_sound = 'sound/effects/ordeals/white_end.ogg'

--- a/code/modules/ordeals/white_ordeals.dm
+++ b/code/modules/ordeals/white_ordeals.dm
@@ -2,7 +2,7 @@
 	name = "Fixers"
 	annonce_text = "This isn't supposed to happen, but they have come for you. Might want to report this to central command."
 	can_run = FALSE
-	delay = 1
+	delay = 2 // It will always give exactly 1 normal meltdown in-between ordeals
 	reward_percent = 0.1
 	annonce_sound = 'sound/effects/ordeals/white_start.ogg'
 	end_sound = 'sound/effects/ordeals/white_end.ogg'
@@ -93,5 +93,5 @@
 /datum/ordeal/white_midnight/End()
 	if(istype(SSlobotomy_corp.core_suppression)) // If it all was a part of core suppression
 		SSlobotomy_corp.core_suppression_state = 3
-		addtimer(CALLBACK(SSlobotomy_corp.core_suppression, /datum/suppression/proc/End), 5 SECONDS)
+		addtimer(CALLBACK(SSlobotomy_corp.core_suppression, /datum/suppression/proc/End), 10 SECONDS)
 	return ..()

--- a/code/modules/suppressions/safety.dm
+++ b/code/modules/suppressions/safety.dm
@@ -1,10 +1,10 @@
 /datum/suppression/safety
 	name = "Safety Core Suppression"
-	desc = "Regenerators will stop operating normally, only reactivating for short time after each meltdown.\n\
-			Sleepers will be non-functional.\n\
+	desc = "Regenerators will stop operating normally, all personnel will be healed after each meltdown instead.\n\
+			Sleepers and EMAIS will be non-functional.\n\
 			Medi-pens will have a chance to malfunction and require a delay on each activation."
 	reward_text = "All regenerators will receive a permanent +3 boost to healing power."
-	run_text = "The core suppression of Safety department has begun. The regenerators and sleepers will stop operating normally. Regenerators will resume their work for a short while on each meltdown instead."
+	run_text = "The core suppression of Safety department has begun. The regenerators and sleepers will stop operating normally. All personnel will be automatically healed after each meltdown instead."
 
 /datum/suppression/safety/Run(run_white = TRUE)
 	. = ..()

--- a/code/modules/suppressions/safety.dm
+++ b/code/modules/suppressions/safety.dm
@@ -9,7 +9,11 @@
 /datum/suppression/safety/Run(run_white = TRUE)
 	. = ..()
 	RegisterSignal(SSdcs, COMSIG_GLOB_MELTDOWN_START, .proc/OnMeltdown)
-	KillRegenerators()
+	for(var/obj/machinery/regenerator/R in GLOB.regenerators)
+		R.icon_state = "smoke0"
+		R.reset_timer = INFINITY
+		R.burst_cooldown = TRUE
+		R.modified = TRUE
 	for(var/obj/machinery/sleeper/S in GLOB.sleepers)
 		S.set_machine_stat(S.machine_stat | BROKEN)
 
@@ -23,19 +27,13 @@
 		S.set_machine_stat(S.machine_stat & (~BROKEN))
 	return ..()
 
-/datum/suppression/safety/proc/KillRegenerators()
-	for(var/obj/machinery/regenerator/R in GLOB.regenerators)
-		R.icon_state = "smoke0"
-		R.reset_timer = INFINITY
-		R.burst_cooldown = TRUE
-		R.modified = TRUE
-
 // On lobotomy_corp meltdown event
 /datum/suppression/safety/proc/OnMeltdown(datum/source, ordeal = FALSE)
-	for(var/obj/machinery/regenerator/R in GLOB.regenerators)
-		R.icon_state = "smoke1"
-		R.reset_timer = 0
-		R.hp_bonus = 15
-		R.sp_bonus = 15
-	addtimer(CALLBACK(src, .proc/KillRegenerators), 10 SECONDS)
+	// Everyone gets healed
+	for(var/mob/living/carbon/human/H in GLOB.human_list)
+		if(!H.ckey)
+			continue
+		H.adjustBruteLoss(-250)
+		H.adjustSanityLoss(-250)
+		to_chat(H, "<span class='notice'>You suddenly feel better!</span>")
 	return

--- a/code/modules/suppressions/training.dm
+++ b/code/modules/suppressions/training.dm
@@ -13,13 +13,13 @@
 	for(var/mob/living/carbon/human/H in GLOB.human_list)
 		if(!H.ckey)
 			continue
-		H.adjust_all_attribute_buffs(-40)
+		H.adjust_all_attribute_buffs(-30)
 		affected_mobs += H
 
 /datum/suppression/training/End()
 	UnregisterSignal(SSdcs, COMSIG_GLOB_CREWMEMBER_JOINED)
 	for(var/mob/living/carbon/human/H in affected_mobs)
-		H.adjust_all_attribute_buffs(45)
+		H.adjust_all_attribute_buffs(35)
 		H.adjust_all_attribute_levels(20) // A tiny reward
 	for(var/datum/job/agent/J in SSjob.occupations)
 		J.normal_attribute_level += 5 // This allows agents to spawn with 100 in all stats
@@ -30,6 +30,6 @@
 	if(!ishuman(L))
 		return FALSE
 	var/mob/living/carbon/human/H = L
-	H.adjust_all_attribute_buffs(-40) // Suffer
+	H.adjust_all_attribute_buffs(-30) // Suffer
 	affected_mobs += H
 	return TRUE

--- a/code/modules/suppressions/training.dm
+++ b/code/modules/suppressions/training.dm
@@ -1,7 +1,7 @@
 // Right now the only core suppression with a proper reward, which is higher spawning stats.
 /datum/suppression/training
 	name = "Training Core Suppression"
-	desc = "All employees will have a -40 debuff on each attribute for the duration of suppression."
+	desc = "All employees will have a -30 debuff on each attribute for the duration of suppression."
 	reward_text = "Employees that survived through the suppression will be awarded with 20 increase and +5 buff to all attributes.\n\
 			All Agents that will join post-suppression will start with higher attributes."
 	run_text = "The core suppression of Training department has begun. All personnel will be suffering from symptoms of work fatigue."

--- a/config/config.txt
+++ b/config/config.txt
@@ -558,3 +558,7 @@ VOTE_AUTOTRANSFER_ENABLED
 VOTE_AUTOTRANSFER_INITIAL 45000
 ## Time (in deciseconds) between subsequent transfer votes. Default: 30 minutes
 VOTE_AUTOTRANSFER_INTERVAL 12000
+
+## Time limit (in deciseconds) for core suppression availability
+## If midnight has started before it has been reached - they will be available
+SUPPRESSION_TIME_LIMIT 36000


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Core Suppressions will be available for choice if midnight was started before time limit. If one is not chosen in 5 minutes - options disappear.
- Safety suppression now simply heals everyone each meltdown.
- Training suppression debuff changed from -40 to -30.
- White ordeals have delay of 2 and are not randomized. This means that core suppressions will have exactly one normal meltdown between ordeals.

## Why It's Good For The Game

- This prevents super long rounds that attempt to "grind for the suppression". Get to it fast or end the round, that's it.
- More accurate to LC and less annoying to deal with.
- Less annoying.
- More consistent with the idea of core suppressions.
