### PR TITLE
Toy tactical uniform sensors

### DIFF
--- a/code/modules/clothing/under/syndicate.dm
+++ b/code/modules/clothing/under/syndicate.dm
@@ -40,6 +40,8 @@
 	name = "tactical uniform"
 	desc = "A simple black turtleneck with digital camo pants, worn by many fixers and corporate security."
 	icon_state = "tactifool"
+	has_sensor = HAS_SENSORS
+	sensor_mode = SENSOR_COORDS
 	inhand_icon_state = "bl_suit"
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0,ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 50, ACID = 40)
 


### PR DESCRIPTION

## About The Pull Request

The fake tactical uniform now has adjustable sensors on by default

## Why It's Good For The Game

The reward from the arcade or finding it shouldn't be a punishment

## Changelog
:cl:
tweak: The fake tactical uniform now has adjustable sensors on by default
/:cl:
