### PR TITLE
Landmine tweaks

### DIFF
--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -43,9 +43,16 @@
 	if(AM.movement_type & FLYING)
 		return
 
+	if(!ismob(AM))
+		return
+
 	triggermine(AM)
 
 /obj/effect/mine/take_damage(damage_amount, damage_type, damage_flag, sound_effect, attack_dir)
+	. = ..()
+	triggermine()
+
+/obj/effect/mine/hitby()
 	. = ..()
 	triggermine()
 


### PR DESCRIPTION

## About The Pull Request

Landmines now dont trigger by items being thrown over them (You can still shoot them)
Landmines now only cross trigger by mobs
If a landmine is dense (none are by default) and something throws and hits it, it now triggers
## Why It's Good For The Game

Light sources, now dont trigger landmines anymore, woo.

## Changelog
:cl:
tweak: Landmines now dont trigger by items being thrown over them and now only mobs when crossing them will trigger.
/:cl:
