### PR TITLE
standardize watch spawn amounts

### DIFF
--- a/_maps/map_files/Lambda/lambdacorp.dmm
+++ b/_maps/map_files/Lambda/lambdacorp.dmm
@@ -9997,9 +9997,6 @@
 /turf/open/floor/plasteel/sepia,
 /area/department_main/information)
 "KK" = (
-/obj/item/records/timestop,
-/obj/item/records/information,
-/obj/item/records/abnodelay,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
@@ -12659,7 +12656,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral,
-/obj/structure/closet/secure_closet/record,
+/obj/structure/closet{
+	icon_state = "records"
+	},
 /obj/structure/disposalpipe/segment{
 	color = "#0000ff"
 	},

--- a/_maps/map_files/Zeta/zetacorp.dmm
+++ b/_maps/map_files/Zeta/zetacorp.dmm
@@ -806,9 +806,6 @@
 	dir = 8
 	},
 /obj/structure/closet/secure_closet/record,
-/obj/item/records/abnodelay,
-/obj/item/records/information,
-/obj/item/records/timestop,
 /obj/item/clothing/accessory/armband/lobotomy/records,
 /obj/item/clothing/accessory/armband/lobotomy/records,
 /obj/item/clothing/accessory/armband/lobotomy/records,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

this *should* in theory be the last of the extra watches. removed extra watches from k corp and f corp.

## Why It's Good For The Game

maps should always have same watch amount for the ro. i checked the other maps, so hopefully thats now true across the board

