### PR TITLE
[TG PORT] adjustHealth Code Cleanup

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/he/porccubus.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/porccubus.dm
@@ -133,7 +133,7 @@
 		return
 	PorcDash(target)
 
-/mob/living/simple_animal/hostile/abnormality/porccubus/adjustHealth(amount)
+/mob/living/simple_animal/hostile/abnormality/porccubus/adjustHealth(amount, updating_health, forced)
 	..()
 	if(amount > 0)
 		damage_taken = TRUE

--- a/code/modules/mob/living/simple_animal/damage_procs.dm
+++ b/code/modules/mob/living/simple_animal/damage_procs.dm
@@ -1,11 +1,23 @@
 
+/**
+ * Adjusts the health of a simple mob by a set amount and wakes AI if its idle to react
+ *
+ * Arguments:
+ * * amount The amount that will be used to adjust the mob's health
+ * * updating_health If the mob's health should be immediately updated to the new value
+ * * forced If we should force update the adjustment of the mob's health no matter the restrictions, like GODMODE
+ */
 /mob/living/simple_animal/proc/adjustHealth(amount, updating_health = TRUE, forced = FALSE)
-	if(!forced && (status_flags & GODMODE))
-		return FALSE
-	bruteloss = round(clamp(bruteloss + amount, 0, maxHealth * 2), DAMAGE_PRECISION)
-	if(updating_health)
-		updatehealth()
-	return amount
+	. = FALSE
+	if(forced || !(status_flags & GODMODE))
+		bruteloss = round(clamp(bruteloss + amount, 0, maxHealth * 2), DAMAGE_PRECISION)
+		if(updating_health)
+			updatehealth()
+		. = amount
+	if(ckey || stat)
+		return
+	if(AIStatus == AI_IDLE)
+		toggle_ai(AI_ON)
 
 /mob/living/simple_animal/adjustBruteLoss(amount, updating_health = TRUE, forced = FALSE)
 	if(forced)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -706,13 +706,6 @@
 	if (pulledby || shouldwakeup)
 		toggle_ai(AI_ON)
 
-/mob/living/simple_animal/adjustHealth(amount, updating_health = TRUE, forced = FALSE)
-	. = ..()
-	if(!ckey && !stat)//Not unconscious
-		if(AIStatus == AI_IDLE)
-			toggle_ai(AI_ON)
-
-
 /mob/living/simple_animal/onTransitZ(old_z, new_z)
 	..()
 	if (AIStatus == AI_Z_OFF)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
**Original PR:** https://github.com/tgstation/tgstation/pull/56966
> This PR cleans up duplicate definition of the AdjustHealth proc for simplemobs, as otherwise you cannot properly locate the definition via VSCode DMcode plugins. No functionality changes, as this is exactly how it already works - duplicate definition calls the "real" proc definition via ..(). Autodoc documentation of the relevant proc included.

## Why It's Good For The Game
Improves code readability without functionality changes.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: adjustHealth proc
/:cl:
