### PR TITLE
Fixes clown smiling at me getting stuck on mob corpses

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/waw/clown_smiling.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/clown_smiling.dm
@@ -86,10 +86,17 @@
 		icon_state = icon_aggro
 
 //Execution code from green dawn with inflated damage numbers
+/mob/living/simple_animal/hostile/abnormality/clown/CanAttack(atom/the_target)
+	if(isliving(the_target) && !ishuman(the_target))
+		var/mob/living/L = the_target
+		if(L.stat == DEAD)
+			return FALSE
+	return ..()
+
 /mob/living/simple_animal/hostile/abnormality/clown/AttackingTarget()
 	. = ..()
 	if(.)
-		if(!istype(target, /mob/living/carbon/human))
+		if(!ishuman(target))
 			return
 		var/mob/living/carbon/human/TH = target
 		if(TH.health < 0)
@@ -170,7 +177,6 @@
 	..()
 	if(locate(/obj/structure/clown_picture) in get_turf(src))
 		return
-	icon_state = "clown_smiling"
 	new /obj/structure/clown_picture(get_turf(src))
 
 /obj/structure/clown_picture


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes a bug introduced in https://github.com/vlggms/lobotomy-corp13/pull/1133 whereupon the abnormality could get stuck when attacking a non-human corpse. Technically a buff, but shouldn't cause any real issues as it fixes a rather critical bug.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes a bug caused by a bugfix, classic.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: the clown can now gib corpses
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
