### PR TITLE
Remove Steel Ordeal Dexteriity

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/ordeal/steel.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/steel.dm
@@ -22,7 +22,6 @@
 	attack_verb_simple = "stab"
 	footstep_type = FOOTSTEP_MOB_SHOE
 	a_intent = INTENT_HELP
-	dextrous = TRUE
 	possible_a_intents = list(INTENT_HELP, INTENT_HARM)
 	//similar to a human
 	damage_coeff = list(BRUTE = 1, RED_DAMAGE = 0.8, WHITE_DAMAGE = 1.2, BLACK_DAMAGE = 1, PALE_DAMAGE = 1)
@@ -67,7 +66,6 @@
 	health = 750
 	rapid_melee = 2
 	damage_coeff = list(BRUTE = 1, RED_DAMAGE = 0.8, WHITE_DAMAGE = 1, BLACK_DAMAGE = 0.8, PALE_DAMAGE = 0.8)
-	dextrous = FALSE
 	attack_verb_continuous = "slashes"
 	attack_verb_simple = "slash"
 	deathsound = 'sound/voice/mook_death.ogg'
@@ -215,7 +213,6 @@
 	wander = FALSE
 	patrol_cooldown_time = 1 MINUTES
 	footstep_type = FOOTSTEP_MOB_SHOE
-	dextrous = TRUE
 	possible_a_intents = list(INTENT_HELP, INTENT_DISARM, INTENT_HARM)
 	deathsound = 'sound/voice/hiss5.ogg'
 	butcher_results = list(/obj/item/food/meat/slab/human = 2, /obj/item/food/meat/slab/human/mutant/moth = 1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Steel Ordeals apparently have been using the elevator and other consoles including the managers console on playables round. 

## Why It's Good For The Game
When a monster has dexterity set to true they get a cute little hud for different intents. I was told when Little Chuckles had dexterity set to True they couldnt work and i assumed that limited what skullduggery they can partake in. I did not consider ordeals going upto the managers office, killing the manager, rolling yellow over and over. 

In summary this devastation is unintentional.

## Changelog
:cl:
tweak: Steel Ordeal Dexterity
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
