### PR TITLE
Fixes Dear Lutemia attack speed

### DIFF
--- a/code/game/objects/items/ego_weapons/teth.dm
+++ b/code/game/objects/items/ego_weapons/teth.dm
@@ -41,6 +41,7 @@
 	desc = "Don't you want your cares to go away?"
 	icon_state = "lutemia"
 	force = 22
+	attack_speed = 1
 	damtype = WHITE_DAMAGE
 	armortype = WHITE_DAMAGE
 	attack_verb_continuous = list("pokes", "jabs", "tears", "lacerates", "gores")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changing Lutemia to a shield subtype caused it to inherit the base shield attack speed of 3, this returns Lutemia back to its original speed
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
A DPS of ~7.33 DPS made this worse than a ZAYIN
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixes Dear Lutemia's attack speed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
