### PR TITLE
Parasite Tree is now from Lobotomy corp

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/waw/parasite_tree.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/parasite_tree.dm
@@ -32,6 +32,7 @@
 		/datum/ego_datum/armor/hypocrisy
 		)
 
+	abnormality_origin = ABNORMALITY_ORIGIN_LOBOTOMY
 	gift_type =  /datum/ego_gifts/hypocrisy
 	gift_message = "Your ears seem to have grown longer. Weird."
 	var/origin_cooldown = 0 //null when compared to numbers is a eldritch concept so world.time cannot be more or less.


### PR DESCRIPTION
## Changelog
:cl:
fix: Parasite Tree is now from Lobotomy corp
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
