### PR TITLE
ZAYIN lore from vanilla LC + Blubbering Toad

### DIFF
--- a/code/modules/paperwork/records/lore/zayin.dm
+++ b/code/modules/paperwork/records/lore/zayin.dm
@@ -35,6 +35,31 @@
 	"Honestly, you can’t expect all of our employees to give honest confessions to that skull. Around every one in ten employees will tend to say something that is not completely true. It’s a bit different from a lie. You can say that it’s a subconscious excuse they make.<br>
 	They distort perspectives to justify their actions, even though they are aware that they should be telling the truth. Once this happens, the confession is no longer truly a confession. Yes, I’m talking about you trying to justify your tardiness for 5 minutes now!"}
 
+//Wellcheers
+/obj/item/paper/fluff/lore/zayin/shrimple
+	name = "F-05-52"
+	info = {"<h2><center>F-05-52</center></h2>	<br>
+	Opened Can of WellCheers <br>
+	<h3><center>Employees’ Records (Source Unknown)</center></h3><br>
+	"Hey have you guys ever been to one of those Lobotomy meetups?? Mind you, it took a lot of courage for me to bring this up again… You see, there’s a bunch of clubs in this company where employees gather up. I once attended some kinda ping-pong group event thing but there weren’t any girls there so I pulled out real quick lol.<br>
+	So like, one day I saw this announcement for some weird get-together on the corp message board. I got interested so I called up the group leader and he introduced himself as <Redacted> from Safety.<br>
+	I asked if there were any girls in the group, and he told me there were a ton of female employees. Now that got me super interested so I signed up right away for the upcoming meetup. So I showed up, got a name tag like everyone else. I don’t remember everything, but I think I saw like three people from Training and two from Information.<br>
+	About maybe half an hour later, the leader brought in dozens of cans of WellCheers on a tray and gave one to each of us… I should have realized something was wrong cause the can was already opened, but I’m a sucker for soda and I just gulped the damn thing down my throat the moment he passed me a can lmaooo"<br>
+	
+	"Now after that the leader told us it’s time to move, and he said he got a van rented for us. We all thought he was an awesome guy for that. I hopped in the van with two employees from the horde and one guy from the same dept as me.<br>
+	Leader said it was gunna take about an hour drive so we could just nap if we wanted, so we did. Weird thing was though, I went to sleep real fast, like real fast. Like, the moment I shut my eyes I was out like a light. I have insomnia but for whatever reason I fell asleep so fast then. Sigh...that was my big mistake.<br>
+	Anyways, I was sound asleep, but then I heard seagulls, and was like, Wtf??? Seagulls??????? Yeah, at first I thought it was someone’s phone alarm, but then I heard waves crashing. I was like, “man this is way too real to be a phone alarm,” so I opened my eyes to find myself……lying on a deck. I was on a goddamn boat, lmfao. AN ACTUAL, REAL-LIFE BOAT. I knew I was screwed the moment I saw shrimp hopping around. Sent chills down my spine. I wanted to believe it was all a dream but I swear that shrimp’s realistic flopping was a sobering sight. The realization crushed me like a hammer.<br>
+	And I was surrounded by people who looked like they were the crew. They were all beefed up, it felt like they’d put me back to sleep with force if I said something wrong. One slip and I’d be swimming with sharks."<br>
+	
+	"The crew was something around 10 people including the captain, boatswain, cook and all that. They all chuckled at me while I was spacing out. The guy who looked like the captain walked towards me and asked me about my height and weight. I asked him when the ship goes to port. He told me it’d be about a month but that I shouldn’t try and run away or anything cause they already made a deal with “my people”.<br>
+	I had no damn idea who “my people” were but I was too scared to ask. Then the other crew members called me over for lunch. They were making instant ramen, putting shrimp, crabs, clams, and all sorts of other stuff in it. They told me to stop acting like I was about to jump into the sea and to try their ramen. I said no at first, but they laughed at me again saying there weren’t any sleeping pills or stuff like that in it and gave me some anyway. A man’s gotta live, so I ate it. It tasted better than I expected it to.<br>
+	As soon as we finished lunch they told me they were going to teach me how to adjust the ropes. I pretty much gave up at that point, so I just simply answered “sure…”. All I could see anyways was these little islands that no one would have a chance at surviving on. For a month, I learned how to pull up fish traps, fill bait boxes, repair fishing nets, cook some ramen, get coffee, and all sorts of stuff.<br>
+	
+	I kept getting better and I got to the point where I could prepare mackerel sashimi and fish stew for the crew. Everyone complimented it. Said I could open a restaurant with that stew. Later on, we went through a couple of typhoons. Them and I started forming some kind of bond. A companionship. Whales were becoming a common sight at that point. Two weeks in, the captain told me I was pretty good and asked me if I was interested in officially joining the crew. When I thought about it, I would have been fired from the Corp anyway, so this seemed like a legit opportunity to make a living. This was the first time I ever got a compliment after all.<br>
+
+	What am I doing now? Well, I’ve been promoted and now I’m living fine. I’ve found true happiness in cracking open a cold one after a hard day’s work, covered in sea water and sweat. I’m at the port now but we gotta take off soon to catch some more shrimp. Never know what your future holds, bros.<br>
+	Sometimes I think about those other folk who were at the meetup that day. Not that I really wanna snoop around to find out though, I just try to keep a positive mind. I wanna say they’re hopefully doing good just like me. Oh, it’s time to sail out, see you guys."}
+
 //BALD
 /obj/item/paper/fluff/lore/zayin/bald
 	name = "BALD-IS-AWESOME"
@@ -86,3 +111,78 @@
 	"The fairies are no more than carnivorous monsters, and their "protection" is their method to keep the meat fresh. When an employee enters another Containment Unit, they gobble them up in fear that they would lose their food to something else.<br>
 	However, the employees were greatly satisfied by the fairies' care, and we saw a drastic decrease in the accident rate, so we deemed it unnecessary to tell the truth to the employees."}
 
+//We can change anything
+/obj/item/paper/fluff/lore/zayin/change
+	name = "T-09-85"
+	info = {"<h2><center>T-09-85</center></h2>	<br>
+	"After the popularity of the “All-Around Helper” skyrocketed, “We Can Change Anything” was released as the second installment of XX Inc’s home robot series."<br>
+	<br>
+	"As to be expected of all of XX Inc’s products, it sports a variety of functions."<br>
+	<br>
+	"Is your child a troublemaker who cries all the time? We can change that!<br>
+	
+	Don’t like how you look? Are you too fat? Too skinny? We can change that!<br>
+	
+	Is your house suffering from an outage because you don’t have the money to pay for the power bill? We can change that!"<br>
+	<br>
+	"It’s quite simple. Just open up the machine, step inside, and press the button to make it shut. Now everything will be just fine."<br>
+	<br>
+	"The machine will produce energy after an employee enters it. Seeing as once inside, nobody ever comes out, it must be rather comfortable."<br>
+	
+	<h3><center>Excerpt from X Corp's Nest</center></h3><br>
+	"In my mind, I've envisioned an ideal world. In this City, there is untold suffering no matter where you go. Whether it be the Backstreets where you fend for your life every day, or the Nest where you toil with no end in sight... there will always be suffering. That's why I created this product: to see that everyone's happiness was assured.<br>
+
+	Many people, even in the face of such untold strife, have trouble ending it all. In a sense, this helper robot is guiding them toward that goal. In the end, everyone dies, right? So why not speed it along so that their suffering can end? It might be painful in this way, sure, but at least they know that they have a companion every step of the way.<br>
+
+	Some might dismiss this machine as a mere suicide vending machine as you would find in N Corp or elsewhere, but I like to think of this machine as beyond that. My machine is akin to a personal care assistant that wishes nothing more than to help its owner. The difference between their machines and mine is that mine has a sense of attachment in its willingness to help. Sure, many might not agree with its method of 'help', but can you deny that death is a much more preferable fate to many of those in the City?<br>
+
+	When I've created enough of these machines to help every last person in the City, that is when I too will step into the machine. I yearn to be freed from the miserable droning day-to-day life of Nest work. No matter how tolerable I try to make it for others and myself, it will forever be an endless yet depressing experience. To that end, I supply everyone with the hope that once our goal is complete, we can all step into the machine and know that everything will be just fine.<br>
+
+	I sincerely believe that, with enough time and resources, we can change everything."}
+
+//Blubbering Toad
+/obj/item/paper/fluff/lore/zayin/blubbering_toad
+	name = "T-02-158"
+	info = {"<h2><center>T-02-158</center></h2>	<br>
+	"A large Abnormality resembling a toad. Despite its giant stature, it is actually quite tame compared to most Abnormalities of its size. It rarely moves from its spot and mainly occupies itself with crooning mournfully within the confines of its containment unit. To some, it sounds like a song- to others, it just sounds like pathetic croaking."<br>
+
+	"When working with this Abnormality, all an Agent has to do is listen to its cries until work is completed. This does not stop rookie Agents from panicking when their first assignment is this large and imposing Abnormality; such incidents frequently produce complaints to their superiors that they were incapable of handling such a basic assignment. Such superiors tend to roll their eyes at how they could fail such a simple task that they consider boring even to the most enthusiastic employees."<br>
+	
+	"More patient Agents will find that listening to the Abnormality's cries has beneficial effects on their mood. On a personality test taken before and after work with this Abnormality, respondents frequently changed their answers from indifferent to sympathetic. Side effects of these beneficial effects include weeping, moaning, sobbing, and fits of harmless emotional outbursts. These changes tend to not last long after working with other more ferocious Abnormalities."<br>
+	<br>
+	<h3>Warning</h3><br>
+	"While some Agents find themselves contented after working with the Abnormality, others might find themselves losing patience and feel the urge to taunt the Abnormality either while off-duty or in the middle of a work. This is a reminder that you are not to touch the Abnormalities or go anywhere near them if you are not the one working on them. Even when working, it is required to not approach the Abnormality unless your work permits it. This Abnormality is an example of why we put this rule into place."	<br>
+
+	"The Abnormality's containment unit is a safe place for it, where it can cry to itself for as long as it wants. Others are welcome to listen if they desire, and the Abnormality would happily welcome such good listeners. When a foolhardy agent invades that safe place, there is nothing left for the Abnormality. After all, tears are a powerful force which drives us to depression and rage alike."<br>
+	<br>
+
+	<h3><center><Excerpt from Counseling Log></center></h3><br>
+	"This new employee, who I will keep anonymous as requested, was a pretty standard-fare rookie employee with an ego. Not E.G.O., mind you, but someone who thought that he was at the top of the world just because he got into a Wing. Judging by his answers to our personality test, he was oblivious to the lethal nature of his job. He seemed to like the idea of punishing Abnormalities for their 'impertinence' as he so put it.<br>
+
+	After his psychiatric evaluation, he got sent to work on the toad: repression work, just as he personally requested. That toad had an obvious effect on Agents sent to it, but I was curious to see how the new employee would respond to it. When he came back, I had to check his employee ID to verify it was him. With his face drenched in tears, he whispered a plea to recommend him to work on the toad again.<br>
+
+	As predicted, I could not find any signs of mental corruption despite this overwhelming personality change. By all accounts, he was a much better person than he had been when he first stepped into my office. Of course, in this facility, that just meant he was doomed to be killed off pretty quickly. Unfortunately, this made it a risk to have him work on any other Abnormalities, so I recommended he continue working on the toad until his state of mind eased itself and he was prepared to work on less forgiving Abnormalities.<br>
+
+	Thankfully, once he worked on the toad a few more times, he recovered enough that he was willing to work on other Abnormalities. Since then, he has been getting traces of his old ego back, but I believe that the experience humbled him. Humility's an important thing in this facility; the second you bite off more than you can chew, it bites you back."<br>
+	<br>
+
+	<h3><center>Excerpt of an Audio Record</center></h3><br>
+	"This is a part of the footage caught by a surveillance camera in the Containment Unit. The visual feed contains the employee sitting in front of the Abnormality in some sort of 'conversation'. Whether the employee understood words from the Abnormality is unclear as of this report.<br>
+
+	- Hey, sorry I didn't bring any snacks. I tried to sneak something in for you, but the captain caught me. I guess it was kinda stupid of me to open the bag before coming here, huh?<br>
+	- (Croaking noises)<br>
+	- Don't worry, I'll try to get something for you next time. What do you have to say today?<br>
+
+	(The employee continues sitting and listening to the Abnormality, which lets out repeated croaking noises for the remainder of the work. As the croaking continues, the employee begins to shed tears.)<br>
+
+	- You all good now, big guy? I gotta get going, but I promise I'll be back to hear more later.<br>
+	- (Croaking noises)<br>
+	- Oh, it's nothing, really. I just remembered someone from a long time ago. They're long gone now, but they helped me back then by listening to me. I was hoping I can do the same for you too.<br>
+	- (Croaking noises)<br>
+	- Don't worry. Even when someone sheds tears, there's always someone to wipe them away.<br>
+	(End of recording)"<br>
+	<br>
+
+	"We remind employees that Abnormalities are not meant to be treated as friends unless it is beneficial for the facility to do so. As the Abnormality does not benefit from such friendships, we require all employees to listen to it and nothing more."}
+	
+	


### PR DESCRIPTION
## About The Pull Request

This PR adds the remaining lore for ZAYIN-class Abnormalities both in LC13 and vanilla Lobotomy Corporation: notably for Wellcheers and We Can Change Anything. I also added an extra excerpt for We Can Change Anything to give it more 'meat' (since the base game lore is just for a tool Abnormality), as well as added completely new lore for Blubbering Toad.

## Why It's Good For The Game

Lore is always fun, I hope!

## Changelog
:cl:
add: Added Wellcheers lore
add: Added We Can Change Anything lore
add: Added Blubbering Toad lore
/:cl:
