### PR TITLE
Thunderbird bug fix

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/waw/thunder_bird.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/thunder_bird.dm
@@ -9,6 +9,7 @@ GLOBAL_LIST_EMPTY(zombies)
 	icon_dead = "thunderbird_dead"
 	del_on_death = FALSE
 	speak_emote = list("intones")
+	gender = NEUTER
 	var/list/thunder_bird_lines = list(
 				"Prostrate yourself! Harder!",
 				"Do you think I am happy, feather? Think again!",
@@ -279,14 +280,13 @@ GLOBAL_LIST_EMPTY(zombies)
 		return
 	can_act = FALSE
 	playsound(src, 'sound/abnormalities/thunderbird/tbird_zombify.ogg', 45, FALSE, 5)
-	for(var/i = 1 to 4)
-		new /obj/effect/temp_visual/sparks(get_turf(src))
 	var/mob/living/simple_animal/hostile/thunder_zombie/C = new(get_turf(src))
 	if(!QDELETED(H))
 		C.name = "[H.real_name]"//applies the target's name and adds the name to its description
 		C.icon_state = "human_thunderbolt"
 		C.icon_living = "human_thunderbolt"
 		C.desc = "What appears to be [H.real_name], only charred and screaming incoherently..."
+		C.gender = H.gender
 		H.gib()
 	can_act = TRUE
 
@@ -314,6 +314,7 @@ GLOBAL_LIST_EMPTY(zombies)
 	icon_living = "human_thunderbolt"
 	icon_dead = "human_thunderbolt_dead"
 	speak_emote = list("groans", "moans", "howls", "screeches", "grunts")
+	gender = NEUTER
 	attack_verb_continuous = "attacks"
 	attack_verb_simple = "attack"
 	attack_sound = 'sound/abnormalities/thunderbird/tbird_zombieattack.ogg'
@@ -343,21 +344,21 @@ GLOBAL_LIST_EMPTY(zombies)
 		return
 	can_act = FALSE
 	forceMove(get_turf(H))
-	damage_coeff = list(BRUTE = 1, RED_DAMAGE = 0, WHITE_DAMAGE = 0, BLACK_DAMAGE = 0, PALE_DAMAGE = 0)
 	playsound(src, 'sound/abnormalities/thunderbird/tbird_zombify.ogg', 45, FALSE, 5)
 	SLEEP_CHECK_DEATH(3)
 	for(var/i = 1 to 4)
 		new /obj/effect/temp_visual/sparks(get_turf(src))
 		SLEEP_CHECK_DEATH(5.5)
-	var/mob/living/simple_animal/hostile/thunder_zombie/C = new(get_turf(src))
 	if(!QDELETED(H))
+		if(!H.real_name)
+			return FALSE
+		var/mob/living/simple_animal/hostile/thunder_zombie/C = new(get_turf(src))
 		C.name = "[H.real_name]"//applies the target's name and adds the name to its description
 		C.icon_state = "human_thunderbolt"
 		C.icon_living = "human_thunderbolt"
 		C.desc = "What appears to be [H.real_name], only charred and screaming incoherently..."
+		C.gender = H.gender
 		H.gib()
-	damage_coeff = list(BRUTE = 1, RED_DAMAGE = 0.6, WHITE_DAMAGE = 0.8, BLACK_DAMAGE = 0.4, PALE_DAMAGE = 1)
-	adjustBruteLoss(-(maxHealth*0.1))
 	can_act = TRUE
 
 //Zombie conversion from zombie kills


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes a bug with thunderbird where multiple attacking zombies on the same target would create duplicate zombies. Also removes some unintended features and cleans the code a bit.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Bugs are generally bad for the game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: adds proper genders to the abnormality and its zombies
fix: changes a bug where duplicate thunder zombies can appear
code: thunderbird zombies no longer change resistances while converting or heal after a kill
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
