### PR TITLE
2 new neutral quirks, minor quirk rebalance

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -339,10 +339,11 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 //positive quirks
 #define TRAIT_RESISTANT      	"resistant"
 #define TRAIT_SKILLED    	    "skilled"
-#define TRAIT_FLUFFY_TONGUE    	    "fluffy_tongue" // technically not positive, but it costs points
+#define TRAIT_FLUFFY_TONGUE     "fluffy_tongue" // technically not positive, but it costs points
 //neutral quirks
 #define TRAIT_NERD          	"nerd"
 #define TRAIT_BRAWLER    	    "brawler"
+#define TRAIT_ARTIST    	    "artist"
 //negative quirks
 #define TRAIT_MINOR_RED     	"minor_red"
 #define TRAIT_MAJOR_RED	        "major_red"
@@ -358,7 +359,7 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define TRAIT_FATAL_PALE      	"fatal_pale"
 #define TRAIT_GUNS          	"guns"       // used for the "no guns" challenge
 #define TRAIT_HEALING          	"healing"    // used for the "no medipens" challenge
-//special quirks end
+//lobotomy quirk traits end
 #define TRAIT_ALCOHOL_TOLERANCE	"alcohol_tolerance"
 #define TRAIT_AGEUSIA			"ageusia"
 #define TRAIT_HEAVY_SLEEPER		"heavy_sleeper"

