### PR TITLE
PE Has a Purpose

### DIFF
--- a/ModularTegustation/tegu_items/records/ordealcheck.dm
+++ b/ModularTegustation/tegu_items/records/ordealcheck.dm
@@ -26,8 +26,13 @@
 
 
 	//PE stuff. He doesn't really need to know this but information and all that
-	if(SSlobotomy_corp.box_goal != INFINITY)	//Make sure it's not infinity
-		to_chat(user, "<span class='notice'>PE Goal: [SSlobotomy_corp.current_box] / [SSlobotomy_corp.box_goal].</span>")
+	if(SSlobotomy_corp.box_goal != 0)	//Make sure it's not infinity
+		if(SSlobotomy_corp.goal_reached)
+			to_chat(user, "<span class='notice'>PE Quota Reached!</span><br><span class='notice'>Current PE: [SSlobotomy_corp.available_box]</span>")
+		else
+			to_chat(user, "<span class='notice'>PE Goal: [SSlobotomy_corp.goal_boxes + SSlobotomy_corp.available_box] / [SSlobotomy_corp.box_goal].</span>")
+	else
+		to_chat(user, "<span class='notice'>PE Quota is still being calculated, please hold.</span>")
 
 	//Ordeal stuff
 	to_chat(user, "<span class='notice'>Current qliphoth meter: [SSlobotomy_corp.qliphoth_meter] / [SSlobotomy_corp.qliphoth_max].</span>")

--- a/ModularTegustation/tegu_items/refinery/sales.dm
+++ b/ModularTegustation/tegu_items/refinery/sales.dm
@@ -48,6 +48,7 @@
 		cut_overlays()
 		var/obj/item/holochip/C = new (get_turf(src))
 		C.credits = rand(ahn_amount/4,ahn_amount)
+		SSlobotomy_corp.AdjustGoalBoxes(100) // 50 PE for 100 PE, not including the cost of filters. This eventually gets us positive in spendable PE, once we reach goal...
 
 	//gacha time
 	if(crate_timer  <= 0)

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -334,6 +334,8 @@
 	parts += goal_report()
 	//Economy & Money
 	parts += market_report()
+	//PE Quota
+	parts += pe_report()
 
 	listclearnulls(parts)
 
@@ -557,6 +559,25 @@
 	else
 		parts += "Somehow, nobody made any money this shift! This'll result in some budget cuts...</div>"
 	return parts
+
+/datum/controller/subsystem/ticker/proc/pe_report()
+	. = list()
+	. += "<span class='header'>PE Quota</span>"
+	. += "<div class='panel stationborder'>"
+	. += "[SSlobotomy_corp.total_generated] total PE was generated.<br>"
+	if(SSlobotomy_corp.goal_boxes)
+		. += "[SSlobotomy_corp.goal_boxes] PE was refined or otherwise generated through alternative means.<br>"
+	if(SSlobotomy_corp.total_spent)
+		. += "[SSlobotomy_corp.total_spent] PE was spent on various things.<br>"
+	if(SSlobotomy_corp.goal_reached)
+		. += "PE Quota was reached!<br>"
+	else
+		if(SSlobotomy_corp.total_spent >= SSlobotomy_corp.box_goal)
+			. += "Enough PE to meet PE Quota was made, but you spent it all!? You'll be hearing from our lawyers.<br>"
+		else
+			. += "PE Quota was not reached! Don't expect to have a job tomorrow...<br>"
+	. += "</div>"
+	return
 
 /datum/controller/subsystem/ticker/proc/medal_report()
 	if(GLOB.commendations.len)

--- a/code/controllers/subsystem/lobotomy_corp.dm
+++ b/code/controllers/subsystem/lobotomy_corp.dm
@@ -185,7 +185,6 @@ SUBSYSTEM_DEF(lobotomy_corp)
 			pod.explosionSize = list(0,0,0,0)
 			to_chat(person, "<span class='nicegreen'>It's pizza time!</span>")
 			new /obj/effect/pod_landingzone(get_turf(person), pod)
-		available_box = max(available_box - (goal_boxes - box_goal), 0) // Consume the remaining "available boxes" (The stuff we can spend) to fill out the goal.
 	return
 
 /datum/controller/subsystem/lobotomy_corp/proc/QliphothUpdate(amount = 1)

--- a/code/controllers/subsystem/lobotomy_corp.dm
+++ b/code/controllers/subsystem/lobotomy_corp.dm
@@ -60,8 +60,17 @@ SUBSYSTEM_DEF(lobotomy_corp)
 	// Work logs from all abnormalities
 	var/list/work_logs = list()
 
-	var/current_box = 0
-	var/box_goal = INFINITY // Initialized later
+	// PE available to be spent
+	var/available_box = 0
+	// PE specifically for PE Quota
+	var/goal_boxes = 0
+	// Total PE generated
+	var/total_generated = 0
+	// Total PE spent
+	var/total_spent = 0
+	// The number we must reach
+	var/box_goal = 0 // Initialized later
+	// Where we reached our goal
 	var/goal_reached = FALSE
 	/// When TRUE - abnormalities can be possessed by ghosts
 	var/enable_possession = FALSE
@@ -138,11 +147,31 @@ SUBSYSTEM_DEF(lobotomy_corp)
 /datum/controller/subsystem/lobotomy_corp/proc/WorkComplete(amount = 0, qliphoth_change = TRUE)
 	if(qliphoth_change)
 		QliphothUpdate()
-	AdjustBoxes(amount)
+	AdjustAvailableBoxes(amount)
 
-/datum/controller/subsystem/lobotomy_corp/proc/AdjustBoxes(amount)
-	current_box = clamp((current_box + amount), 0, box_goal)
-	if((current_box >= box_goal) && !goal_reached) // Also TODO: Make it do something other than this
+/datum/controller/subsystem/lobotomy_corp/proc/AdjustAvailableBoxes(amount)
+	available_box = max((available_box + amount), 0)
+	if(amount > 0)
+		total_generated += amount
+	else
+		total_spent -= amount
+	CheckGoal()
+
+/datum/controller/subsystem/lobotomy_corp/proc/AdjustGoalBoxes(amount)
+	if(goal_reached)
+		AdjustAvailableBoxes(amount)
+		return
+	goal_boxes = max(goal_boxes + amount, 0)
+	if(amount > 0)
+		total_generated += amount
+	else
+		total_spent -= amount
+	CheckGoal()
+
+/datum/controller/subsystem/lobotomy_corp/proc/CheckGoal()
+	if(goal_reached || box_goal == 0)
+		return
+	if(available_box + goal_boxes >= box_goal)
 		goal_reached = TRUE
 		priority_announce("The energy production goal has been reached.", "Energy Production", sound='sound/misc/notice2.ogg')
 		var/pizzatype_list = subtypesof(/obj/item/food/pizza)
@@ -156,7 +185,8 @@ SUBSYSTEM_DEF(lobotomy_corp)
 			pod.explosionSize = list(0,0,0,0)
 			to_chat(person, "<span class='nicegreen'>It's pizza time!</span>")
 			new /obj/effect/pod_landingzone(get_turf(person), pod)
-		return
+		available_box = max(available_box - (goal_boxes - box_goal), 0) // Consume the remaining "available boxes" (The stuff we can spend) to fill out the goal.
+	return
 
 /datum/controller/subsystem/lobotomy_corp/proc/QliphothUpdate(amount = 1)
 	qliphoth_meter += amount

--- a/code/game/machinery/computer/abnormality_queue.dm
+++ b/code/game/machinery/computer/abnormality_queue.dm
@@ -97,7 +97,7 @@
 		message_admins("[usr] has [logstring] the anomaly to [initial(target_type.name)].")
 		locked = TRUE
 		// PE awarded for yellow roll - just as kirie had wanted.
-		SSlobotomy_corp.current_box += 250
+		SSlobotomy_corp.available_box += 250
 		to_chat(usr, "<span class='notice'>The headquarters reimbursed you the costs of extracting a specific abnormality. You will receive a random one.</span>")
 		SSabnormality_queue.AnnounceLock()
 		SSabnormality_queue.ClearChoices()

--- a/code/game/machinery/computer/extraction_cargo.dm
+++ b/code/game/machinery/computer/extraction_cargo.dm
@@ -112,7 +112,14 @@
 	if(isliving(user))
 		playsound(src, 'sound/machines/terminal_prompt_confirm.ogg', 50, FALSE)
 	var/dat
