### PR TITLE
Makes Bots Go Through Crates & Doors + Adds Missing Ego To Realizer

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/_tools/zayin/realizer.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_tools/zayin/realizer.dm
@@ -27,8 +27,10 @@
 		/obj/item/clothing/suit/armor/ego_gear/waw/despair 			= /obj/item/clothing/suit/armor/ego_gear/realization/quenchedblood,
 		/obj/item/clothing/suit/armor/ego_gear/waw/hatred 			= /obj/item/clothing/suit/armor/ego_gear/realization/lovejustice,
 		/obj/item/clothing/suit/armor/ego_gear/waw/blind_rage 		= /obj/item/clothing/suit/armor/ego_gear/realization/woundedcourage,
+		/obj/item/clothing/suit/armor/ego_gear/waw/crimson 			= /obj/item/clothing/suit/armor/ego_gear/realization/crimson,
 		/obj/item/clothing/suit/armor/ego_gear/waw/lamp 			= /obj/item/clothing/suit/armor/ego_gear/realization/eyes,
 		/obj/item/clothing/suit/armor/ego_gear/waw/oppression 		= /obj/item/clothing/suit/armor/ego_gear/realization/cruelty,
+		/obj/item/clothing/suit/armor/ego_gear/waw/thirteen 		= /obj/item/clothing/suit/armor/ego_gear/realization/bell_tolls,
 		/obj/item/clothing/suit/armor/ego_gear/waw/executive 		= /obj/item/clothing/suit/armor/ego_gear/realization/capitalism,
 		// ALEPH
 		/obj/item/clothing/suit/armor/ego_gear/aleph/da_capo 		= /obj/item/clothing/suit/armor/ego_gear/realization/alcoda,

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -871,13 +871,20 @@ Pass a positive integer as an argument to override a bot's default speed.
 	calc_summon_path()
 	tries = 0
 
-/mob/living/simple_animal/bot/Bump(atom/A) //Leave no door unopened!
-	. = ..()
+/mob/living/simple_animal/bot/Bump(atom/A)
+	var/turf/destination = get_turf(A)
 	if((istype(A, /obj/machinery/door/airlock) ||  istype(A, /obj/machinery/door/window)) && (!isnull(access_card)))
 		var/obj/machinery/door/D = A
-		if(D.check_access(access_card))
-			D.open()
+		if(D.check_access(access_card) && !D.locked)
+			forceMove(destination)
 			frustration = 0
+			return
+	if(istype(A, /obj/structure/closet))
+		var/obj/structure/closet/C = A
+		if(!C.anchored)
+			forceMove(destination)
+			return
+	. = ..()
 
 /mob/living/simple_animal/bot/proc/show_controls(mob/M)
 	users |= M


### PR DESCRIPTION
## About The Pull Request

Tbh I just wanted a reason to add crimson lust to the realizer
Anyways, this PR makes cleanbots (all bots) go through doors instead of opening them if they have access and not locked
Also adds PoS and Crimson Scar to realizer list even though they don't have abilities yet

## Why It's Good For The Game

Crimson Lust & Bell Toll Drips
Bots will no longer push your crates away
Also bots won't kill you with ordeals I guess

## Changelog
:cl:
add: Added RRH and POS armor to realizer
tweak: tweaked bot movement
/:cl: