### PR TITLE
Teth Tweak

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/teth/dingle_dangle.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/dingle_dangle.dm
@@ -26,7 +26,7 @@
 
 
 /mob/living/simple_animal/hostile/abnormality/dingledangle/PostWorkEffect(mob/living/carbon/human/user, work_type, pe)
-	if(get_attribute_level(user, PRUDENCE_ATTRIBUTE) >= 60)
+	if(get_attribute_level(user, PRUDENCE_ATTRIBUTE) >= 60 && get_attribute_level(user, FORTITUDE_ATTRIBUTE) <= 100)
 		//I mean it does this in wonderlabs
 		user.dust()
 

--- a/code/modules/mob/living/simple_animal/abnormality/teth/drowned_sisters.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/drowned_sisters.dm
@@ -39,7 +39,7 @@
 		user.adjustSanityLoss(-heal_amount)
 	..()
 
-/mob/living/simple_animal/hostile/abnormality/drownedsisters/FailureEffect(mob/living/carbon/human/user, work_type, pe)
+/mob/living/simple_animal/hostile/abnormality/drownedsisters/NeutralEffect(mob/living/carbon/human/user, work_type, pe)
 	user.Paralyze(30)
 	user.adjustOxyLoss(100)
 	visible_message("<span class='boldwarning'>[user] falls into the pool!</span>")

--- a/code/modules/mob/living/simple_animal/abnormality/teth/drowned_sisters.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/drowned_sisters.dm
@@ -29,11 +29,21 @@
 /mob/living/simple_animal/hostile/abnormality/drownedsisters/AttemptWork(mob/living/carbon/human/user, work_type)
 	//Deals scaling work damage based off your stats.
 	work_damage_amount = (get_attribute_level(user, PRUDENCE_ATTRIBUTE) -60) * -0.5
-	work_damage_amount = max(1, work_damage_amount)	//So you don't get healing
+	work_damage_amount = max(5, work_damage_amount)	//So you don't get healing
 	return TRUE
 
 /mob/living/simple_animal/hostile/abnormality/drownedsisters/PostWorkEffect(mob/living/carbon/human/user, work_type, pe, work_time)
 // okay so according to the lore you're not really supposed to remember the stories she says so we're going to make it so your sanity goes back up
 	if(!user.sanity_lost && pe != 0)
-		user.adjustSanityLoss(-get_attribute_level(user, PRUDENCE_ATTRIBUTE))
+		var/heal_amount = min(30, get_attribute_level(user, PRUDENCE_ATTRIBUTE)* -0.5)
+		user.adjustSanityLoss(-heal_amount)
 	..()
+
+/mob/living/simple_animal/hostile/abnormality/drownedsisters/FailureEffect(mob/living/carbon/human/user, work_type, pe)
+	user.Paralyze(30)
+	user.adjustOxyLoss(100)
+	visible_message("<span class='boldwarning'>[user] falls into the pool!</span>")
+	to_chat(user, "<span class='userdanger'>You're lungs are filling with water!</span>")
+	user.forceMove(pick(GLOB.department_centers))
+
+

--- a/code/modules/mob/living/simple_animal/abnormality/teth/penitent_girl.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/penitent_girl.dm
@@ -33,12 +33,19 @@
 	return TRUE
 
 /mob/living/simple_animal/hostile/abnormality/penitentgirl/PostWorkEffect(mob/living/carbon/human/user, work_type, pe, work_time)
-	// you are going to cut your own leg off
+	work_damage_type = initial(work_damage_type)
 	if(get_attribute_level(user, TEMPERANCE_ATTRIBUTE) < 40)
-		user.apply_status_effect(STATUS_EFFECT_PENITENCE)
-		to_chat(user, "<span class='danger'>Something feels strange.</span>") //I have to write something here
-		work_damage_type = initial(work_damage_type)
+		CutLegs(user)
 
+/mob/living/simple_animal/hostile/abnormality/penitentgirl/NeutralEffect(mob/living/carbon/human/user, work_type, pe)
+	if(prob(50))
+		CutLegs(user)
+
+
+	// you are going to cut your own leg off
+/mob/living/simple_animal/hostile/abnormality/proc/penitentgirl/CutLegs(mob/living/carbon/human/user)
+	user.apply_status_effect(STATUS_EFFECT_PENITENCE)
+	to_chat(user, "<span class='danger'>Something feels strange.</span>") //I have to write something here
 
 /datum/status_effect/penitence
 	id = "penitence"

--- a/code/modules/mob/living/simple_animal/abnormality/teth/penitent_girl.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/penitent_girl.dm
@@ -38,7 +38,7 @@
 		CutLegs(user)
 
 /mob/living/simple_animal/hostile/abnormality/penitentgirl/NeutralEffect(mob/living/carbon/human/user, work_type, pe)
-	if(prob(50))
+	if(prob(20))
 		CutLegs(user)
 
 

--- a/code/modules/paperwork/records/info/teth.dm
+++ b/code/modules/paperwork/records/info/teth.dm
@@ -50,6 +50,7 @@
 	abno_code = "T-04-111"
 	abno_info = list(
 		"When employees with Prudence Level 3 or higher completed their work, they were immediately consumed by Dingle-Dangle.",
+		"When employees with Fortitude Level 5 were immune to the above effect.",
 		"When the work result was Bad, the employee was consumed by Dingle-Dangle with a normal probability.")
 
 //Beauty and the Beast
@@ -169,6 +170,7 @@
 	abno_type = /mob/living/simple_animal/hostile/abnormality/drownedsisters
 	abno_code = "T-01-133"
 	abno_info = list(
+		"When the work result was Bad, the employee was dragged into the pool, and re-emerged at a department centre.",
 		"The work damage done to the employee working on The Drowned Sisters increased inversely to their Prudence.",
 		"After work was completed, the employee was unable to recall their conversation with The Drowned Sisters. It was found that the employee’s sanity was slightly restored.")
 

--- a/code/modules/paperwork/records/info/teth.dm
+++ b/code/modules/paperwork/records/info/teth.dm
@@ -162,6 +162,7 @@
 	abno_type = /mob/living/simple_animal/hostile/abnormality/penitentgirl
 	abno_code = "T-01-115"
 	abno_info = list(
+		"When the work result was Neutral, the employee working on T-01-115 may have been compelled to cut their own feet off.",
 		"When an Agent, who had Temperance Level 1, completed the work process, they eventually cut off their own feet.",
 		"When an Agent, who had Temperance Level 2 or higher, started the work process, Penitent Girl’s work damage type changed.")
 

--- a/code/modules/paperwork/records/info/teth.dm
+++ b/code/modules/paperwork/records/info/teth.dm
@@ -171,7 +171,7 @@
 	abno_type = /mob/living/simple_animal/hostile/abnormality/drownedsisters
 	abno_code = "T-01-133"
 	abno_info = list(
-		"When the work result was Bad, the employee was dragged into the pool, and re-emerged at a department centre.",
+		"When the work result was Neutral, the employee was dragged into the pool, and re-emerged at a department centre.",
 		"The work damage done to the employee working on The Drowned Sisters increased inversely to their Prudence.",
 		"After work was completed, the employee was unable to recall their conversation with The Drowned Sisters. It was found that the employee’s sanity was slightly restored.")
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Enhances a small amount of teths.
Drowned Sisters and Penitent Girl both have new, negative neutral effects.
Drowned Sister won't kill you if you have full HP, and teleport you to a main room.
Drowned Sister now has a max on healing and min on damage. (no more healing 130 Sanity)
Penitent girl has a small chance to legcut on neutral

Dangle now spares you at Fort 5.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
DS and PG were both kinda bland, this makes them a little more exciting.
Dangle now actually can be worked during binah.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Drowned Sisters attacks you on neutral
tweak: Penitent girl now has a small chance to legcut on neutral
tweak: Drowned Sisters has a cap on healing and work damage
tweak: Dangle can be worked on at 5 fort again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
