### PR TITLE
Tweaks to range/view procs

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -979,10 +979,10 @@ rough example of the "cone" made by the 3 dirs checked
 
 	var/list/mobs = list()
 	for(var/mob/living/L in GLOB.mob_living_list)
-		var/check_place = L
+		var/atom/check_place = L
 		if(isatom(L.loc)) // Not a turf/area
 			check_place = L.loc
-		if(get_dist(center, check_place) <= dist)
+		if(get_dist(center, check_place) <= dist && center.z == check_place.z)
 			mobs += L
 
 	return mobs
@@ -993,11 +993,12 @@ rough example of the "cone" made by the 3 dirs checked
 		return list()
 
 	var/list/mobs = list()
+	var/list/my_view = view(dist, center)
 	for(var/mob/living/L in GLOB.mob_living_list)
 		var/check_place = L
 		if(isatom(L.loc)) // Not a turf/area
 			check_place = L.loc
-		if(check_place in view(dist, center))
+		if(check_place in my_view)
 			mobs += L
 
 	return mobs


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Optimizes livinginview() and fixes livinginrange().

## Why It's Good For The Game

The "living in view" proc would loop through mobs, each time generating a new list by calling view(dist, center), despite only needing to do so once. That's what I "optimized".
The "living in range" used get_dist(), which, as far as I am aware, ignored z level. I added a z level check to fix potential issues.