--- a/code/_globalvars/traits.dm
+++ b/code/_globalvars/traits.dm
@@ -179,6 +179,7 @@ GLOBAL_LIST_INIT(traits_by_type, list(
 		"TRAIT_SKILLED" = TRAIT_SKILLED,
 		"TRAIT_NERD" = TRAIT_NERD,
 		"TRAIT_BRAWLER" = TRAIT_BRAWLER,
+		"TRAIT_ARTIST" = TRAIT_ARTIST,
 		"TRAIT_GUNS" = TRAIT_GUNS,               // used for the "no guns" challenge
 		"TRAIT_HEALING" = TRAIT_HEALING,          // used for the "no medipens" challenge
 		"TRAIT_FLUFFY_TONGUE" = TRAIT_FLUFFY_TONGUE

--- a/code/datums/quirks/negative.dm
+++ b/code/datums/quirks/negative.dm
@@ -392,7 +392,7 @@
 /datum/quirk/insanity
 	name = "Reality Dissociation Syndrome"
 	desc = "You suffer from a severe disorder that causes very vivid hallucinations. Mindbreaker toxin can suppress its effects, and you are immune to mindbreaker's hallucinogenic properties. <b>This is not a license to grief.</b>"
-	value = -1
+	value = -2
 	//no mob trait because it's handled uniquely
 	gain_text = "<span class='userdanger'>...</span>"
 	lose_text = "<span class='notice'>You feel in tune with the world again.</span>"

--- a/code/datums/quirks/neutral.dm
+++ b/code/datums/quirks/neutral.dm
@@ -25,6 +25,73 @@
 	H.physiology.red_mod -= 0.05
 	H.physiology.white_mod += 0.1
 
+/datum/quirk/family_heirloom // re-naming the quirk in the code causes a lot of problems, so leaving it as-is
+	name = "Plushie lover"
+	desc = "You love plushies so much that you take them to work with you, you start with 1 plushie that changes depending on your job"
+	value = 0
+	var/obj/item/heirloom
+	var/where
+	medical_record_text = "This patient takes their plushies everywhere."
+
+/datum/quirk/family_heirloom/on_spawn()
+	var/mob/living/carbon/human/H = quirk_holder
+	var/obj/item/heirloom_type
+	switch(quirk_holder.mind.assigned_role)
+		// Command
+		if("Manager")
+			heirloom_type = pick(/obj/item/toy/plush/angela)
+		if("Extraction Officer")
+			heirloom_type = pick(/obj/item/toy/plush/binah)
+		if("Records Officer")
+			heirloom_type = pick(/obj/item/toy/plush/hokma)
+		if("Agent Captain")
+			heirloom_type = pick(/obj/item/toy/plush/mosb, /obj/item/toy/plush/melt)
+		if("Sephirah") //Today im NOT giving a GUN to HOD
+			heirloom_type = pick(/obj/item/toy/plush/malkuth, /obj/item/toy/plush/netzach, /obj/item/toy/plush/hod, /obj/item/toy/plush/lisa, /obj/item/toy/plush/enoch, /obj/item/toy/plush/yesod, /obj/item/toy/plush/gebura)
+		// Common folk
+		if("Agent")
+			heirloom_type = pick(/obj/item/toy/plush/bigbird, /obj/item/toy/plush/big_bad_wolf)
+		if("Agent Intern")
+			heirloom_type = pick(/obj/item/toy/plush/scorched)
+		if("Clerk")
+			heirloom_type = pick(/obj/item/toy/plush/moth)
+		// Ruins test
+		if("Rabbit Team Leader")
+			heirloom_type = pick(/obj/item/toy/plush/myo)
+		if("Rabbit Team")
+			heirloom_type = pick(/obj/item/toy/plush/rabbit)
+	if(!heirloom_type) // we fucked up, give them whatever
+		heirloom_type = pick(
+		/obj/item/toy/cards/deck,
+		/obj/item/lighter,
+		/obj/item/dice/d20)
+	heirloom = new heirloom_type(get_turf(quirk_holder))
+	var/list/slots = list(
+		LOCATION_LPOCKET = ITEM_SLOT_LPOCKET,
+		LOCATION_RPOCKET = ITEM_SLOT_RPOCKET,
+		LOCATION_HANDS = ITEM_SLOT_HANDS
+	)
+	where = H.equip_in_one_of_slots(heirloom, slots, FALSE) || "at your feet"
+
+/datum/quirk/family_heirloom/post_add()
+	to_chat(quirk_holder, "<span class='boldnotice'>There is a precious family [heirloom.name] [where], passed down from generation to generation. Keep it safe!</span>")
+
+	var/list/names = splittext(quirk_holder.real_name, " ")
+	var/family_name = names[names.len]
+
+	heirloom.AddComponent(/datum/component/heirloom, quirk_holder.mind, family_name)
+
+/datum/quirk/artist
+	name = "Artist"
+	desc = "You are an artist and constantly seek out inspiration in your enviroment, you carry art supplies with you"
+	value = 0
+	medical_record_text = "The patient always has painting supplies with them, do not ask them why else they might become aggresive"
+
+/datum/quirk/artist/on_spawn()
+	var/mob/living/carbon/human/H = quirk_holder
+	var/obj/item/storage/toolbox/artistic/art = new(get_turf(H))
+	H.put_in_hands(art)
+
 // Special quirks end
 
 /datum/quirk/nearsighted //t. errorage
@@ -52,72 +119,6 @@
 	gain_text = "<span class='danger'>You feel like a pushover.</span>"
 	lose_text = "<span class='notice'>You feel like standing up for yourself.</span>"
 	medical_record_text = "Patient presents a notably unassertive personality and is easy to manipulate."
-
-/datum/quirk/family_heirloom
-	name = "Family Heirloom"
-	desc = "You are the current owner of an heirloom, passed down for generations. You have to keep it safe!"
-	value = 0
-	var/obj/item/heirloom
-	var/where
-	medical_record_text = "This patient takes their family heirloom everywhere."
-
-/datum/quirk/family_heirloom/on_spawn()
-	var/mob/living/carbon/human/H = quirk_holder
-	var/obj/item/heirloom_type
-
-	if(ismoth(H) && prob(50))
-		heirloom_type = /obj/item/flashlight/lantern/heirloom_moth
-	else
-		switch(quirk_holder.mind.assigned_role)
-			//Command
-			if("Manager")
-				heirloom_type = pick(/obj/item/toy/plush/angela)
-			if("Extraction Officer")
-				heirloom_type = pick(/obj/item/toy/plush/binah)
-			if("Records Officer")
-				heirloom_type = pick(/obj/item/toy/plush/hokma)
-			if("Agent Captain")
-				heirloom_type = pick(/obj/item/reagent_containers/food/drinks/soda_cans/outskirts_wind)
-			//Common folk
-			if("Veteran Agent")
-				heirloom_type = pick(/obj/item/toy/plush/mosb, /obj/item/toy/plush/melt, /obj/item/toy/plush/moth)
-			if("Senior Agent")
-				heirloom_type = pick(/obj/item/toy/plush/malkuth, /obj/item/toy/plush/netzach, /obj/item/toy/plush/hod, /obj/item/toy/plush/lisa, /obj/item/toy/plush/enoch, /obj/item/toy/plush/yesod, /obj/item/toy/plush/gebura)
-			if("Agent")
-				heirloom_type = pick(/obj/item/clothing/accessory/armband/lobotomy, /obj/item/clothing/accessory/armband/lobotomy/training, /obj/item/clothing/accessory/armband/lobotomy/safety, /obj/item/clothing/accessory/armband/lobotomy/command, /obj/item/clothing/accessory/armband/lobotomy/info, /obj/item/clothing/accessory/armband/lobotomy/discipline)
-			if("Agent Intern")
-				heirloom_type = pick(/obj/item/paper/guides/jobs/zayin/guide)
-			if("Clerk")
-				heirloom_type = pick(/obj/item/toy/crayon/spraycan/infinite)
-			//Technically un-obtainable, but im adding them anyway because why not.
-			if("Rabbit Team Leader")
-				heirloom_type = pick(/obj/item/toy/plush/myo)
-			if("Rabbit Team")
-				heirloom_type = pick(/obj/item/toy/plush/rabbit)
-			//Today im giving a GUN to HOD, lets see what happens :)
-			if("Sephirah")
-				heirloom_type = pick(/obj/item/gun/ego_gun/clerk)
-
-	if(!heirloom_type)
-		heirloom_type = pick(
-		/obj/item/toy/cards/deck,
-		/obj/item/lighter,
-		/obj/item/dice/d20)
-	heirloom = new heirloom_type(get_turf(quirk_holder))
-	var/list/slots = list(
-		LOCATION_LPOCKET = ITEM_SLOT_LPOCKET,
-		LOCATION_RPOCKET = ITEM_SLOT_RPOCKET,
-		LOCATION_HANDS = ITEM_SLOT_HANDS
-	)
-	where = H.equip_in_one_of_slots(heirloom, slots, FALSE) || "at your feet"
-
-/datum/quirk/family_heirloom/post_add()
-	to_chat(quirk_holder, "<span class='boldnotice'>There is a precious family [heirloom.name] [where], passed down from generation to generation. Keep it safe!</span>")
-
-	var/list/names = splittext(quirk_holder.real_name, " ")
-	var/family_name = names[names.len]
-
-	heirloom.AddComponent(/datum/component/heirloom, quirk_holder.mind, family_name)
 
 /datum/quirk/empath
 	name = "Empath"

--- a/code/game/objects/items/RCL.dm
+++ b/code/game/objects/items/RCL.dm
@@ -12,7 +12,7 @@
 	throw_speed = 1
 	throw_range = 7
 	w_class = WEIGHT_CLASS_NORMAL
-	var/max_amount = 90
+	var/max_amount = 1000
 	var/active = FALSE
 	actions_types = list(/datum/action/item_action/rcl_col,/datum/action/item_action/rcl_gui,)
 	var/list/colors = list("red", "yellow", "green", "blue", "pink", "orange", "cyan", "white")
@@ -66,37 +66,6 @@
 			return
 		update_icon()
 		to_chat(user, "<span class='notice'>You add the pipe cleaners to [src]. It now contains [loaded.amount].</span>")
-	else if(W.tool_behaviour == TOOL_SCREWDRIVER)
-		if(!loaded)
-			return
-		if(ghetto && prob(10)) //Is it a ghetto RCL? If so, give it a 10% chance to fall apart
-			to_chat(user, "<span class='warning'>You attempt to loosen the securing screws on the side, but it falls apart!</span>")
-			while(loaded.amount > 30) //There are only two kinds of situations: "nodiff" (60,90), or "diff" (31-59, 61-89)
-				var/diff = loaded.amount % 30
-				if(diff)
-					loaded.use(diff)
-					new /obj/item/stack/pipe_cleaner_coil(get_turf(user), diff)
-				else
-					loaded.use(30)
-					new /obj/item/stack/pipe_cleaner_coil(get_turf(user), 30)
-			qdel(src)
-			return
-
-		to_chat(user, "<span class='notice'>You loosen the securing screws on the side, allowing you to lower the guiding edge and retrieve the wires.</span>")
-		while(loaded.amount > 30) //There are only two kinds of situations: "nodiff" (60,90), or "diff" (31-59, 61-89)
-			var/diff = loaded.amount % 30
-			if(diff)
-				loaded.use(diff)
-				new /obj/item/stack/pipe_cleaner_coil(get_turf(user), diff)
-			else
-				loaded.use(30)
-				new /obj/item/stack/pipe_cleaner_coil(get_turf(user), 30)
-		loaded.max_amount = initial(loaded.max_amount)
-		if(!user.put_in_hands(loaded))
-			loaded.forceMove(get_turf(user))
-
-		loaded = null
-		update_icon()
 	else
 		..()
 

--- a/code/game/objects/items/storage/toolbox.dm
+++ b/code/game/objects/items/storage/toolbox.dm
@@ -202,16 +202,12 @@
 	STR.max_items = 10
 
 /obj/item/storage/toolbox/artistic/PopulateContents()
-	new /obj/item/storage/crayons(src)
 	new /obj/item/crowbar(src)
-	new /obj/item/stack/pipe_cleaner_coil/red(src)
-	new /obj/item/stack/pipe_cleaner_coil/yellow(src)
-	new /obj/item/stack/pipe_cleaner_coil/blue(src)
-	new /obj/item/stack/pipe_cleaner_coil/green(src)
-	new /obj/item/stack/pipe_cleaner_coil/pink(src)
-	new /obj/item/stack/pipe_cleaner_coil/orange(src)
-	new /obj/item/stack/pipe_cleaner_coil/cyan(src)
-	new /obj/item/stack/pipe_cleaner_coil/white(src)
+	new /obj/item/wirecutters(src)
+	new /obj/item/soap(src)
+	new /obj/item/toy/crayon/spraycan/infinite(src)
+	new /obj/item/stack/pipe_cleaner_coil/random(src)
+	new /obj/item/rcl/pre_loaded(src)
 
 /obj/item/storage/toolbox/ammo
 	name = "ammo box"


### PR DESCRIPTION

## About The Pull Request

Adds 2 "new" neutral quirks:

- Plushie lover:
gives you a random plushie depending on your job, previously family heirloom but its named and description were made more clear, along with removing some junk

- Artist:
Gives you the new lobotomy corporation certified artistic toolbox, its contents include:
wirecutters and crowbar, for floor and cable layer removal
soap for spraycan removal
infinite spraycan, for making spraycan art
cable coils and the rapid cable coil layer device, for making cable art


This also deletes the interaction of a screwdriver on the cable coil device
increases the max wire of cable coils from 90 to 1000, as normal cable coils already had that
of course replaces the artistic toolbox that ss13 had, making it more with our type
makes the hallucination quirk worth 1 more point (it was meant to be 2 originally since it can straight up insta-stun you)


## Why It's Good For The Game

More art = more good, Also i think only betacorp has the rapid cable layer device... mappers you have failed me

## Changelog
:cl:
add: Added 2 new neutral quirks
tweak: tweaked the contents of the artistic toolbox
balance: insanity quirk now is worth 2 points, from 1
fix: rapid cable coil device now holds 1000 coils, up from 90.
/:cl:
