### PR TITLE
Fixes the harmony gift

### DIFF
--- a/code/modules/mob/living/carbon/human/ego_gifts.dm
+++ b/code/modules/mob/living/carbon/human/ego_gifts.dm
@@ -637,14 +637,6 @@
 	justice_bonus = 1
 	slot = HAND_1
 
-/datum/ego_gifts/harmony
-	name = "Harmony"
-	icon_state = "harmony"
-	prudence_bonus = 5
-	temperance_bonus = -5
-	justice_bonus = 5
-	slot = MOUTH_2
-
 /datum/ego_gifts/homing_instinct
 	name = "Homing Instinct"
 	icon_state = "homing_instinct"


### PR DESCRIPTION

## About The Pull Request

Removes the re-defined harmony gift that for some reason existed, the normal HE gift is actually its HE grade. and the re-defined one is ALEPH for some reason

## Why It's Good For The Game

because gifts being defined multiple times make it confusing for people to see a gift, also it was probably un-intentional since the change came in PR #879 that added a lot of missing gifts

## Changelog
:cl:
fix: fixed the harmony gift
/:cl:
