### PR TITLE
Removes LC armor protection Classes.

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -360,7 +360,7 @@
 		readout += "\nThe Roman numeral system uses only seven symbols: I, V, X, L, C, D, and M. To read the armor values, you need to know: I represents the number 1, V represents 5, X is 10."
 		readout += "\nYou can add numbers together by putting the symbols in descending order from left to right. You’d add all of the symbols’ individual values together to get the total value. For example, VI is 5 + 1 or 6."
 		readout += "\nYou can also subtract numbers from each other by placing a symbol with a smaller value to the left of one with a larger value. The value of the smaller symbol is subtracted from that of the larger symbol to get the total value, so IV is 5 - 1, or 4."
-		readout += "\nExamples: \nIX = 10-1 = 9. \nVI = 5+1 = 6. \nVIII = 5+1+1+1 = 8.
+		readout += "\nExamples: \nIX = 10-1 = 9. \nVI = 5+1 = 6. \nVIII = 5+1+1+1 = 8."
 		to_chat(usr, "[readout.Join()]")
 
 /**

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -333,7 +333,7 @@
 		durability_list += list("ACID" = armor.acid)
 
 	if(LAZYLEN(armor_list) || LAZYLEN(durability_list))
-		. += "<span class='notice'>It has a <a href='?src=[REF(src)];list_armor=1'>tag</a> listing its protection classes.</span>"
+		. += "<span class='notice'>It has a <a href='?src=[REF(src)];list_armor=1'>tag</a> listing its protection classes, and a <a href='?src=[REF(src)];explain=1'>tag</a> explaining the armor system.</span>"
 
 /obj/item/clothing/Topic(href, href_list)
 	. = ..()
@@ -354,6 +354,14 @@
 
 		to_chat(usr, "[readout.Join()]")
 
+	if(href_list["explain"])
+		var/list/readout = list("<span class='notice'><u><b>ROMAN NUMERAL ARMOR SYSTEM</u></b>")
+		readout += "\nThis system is a % of damage resisted, multiplied by 10. Each 1 armor is 10% resisted."
+		readout += "\nThe Roman numeral system uses only seven symbols: I, V, X, L, C, D, and M. To read the armor values, you need to know: I represents the number 1, V represents 5, X is 10."
+		readout += "\nYou can add numbers together by putting the symbols in descending order from left to right. You’d add all of the symbols’ individual values together to get the total value. For example, VI is 5 + 1 or 6."
+		readout += "\nYou can also subtract numbers from each other by placing a symbol with a smaller value to the left of one with a larger value. The value of the smaller symbol is subtracted from that of the larger symbol to get the total value, so IV is 5 - 1, or 4."
+		readout += "\nExamples: \nIX = 10-1 = 9. \nVI = 5+1 = 6. \nVIII = 5+1+1+1 = 8.
+		to_chat(usr, "[readout.Join()]")
 
 /**
  * Rounds armor_value to nearest 10, divides it by 10 and then expresses it in roman numerals up to 10

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -333,7 +333,7 @@
 		durability_list += list("ACID" = armor.acid)
 
 	if(LAZYLEN(armor_list) || LAZYLEN(durability_list))
-		. += "<span class='notice'>It has a <a href='?src=[REF(src)];list_armor=1'>tag</a> listing its protection classes, and beside it is the same <a href='?src=[REF(src)];list_lobotomy=1'>tag</a> written out for foreign agents.</span>"
+		. += "<span class='notice'>It has a <a href='?src=[REF(src)];list_armor=1'>tag</a> listing its protection classes.</span>"
 
 /obj/item/clothing/Topic(href, href_list)
 	. = ..()
@@ -354,14 +354,6 @@
 
 		to_chat(usr, "[readout.Join()]")
 
-	if(href_list["list_lobotomy"])
-		var/list/readout = list("<span class='notice'><u><b>EGO DEFENSE VALUES</u></b>")
-		if(LAZYLEN(armor_list))
-			for(var/dam_type in armor_list)
-				var/armor_amount = armor_list[dam_type]
-				readout += "\n[dam_type] [armor_to_LC_protection(armor_amount)]" //e.g. BOMB IV
-		readout += "</span>"
-		to_chat(usr, "[readout.Join()]")
 
 /**
  * Rounds armor_value to nearest 10, divides it by 10 and then expresses it in roman numerals up to 10
@@ -415,12 +407,6 @@
 		if (10 to INFINITY)
 			. = "X"
 	return .
-
-/obj/item/clothing/proc/armor_to_LC_protection(armor_value)
-	armor_value = round(armor_value,10) / 100
-	armor_value = 1 - armor_value
-
-	return armor_value
 
 /obj/item/clothing/obj_break(damage_flag)
 	update_clothes_damaged_state(CLOTHING_DAMAGED)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes LC armor protection tag.

## Why It's Good For The Game
This feature was originally added by myself as an integration feature for base LC players to easily integrate into our system.
In recent times, I've noticed this feature be used more and more by experienced players, much to my dismay.
Having to constantly convert between two armor systems is counter productive, and I would like to finalize the SS13 armor values as the only armor system.

Having two armor systems is counterproductive to our mission of information clarity, and as we originally used the SS13 Armor values, and we are an SS13 server; I think it would be best to do away with the LC armor system.
It is easier for LC players to integrate to SS13 systems than the other way around.

## Changelog
:cl:
del: Removed LC armor values
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