-	dat += "[SSlobotomy_corp.current_box]/[SSlobotomy_corp.box_goal] PE <br>"
+	dat += "Available PE: [SSlobotomy_corp.available_box] <br>"
+	if(SSlobotomy_corp.box_goal != 0)
+		if(SSlobotomy_corp.goal_reached)
+			dat += "PE Quota has been reached, well done!<br>"
+		else
+			dat += "Goal Progress: [max(SSlobotomy_corp.available_box+SSlobotomy_corp.goal_boxes, 0)]/[SSlobotomy_corp.box_goal] <br>"
+	else
+		dat += "Today's PE Quota is still being calculated, please hold. <br>"
 	for(var/level = CAT_GADGET to CAT_OTHER) //IF YOU ADD A NEW CATAGORY GO FROM FIRST DEFINED CATAGORY TO LAST TO AVOID BREAKAGE  -IP
 		dat += "<A href='byond://?src=[REF(src)];set_level=[level]'>[level == selected_level ? "<b><u>[name_catagory(level)]</u></b>" : "[name_catagory(level)]"]</A>"
 	dat += "<br>"
@@ -145,12 +152,12 @@
 			if(!product_datum)
 				to_chat(usr, "<span class='warning'>ERROR.</span>")
 				return FALSE
-			if(SSlobotomy_corp.current_box < product_datum.cost)
+			if(SSlobotomy_corp.available_box < product_datum.cost)
 				to_chat(usr, "<span class='warning'>Not enough PE boxes stored for this operation.</span>")
 				playsound(get_turf(src), 'sound/machines/terminal_prompt_deny.ogg', 50, TRUE)
 				return FALSE
 			new product_datum.equipment_path(get_turf(src))
-			SSlobotomy_corp.AdjustBoxes(-1 * product_datum.cost)
+			SSlobotomy_corp.AdjustAvailableBoxes(-1 * product_datum.cost)
 			playsound(get_turf(src), 'sound/machines/terminal_prompt_confirm.ogg', 50, TRUE)
 			updateUsrDialog()
 			return TRUE

--- a/code/modules/ordeals/_ordeal.dm
+++ b/code/modules/ordeals/_ordeal.dm
@@ -42,9 +42,9 @@
 
 // Ends the event
 /datum/ordeal/proc/End()
-	var/total_reward = SSlobotomy_corp.box_goal * reward_percent
+	var/total_reward = max(SSlobotomy_corp.box_goal, 3000) * reward_percent
 	priority_announce("The ordeal has ended. Facility has been rewarded with [reward_percent*100]% PE.", name, sound=null)
-	SSlobotomy_corp.AdjustBoxes(total_reward)
+	SSlobotomy_corp.AdjustAvailableBoxes(total_reward)
 	SSlobotomy_corp.current_ordeals -= src
 	if(end_sound)
 		for(var/mob/M in GLOB.player_list)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This introduces the following changes, I'll go by category:
Lobotomy Subsystem:

- Added `goal_boxes` variable, a variable designed to track unspendable PE.
- Added `total_generated` and `total_spent` variables, designed to track exactly what they say.
- Renamed `AdjustBoxes` to `AdjustAvailableBoxes` and added an `AdjustGoalBoxes` proc that redirects toward the prior if goal has been reached.
- Moved the PE goal checking function to a separate proc so it could be called by both above procs without copy-pasting code.
- `box_goal` is no longer defaulted to INFINITY, instead it's defaulted to 0 and anything checking for PE Quota will return an in-progress message if it is 0.
- `available_boxes` is no longer capped by `box_goal`.

Cargo Console:

- Shows both Available PE (The stuff you can spend) and progress toward quota, or a congratulatory message if met.

Round End:

- Added a PE Generation report that shows how much PE was generated, how much was spent, how much was made through alternative methods (such as cargo), and if PE Quota was reached.

Refinery (Sales):

- Sales machines now generate 100 PE, aimed towards `goal_boxes`. If Quota is reached, this PE is instead spendable.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The statistics are nice.
Overall helps make refining PE actually progress the round, instead of bricking Quota. Also generates excess if you've already completed the requirements. 
Otherwise, it's presentation.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->


<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
