### PR TITLE
Removes Attacking Through Walls Cheese From Some Egos

### DIFF
--- a/code/game/objects/items/ego_weapons/aleph.dm
+++ b/code/game/objects/items/ego_weapons/aleph.dm
@@ -29,7 +29,7 @@
 	var/turf/target_turf = get_turf(A)
 	if(!istype(target_turf))
 		return
-	if((get_dist(user, target_turf) < 2) || (get_dist(user, target_turf) > 10))
+	if((get_dist(user, target_turf) < 2) || !(target_turf in view(10, user)))
 		return
 	..()
 	var/mob/living/carbon/human/H = user

--- a/code/game/objects/items/ego_weapons/teth.dm
+++ b/code/game/objects/items/ego_weapons/teth.dm
@@ -311,7 +311,7 @@
 	var/turf/target_turf = get_turf(A)
 	if(!istype(target_turf))
 		return
-	if((get_dist(user, target_turf) < 2) || (get_dist(user, target_turf) > 5))
+	if((get_dist(user, target_turf) < 2) || !(target_turf in view(5, user)))
 		return
 	..()
 	ranged_cooldown = world.time + ranged_cooldown_time

--- a/code/game/objects/items/ego_weapons/waw.dm
+++ b/code/game/objects/items/ego_weapons/waw.dm
@@ -448,7 +448,7 @@
 	var/turf/target_turf = get_turf(A)
 	if(!istype(target_turf))
 		return
-	if((get_dist(user, target_turf) < 2) || (get_dist(user, target_turf) > 10))
+	if((get_dist(user, target_turf) < 2) || !(target_turf in view(10, user)))
 		return
 	..()
 	ranged_cooldown = world.time + ranged_cooldown_time


### PR DESCRIPTION
## About The Pull Request

Removes the ability to attack mobs through walls for Paradise Lost, Ebony Stem, and Hearth

## Why It's Good For The Game

The only good cheese is the cheesecake

## Changelog
:cl:
fix: fixed egos attacking through walls
/:cl: