### PR TITLE
Fixes the waltz of flowers to no longer deal double damage to humans

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/he/white_lake.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/white_lake.dm
@@ -128,13 +128,14 @@
 		REMOVE_TRAIT(src, TRAIT_NODROP, src)
 
 /obj/item/ego_weapon/flower_waltz/attack(mob/living/target, mob/living/carbon/human/user, proximity)
-	var/enemy = 0
+	var/enemy = FALSE
 	for(var/found_faction in target.faction)
 		if(found_faction in nemesis_factions) // if we are hitting a nemesis...
 			force += faction_bonus_force
-			enemy = 1
+			enemy = TRUE
+			break
 	. = ..()
-	if(enemy == 1) // we should delete the extra force ONLY if we hit a nemesis
+	if(enemy) // we should delete the extra force ONLY if we hit a nemesis
 		force -= faction_bonus_force
 
 //Slightly different AI lines

--- a/code/modules/mob/living/simple_animal/abnormality/he/white_lake.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/white_lake.dm
@@ -115,6 +115,10 @@
 	attack_verb_continuous = list("slices", "cuts")
 	attack_verb_simple = list("slices", "cuts")
 	hitsound = 'sound/weapons/bladeslice.ogg'
+	// The damage we add when attacking the nemesis faction (abnormalities)
+	var/faction_bonus_force = 22
+	// list of nemesis factions (things we deal bonus damage to)
+	var/list/nemesis_factions = list("hostile")
 	//No requirements because who knows who will use it.
 
 // Sets the weapon to not be droppable until it's moved from the main hand. No more leg sweeping.
@@ -123,16 +127,15 @@
 	if (slot != ITEM_SLOT_HANDS)
 		REMOVE_TRAIT(src, TRAIT_NODROP, src)
 
-/obj/item/ego_weapon/flower_waltz/pre_attack(atom/A, mob/living/user, params)
+/obj/item/ego_weapon/flower_waltz/attack(mob/living/target, mob/living/carbon/human/user, proximity)
+	var/enemy = 0
+	for(var/found_faction in target.faction)
+		if(found_faction in nemesis_factions) // if we are hitting a nemesis...
+			force += faction_bonus_force
+			enemy = 1
 	. = ..()
-	if (!ishuman(A) && istype(A, /mob/living))
-		force = 44
-	return
-
-/obj/item/ego_weapon/flower_waltz/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
-	. = ..()
-	force = 22
-	return
+	if(enemy == 1) // we should delete the extra force ONLY if we hit a nemesis
+		force -= faction_bonus_force
 
 //Slightly different AI lines
 /datum/ai_controller/insane/murder/whitelake


### PR DESCRIPTION

## About The Pull Request

(needs a bit of test-merging on the real server, just to make sure it works properly)

Currently the waltz of flowers refuses to change its force back to 22 when you end an attack, causing it to become a permanent 44 pale damage weapon when you hit an abnormality (if the champion hits an abnormality whilst insane, they are now 2 times as effective as they should be against humans. oh no)

So instead i made it like it should have been from the beginning, 
if you hit a person it will deal 22 pale 
and any simple mob that is in the hostile faction (sorry pug murderers, this wont apply to you) will be dealt 44 pale damage instead

## Video's showing how it was broken

<details>
<summary>Before</summary>

https://github.com/vlggms/lobotomy-corp13/assets/82319946/1faeaea4-8ab4-4683-8a62-55c33fa1d0f5

</details>

<details>
<summary>After</summary>

https://github.com/vlggms/lobotomy-corp13/assets/82319946/8b1a7728-4be1-494a-b63f-1536f79b1dc7

</details>

## Why It's Good For The Game

Because it dosent function as it should, holy the friendly fire is real

## Changelog
:cl:
fix: fixed WL's weapon
/:cl:
