### PR TITLE
Time-related and other QOL changes

### DIFF
--- a/code/__DEFINES/time.dm
+++ b/code/__DEFINES/time.dm
@@ -50,3 +50,5 @@ When using time2text(), please use "DDD" to find the weekday. Refrain from using
 #define DS2TICKS(DS) ((DS)/world.tick_lag)
 
 #define TICKS2DS(T) ((T) TICKS)
+
+#define ROUNDTIME world.time - SSticker.round_start_time

--- a/code/controllers/subsystem/abnormality_queue.dm
+++ b/code/controllers/subsystem/abnormality_queue.dm
@@ -22,7 +22,7 @@ SUBSYSTEM_DEF(abnormality_queue)
 	/// World time at which new abnormality will be spawned
 	var/next_abno_spawn = INFINITY
 	/// Wait time for next abno spawn; This time is further affected by amount of abnos in facility
-	var/next_abno_spawn_time = 3.5 MINUTES
+	var/next_abno_spawn_time = 4 MINUTES
 	/// Tracks if the current pick is forced
 	var/fucked_it_lets_rolled = FALSE
 	/// Due to Managers not passing the Litmus Test, divine approval is now necessary for red roll
@@ -46,7 +46,7 @@ SUBSYSTEM_DEF(abnormality_queue)
 
 /datum/controller/subsystem/abnormality_queue/proc/SpawnAbno()
 	// Earlier in the game, abnormalities will spawn faster and then slow down a bit
-	next_abno_spawn = world.time + next_abno_spawn_time + ((min(16, spawned_abnos) - 5) * 6) SECONDS
+	next_abno_spawn = world.time + next_abno_spawn_time + ((min(16, spawned_abnos) - 4) * 6) SECONDS
 	// HE enabled, ZAYIN disabled
 	if(spawned_abnos > rooms_start * 0.2 && spawned_abnos <= rooms_start * 0.6)
 		if(ZAYIN_LEVEL in available_levels)

--- a/code/controllers/subsystem/abnormality_queue.dm
+++ b/code/controllers/subsystem/abnormality_queue.dm
@@ -22,7 +22,7 @@ SUBSYSTEM_DEF(abnormality_queue)
 	/// World time at which new abnormality will be spawned
 	var/next_abno_spawn = INFINITY
 	/// Wait time for next abno spawn; This time is further affected by amount of abnos in facility
-	var/next_abno_spawn_time = 3.3 MINUTES
+	var/next_abno_spawn_time = 3.4 MINUTES
 	/// Tracks if the current pick is forced
 	var/fucked_it_lets_rolled = FALSE
 	/// Due to Managers not passing the Litmus Test, divine approval is now necessary for red roll

--- a/code/controllers/subsystem/abnormality_queue.dm
+++ b/code/controllers/subsystem/abnormality_queue.dm
@@ -22,7 +22,7 @@ SUBSYSTEM_DEF(abnormality_queue)
 	/// World time at which new abnormality will be spawned
 	var/next_abno_spawn = INFINITY
 	/// Wait time for next abno spawn; This time is further affected by amount of abnos in facility
-	var/next_abno_spawn_time = 3.4 MINUTES
+	var/next_abno_spawn_time = 3.5 MINUTES
 	/// Tracks if the current pick is forced
 	var/fucked_it_lets_rolled = FALSE
 	/// Due to Managers not passing the Litmus Test, divine approval is now necessary for red roll
@@ -118,10 +118,12 @@ SUBSYSTEM_DEF(abnormality_queue)
 /datum/controller/subsystem/abnormality_queue/proc/HandleStartingAbnormalities()
 	var/player_count = GLOB.clients.len
 	var/i
-	for(i=1 to round(clamp(player_count, 6, 30) / 6))
+	for(i=1 to round(clamp(player_count, 5, 30) / 5))
+		sleep(15 SECONDS) // Allows manager to select abnormalities if he is fast enough.
 		SpawnAbno()
-		sleep(10 SECONDS) // Allows manager to select abnormalities if he is fast enough.
 	message_admins("[i] round-start abnormalities have been spawned.")
+	for(var/obj/machinery/computer/abnormality_queue/Q in GLOB.abnormality_queue_consoles)
+		Q.visible_message("<span class='notice'>All the initial abnormalities have arrived. Have a nice day.</span>")
 	return
 
 /datum/controller/subsystem/abnormality_queue/proc/AnnounceLock()

--- a/code/controllers/subsystem/abnormality_queue.dm
+++ b/code/controllers/subsystem/abnormality_queue.dm
@@ -21,8 +21,8 @@ SUBSYSTEM_DEF(abnormality_queue)
 	// I am using this all because default subsystem waiting and next_fire is done in a very... interesting way.
 	/// World time at which new abnormality will be spawned
 	var/next_abno_spawn = INFINITY
-	/// Wait time for next abno spawn
-	var/next_abno_spawn_time = 4 MINUTES
+	/// Wait time for next abno spawn; This time is further affected by amount of abnos in facility
+	var/next_abno_spawn_time = 3 MINUTES
 	/// Tracks if the current pick is forced
 	var/fucked_it_lets_rolled = FALSE
 	/// Due to Managers not passing the Litmus Test, divine approval is now necessary for red roll
@@ -46,7 +46,7 @@ SUBSYSTEM_DEF(abnormality_queue)
 
 /datum/controller/subsystem/abnormality_queue/proc/SpawnAbno()
 	// Earlier in the game, abnormalities will spawn faster and then slow down a bit
-	next_abno_spawn = world.time + next_abno_spawn_time + ((min(16, spawned_abnos) - 4) * 6) SECONDS
+	next_abno_spawn = world.time + next_abno_spawn_time + ((min(16, spawned_abnos) - 6) * 6) SECONDS
 	// HE enabled, ZAYIN disabled
 	if(spawned_abnos > rooms_start * 0.2 && spawned_abnos <= rooms_start * 0.6)
 		if(ZAYIN_LEVEL in available_levels)

--- a/code/controllers/subsystem/abnormality_queue.dm
+++ b/code/controllers/subsystem/abnormality_queue.dm
@@ -22,7 +22,7 @@ SUBSYSTEM_DEF(abnormality_queue)
 	/// World time at which new abnormality will be spawned
 	var/next_abno_spawn = INFINITY
 	/// Wait time for next abno spawn; This time is further affected by amount of abnos in facility
-	var/next_abno_spawn_time = 3 MINUTES
+	var/next_abno_spawn_time = 3.3 MINUTES
 	/// Tracks if the current pick is forced
 	var/fucked_it_lets_rolled = FALSE
 	/// Due to Managers not passing the Litmus Test, divine approval is now necessary for red roll
@@ -37,7 +37,7 @@ SUBSYSTEM_DEF(abnormality_queue)
 	if(LAZYLEN(possible_abnormalities))
 		pick_abno()
 	rooms_start = GLOB.abnormality_room_spawners.len
-	next_abno_spawn_time -= min(30, rooms_start * 0.05) MINUTES // 20 rooms will decrease wait time by 1 minute
+	next_abno_spawn_time -= min(2, rooms_start * 0.05) MINUTES // 20 rooms will decrease wait time by 1 minute
 	..()
 
 /datum/controller/subsystem/abnormality_queue/fire()
@@ -46,7 +46,7 @@ SUBSYSTEM_DEF(abnormality_queue)
 
 /datum/controller/subsystem/abnormality_queue/proc/SpawnAbno()
 	// Earlier in the game, abnormalities will spawn faster and then slow down a bit
-	next_abno_spawn = world.time + next_abno_spawn_time + ((min(16, spawned_abnos) - 6) * 6) SECONDS
+	next_abno_spawn = world.time + next_abno_spawn_time + ((min(16, spawned_abnos) - 5) * 6) SECONDS
 	// HE enabled, ZAYIN disabled
 	if(spawned_abnos > rooms_start * 0.2 && spawned_abnos <= rooms_start * 0.6)
 		if(ZAYIN_LEVEL in available_levels)

