### PR TITLE
Twilight nerf

### DIFF
--- a/code/modules/clothing/suits/ego_gear/aleph.dm
+++ b/code/modules/clothing/suits/ego_gear/aleph.dm
@@ -76,7 +76,7 @@ Any attempt to code risk class armor will result in a 10 day Github ban.*/
 	desc = "The three birds united their efforts to defeat the beast. \
 	This could stop countless incidents, but you’ll have to be prepared to step into the Black Forest…"
 	icon_state = "twilight"
-	armor = list(RED_DAMAGE = 90, WHITE_DAMAGE = 90, BLACK_DAMAGE = 90, PALE_DAMAGE = 90) // 360
+	armor = list(RED_DAMAGE = 80, WHITE_DAMAGE = 60, BLACK_DAMAGE = 80, PALE_DAMAGE = 80) // 360
 	attribute_requirements = list(
 							FORTITUDE_ATTRIBUTE = 120,
 							PRUDENCE_ATTRIBUTE = 120,

--- a/code/modules/clothing/suits/ego_gear/aleph.dm
+++ b/code/modules/clothing/suits/ego_gear/aleph.dm
@@ -76,7 +76,7 @@ Any attempt to code risk class armor will result in a 10 day Github ban.*/
 	desc = "The three birds united their efforts to defeat the beast. \
 	This could stop countless incidents, but you’ll have to be prepared to step into the Black Forest…"
 	icon_state = "twilight"
-	armor = list(RED_DAMAGE = 80, WHITE_DAMAGE = 60, BLACK_DAMAGE = 80, PALE_DAMAGE = 80) // 360
+	armor = list(RED_DAMAGE = 80, WHITE_DAMAGE = 60, BLACK_DAMAGE = 80, PALE_DAMAGE = 80) // 300
 	attribute_requirements = list(
 							FORTITUDE_ATTRIBUTE = 120,
 							PRUDENCE_ATTRIBUTE = 120,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Twilight is now nerfed from 9/9/9/9 to 8/6/8/8
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Late game really feels like twilight makes it moot, because it's all round the best armor in the game.
This tones it back a little while still being in line with "being better than aleph"
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: twilight nerfed to 8/6/8/8
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
