### PR TITLE
Doomsday Calendar Adjustments 2: Electric Boogaloo

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/he/doomsday_calendar.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/doomsday_calendar.dm
@@ -180,6 +180,7 @@
 	SpawnAdds()
 
 /mob/living/simple_animal/hostile/abnormality/doomsday_calendar/proc/AnnounceBreach()
+	addtimer(CALLBACK(GLOBAL_PROC, .proc/show_global_blurb, 5, "The day of the apocalypse has arrived.", 25))
 	for(var/mob/living/carbon/human/H in livinginrange(20, src))//same range as universe aflame when fully charged
 		if(H.z != z)
 			return
@@ -244,14 +245,17 @@
 			for(var/turf/T in range(aflame_range, src))
 				new /obj/effect/temp_visual/doomsday(T)
 				for(var/mob/living/H in T)
+					for(var/mob/living/simple_animal/hostile/abnormality/A in T)
+						if(!(A.IsContained()))
+							continue
+						A.datum_reference.qliphoth_change(-1)
 					if(faction_check_mob(H))
 						continue
 					H.apply_damage(aflame_damage, BLACK_DAMAGE, null, H.run_armor_check(null, BLACK_DAMAGE), spread_damage = TRUE)
 					if(H.stat >= SOFT_CRIT || H.health < 0)
 						H.fire_stacks += 1
 						H.IgniteMob()//unforunately this fire isn' blue.
-						//H.add_overlay(mutable_appearance('icons/mob/onfire.dmi', "Standing", -ABOVE_OBJ_LAYER))
-			adjustBruteLoss(500)
+			adjustBruteLoss(1000)
 
 /mob/living/simple_animal/hostile/abnormality/doomsday_calendar/proc/AoeBurn()
 	pulse_cooldown = world.time + pulse_cooldown_time

--- a/code/modules/paperwork/records/info/he.dm
+++ b/code/modules/paperwork/records/info/he.dm
@@ -340,7 +340,7 @@
 	abno_type = /mob/living/simple_animal/hostile/abnormality/doomsday_calendar
 	abno_code = "M-04-146"//M-04-04-05 in LCB
 	abno_info = list(
-		"Performing any work on three other abnormalities reduced the Qliphoth Counter.",
+		"Performing any work on other abnormalities slowly reduced the Qliphoth Counter.",
 		"When the work result was Bad, the Qliphoth Counter lowered.",
 		"This abnormality generates additional PE-boxes when the Qliphoth Counter is lower.",
 		"When an employee performed Instinct work, the Qliphoth Counter rose to the maximum.",
@@ -348,7 +348,8 @@
 		"Instinct work was more successful at lower Qliphoth counters.",
 		"When the Qliphoth Counter reached 0, Doomsday Calendar appeared at a department center with an entourage of clay dolls, dubbed M-04-145-A.",
 		"Offering human remains or the remains of M-04-145-A to Doomsday Calendar during suppression work aided in suppression.",
-		"If suppression work is performed too slowly, Doomsday Calendar will become progressively more dangerous.")
+		"If suppression work is performed too slowly, Doomsday Calendar will become progressively more dangerous.",
+		"Failure to complete suppression work led to the reduction of Qliphoth Counters near the location of Doomsday Calendar.")
 	abno_breach_damage_type = "Red"
 	abno_breach_damage_count = "High"
 	abno_resistances = list(RED_DAMAGE = "Normal", WHITE_DAMAGE = "Weak", BLACK_DAMAGE = "Endured", PALE_DAMAGE = "Weak")//for clay dolls


### PR DESCRIPTION
A threat you cannot ignore

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Currently, players have 2.5 minutes to suppress the abnormality following its breach, and the abnormality itself is immobile. With these in mind, there is currently no penalty for simply ignoring the breach and moving to a different department. This PR will double the self-damage caused by Doomsday Calendar's black AOE from 500 to 1,000, reducing its maximum activations from 5 to 3. Since it has 2012 maximum health, only two will be possible after dealing 12 damage to it. However, this PR will make it more threatening by causing its radial BLACK damage AOE to reduce qliphoth counters. 

Additionally, a highly visible warning will be provided in the event of a breach. While it may be a bit flashy, I believe that it is necessary for an abnormality of a rather low risk level and tendency to breach when ignored.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

In a playtest, I was able to prevent this wearing nothing but fourth match flame, sorority, and 60 fortitude & justice. The breach announcement will also make its suppression much easier to co-ordinate with other players.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: changes doomsday calendar's penalty for failing to suppress it, makes its breach more obvious.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
