### PR TITLE
Timestop Fix

### DIFF
--- a/code/modules/fields/timestop.dm
+++ b/code/modules/fields/timestop.dm
@@ -184,7 +184,7 @@
 	L.Stun(20, ignore_canstun = TRUE)
 	ADD_TRAIT(L, TRAIT_MUTE, TIMESTOP_TRAIT)
 	walk(L, 0) //stops them mid pathing even if they're stunimmune
-	if(isanimal(L))
+	if(isanimal(L) && !(L.status_flags & GODMODE))
 		var/mob/living/simple_animal/S = L
 		S.toggle_ai(AI_OFF)
 	if(ishostile(L))
@@ -195,7 +195,7 @@
 	L.AdjustStun(-20, ignore_canstun = TRUE)
 	REMOVE_TRAIT(L, TRAIT_MUTE, TIMESTOP_TRAIT)
 	frozen_mobs -= L
-	if(isanimal(L))
+	if(isanimal(L) && !(L.status_flags & GODMODE))
 		var/mob/living/simple_animal/S = L
 		S.toggle_ai(initial(S.AIStatus))
 


### PR DESCRIPTION
## About The Pull Request

These goddamn Jojo roleplayers keep breaking the game!!
Makes the AI fuckery to check for godmode so it won't mess with contained abos
You're not supposed to fuck with any godmoded NPCs anyway

This is a really small change, maybe you should close it and put it in a bigger project

## Why It's Good For The Game

Stops ROs from breaking the game

## Changelog
:cl:
fix: fixed RO watch
/:cl: