### PR TITLE
Meltdown Rebalance and Autovote Removal

### DIFF
--- a/code/controllers/subsystem/autotransfer.dm
+++ b/code/controllers/subsystem/autotransfer.dm
@@ -10,9 +10,8 @@ SUBSYSTEM_DEF(autotransfer)
 /datum/controller/subsystem/autotransfer/Initialize(timeofday)
 	starttime = world.time
 	targettime = starttime + CONFIG_GET(number/vote_autotransfer_initial)
-
-	if(!CONFIG_GET(flag/vote_autotransfer_enabled))
-		can_fire = FALSE
+	
+	can_fire = FALSE
 
 	. = ..()
 

--- a/code/controllers/subsystem/lobotomy_corp.dm
+++ b/code/controllers/subsystem/lobotomy_corp.dm
@@ -202,9 +202,9 @@ SUBSYSTEM_DEF(lobotomy_corp)
 	var/abno_amount = all_abnormality_datums.len
 	var/player_count = 0
 	for(var/mob/player in GLOB.player_list)
-		if(isliving(player))
+		if(isliving(player) && (player.mind?.assigned_role in GLOB.security_positions))
 			player_count += 1
-	qliphoth_max = 3 + round(player_count * 0.65)
+	qliphoth_max = (player_count > 1 ? 4 : 3) + round(player_count * 0.8) // Some extra help on non solo rounds
 	qliphoth_state += 1
 	for(var/datum/abnormality/A in all_abnormality_datums)
 		if(istype(A.current))

--- a/code/modules/suppressions/extraction.dm
+++ b/code/modules/suppressions/extraction.dm
@@ -316,8 +316,9 @@
 	current_meltdown_type = meltdown_type
 	var/player_count = 0
 	for(var/mob/player in GLOB.player_list)
-		if(isliving(player))
-			player_count += 1
+		if(isliving(player) && (player.mind?.assigned_role in GLOB.security_positions))
+			player_count += 1.5
+	player_count = round(player_count) + (player_count > round(player_count) ? 1 : 0) // Trying to round up
 	meltdowns = SSlobotomy_corp.InitiateMeltdown(clamp(rand(player_count*0.5, player_count), 1, 10), TRUE, meltdown_type, meltdown_min_time, meltdown_max_time, meltdown_text, 'sound/magic/arbiter/meltdown.ogg')
 	for(var/obj/machinery/computer/abnormality/A in meltdowns)
 		RegisterSignal(A, COMSIG_MELTDOWN_FINISHED, .proc/OnMeltdownFinish)


### PR DESCRIPTION
## About The Pull Request

- Removes timed shuttle votes that keeps happening automatically
- Changes meltdown counter to only count agents that is controlled and increases the melt/agent by a bit
- Changes Binyah meltdown amount to only count agents that is controlled. (1,5 each, rounded up. 1 melt per person is too easy)

For reference, normal meltdown counter per agent:
3, 5, 6, 7, 8, 8, 9

## Why It's Good For The Game

- Stops the 4 officers, 5 clerks, and 2 fishooks from prolonging the game
- Stops Ecorp from breaking the game
- Stops the pesky shuttle vote that keeps happening automatically
- Makes Binyah more fair on lower pops

## Notes
Apparently the meltdown amount for normal and apog meltdowns are always 35% of current abos
Idk if I should change it to help lowpop or nah, choosing the melts you do seems like a good mechanic
Also need a TM

## Changelog
:cl:
del: Autotransfer vote
balance: Normal meltdown's counter and Binyah's meltdown amount
/:cl: