### PR TITLE
Work damage is now consistent

### DIFF
--- a/code/__HELPERS/abnormalities.dm
+++ b/code/__HELPERS/abnormalities.dm
@@ -3,7 +3,7 @@
 	switch(resist)
 		if(0 to 0) //Just putting 0 doesn't work.
 			return "Immune"
-		if(1 to 1) 
+		if(1 to 1)
 			return "Normal"
 		if(-INFINITY to 0)
 			return "Absorbed"
@@ -48,17 +48,17 @@
 			return "None"
 		if(-INFINITY to 0)
 			return "Healing"
-		if(0 to 3)
+		if(0 to 5)
 			return "Very Low"
-		if(3 to 6)
+		if(5 to 7)
 			return "Low"
-		if(6 to 9)
+		if(7 to 10)
 			return "Moderate"
-		if(9 to 12)
+		if(10 to 14)
 			return "High"
-		if(15 to INFINITY)
+		if(18 to INFINITY)
 			return "Extreme"
-		if(12 to 15)
+		if(14 to 18)
 			return "Very High"
 
 	return "Unknown ([damage])"

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/blue_star.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/blue_star.dm
@@ -23,7 +23,7 @@
 						ABNORMALITY_WORK_ATTACHMENT = 0,
 						ABNORMALITY_WORK_REPRESSION = 40
 						)
-	work_damage_amount = 16
+	work_damage_amount = 19
 	work_damage_type = WHITE_DAMAGE
 	can_patrol = FALSE
 

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/censored.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/censored.dm
@@ -32,7 +32,7 @@
 						ABNORMALITY_WORK_REPRESSION = 0,
 						"Sacrifice" = 999,
 						)
-	work_damage_amount = 14
+	work_damage_amount = 16
 	work_damage_type = BLACK_DAMAGE
 
 	ego_list = list(

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/melting_love.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/melting_love.dm
@@ -32,7 +32,7 @@
 						ABNORMALITY_WORK_ATTACHMENT = list(20, 30, 40, 50, 55),
 						ABNORMALITY_WORK_REPRESSION = list(0, 0, 0, 0, 0),
 						)
-	work_damage_amount = 14
+	work_damage_amount = 17
 	work_damage_type = BLACK_DAMAGE
 	/* Sounds */
 	projectilesound = 'sound/effects/attackblob.ogg'

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/mountain.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/mountain.dm
@@ -32,7 +32,7 @@
 						ABNORMALITY_WORK_ATTACHMENT = 0,
 						ABNORMALITY_WORK_REPRESSION = list(0, 0, 0, 50, 55)
 						)
-	work_damage_amount = 16
+	work_damage_amount = 17
 	work_damage_type = BLACK_DAMAGE
 
 	ego_list = list(

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/nihil.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/nihil.dm
@@ -25,7 +25,7 @@
 	melee_damage_type = RED_DAMAGE
 	armortype = RED_DAMAGE
 	stat_attack = HARD_CRIT
-	work_damage_amount = 16
+	work_damage_amount = 20
 	work_damage_type = RED_DAMAGE
 	attack_verb_continuous = "claws"
 	attack_verb_simple = "claw"

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/nothing_there.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/nothing_there.dm
@@ -29,7 +29,7 @@
 						ABNORMALITY_WORK_ATTACHMENT = 50,
 						ABNORMALITY_WORK_REPRESSION = 0
 						)
-	work_damage_amount = 16
+	work_damage_amount = 17
 	work_damage_type = RED_DAMAGE
 
 	ego_list = list(

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/seasons.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/seasons.dm
@@ -36,7 +36,7 @@
 						ABNORMALITY_WORK_ATTACHMENT = list(5, 10, 15, 50, 55),
 						ABNORMALITY_WORK_REPRESSION = list(5, 10, 15, 50, 55)
 						)
-	work_damage_amount = 14
+	work_damage_amount = 19
 	work_damage_type = WHITE_DAMAGE
 
 	ego_list = list(

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/space_lady.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/space_lady.dm
@@ -21,7 +21,7 @@
 						ABNORMALITY_WORK_ATTACHMENT = list(40, 40, 40, 45, 45),
 						ABNORMALITY_WORK_REPRESSION = list(0, 0, 30, 30, 30)
 						)
-	work_damage_amount = 8	//Half white, half black damage
+	work_damage_amount = 9	//Half white, half black damage
 	work_damage_type = WHITE_DAMAGE
 
 	ego_list = list(

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/staining_rose.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/staining_rose.dm
@@ -17,7 +17,7 @@
 		ABNORMALITY_WORK_REPRESSION = list(0, 0, 0, 45, 50)
 			)
 	start_qliphoth = 1
-	work_damage_amount = 14
+	work_damage_amount = 15
 	work_damage_type = PALE_DAMAGE
 	pixel_x = -16
 	base_pixel_x = -16

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/titania.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/titania.dm
@@ -18,7 +18,7 @@
 	start_qliphoth = 3
 	move_to_delay = 4
 
-	work_damage_amount = 16
+	work_damage_amount = 17
 	work_damage_type = RED_DAMAGE
 	can_breach = TRUE
 

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/white_night.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/white_night.dm
@@ -32,7 +32,7 @@ GLOBAL_LIST_EMPTY(apostles)
 						ABNORMALITY_WORK_ATTACHMENT = list(30, 30, 35, 40, 45),
 						ABNORMALITY_WORK_REPRESSION = list(30, 30, 35, 40, 45)
 						)
-	work_damage_amount = 14
+	work_damage_amount = 17
 	work_damage_type = PALE_DAMAGE
 	can_patrol = FALSE
 

--- a/code/modules/mob/living/simple_animal/abnormality/he/KHz.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/KHz.dm
@@ -15,7 +15,7 @@
 		"Input One" = 0,		//These should never be used, but it's here for brevity
 		"Input Zero" = 0
 	)
-	work_damage_amount = 12
+	work_damage_amount = 9
 	work_damage_type = WHITE_DAMAGE
 
 	ego_list = list(

--- a/code/modules/mob/living/simple_animal/abnormality/he/blue_shepherd.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/blue_shepherd.dm
@@ -32,7 +32,7 @@
 	melee_damage_type = BLACK_DAMAGE
 	armortype = BLACK_DAMAGE
 	stat_attack = HARD_CRIT
-	work_damage_amount = 10
+	work_damage_amount = 11
 	work_damage_type = BLACK_DAMAGE
 	attack_verb_continuous = "cuts"
 	attack_verb_simple = "cuts"

--- a/code/modules/mob/living/simple_animal/abnormality/he/der_freischutz.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/der_freischutz.dm
@@ -11,7 +11,7 @@
 		ABNORMALITY_WORK_ATTACHMENT = 30, // Can you believe he has actual attachment work rates in LC proper, despite that you can't do attachment work on him there?
 		ABNORMALITY_WORK_REPRESSION = list(0, 0, 60, 60, 60)
 		)
-	work_damage_amount = 8 // This was halved what it should be.
+	work_damage_amount = 9 // This was halved what it should be.
 	work_damage_type = BLACK_DAMAGE
 
 	ego_list = list(

--- a/code/modules/mob/living/simple_animal/abnormality/he/doomsday_calendar.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/doomsday_calendar.dm
@@ -24,7 +24,7 @@
 						ABNORMALITY_WORK_ATTACHMENT = 20,
 						ABNORMALITY_WORK_REPRESSION = 50
 						)
-	work_damage_amount = 8
+	work_damage_amount = 9
 	work_damage_type = BLACK_DAMAGE
 	can_patrol = FALSE
 	wander = FALSE

--- a/code/modules/mob/living/simple_animal/abnormality/he/fan.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/fan.dm
@@ -14,7 +14,7 @@
 		ABNORMALITY_WORK_ATTACHMENT = 100,
 		ABNORMALITY_WORK_REPRESSION = 100
 	)
-	work_damage_amount = 5	//This literally does not matter
+	work_damage_amount = 10
 	work_damage_type = RED_DAMAGE
 	max_boxes = 12
 

--- a/code/modules/mob/living/simple_animal/abnormality/he/funeral.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/funeral.dm
@@ -30,7 +30,7 @@
 						ABNORMALITY_WORK_ATTACHMENT = 0,
 						ABNORMALITY_WORK_REPRESSION = list(0, 0, 60, 60, 60),
 						)
-	work_damage_amount = 12
+	work_damage_amount = 11
 	work_damage_type = WHITE_DAMAGE
 	max_boxes = 16
 	deathmessage = "gently descends into its own coffin."

--- a/code/modules/mob/living/simple_animal/abnormality/he/golden_false_apple.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/golden_false_apple.dm
@@ -47,7 +47,7 @@
 		ABNORMALITY_WORK_ATTACHMENT = 0,
 		ABNORMALITY_WORK_REPRESSION = list(0, 0, 15, 30, 45)
 		)
-	work_damage_amount = 12//decently high due to mechanics
+	work_damage_amount = 11//decently high due to mechanics
 	work_damage_type = RED_DAMAGE
 	max_boxes = 18
 

--- a/code/modules/mob/living/simple_animal/abnormality/he/happy_teddy_bear.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/happy_teddy_bear.dm
@@ -17,7 +17,7 @@
 		ABNORMALITY_WORK_ATTACHMENT = list(60, 60, 60, 50, 45),
 		ABNORMALITY_WORK_REPRESSION = list(40, 45, 45, 40, 35)
 	)
-	work_damage_amount = 10
+	work_damage_amount = 9
 	work_damage_type = WHITE_DAMAGE
 	max_boxes = 15
 	response_help_continuous = "hugs" // :-)

--- a/code/modules/mob/living/simple_animal/abnormality/he/helper.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/helper.dm
@@ -29,7 +29,7 @@
 						ABNORMALITY_WORK_ATTACHMENT = list(35, 40, 40, 35, 35),
 						ABNORMALITY_WORK_REPRESSION = list(50, 55, 55, 50, 45)
 						)
-	work_damage_amount = 10
+	work_damage_amount = 11
 	work_damage_type = RED_DAMAGE
 
 	ego_list = list(

--- a/code/modules/mob/living/simple_animal/abnormality/he/jangsan.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/jangsan.dm
@@ -25,7 +25,7 @@
 						ABNORMALITY_WORK_ATTACHMENT = 60,
 						ABNORMALITY_WORK_REPRESSION = 60
 						)
-	work_damage_amount = 10
+	work_damage_amount = 11
 	work_damage_type = RED_DAMAGE
 
 //Only done to non-humans, objects, and strong(er) agents

--- a/code/modules/mob/living/simple_animal/abnormality/he/laetitia.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/laetitia.dm
@@ -13,7 +13,7 @@
 		ABNORMALITY_WORK_ATTACHMENT = list(60, 60, 60, 65, 65),
 		ABNORMALITY_WORK_REPRESSION = 0
 			)
-	work_damage_amount = 8
+	work_damage_amount = 9
 	work_damage_type = BLACK_DAMAGE
 	max_boxes = 16 // Accurate to base game
 

--- a/code/modules/mob/living/simple_animal/abnormality/he/nameless_fetus.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/nameless_fetus.dm
@@ -17,7 +17,7 @@
 	base_pixel_x = -8
 
 	max_boxes = 16
-	work_damage_amount = 7
+	work_damage_amount = 9
 	work_damage_type = RED_DAMAGE
 	ego_list = list(
 //		/datum/ego_datum/weapon/syrinx,		Will update with the rest of the dump EGO

--- a/code/modules/mob/living/simple_animal/abnormality/he/pinocchio.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/pinocchio.dm
@@ -20,7 +20,7 @@
 	)
 
 	damage_coeff = list(BRUTE = 1, RED_DAMAGE = 1.2, WHITE_DAMAGE = 0.5, BLACK_DAMAGE = 0.7, PALE_DAMAGE = 0.9)
-	work_damage_amount = 8
+	work_damage_amount = 9
 	work_damage_type = WHITE_DAMAGE
 	max_boxes = 16
 

--- a/code/modules/mob/living/simple_animal/abnormality/he/porccubus.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/porccubus.dm
@@ -21,7 +21,7 @@
 	melee_damage_lower = 15
 	melee_damage_upper = 20
 	rapid_melee = 3 //you can withdraw out of its range very easily so it needs to be a little harder to melee it
-	work_damage_amount = 12
+	work_damage_amount = 11
 	can_patrol = FALSE //it can't move anyway but why not
 	stat_attack = HARD_CRIT
 	work_damage_type = BLACK_DAMAGE

--- a/code/modules/mob/living/simple_animal/abnormality/he/road_home.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/road_home.dm
@@ -23,7 +23,7 @@
 						ABNORMALITY_WORK_ATTACHMENT = 45,
 						ABNORMALITY_WORK_REPRESSION = list(50, 60, 70, 80, 90)
 						)
-	work_damage_amount = 10
+	work_damage_amount = 11
 	work_damage_type = BLACK_DAMAGE
 	can_patrol = FALSE
 	deathsound = 'sound/abnormalities/roadhome/House_NormalAtk.ogg'

--- a/code/modules/mob/living/simple_animal/abnormality/he/rudolta.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/rudolta.dm
@@ -24,7 +24,7 @@
 						ABNORMALITY_WORK_ATTACHMENT = list(40, 50, 50, 45, 40),
 						ABNORMALITY_WORK_REPRESSION = 0
 						)
-	work_damage_amount = 10
+	work_damage_amount = 9
 	work_damage_type = WHITE_DAMAGE
 	friendly_verb_continuous = "scorns"
 	friendly_verb_simple = "scorns"

--- a/code/modules/mob/living/simple_animal/abnormality/he/scaredy_cat.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/scaredy_cat.dm
@@ -30,7 +30,7 @@
 						ABNORMALITY_WORK_ATTACHMENT = list(40, 50, 55, 55, 55),
 						ABNORMALITY_WORK_REPRESSION = list(20, 30, 40, 40, 40)
 						) //higher work chance than the rest of oz because he can breach so easily
-	work_damage_amount = 7 //Shit damage because it's a small cat
+	work_damage_amount = 9 //Shit damage because it's a small cat
 	work_damage_type = RED_DAMAGE
 	can_patrol = FALSE
 	deathsound = 'sound/abnormalities/scaredycat/catgrunt.ogg'

--- a/code/modules/mob/living/simple_animal/abnormality/he/schadenfreude.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/schadenfreude.dm
@@ -28,7 +28,7 @@
 						ABNORMALITY_WORK_ATTACHMENT = list(40, 40, 40, 30, 20),
 						ABNORMALITY_WORK_REPRESSION = list(40, 45, 50, 55, 60)
 						)
-	work_damage_amount = 7
+	work_damage_amount = 10
 	work_damage_type = RED_DAMAGE
 
 	ego_list = list(

--- a/code/modules/mob/living/simple_animal/abnormality/he/silent_girl.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/silent_girl.dm
@@ -22,7 +22,7 @@
 						ABNORMALITY_WORK_ATTACHMENT = -50,
 						ABNORMALITY_WORK_REPRESSION = list(50, 55, 55, 60, 60)
 						)
-	work_damage_amount = 0
+	work_damage_amount = 9
 	work_damage_type = WHITE_DAMAGE
 	start_qliphoth = 3
 

--- a/code/modules/mob/living/simple_animal/abnormality/he/singing_machine.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/singing_machine.dm
@@ -20,7 +20,7 @@ Finally, an abnormality that DOESN'T have to do any fancy movement shit. It's a 
 		ABNORMALITY_WORK_REPRESSION = 40
 	)
 	// Adjusted the work chances a little to really funnel people through Instinct work. You can do other stuff... sort of.
-	work_damage_amount = 12
+	work_damage_amount = 10
 	work_damage_type = WHITE_DAMAGE
 	ego_list = list(
 		/datum/ego_datum/weapon/harmony,

--- a/code/modules/mob/living/simple_animal/abnormality/he/siren.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/siren.dm
@@ -17,7 +17,7 @@
 		ABNORMALITY_WORK_ATTACHMENT = 40,
 		ABNORMALITY_WORK_REPRESSION = 50
 		)
-	work_damage_amount = 11
+	work_damage_amount = 10
 	work_damage_type = WHITE_DAMAGE
 
 	ego_list = list(

--- a/code/modules/mob/living/simple_animal/abnormality/he/watchman.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/watchman.dm
@@ -28,7 +28,7 @@
 						ABNORMALITY_WORK_ATTACHMENT = 40,
 						ABNORMALITY_WORK_REPRESSION = 10
 						)
-	work_damage_amount = 7
+	work_damage_amount = 9
 	work_damage_type = BLACK_DAMAGE
 
 	ego_list = list(

--- a/code/modules/mob/living/simple_animal/abnormality/he/woodsman.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/woodsman.dm
@@ -28,7 +28,7 @@
 						ABNORMALITY_WORK_ATTACHMENT = list(50, 60, 70, 80, 90),
 						ABNORMALITY_WORK_REPRESSION = 45
 						)
-	work_damage_amount = 10
+	work_damage_amount = 9
 	work_damage_type = WHITE_DAMAGE
 	move_to_delay = 4
 	base_pixel_x = -16

--- a/code/modules/mob/living/simple_animal/abnormality/he/you_strong.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/you_strong.dm
@@ -16,7 +16,7 @@
 		"YES" = 0,
 		"NO" = 0
 	)
-	work_damage_amount = 8
+	work_damage_amount = 9
 	work_damage_type = RED_DAMAGE
 	ego_list = list(
 			/datum/ego_datum/weapon/get_strong,

--- a/code/modules/mob/living/simple_animal/abnormality/teth/MHz.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/MHz.dm
@@ -18,7 +18,7 @@
 		ABNORMALITY_WORK_ATTACHMENT = list(20, 10, 0, 0, 0),
 		ABNORMALITY_WORK_REPRESSION = list(55, 55, 60, 60, 60)
 		)
-	work_damage_amount = 5
+	work_damage_amount = 6
 	work_damage_type = WHITE_DAMAGE
 
 	ego_list = list(

--- a/code/modules/mob/living/simple_animal/abnormality/teth/beauty_beast.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/beauty_beast.dm
@@ -19,7 +19,7 @@
 		ABNORMALITY_WORK_ATTACHMENT = list(30, 15, -50, -50, -50),
 		ABNORMALITY_WORK_REPRESSION = 65
 		)
-	work_damage_amount = 5
+	work_damage_amount = 8
 	work_damage_type = WHITE_DAMAGE
 
 	ego_list = list(

--- a/code/modules/mob/living/simple_animal/abnormality/teth/cherry_blossoms.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/cherry_blossoms.dm
@@ -18,7 +18,7 @@
 		ABNORMALITY_WORK_REPRESSION = 20
 			)
 	start_qliphoth = 3
-	work_damage_amount = 5
+	work_damage_amount = 7
 	work_damage_type = WHITE_DAMAGE
 
 	ego_list = list(

--- a/code/modules/mob/living/simple_animal/abnormality/teth/crumbling_armor.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/crumbling_armor.dm
@@ -14,7 +14,7 @@
 		ABNORMALITY_WORK_ATTACHMENT = 0,
 		ABNORMALITY_WORK_REPRESSION = list(60, 60, 65, 65, 70)
 			)
-	work_damage_amount = 5
+	work_damage_amount = 8
 	work_damage_type = RED_DAMAGE
 
 	ego_list = list(

--- a/code/modules/mob/living/simple_animal/abnormality/teth/fairy_gentleman.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/fairy_gentleman.dm
@@ -14,7 +14,7 @@
 			)
 	pixel_x = -32
 	base_pixel_x = -32
-	work_damage_amount = 8
+	work_damage_amount = 7
 	work_damage_type = RED_DAMAGE
 
 	ego_list = list(

--- a/code/modules/mob/living/simple_animal/abnormality/teth/fairy_long_legs.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/fairy_long_legs.dm
@@ -31,7 +31,7 @@
 						ABNORMALITY_WORK_REPRESSION = 0,
 						"Take cover" = 0,
 						)
-	work_damage_amount = 5
+	work_damage_amount = 8
 	work_damage_type = RED_DAMAGE
 	deathmessage = "coalesces into a primordial egg."
 	deathsound = 'sound/abnormalities/fairy_longlegs/death.ogg'

--- a/code/modules/mob/living/simple_animal/abnormality/teth/fragment.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/fragment.dm
@@ -27,7 +27,7 @@
 						ABNORMALITY_WORK_ATTACHMENT = list(60, 60, 50, 50, 50),
 						ABNORMALITY_WORK_REPRESSION = list(50, 50, 40, 40, 40)
 						)
-	work_damage_amount = 5
+	work_damage_amount = 6
 	work_damage_type = BLACK_DAMAGE
 
 	attack_action_types = list(/datum/action/innate/abnormality_attack/fragment_song)

--- a/code/modules/mob/living/simple_animal/abnormality/teth/lady_facing_the_wall.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/lady_facing_the_wall.dm
@@ -15,7 +15,7 @@
 	pixel_x = -32
 	base_pixel_x = -8
 
-	work_damage_amount = 7
+	work_damage_amount = 6
 	work_damage_type = WHITE_DAMAGE
 	start_qliphoth = 2
 	var/scream_range = 10

--- a/code/modules/mob/living/simple_animal/abnormality/teth/meat_lantern.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/meat_lantern.dm
@@ -22,7 +22,7 @@
 	del_on_death = FALSE
 	deathmessage = "explodes in a shower of gore."
 
-	work_damage_amount = 5
+	work_damage_amount = 7
 	work_damage_type = WHITE_DAMAGE
 	start_qliphoth = 1
 	max_boxes = 14

--- a/code/modules/mob/living/simple_animal/abnormality/teth/my_sweet_home.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/my_sweet_home.dm
@@ -36,7 +36,7 @@
 						ABNORMALITY_WORK_ATTACHMENT = list(70, 70, 80, 80, 90),
 						ABNORMALITY_WORK_REPRESSION = list(60, 60, 50, 40, 40),
 						)
-	work_damage_amount = 5
+	work_damage_amount = 7
 	work_damage_type = BLACK_DAMAGE
 
 	var/list/counter1 = list() //from FAN, although changed

--- a/code/modules/mob/living/simple_animal/abnormality/teth/pale_horse.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/pale_horse.dm
@@ -24,7 +24,7 @@
 						ABNORMALITY_WORK_ATTACHMENT = 55,
 						ABNORMALITY_WORK_REPRESSION = list(70, 65, 60, 50, 50)
 						)
-	work_damage_amount = 3
+	work_damage_amount = 4
 	work_damage_type = PALE_DAMAGE
 
 	ego_list = list(

--- a/code/modules/mob/living/simple_animal/abnormality/teth/penitent_girl.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/penitent_girl.dm
@@ -15,7 +15,7 @@
 		ABNORMALITY_WORK_REPRESSION = 50
 	)
 	is_flying_animal = TRUE
-	work_damage_amount = 6
+	work_damage_amount = 7
 	work_damage_type = WHITE_DAMAGE
 
 	ego_list = list(

--- a/code/modules/mob/living/simple_animal/abnormality/teth/ppodae.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/ppodae.dm
@@ -19,7 +19,7 @@
 						ABNORMALITY_WORK_ATTACHMENT = 40,
 						ABNORMALITY_WORK_REPRESSION = list(40, 40, 30, 30, 30),
 						)
-	work_damage_amount = 6
+	work_damage_amount = 7
 	work_damage_type = RED_DAMAGE
 	damage_coeff = list(BRUTE = 1, RED_DAMAGE = 1.5, WHITE_DAMAGE = 0.8, BLACK_DAMAGE = 1, PALE_DAMAGE = 2)
 	can_breach = TRUE

--- a/code/modules/mob/living/simple_animal/abnormality/teth/punishing_bird.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/punishing_bird.dm
@@ -41,7 +41,7 @@
 						ABNORMALITY_WORK_ATTACHMENT = list(55, 55, 50, 50, 50),
 						ABNORMALITY_WORK_REPRESSION = list(30, 20, 10, 0, 0)
 						)
-	work_damage_amount = 5
+	work_damage_amount = 6
 	work_damage_type = RED_DAMAGE
 
 	ego_list = list(

--- a/code/modules/mob/living/simple_animal/abnormality/teth/scorched_girl.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/scorched_girl.dm
@@ -18,7 +18,7 @@
 		ABNORMALITY_WORK_ATTACHMENT = list(30, 15, 0, -40, -50),
 		ABNORMALITY_WORK_REPRESSION = list(50, 50, 40, 40, 40)
 		)
-	work_damage_amount = 6
+	work_damage_amount = 8
 	work_damage_type = RED_DAMAGE
 	damage_coeff = list(BRUTE = 1, RED_DAMAGE = 0.5, WHITE_DAMAGE = 2, BLACK_DAMAGE = 1, PALE_DAMAGE = 2)
 	faction = list("hostile")

--- a/code/modules/mob/living/simple_animal/abnormality/teth/simple_smile.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/simple_smile.dm
@@ -33,7 +33,7 @@
 						ABNORMALITY_WORK_ATTACHMENT = 80,
 						ABNORMALITY_WORK_REPRESSION = 80,
 						)
-	work_damage_amount = 5
+	work_damage_amount = 7
 	work_damage_type = BLACK_DAMAGE
 
 	ego_list = list(

--- a/code/modules/mob/living/simple_animal/abnormality/waw/alriune.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/alriune.dm
@@ -23,7 +23,7 @@
 						ABNORMALITY_WORK_ATTACHMENT = list(0, 0, 40, 30, 20),
 						ABNORMALITY_WORK_REPRESSION = 0
 						)
-	work_damage_amount = 10
+	work_damage_amount = 12
 	work_damage_type = WHITE_DAMAGE
 
 	light_color = COLOR_PINK

--- a/code/modules/mob/living/simple_animal/abnormality/waw/apex_predator.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/apex_predator.dm
@@ -35,7 +35,7 @@
 						ABNORMALITY_WORK_ATTACHMENT = list(25, 20, 15, 10, 0),
 						ABNORMALITY_WORK_REPRESSION = list(0, 0, 50, 55, 55)
 						)
-	work_damage_amount = 10
+	work_damage_amount = 14
 	work_damage_type = RED_DAMAGE
 
 	ego_list = list(

--- a/code/modules/mob/living/simple_animal/abnormality/waw/big_bird.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/big_bird.dm
@@ -28,7 +28,7 @@
 						ABNORMALITY_WORK_ATTACHMENT = list(40, 45, 50, 55, 55),
 						ABNORMALITY_WORK_REPRESSION = list(25, 20, 15, 10, 0)
 						)
-	work_damage_amount = 10
+	work_damage_amount = 15
 	work_damage_type = BLACK_DAMAGE
 
 	light_color = COLOR_ORANGE

--- a/code/modules/mob/living/simple_animal/abnormality/waw/black_swan.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/black_swan.dm
@@ -40,7 +40,7 @@
 						ABNORMALITY_WORK_ATTACHMENT = 0,
 						ABNORMALITY_WORK_REPRESSION = list(0, 0, 45, 50, 55),
 						)
-	work_damage_amount = 12
+	work_damage_amount = 14
 	work_damage_type = WHITE_DAMAGE
 	deathmessage = "weeps a green sludge while clutching her brooch."
 	base_pixel_x = -16

--- a/code/modules/mob/living/simple_animal/abnormality/waw/clouded_monk.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/clouded_monk.dm
@@ -30,7 +30,7 @@
 						ABNORMALITY_WORK_ATTACHMENT = list(20, 45, 45, 45, 45),
 						ABNORMALITY_WORK_REPRESSION = list(40, 20, 40, 40, 40)
 						)
-	work_damage_amount = 10
+	work_damage_amount = 13
 	work_damage_type = WHITE_DAMAGE
 
 	ego_list = list(

--- a/code/modules/mob/living/simple_animal/abnormality/waw/clown_smiling.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/clown_smiling.dm
@@ -36,7 +36,7 @@
 						ABNORMALITY_WORK_ATTACHMENT = list(50, 55, 60, 65, 65),
 						ABNORMALITY_WORK_REPRESSION = 35
 						)
-	work_damage_amount = 12
+	work_damage_amount = 13
 	work_damage_type = WHITE_DAMAGE
 	deathmessage = "blows up like a balloon!"
 	speak_chance = 2

--- a/code/modules/mob/living/simple_animal/abnormality/waw/contract.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/contract.dm
@@ -16,7 +16,7 @@
 	pixel_x = -16
 	base_pixel_x = -16
 	start_qliphoth = 2
-	work_damage_amount = 8
+	work_damage_amount = 9
 	work_damage_type = PALE_DAMAGE	//Lawyers take your fucking soul
 
 	ego_list = list(
@@ -112,14 +112,14 @@
 				temp_havers |= user
 			else
 				return
-				
+
 		if(ABNORMALITY_WORK_REPRESSION)
 			if(just_havers.len < total_per_contract)
 				user.adjust_attribute_buff(JUSTICE_ATTRIBUTE, (just_havers.len - 3)*-1 )
 				just_havers |= user
 			else
 				return
-				
+
 	total_havers |= user
 	say("Just sign here on the dotted line... and I'll take care of the rest.")
 	return

--- a/code/modules/mob/living/simple_animal/abnormality/waw/despair_knight.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/despair_knight.dm
@@ -32,7 +32,7 @@
 						ABNORMALITY_WORK_ATTACHMENT = list(50, 50, 55, 55, 60),
 						ABNORMALITY_WORK_REPRESSION = list(40, 40, 40, 35, 30)
 						)
-	work_damage_amount = 10
+	work_damage_amount = 15
 	work_damage_type = WHITE_DAMAGE
 
 	ego_list = list(

--- a/code/modules/mob/living/simple_animal/abnormality/waw/dimension_refraction.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/dimension_refraction.dm
@@ -27,7 +27,7 @@
 						ABNORMALITY_WORK_ATTACHMENT = list(0, 0, 40, 40, 40),
 						ABNORMALITY_WORK_REPRESSION = list(0, 0, 40, 40, 40)
 						)
-	work_damage_amount = 10
+	work_damage_amount = 13
 	work_damage_type = WHITE_DAMAGE
 
 	ego_list = list(

--- a/code/modules/mob/living/simple_animal/abnormality/waw/dreaming_current.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/dreaming_current.dm
@@ -23,7 +23,7 @@
 						ABNORMALITY_WORK_ATTACHMENT = list(45, 45, 45, 50, 55),
 						ABNORMALITY_WORK_REPRESSION = 45
 						)
-	work_damage_amount = 10
+	work_damage_amount = 14
 	work_damage_type = WHITE_DAMAGE
 
 	can_breach = TRUE

--- a/code/modules/mob/living/simple_animal/abnormality/waw/ebony_queen.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/ebony_queen.dm
@@ -36,7 +36,7 @@
 						ABNORMALITY_WORK_ATTACHMENT = list(0, 0, 40, 40, 40),
 						ABNORMALITY_WORK_REPRESSION = list(20, 30, 55, 55, 60)
 						)
-	work_damage_amount = 8
+	work_damage_amount = 12
 	work_damage_type = BLACK_DAMAGE
 	var/teleport_cooldown
 	var/teleport_cooldown_time = 60 SECONDS

--- a/code/modules/mob/living/simple_animal/abnormality/waw/express_train.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/express_train.dm
@@ -15,7 +15,7 @@
 						ABNORMALITY_WORK_ATTACHMENT = 35,
 						ABNORMALITY_WORK_REPRESSION = 35
 						)
-	work_damage_amount = 8
+	work_damage_amount = 12
 	work_damage_type = BLACK_DAMAGE
 	pixel_x = -16
 	base_pixel_x = -16

--- a/code/modules/mob/living/simple_animal/abnormality/waw/fire_bird.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/fire_bird.dm
@@ -21,7 +21,7 @@
 		ABNORMALITY_WORK_ATTACHMENT = list(45, 45, 40, 40, 50),
 		ABNORMALITY_WORK_REPRESSION = list(45, 45, 40, 40, 50)
 		)
-	work_damage_amount = 10
+	work_damage_amount = 13
 	work_damage_type = RED_DAMAGE
 	faction = list("hostile", "neutral")
 	can_breach = TRUE

--- a/code/modules/mob/living/simple_animal/abnormality/waw/flesh_idol.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/flesh_idol.dm
@@ -29,7 +29,7 @@
 	var/work_count = 0
 	var/breach_count = 4	//when do you breach?
 	var/reset_time = 1 MINUTES
-	var/damage_amount = 7
+	var/damage_amount = 13
 	var/run_num = 2		//How many things you breach
 
 	var/list/blacklist = list(/mob/living/simple_animal/hostile/abnormality/melting_love,

--- a/code/modules/mob/living/simple_animal/abnormality/waw/flesh_idol.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/flesh_idol.dm
@@ -29,7 +29,7 @@
 	var/work_count = 0
 	var/breach_count = 4	//when do you breach?
 	var/reset_time = 1 MINUTES
-	var/damage_amount = 13
+	var/damage_amount = 9
 	var/run_num = 2		//How many things you breach
 
 	var/list/blacklist = list(/mob/living/simple_animal/hostile/abnormality/melting_love,

--- a/code/modules/mob/living/simple_animal/abnormality/waw/generalb.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/generalb.dm
@@ -15,7 +15,7 @@
 						ABNORMALITY_WORK_ATTACHMENT = 0,						//DO NOT FUCK THE BEEGIRL
 						ABNORMALITY_WORK_REPRESSION = list(0, 0, 40, 40, 40)
 						)
-	work_damage_amount = 10
+	work_damage_amount = 15
 	work_damage_type = RED_DAMAGE
 	ego_list = list(
 		/datum/ego_datum/weapon/loyalty,

--- a/code/modules/mob/living/simple_animal/abnormality/waw/greed_king.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/greed_king.dm
@@ -29,7 +29,7 @@
 						ABNORMALITY_WORK_ATTACHMENT = list(0, 0, 50, 50, 55),
 						ABNORMALITY_WORK_REPRESSION = list(0, 0, 40, 40, 40)
 						)
-	work_damage_amount = 10
+	work_damage_amount = 13
 	work_damage_type = RED_DAMAGE
 	//Some Variables cannibalized from helper
 	var/charge_check_time = 1 SECONDS

--- a/code/modules/mob/living/simple_animal/abnormality/waw/hatred_queen.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/hatred_queen.dm
@@ -38,7 +38,7 @@
 						ABNORMALITY_WORK_ATTACHMENT = list(50, 50, 55, 55, 60),
 						ABNORMALITY_WORK_REPRESSION = list(20, 20, 20, 0, 0)
 						)
-	work_damage_amount = 7
+	work_damage_amount = 15
 	work_damage_type = BLACK_DAMAGE
 
 	can_breach = TRUE

--- a/code/modules/mob/living/simple_animal/abnormality/waw/hatred_queen.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/hatred_queen.dm
@@ -38,7 +38,7 @@
 						ABNORMALITY_WORK_ATTACHMENT = list(50, 50, 55, 55, 60),
 						ABNORMALITY_WORK_REPRESSION = list(20, 20, 20, 0, 0)
 						)
-	work_damage_amount = 15
+	work_damage_amount = 10
 	work_damage_type = BLACK_DAMAGE
 
 	can_breach = TRUE

--- a/code/modules/mob/living/simple_animal/abnormality/waw/judgement_bird.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/judgement_bird.dm
@@ -29,7 +29,7 @@
 						ABNORMALITY_WORK_ATTACHMENT = list(20, 20, 35, 45, 45),
 						ABNORMALITY_WORK_REPRESSION = 0
 						)
-	work_damage_amount = 10
+	work_damage_amount = 12
 	work_damage_type = PALE_DAMAGE
 
 	attack_action_types = list(/datum/action/innate/abnormality_attack/judgement)

--- a/code/modules/mob/living/simple_animal/abnormality/waw/little_prince.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/little_prince.dm
@@ -12,7 +12,7 @@
 						ABNORMALITY_WORK_ATTACHMENT = list(0, 0, 50, 50, 55),
 						ABNORMALITY_WORK_REPRESSION = list(0, 0, 50, 50, 55)
 						)
-	work_damage_amount = 7
+	work_damage_amount = 14
 	work_damage_type = BLACK_DAMAGE
 	start_qliphoth = 2
 

--- a/code/modules/mob/living/simple_animal/abnormality/waw/luna.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/luna.dm
@@ -19,7 +19,7 @@
 		)
 	pixel_x = -32
 	base_pixel_x = -32
-	work_damage_amount = 10
+	work_damage_amount = 13
 	work_damage_type = WHITE_DAMAGE
 	max_boxes = 20
 	ego_list = list(

--- a/code/modules/mob/living/simple_animal/abnormality/waw/luna.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/luna.dm
@@ -19,7 +19,7 @@
 		)
 	pixel_x = -32
 	base_pixel_x = -32
-	work_damage_amount = 13
+	work_damage_amount = 10
 	work_damage_type = WHITE_DAMAGE
 	max_boxes = 20
 	ego_list = list(

--- a/code/modules/mob/living/simple_animal/abnormality/waw/nosferatu.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/nosferatu.dm
@@ -25,7 +25,7 @@
 	melee_damage_type = RED_DAMAGE
 	armortype = RED_DAMAGE
 	stat_attack = HARD_CRIT
-	work_damage_amount = 8
+	work_damage_amount = 13
 	work_damage_type = RED_DAMAGE
 	attack_verb_continuous = "claws"
 	attack_verb_simple = "claw"

--- a/code/modules/mob/living/simple_animal/abnormality/waw/orange_tree.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/orange_tree.dm
@@ -19,7 +19,7 @@
 						ABNORMALITY_WORK_ATTACHMENT = list(0, 0, 55, 55, 60),
 						ABNORMALITY_WORK_REPRESSION = list(0, 0, 45, 45, 45)
 						)
-	work_damage_amount = 10
+	work_damage_amount = 13
 	work_damage_type = WHITE_DAMAGE
 
 	light_color = COLOR_ORANGE

--- a/code/modules/mob/living/simple_animal/abnormality/waw/pygmalion.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/pygmalion.dm
@@ -32,7 +32,7 @@
 						ABNORMALITY_WORK_ATTACHMENT = 50,
 						ABNORMALITY_WORK_REPRESSION = list(40, 40, 40, 35, 30)
 						)
-	work_damage_amount = 10
+	work_damage_amount = 13
 	work_damage_type = WHITE_DAMAGE
 
 	ego_list = list(

--- a/code/modules/mob/living/simple_animal/abnormality/waw/queen_bee.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/queen_bee.dm
@@ -18,7 +18,7 @@
 						ABNORMALITY_WORK_ATTACHMENT = list(0, 0, 40, 40, 40),
 						ABNORMALITY_WORK_REPRESSION = 0
 						)
-	work_damage_amount = 10
+	work_damage_amount = 13
 	work_damage_type = RED_DAMAGE
 
 	ego_list = list(

--- a/code/modules/mob/living/simple_animal/abnormality/waw/shrimp.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/shrimp.dm
@@ -15,7 +15,7 @@
 						ABNORMALITY_WORK_ATTACHMENT = 30,
 						ABNORMALITY_WORK_REPRESSION = -100	//He's a snobby shrimp dude.
 						)
-	work_damage_amount = 11
+	work_damage_amount = 12
 	work_damage_type = WHITE_DAMAGE	//He insults you.
 
 	ego_list = list(

--- a/code/modules/mob/living/simple_animal/abnormality/waw/silence.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/silence.dm
@@ -12,7 +12,7 @@
 		ABNORMALITY_WORK_REPRESSION = list(0, 0, 50, 45, 45)
 			)
 	start_qliphoth = 1
-	work_damage_amount = 10
+	work_damage_amount = 13
 	work_damage_type = PALE_DAMAGE
 
 	ego_list = list(

--- a/code/modules/mob/living/simple_animal/abnormality/waw/snow_whites_apple.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/snow_whites_apple.dm
@@ -34,7 +34,7 @@ GLOBAL_LIST_EMPTY(vine_list)
 						ABNORMALITY_WORK_ATTACHMENT = list(0, 0, 0, 0, 0),
 						ABNORMALITY_WORK_REPRESSION = list(20, 30, 55, 55, 60)
 						)
-	work_damage_amount = 8
+	work_damage_amount = 13
 	work_damage_type = BLACK_DAMAGE
 	initial_language_holder = /datum/language_holder/plant //mostly flavor
 	var/togglemovement

--- a/code/modules/mob/living/simple_animal/abnormality/waw/sphinx.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/sphinx.dm
@@ -31,7 +31,7 @@
 		"Riddle" = 0,		//These should never be used, but they're here for clarity.
 		"Make Offering" = 0
 	)
-	work_damage_amount = 12
+	work_damage_amount = 14
 	work_damage_type = WHITE_DAMAGE
 
 	ego_list = list(

--- a/code/modules/mob/living/simple_animal/abnormality/waw/thunder_bird.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/thunder_bird.dm
@@ -42,7 +42,7 @@ GLOBAL_LIST_EMPTY(zombies)
 						ABNORMALITY_WORK_ATTACHMENT = list(10, 10, 5, 5, 15),
 						ABNORMALITY_WORK_REPRESSION = list(50, 45, 50, 55, 55)
 						)
-	work_damage_amount = 10
+	work_damage_amount = 15
 	work_damage_type = WHITE_DAMAGE
 
 	//change the E.G.O to "warring"

--- a/code/modules/mob/living/simple_animal/abnormality/waw/warden.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/warden.dm
@@ -30,7 +30,7 @@
 						ABNORMALITY_WORK_ATTACHMENT = 0,
 						ABNORMALITY_WORK_REPRESSION = 50
 						)
-	work_damage_amount = 8
+	work_damage_amount = 12
 	work_damage_type = BLACK_DAMAGE
 
 	ego_list = list(

--- a/code/modules/mob/living/simple_animal/abnormality/waw/wrath_servant.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/wrath_servant.dm
@@ -28,7 +28,7 @@
 		ABNORMALITY_WORK_REPRESSION = list(30, 30, 40, 40, 50),
 		"Request" = 100
 	)
-	work_damage_amount = 12
+	work_damage_amount = 14
 	work_damage_type = BLACK_DAMAGE
 
 	armortype = RED_DAMAGE

--- a/code/modules/mob/living/simple_animal/abnormality/waw/yang.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/yang.dm
@@ -20,7 +20,7 @@
 	can_breach = TRUE
 	start_qliphoth = 2
 	threat_level = WAW_LEVEL
-	work_damage_amount = 11
+	work_damage_amount = 12
 	work_damage_type = WHITE_DAMAGE
 	work_chances = list(
 						ABNORMALITY_WORK_INSTINCT = 0,

--- a/code/modules/mob/living/simple_animal/abnormality/waw/yin.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/yin.dm
@@ -20,7 +20,7 @@
 	can_breach = TRUE
 	start_qliphoth = 2
 	threat_level = WAW_LEVEL
-	work_damage_amount = 10
+	work_damage_amount = 14
 	work_damage_type = BLACK_DAMAGE
 	work_chances = list(
 						ABNORMALITY_WORK_INSTINCT = list(0, 0, 40, 40, 40),

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/blubbering_toad.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/blubbering_toad.dm
@@ -34,7 +34,7 @@
 		ABNORMALITY_WORK_ATTACHMENT = list(50, 40, 30, 30, 30),
 		ABNORMALITY_WORK_REPRESSION = list(70, 30, 30, 30, 30)
 		)
-	work_damage_amount = 6
+	work_damage_amount = 5
 	work_damage_type = BLACK_DAMAGE
 
 	//work

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/fairy_festival.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/fairy_festival.dm
@@ -14,7 +14,7 @@
 		ABNORMALITY_WORK_ATTACHMENT = list(70, 60, 50, 50, 50),
 		ABNORMALITY_WORK_REPRESSION = list(50, 40, 30, 30, 30)
 		)
-	work_damage_amount = 6
+	work_damage_amount = 4
 	work_damage_type = RED_DAMAGE
 	max_boxes = 10
 

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/fallen_amurdad.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/fallen_amurdad.dm
@@ -12,7 +12,7 @@
 						ABNORMALITY_WORK_ATTACHMENT = list(50, 40, 30, 30, 30),
 						ABNORMALITY_WORK_REPRESSION = list(70, 60, 50, 50, 50)
 						)
-	work_damage_amount = 6
+	work_damage_amount = 5
 	work_damage_type = BLACK_DAMAGE
 	max_boxes = 10
 

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/one_sin.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/one_sin.dm
@@ -15,7 +15,7 @@
 		ABNORMALITY_WORK_REPRESSION = list(50, 40, 30, 30, 30),
 		"Confess" = 100
 		)
-	work_damage_amount = 6
+	work_damage_amount = 4
 	work_damage_type = WHITE_DAMAGE
 
 	ego_list = list(

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/pile_of_mail.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/pile_of_mail.dm
@@ -50,6 +50,7 @@
 
 //papercut due to failed work
 /mob/living/simple_animal/hostile/abnormality/mailpile/WorktickFailure(mob/living/carbon/human/user)
+	..()
 	if(prob(10))
 		to_chat(user,"<span class='warning'>Ouch! I got a paper cut!</span>")
 	return

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/sleeping_beauty.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/sleeping_beauty.dm
@@ -20,7 +20,7 @@
 		ABNORMALITY_WORK_ATTACHMENT = 50,
 		ABNORMALITY_WORK_REPRESSION = 70
 		)
-	work_damage_amount = 6
+	work_damage_amount = 5
 	work_damage_type = WHITE_DAMAGE
 
 	ego_list = list(

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/wellcheers.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/wellcheers.dm
@@ -13,7 +13,7 @@
 						ABNORMALITY_WORK_ATTACHMENT = list(50, 50, 40, 40, 40),
 						ABNORMALITY_WORK_REPRESSION = list(50, 50, 40, 40, 40)
 						)
-	work_damage_amount = 1
+	work_damage_amount = 5
 	work_damage_type = RED_DAMAGE
 	max_boxes = 10
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes work damage more consistent.
Zayin: 4-6 
Teth: 6-8 
He: 9-11
Waw: 12-15
Aleph: 16-20
Pale is excluded,

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Many, Many inconsistencies.
Some Waws did the same work damage as Zayins.
Wellcheers did 1 red.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: rebalanced all work damage to be consistent
fix: Letters on Standby now actually does work damage
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
