### PR TITLE
Alriune upgrades

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1509,4 +1509,8 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 	for(var/client/C in GLOB.clients)
 		show_blurb(C, duration, blurb_text, fade_time, text_color, outline_color, text_align, screen_location)
 
+// Animates atom's color over time
+/proc/SetColorOverTime(atom/A, new_color = "#FFFFFF", new_time = 2)
+	animate(A, color = new_color, time = new_time)
+
 #define TURF_FROM_COORDS_LIST(List) (locate(List[1], List[2], List[3]))

--- a/code/modules/clothing/suits/ego_gear/waw.dm
+++ b/code/modules/clothing/suits/ego_gear/waw.dm
@@ -218,7 +218,7 @@ Any attempt to code risk class armor will result in a 10 day Github ban.*/
 	desc = "The ceramic surface is tough as if it had been glazed several times. \
 			It may crumble back into primal clay if it is exposed to a powerful mental attack."
 	icon_state = "aroma"
-	armor = list(RED_DAMAGE = 0, WHITE_DAMAGE = 60, BLACK_DAMAGE = 50, PALE_DAMAGE = 30) // 140
+	armor = list(RED_DAMAGE = 0, WHITE_DAMAGE = 70, BLACK_DAMAGE = 40, PALE_DAMAGE = 30) // 140
 	attribute_requirements = list(
 							FORTITUDE_ATTRIBUTE = 60,
 							PRUDENCE_ATTRIBUTE = 60

--- a/code/modules/mob/living/carbon/human/ego_gifts.dm
+++ b/code/modules/mob/living/carbon/human/ego_gifts.dm
@@ -775,11 +775,12 @@
 	instinct_mod = 6
 	slot = HAND_1
 
+// Slightly buffed compared to base game
 /datum/ego_gifts/aroma
 	name = "Faint Aroma"
 	icon_state = "aroma"
-	prudence_bonus = 4
-	temperance_bonus = 2 // This is techincally a buff from base game.
+	prudence_bonus = 6
+	temperance_bonus = 4
 	slot = HAT
 
 /datum/ego_gifts/stem

--- a/code/modules/mob/living/carbon/human/ego_gifts.dm
+++ b/code/modules/mob/living/carbon/human/ego_gifts.dm
@@ -775,13 +775,31 @@
 	instinct_mod = 6
 	slot = HAND_1
 
-// Slightly buffed compared to base game
+// Converts 10% of WHITE damage taken(before armor calculations!) as health
+// tl;dr - If you were to get hit by an attack of 200 WHITE damage - you restore 20 health, regardless of how much
+// damage you actually took
 /datum/ego_gifts/aroma
 	name = "Faint Aroma"
+	desc = "Restores 10% of WHITE damage taken as health. This effect ignores armor."
 	icon_state = "aroma"
-	prudence_bonus = 6
-	temperance_bonus = 4
+	prudence_bonus = 4
+	temperance_bonus = 2
 	slot = HAT
+
+/datum/ego_gifts/aroma/Initialize(mob/living/carbon/human/user)
+	. = ..()
+	RegisterSignal(user, COMSIG_MOB_APPLY_DAMGE, .proc/AttemptHeal)
+
+/datum/ego_gifts/aroma/Remove(mob/living/carbon/human/user)
+	UnregisterSignal(user, COMSIG_MOB_APPLY_DAMGE, .proc/AttemptHeal)
+	return ..()
+
+/datum/ego_gifts/aroma/proc/AttemptHeal(datum/source, damage, damagetype, def_zone)
+	if(!owner && damagetype != WHITE_DAMAGE)
+		return
+	if(!damage)
+		return
+	owner.adjustBruteLoss(-damage*0.1)
 
 /datum/ego_gifts/stem
 	name = "Green Stem"

--- a/code/modules/mob/living/simple_animal/abnormality/waw/alriune.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/alriune.dm
@@ -11,23 +11,23 @@
 
 	maxHealth = 2000
 	health = 2000
-	damage_coeff = list(BRUTE = 1, RED_DAMAGE = 1.2, WHITE_DAMAGE = 0, BLACK_DAMAGE = 0.5, PALE_DAMAGE = 1.5)
+	damage_coeff = list(BRUTE = 1, RED_DAMAGE = 1.2, WHITE_DAMAGE = 0, BLACK_DAMAGE = 0.7, PALE_DAMAGE = 1.5)
 
 	threat_level = WAW_LEVEL
 	can_breach = TRUE
-	start_qliphoth = 1
-	// Insight and Instinct work chances were slightly changed for it to be possible to get neutral result
+	start_qliphoth = 2
+	// Work chances were slightly changed for it to be possible to get neutral result
 	work_chances = list(
-						ABNORMALITY_WORK_INSTINCT = list(0, 0, 40, 45, 50),
+						ABNORMALITY_WORK_INSTINCT = list(0, 0, 45, 40, 35),
 						ABNORMALITY_WORK_INSIGHT = list(0, 0, 50, 45, 40),
-						ABNORMALITY_WORK_ATTACHMENT = list(0, 0, 40, 30, 20),
-						ABNORMALITY_WORK_REPRESSION = 0
+						ABNORMALITY_WORK_ATTACHMENT = list(0, 0, 40, 35, 30),
+						ABNORMALITY_WORK_REPRESSION = list(0, 0, 35, 30, 25),
 						)
-	work_damage_amount = 10
+	work_damage_amount = 8 // Lower than average due to work rates and requirement to get neutral results
 	work_damage_type = WHITE_DAMAGE
 
 	light_color = COLOR_PINK
-	light_range = 5
+	light_range = 9
 	light_power = 1
 
 	/// Currently displayed petals. When value is at 3 - reset to 0 and perform attack
@@ -35,7 +35,7 @@
 	/// World time when petals_current will increase by 1
 	var/petals_next = 0
 	/// Delay used for petals_next
-	var/petals_next_time = 6 SECONDS
+	var/petals_next_time = 5 SECONDS
 	/// Amount of white damage done to everyone in view by the attack
 	var/pulse_damage = 180
 
@@ -68,14 +68,18 @@
 		petals_current += 1
 		if(petals_current >= 3) // Attack
 			petals_current = 0
-			for(var/mob/living/L in livinginview(9, get_turf(src)))
+			playsound(src, 'sound/abnormalities/alriune/damage.ogg', 75, TRUE, 12)
+			// Attack visual effect, so to speak
+			for(var/turf/T in view(7, get_turf(src)))
+				animate(T, color = COLOR_PINK, time = 2)
+				addtimer(CALLBACK(GLOBAL_PROC, .proc/SetColorOverTime, T, initial(T.color), (2 SECONDS)), 4)
+			for(var/mob/living/L in livinginview(7, get_turf(src)))
 				if(faction_check_mob(L))
 					continue
 				if(L.stat == DEAD)
 					continue
 				L.apply_damage(pulse_damage, WHITE_DAMAGE, null, L.run_armor_check(null, WHITE_DAMAGE))
 				new /obj/effect/temp_visual/alriune_attack(get_turf(L))
-				playsound(L, 'sound/abnormalities/alriune/damage.ogg', 25, TRUE)
 				if(ishuman(L))
 					var/mob/living/carbon/human/H = L
 					if(H.sanity_lost)
@@ -87,7 +91,7 @@
 			petals_next = world.time + (petals_next_time * 2)
 			addtimer(CALLBACK(src, .proc/TeleportAway), 2 SECONDS)
 		else
-			playsound(src, 'sound/abnormalities/alriune/timer.ogg', 50, FALSE)
+			playsound(src, 'sound/abnormalities/alriune/timer.ogg', 50, FALSE, 12)
 		update_icon()
 
 
@@ -100,12 +104,12 @@
 	var/turf/T = pick(potential_turfs)
 	if(!istype(T))
 		return FALSE
-	playsound(src, 'sound/abnormalities/alriune/curtain_out.ogg', 50, TRUE)
+	playsound(src, 'sound/abnormalities/alriune/curtain_out.ogg', 50, TRUE, 12)
 	animate(src, alpha = 0, time = 15)
 	SLEEP_CHECK_DEATH(15)
 	forceMove(T)
 	animate(src, alpha = 255, time = 15)
-	playsound(src, 'sound/abnormalities/alriune/curtain_in.ogg', 50, TRUE)
+	playsound(src, 'sound/abnormalities/alriune/curtain_in.ogg', 50, TRUE, 12)
 
 /* Overlays */
 /mob/living/simple_animal/hostile/abnormality/alriune/update_overlays()
@@ -118,9 +122,8 @@
 	. += petal_overlay
 
 /* Work stuff */
-
 /mob/living/simple_animal/hostile/abnormality/alriune/SuccessEffect(mob/living/carbon/human/user, work_type, pe)
-	if(prob(50))
+	if(prob(33))
 		datum_reference.qliphoth_change(-1)
 	return
 

--- a/code/modules/mob/living/simple_animal/abnormality/waw/alriune.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/alriune.dm
@@ -23,7 +23,7 @@
 						ABNORMALITY_WORK_ATTACHMENT = list(0, 0, 40, 35, 30),
 						ABNORMALITY_WORK_REPRESSION = list(0, 0, 35, 30, 25),
 						)
-	work_damage_amount = 8 // Lower than average due to work rates and requirement to get neutral results
+	work_damage_amount = 10
 	work_damage_type = WHITE_DAMAGE
 
 	light_color = COLOR_PINK


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Alriune work rates rearranged slightly;
- Alriune qliphoth counter starts at 2 now;
- Alriune's EGO armor rebalanced to [0, 70, 40, 30];
- Alriune's EGO gift now restores 10% of WHITE damage taken as your health;
- Alriune has slightly higher weakness to black damage(0.5 -> 0.7);
- Cooldown of petals decreased(6 -> 5 seconds);
- When performing the attack - turfs will turn pink for a while;
- Most of the Alriune's sounds now have extra range.

## Why It's Good For The Game

- Work rates are saner now, allowing people to get neutral results more often;
- Gives some room for errors, even TSO has counter 2;
- One high defense is better than multiples of mediocre;
- Slight bonus for dealing with this "terrible abno";
- Black weapons no longer mean you're shooting yourself in the foot for using them;
- If it breaches - you will have to be on lookout, which is made easier with sound extra-range;
- I think it would look neat;
- Allows people to find it with relative ease.