--- a/code/controllers/subsystem/lobotomy_corp.dm
+++ b/code/controllers/subsystem/lobotomy_corp.dm
@@ -165,9 +165,9 @@ SUBSYSTEM_DEF(lobotomy_corp)
 
 /datum/controller/subsystem/lobotomy_corp/proc/QliphothEvent()
 	// Update list of abnormalities that can be affected by meltdown
-	if((ZAYIN_LEVEL in qliphoth_meltdown_affected) && world.time >= 20 MINUTES)
+	if((ZAYIN_LEVEL in qliphoth_meltdown_affected) && ROUNDTIME >= 20 MINUTES)
 		qliphoth_meltdown_affected -= ZAYIN_LEVEL
-	if((TETH_LEVEL in qliphoth_meltdown_affected) && world.time >= 50 MINUTES)
+	if((TETH_LEVEL in qliphoth_meltdown_affected) && ROUNDTIME >= 50 MINUTES)
 		qliphoth_meltdown_affected -= TETH_LEVEL
 	qliphoth_meter = 0
 	var/abno_amount = all_abnormality_datums.len
@@ -182,7 +182,7 @@ SUBSYSTEM_DEF(lobotomy_corp)
 			A.current.OnQliphothEvent()
 	var/ran_ordeal = FALSE
 	if(qliphoth_state + 1 >= next_ordeal_time) // If ordeal is supposed to happen on the meltdown after that one
-		if(istype(next_ordeal) && ordeal_timelock[next_ordeal.level] > world.time) // And it's on timelock
+		if(istype(next_ordeal) && ordeal_timelock[next_ordeal.level] > ROUNDTIME) // And it's on timelock
 			next_ordeal_time += 1 // So it does not appear on the ordeal monitors until timelock is off
 	if(qliphoth_state >= next_ordeal_time)
 		if(OrdealEvent())
@@ -252,7 +252,7 @@ SUBSYSTEM_DEF(lobotomy_corp)
 /datum/controller/subsystem/lobotomy_corp/proc/OrdealEvent()
 	if(!next_ordeal)
 		return FALSE
-	if(ordeal_timelock[next_ordeal.level] > world.time)
+	if(ordeal_timelock[next_ordeal.level] > ROUNDTIME)
 		return FALSE // Time lock
 	next_ordeal.Run()
 	next_ordeal = null

--- a/code/controllers/subsystem/lobotomy_corp.dm
+++ b/code/controllers/subsystem/lobotomy_corp.dm
@@ -46,7 +46,7 @@ SUBSYSTEM_DEF(lobotomy_corp)
 	// What ordeal level is being rolled for
 	var/next_ordeal_level = 1
 	// Minimum time for each ordeal level to occur. If requirement is not met - normal meltdown will occur
-	var/list/ordeal_timelock = list(10 MINUTES, 20 MINUTES, 35 MINUTES, 50 MINUTES, 0, 0, 0, 0, 0)
+	var/list/ordeal_timelock = list(10 MINUTES, 25 MINUTES, 45 MINUTES, 60 MINUTES, 0, 0, 0, 0, 0)
 	// Datum of the chosen ordeal. It's stored so manager can know what's about to happen
 	var/datum/ordeal/next_ordeal = null
 	/// List of currently running ordeals
@@ -165,9 +165,9 @@ SUBSYSTEM_DEF(lobotomy_corp)
 
 /datum/controller/subsystem/lobotomy_corp/proc/QliphothEvent()
 	// Update list of abnormalities that can be affected by meltdown
-	if((ZAYIN_LEVEL in qliphoth_meltdown_affected) && ROUNDTIME >= 20 MINUTES)
+	if((ZAYIN_LEVEL in qliphoth_meltdown_affected) && ROUNDTIME >= 30 MINUTES)
 		qliphoth_meltdown_affected -= ZAYIN_LEVEL
-	if((TETH_LEVEL in qliphoth_meltdown_affected) && ROUNDTIME >= 50 MINUTES)
+	if((TETH_LEVEL in qliphoth_meltdown_affected) && ROUNDTIME >= 60 MINUTES)
 		qliphoth_meltdown_affected -= TETH_LEVEL
 	qliphoth_meter = 0
 	var/abno_amount = all_abnormality_datums.len

--- a/code/controllers/subsystem/lobotomy_corp.dm
+++ b/code/controllers/subsystem/lobotomy_corp.dm
@@ -175,7 +175,7 @@ SUBSYSTEM_DEF(lobotomy_corp)
 	for(var/mob/player in GLOB.player_list)
 		if(isliving(player))
 			player_count += 1
-	qliphoth_max = 2 + round(player_count * 0.65)
+	qliphoth_max = 3 + round(player_count * 0.65)
 	qliphoth_state += 1
 	for(var/datum/abnormality/A in all_abnormality_datums)
 		if(istype(A.current))
@@ -224,7 +224,7 @@ SUBSYSTEM_DEF(lobotomy_corp)
 			text_info += computer.datum_reference.name
 			if(y != meltdown_occured.len)
 				text_info += ", "
-			text_info += "."
+		text_info += "."
 		// Announce next ordeal
 		if(next_ordeal && (qliphoth_state + 1 >= next_ordeal_time))
 			text_info += "\n\n[next_ordeal.name] will trigger on the next meltdown."

--- a/code/controllers/subsystem/statpanel.dm
+++ b/code/controllers/subsystem/statpanel.dm
@@ -12,7 +12,7 @@ SUBSYSTEM_DEF(statpanels)
 /datum/controller/subsystem/statpanels/fire(resumed = FALSE)
 	if (!resumed)
 		var/datum/map_config/cached = SSmapping.next_map_config
-		var/round_time = world.time - SSticker.round_start_time
+		var/round_time = ROUNDTIME
 		var/list/global_data = list(
 			"Map: [SSmapping.config?.map_name || "Loading..."]",
 			cached ? "Next Map: [cached.map_name]" : null,

--- a/code/datums/abnormality/datum/abnormality.dm
+++ b/code/datums/abnormality/datum/abnormality.dm
@@ -172,12 +172,12 @@
 	if(!user_attribute) //To avoid runtime if it's a custom work type like "Release".
 		return
 	var/user_attribute_level = max(1, user_attribute.level)
-	var/attribute_given = clamp(((maximum_attribute_level / (user_attribute_level * 0.25)) * (0.25 + (pe / max_boxes))), 0, 16)
-	if((user_attribute_level + attribute_given) >= maximum_attribute_level) // Already/Will be at maximum.
+	var/attribute_given = clamp(((maximum_attribute_level / (user_attribute_level * 0.22)) * (0.25 + (pe / max_boxes))), 0, 16)
+	if((user_attribute_level + attribute_given + 1) >= maximum_attribute_level) // Already/Will/Should be at maximum.
 		attribute_given = max(0, maximum_attribute_level - user_attribute_level)
 	if(attribute_given == 0)
 		if(was_melting)
-			attribute_given = 2 //pity stats on meltdowns
+			attribute_given = threat_level //pity stats on meltdowns
 		else
 			to_chat(user, "<span class='warning'>You don't feel like you've learned anything from this!</span>")
 	user.adjust_attribute_level(attribute_type, attribute_given)

--- a/code/datums/abnormality/datum/abnormality.dm
+++ b/code/datums/abnormality/datum/abnormality.dm
@@ -172,7 +172,7 @@
 	if(!user_attribute) //To avoid runtime if it's a custom work type like "Release".
 		return
 	var/user_attribute_level = max(1, user_attribute.level)
-	var/attribute_given = clamp(((maximum_attribute_level / (user_attribute_level * 0.22)) * (0.25 + (pe / max_boxes))), 0, 16)
+	var/attribute_given = clamp(((maximum_attribute_level / (user_attribute_level * 0.25)) * (0.25 + (pe / max_boxes))), 0, 16)
 	if((user_attribute_level + attribute_given + 1) >= maximum_attribute_level) // Already/Will/Should be at maximum.
 		attribute_given = max(0, maximum_attribute_level - user_attribute_level)
 	if(attribute_given == 0)

--- a/code/modules/admin/chat_commands.dm
+++ b/code/modules/admin/chat_commands.dm
@@ -134,7 +134,7 @@ GLOBAL_LIST(round_end_notifiees)
 	help_text = "Gets the current abnormalities in the facility by threat level."
 
 /datum/tgs_chat_command/tgsabnos/Run(datum/tgs_chat_user/sender, params)
-	var/list/abnos = list(ZAYIN_LEVEL = list(), TETH_LEVEL = list(), HE_LEVEL = list(), WAW_LEVEL = list(), ALEPH_LEVEL = list())
+	var/list/abnos = list(list(), list(), list(), list(), list())
 	if(!LAZYLEN(SSlobotomy_corp.all_abnormality_datums))
 		return "There's currently no abnormalities in the facility!"
 
@@ -144,7 +144,7 @@ GLOBAL_LIST(round_end_notifiees)
 			continue
 		abnos[A.threat_level] += A.name
 
-	for(var/threat in abnos)
+	for(var/threat = 1 to length(abnos))
 		if(!LAZYLEN(abnos[threat]))
 			continue
 		abnos_report += "\n- **[THREAT_TO_NAME[threat]]**: [english_list(abnos[threat])]."

--- a/code/modules/admin/chat_commands.dm
+++ b/code/modules/admin/chat_commands.dm
@@ -128,3 +128,25 @@ GLOBAL_LIST(round_end_notifiees)
 /datum/tgs_chat_command/reload_admins/proc/ReloadAsync()
 	set waitfor = FALSE
 	load_admins()
+
+/datum/tgs_chat_command/tgsabnos
+	name = "abnos"
+	help_text = "Gets the current abnormalities in the facility by threat level."
+
+/datum/tgs_chat_command/tgsabnos/Run(datum/tgs_chat_user/sender, params)
+	var/abnos = list(ZAYIN_LEVEL = list(), TETH_LEVEL = list(), HE_LEVEL = list(), WAW_LEVEL = list(), ALEPH_LEVEL = list())
+	if(!LAZYLEN(SSlobotomy_corp.all_abnormality_datums))
+		return "There's currently no abnormalities in the facility!"
+
+	var/abnos_report = "Current abnormalities in the facility:\n"
+	for(var/datum/abnormality/A in SSlobotomy_corp.all_abnormality_datums)
+		if(!(A.threat_level in abnos)) // How???
+			continue
+		abnos[A.threat_level] += A.name
+
+	for(var/threat in abnos)
+		if(!LAZYLEN(abnos[threat]))
+			continue
+		abnos_report += "- **[THREAT_TO_NAME[threat]]**: [english_list(abnos[threat])]."
+
+	return abnos_report

--- a/code/modules/admin/chat_commands.dm
+++ b/code/modules/admin/chat_commands.dm
@@ -29,6 +29,11 @@
 	var/abno_count = SSlobotomy_corp.all_abnormality_datums.len
 	if(abno_count > 0)
 		check += "Abnormalit[abno_count > 1 ? "ies" : "y"] in the facility: __[abno_count]__.\n"
+	if(LAZYLEN(SSlobotomy_corp.current_ordeals))
+		var/list/ordeal_names = list()
+		for(var/datum/ordeal/O in SSlobotomy_corp.current_ordeals)
+			ordeal_names += O.name
+		check += "[english_list(ordeal_names)] [length(ordeal_names) > 1 ? "are" : "is"] currently in the process.\n"
 	if(istype(SSlobotomy_corp.next_ordeal)) // Let's tell people what ordeal type is next
 		check += "Next ordeal type will be __[SSlobotomy_corp.next_ordeal.ReturnSecretName()]__.\n"
 	if(istype(SSlobotomy_corp.core_suppression)) // Currently active core suppression

--- a/code/modules/admin/chat_commands.dm
+++ b/code/modules/admin/chat_commands.dm
@@ -134,19 +134,20 @@ GLOBAL_LIST(round_end_notifiees)
 	help_text = "Gets the current abnormalities in the facility by threat level."
 
 /datum/tgs_chat_command/tgsabnos/Run(datum/tgs_chat_user/sender, params)
-	var/list/abnos = list(list(), list(), list(), list(), list())
+	var/list/abnos = list("ZAYIN" = list(), "TETH" = list(), "HE" = list(), "WAW" = list(), "ALEPH" = list())
 	if(!LAZYLEN(SSlobotomy_corp.all_abnormality_datums))
 		return "There's currently no abnormalities in the facility!"
 
 	var/abnos_report = "Current abnormalities in the facility:"
 	for(var/datum/abnormality/A in SSlobotomy_corp.all_abnormality_datums)
-		if(!(A.threat_level in abnos)) // How???
+		var/a_threat = THREAT_TO_NAME[A.threat_level]
+		if(!(a_threat in abnos)) // How???
 			continue
-		abnos[A.threat_level] += A.name
+		abnos[a_threat] += A.name
 
-	for(var/threat = 1 to length(abnos))
+	for(var/threat in abnos)
 		if(!LAZYLEN(abnos[threat]))
 			continue
-		abnos_report += "\n- **[THREAT_TO_NAME[threat]]**: [english_list(abnos[threat])]."
+		abnos_report += "\n- **[threat]**: [english_list(abnos[threat])]."
 
 	return abnos_report

--- a/code/modules/admin/chat_commands.dm
+++ b/code/modules/admin/chat_commands.dm
@@ -134,11 +134,11 @@ GLOBAL_LIST(round_end_notifiees)
 	help_text = "Gets the current abnormalities in the facility by threat level."
 
 /datum/tgs_chat_command/tgsabnos/Run(datum/tgs_chat_user/sender, params)
-	var/abnos = list(ZAYIN_LEVEL = list(), TETH_LEVEL = list(), HE_LEVEL = list(), WAW_LEVEL = list(), ALEPH_LEVEL = list())
+	var/list/abnos = list(ZAYIN_LEVEL = list(), TETH_LEVEL = list(), HE_LEVEL = list(), WAW_LEVEL = list(), ALEPH_LEVEL = list())
 	if(!LAZYLEN(SSlobotomy_corp.all_abnormality_datums))
 		return "There's currently no abnormalities in the facility!"
 
-	var/abnos_report = "Current abnormalities in the facility:\n"
+	var/abnos_report = "Current abnormalities in the facility:"
 	for(var/datum/abnormality/A in SSlobotomy_corp.all_abnormality_datums)
 		if(!(A.threat_level in abnos)) // How???
 			continue
@@ -147,6 +147,6 @@ GLOBAL_LIST(round_end_notifiees)
 	for(var/threat in abnos)
 		if(!LAZYLEN(abnos[threat]))
 			continue
-		abnos_report += "- **[THREAT_TO_NAME[threat]]**: [english_list(abnos[threat])]."
+		abnos_report += "\n- **[THREAT_TO_NAME[threat]]**: [english_list(abnos[threat])]."
 
 	return abnos_report

--- a/code/modules/jobs/job_types/agent.dm
+++ b/code/modules/jobs/job_types/agent.dm
@@ -81,15 +81,15 @@
 
 	var/set_attribute = normal_attribute_level
 
-	if(ROUNDTIME >= 60 MINUTES) // Full facility expected
+	if(world.time >= 75 MINUTES) // Full facility expected
 		set_attribute *= 4
-	else if(ROUNDTIME >= 45 MINUTES) // More than one ALEPH
+	else if(world.time >= 60 MINUTES) // More than one ALEPH
 		set_attribute *= 3
-	else if(ROUNDTIME >= 30 MINUTES) // Wowzer, an ALEPH?
+	else if(world.time >= 45 MINUTES) // Wowzer, an ALEPH?
 		set_attribute *= 2.5
-	else if(ROUNDTIME >= 20 MINUTES) // Expecting WAW
+	else if(world.time >= 30 MINUTES) // Expecting WAW
 		set_attribute *= 2
-	else if(ROUNDTIME >= 10 MINUTES) // Usual time for HEs
+	else if(world.time >= 15 MINUTES) // Usual time for HEs
 		set_attribute *= 1.5
 
 	//if(SSlobotomy_corp.understood_abnos.len && SSlobotomy_corp.understood_abnos.len > 0)

--- a/code/modules/jobs/job_types/agent.dm
+++ b/code/modules/jobs/job_types/agent.dm
@@ -81,15 +81,15 @@
 
 	var/set_attribute = normal_attribute_level
 
-	if(world.time >= 75 MINUTES) // Full facility expected
+	if(ROUNDTIME >= 60 MINUTES) // Full facility expected
 		set_attribute *= 4
-	else if(world.time >= 60 MINUTES) // More than one ALEPH
+	else if(ROUNDTIME >= 45 MINUTES) // More than one ALEPH
 		set_attribute *= 3
-	else if(world.time >= 45 MINUTES) // Wowzer, an ALEPH?
+	else if(ROUNDTIME >= 30 MINUTES) // Wowzer, an ALEPH?
 		set_attribute *= 2.5
-	else if(world.time >= 30 MINUTES) // Expecting WAW
+	else if(ROUNDTIME >= 20 MINUTES) // Expecting WAW
 		set_attribute *= 2
-	else if(world.time >= 15 MINUTES) // Usual time for HEs
+	else if(ROUNDTIME >= 10 MINUTES) // Usual time for HEs
 		set_attribute *= 1.5
 
 	//if(SSlobotomy_corp.understood_abnos.len && SSlobotomy_corp.understood_abnos.len > 0)

--- a/code/modules/ordeals/_ordeal.dm
+++ b/code/modules/ordeals/_ordeal.dm
@@ -31,7 +31,7 @@
 
 // Runs the event itself
 /datum/ordeal/proc/Run()
-	start_time = world.time
+	start_time = ROUNDTIME
 	SSlobotomy_corp.current_ordeals += src
 	priority_announce(annonce_text, name, sound='sound/effects/meltdownAlert.ogg')
 	if(annonce_sound)

--- a/code/modules/ordeals/_ordeal.dm
+++ b/code/modules/ordeals/_ordeal.dm
@@ -32,6 +32,7 @@
 // Runs the event itself
 /datum/ordeal/proc/Run()
 	start_time = world.time
+	SSlobotomy_corp.current_ordeals += src
 	priority_announce(annonce_text, name, sound='sound/effects/meltdownAlert.ogg')
 	if(annonce_sound)
 		for(var/mob/M in GLOB.player_list)
@@ -42,8 +43,9 @@
 // Ends the event
 /datum/ordeal/proc/End()
 	var/total_reward = SSlobotomy_corp.box_goal * reward_percent
-	SSlobotomy_corp.AdjustBoxes(total_reward)
 	priority_announce("The ordeal has ended. Facility has been rewarded with [reward_percent*100]% PE.", name, sound=null)
+	SSlobotomy_corp.AdjustBoxes(total_reward)
+	SSlobotomy_corp.current_ordeals -= src
 	if(end_sound)
 		for(var/mob/M in GLOB.player_list)
 			if(M.client)
@@ -52,7 +54,7 @@
 	if(level == 4 && !istype(SSlobotomy_corp.core_suppression) && \
 	!LAZYLEN(SSlobotomy_corp.available_core_suppressions) && \
 	start_time <= CONFIG_GET(number/suppression_time_limit))
-		addtimer(CALLBACK(SSlobotomy_corp, /datum/controller/subsystem/lobotomy_corp/proc/PickPotentialSuppressions), 10 SECONDS)
+		addtimer(CALLBACK(SSlobotomy_corp, /datum/controller/subsystem/lobotomy_corp/proc/PickPotentialSuppressions), 20 SECONDS)
 	qdel(src)
 	return
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

A small experimental PR that adjusts things related to time locks and such.

- Qliphoth counter(how many works it takes for meltdown) calculation adjusted slightly. Each player will increase it by 0.65(instead of 0.5), but starts at minimum of 3 instead of 4.
- Qliphoth meltdown announcement will now say what next ordeal will be, if it happens on next meltdown.
- Currently running ordeals are stored in a list in SSlobotomy_corp. This is used in "!tgs check" Discord command.
- Some cases of world.time usage have been replaced with ROUNDTIME define, which is adjusted by round-start time.

## Why It's Good For The Game

- Makes highpop slightly more bearable. On the other hand, lowpop will get a bit more demanding.
- QOL.
- Nice way of knowing what is really going on in the round before joining.
- World.time ticks before round has started, making some time checks incorrect. This fixes it.
