### PR TITLE
Core Suppressions rework

### DIFF
--- a/code/controllers/subsystem/lobotomy_corp.dm
+++ b/code/controllers/subsystem/lobotomy_corp.dm
@@ -72,6 +72,8 @@ SUBSYSTEM_DEF(lobotomy_corp)
 	var/box_goal = 0 // Initialized later
 	// Where we reached our goal
 	var/goal_reached = FALSE
+	/// Multiplier to PE earned from working on abnormalities
+	var/box_work_multiplier = 1
 	/// When TRUE - abnormalities can be possessed by ghosts
 	var/enable_possession = FALSE
 	/// Amount of abnormalities that agents achieved full understanding on
@@ -83,6 +85,7 @@ SUBSYSTEM_DEF(lobotomy_corp)
 	. = ..()
 	addtimer(CALLBACK(src, .proc/SetGoal), 5 MINUTES)
 	addtimer(CALLBACK(src, .proc/InitializeOrdeals), 60 SECONDS)
+	addtimer(CALLBACK(src, .proc/PickPotentialSuppressions), 60 SECONDS)
 
 /datum/controller/subsystem/lobotomy_corp/proc/SetGoal()
 	var/player_mod = GLOB.clients.len * 0.15
@@ -101,13 +104,21 @@ SUBSYSTEM_DEF(lobotomy_corp)
 	return TRUE
 
 // Called when any normal midnight ends
-/datum/controller/subsystem/lobotomy_corp/proc/PickPotentialSuppressions()
+/datum/controller/subsystem/lobotomy_corp/proc/PickPotentialSuppressions(announce = FALSE, extra_core = FALSE)
 	if(istype(core_suppression))
 		return
 	if(!LAZYLEN(GLOB.abnormality_auxiliary_consoles)) // There's no consoles, for some reason
 		message_admins("Tried to pick potential core suppressions, but there was no auxiliary consoles! Fix it!")
 		return
 	var/list/cores = subtypesof(/datum/suppression)
+	// Remove cores that don't fit requirements
+	for(var/core_type in cores)
+		var/datum/suppression/C = core_type
+		if(!extra_core && initial(C.after_midnight))
+			cores -= core_type
+			continue
+		if(extra_core && !initial(C.after_midnight))
+			cores -= core_type
 	for(var/i = 1 to max_core_options)
 		if(!LAZYLEN(cores))
 			break
@@ -116,26 +127,24 @@ SUBSYSTEM_DEF(lobotomy_corp)
 		cores -= core_type
 	if(!LAZYLEN(available_core_suppressions))
 		return
-	priority_announce("Sephirah Core Suppressions have been made available via auxiliary managerial consoles.", \
-					"Sephirah Core Suppression", sound = 'sound/machines/dun_don_alert.ogg')
+	if(announce)
+		var/announce_text = "[extra_core ? "Extra" : "Sephirah"] Core Suppressions have been made available via auxiliary managerial consoles."
+		var/announce_title = "[extra_core ? "Extra" : "Sephirah"] Core Suppression"
+		priority_announce(announce_text, \
+						announce_title, sound = 'sound/machines/dun_don_alert.ogg')
 	for(var/obj/machinery/computer/abnormality_auxiliary/A in GLOB.abnormality_auxiliary_consoles)
-		A.audible_message("<span class='notice'>Core Suppressions are now available!</span>")
+		A.audible_message("<span class='notice'>[extra_core ? "Extra " : ""]Core Suppressions are now available!</span>")
 		playsound(get_turf(A), 'sound/machines/dun_don_alert.ogg', 50, TRUE)
 		A.updateUsrDialog()
-	addtimer(CALLBACK(src, .proc/ResetPotentialSuppressions, FALSE), 4 MINUTES)
 
-/datum/controller/subsystem/lobotomy_corp/proc/ResetPotentialSuppressions(for_real = FALSE)
-	if(istype(core_suppression))
+/datum/controller/subsystem/lobotomy_corp/proc/ResetPotentialSuppressions()
+	if(istype(core_suppression) || !LAZYLEN(available_core_suppressions))
 		return
-	if(!for_real) // Just a warning for manager to pick one fast
-		for(var/obj/machinery/computer/abnormality_auxiliary/A in GLOB.abnormality_auxiliary_consoles)
-			A.audible_message("<span class='userdanger'>Core Suppression options will be disabled if you don't pick one in a minute!</span>")
-			playsound(get_turf(A), 'sound/machines/dun_don_alert.ogg', 100, TRUE, 14)
-		addtimer(CALLBACK(src, .proc/ResetPotentialSuppressions, TRUE), 1 MINUTES)
-		return
+	for(var/obj/machinery/computer/abnormality_auxiliary/A in GLOB.abnormality_auxiliary_consoles)
+		A.audible_message("<span class='userdanger'>Core Suppression options have been disabled for this shift!</span>")
+		playsound(get_turf(A), 'sound/machines/dun_don_alert.ogg', 100, TRUE, 14)
+		A.updateUsrDialog()
 	available_core_suppressions = list()
-	priority_announce("Core Suppression hasn't been chosen in 5 minutes window and have been disabled for this shift.", \
-					"Sephirah Core Suppression", sound = 'sound/machines/dun_don_alert.ogg')
 
 /datum/controller/subsystem/lobotomy_corp/proc/NewAbnormality(datum/abnormality/new_abno)
 	if(!istype(new_abno))

--- a/code/datums/abnormality/datum/abnormality.dm
+++ b/code/datums/abnormality/datum/abnormality.dm
@@ -187,7 +187,7 @@
 		if (understanding == max_understanding) // Checks for max understanding after the fact
 			current.gift_chance *= 1.5
 			SSlobotomy_corp.understood_abnos++
-	stored_boxes += pe
+	stored_boxes += round(pe * SSlobotomy_corp.box_work_multiplier)
 	if(overload_chance > overload_chance_limit)
 		overload_chance += overload_chance_amount
 

--- a/code/modules/ordeals/_ordeal.dm
+++ b/code/modules/ordeals/_ordeal.dm
@@ -50,11 +50,16 @@
 		for(var/mob/M in GLOB.player_list)
 			if(M.client)
 				M.playsound_local(get_turf(M), end_sound, 35, 0)
-	/// If it was a midnight and we got to it before time limit
-	if(level == 4 && !istype(SSlobotomy_corp.core_suppression) && \
-	!LAZYLEN(SSlobotomy_corp.available_core_suppressions) && \
+	/// If it was a midnight and we got to it before time limit after previously completing a core suppression
+	if(level == 4 && SSlobotomy_corp.core_suppression_state == 2 && \
 	start_time <= CONFIG_GET(number/suppression_time_limit))
-		addtimer(CALLBACK(SSlobotomy_corp, /datum/controller/subsystem/lobotomy_corp/proc/PickPotentialSuppressions), 20 SECONDS)
+		SSlobotomy_corp.PickPotentialSuppressions(TRUE, TRUE) // Extra cores, and announced!
+	/// If it was a dusk - we end running core suppression
+	else if(level == 3 && istype(SSlobotomy_corp.core_suppression))
+		SSlobotomy_corp.core_suppression.End()
+	/// If dawn ended - clear suppression options
+	else if(level == 1 && !istype(SSlobotomy_corp.core_suppression))
+		SSlobotomy_corp.ResetPotentialSuppressions()
 	qdel(src)
 	return
 

--- a/code/modules/ordeals/white_ordeals.dm
+++ b/code/modules/ordeals/white_ordeals.dm
@@ -2,7 +2,7 @@
 	name = "Fixers"
 	annonce_text = "This isn't supposed to happen, but they have come for you. Might want to report this to central command."
 	can_run = FALSE
-	delay = 2 // It will always give exactly 1 normal meltdown in-between ordeals
+	delay = 1 // Goes back-to-back
 	random_delay = FALSE
 	reward_percent = 0.1
 	annonce_sound = 'sound/effects/ordeals/white_start.ogg'
@@ -79,6 +79,7 @@
 	privilege of the Head, the Eye, and the Claws. It is their honor and absolute power."
 	level = 9
 	delay = 1
+	random_delay = FALSE
 	reward_percent = 0.25
 	annonce_sound = 'sound/effects/ordeals/white_start.ogg'
 	end_sound = 'sound/effects/ordeals/white_end.ogg'

--- a/code/modules/suppressions/_core_suppression.dm
+++ b/code/modules/suppressions/_core_suppression.dm
@@ -4,7 +4,7 @@
 	/// This is displayed in auxiliary manager's console when selected
 	var/desc = "Normal effects of core suppression will apply. Yell at coders to fix description."
 	/// Same as above, but what facility has to do to win
-	var/goal_text = "Complete the Midnight of White."
+	var/goal_text = "Complete the Dusk ordeal."
 	/// Ditto, but for reward
 	var/reward_text = "N/A"
 	/// Announcement text. Self-explanatory
@@ -15,9 +15,11 @@
 	var/annonce_sound = 'sound/effects/suppression.ogg'
 	/// Sound to play on event end, if any
 	var/end_sound = null
+	/// If TRUE - will only show up after clearing midnight; Those suppressions are essentially the extra bossfight
+	var/after_midnight = FALSE
 
 // Runs the event itself
-/datum/suppression/proc/Run(run_white = TRUE)
+/datum/suppression/proc/Run(run_white = FALSE)
 	priority_announce(run_text, name, sound=annonce_sound)
 	SSlobotomy_corp.core_suppression_state = max(SSlobotomy_corp.core_suppression_state, 1) // Started suppression
 	SSticker.news_report = max(SSticker.news_report, CORE_STARTED)

--- a/code/modules/suppressions/control.dm
+++ b/code/modules/suppressions/control.dm
@@ -1,9 +1,10 @@
 /datum/suppression/control
 	name = "Control Core Suppression"
 	desc = "Assignments on the abnormality work consoles will be scrambled each meltdown/ordeal."
+	reward_text = "All employees, including those that may join later in the shift will receive a +30 justice attribute buff."
 	run_text = "The core suppression of Control department has begun. The work assignments will be scrambled each meltdown."
 
-/datum/suppression/control/Run(run_white = TRUE)
+/datum/suppression/control/Run(run_white = FALSE)
 	. = ..()
 	RegisterSignal(SSdcs, COMSIG_GLOB_MELTDOWN_START, .proc/OnMeltdown)
 	OnMeltdown()
@@ -12,6 +13,13 @@
 	UnregisterSignal(SSdcs, COMSIG_GLOB_MELTDOWN_START)
 	for(var/obj/machinery/computer/abnormality/C in GLOB.abnormality_consoles)
 		C.scramble_list = list()
+	// Reward!
+	for(var/mob/living/carbon/human/H in GLOB.human_list)
+		if(!H.ckey)
+			continue
+		H.adjust_attribute_buff(JUSTICE_ATTRIBUTE, 30)
+		to_chat(H, "<span class='notice'>You feel much better than ever before!</span>")
+	new /datum/control_reward_tracker() // Gives the reward to late-joiners after it ends
 	return ..()
 
 // On lobotomy_corp meltdown event
@@ -24,3 +32,22 @@
 		choose_from -= application_scramble_list[work]
 	for(var/obj/machinery/computer/abnormality/C in GLOB.abnormality_consoles)
 		C.scramble_list = application_scramble_list
+
+// Created when control suppression ends; Used to track new spawns to apply the reward
+
+/datum/control_reward_tracker/New()
+	. = ..()
+	RegisterSignal(SSdcs, COMSIG_GLOB_CREWMEMBER_JOINED, .proc/OnJoin)
+
+/datum/control_reward_tracker/Destroy()
+	UnregisterSignal(SSdcs, COMSIG_GLOB_CREWMEMBER_JOINED)
+	return ..()
+
+// When a new employee spawns in
+/datum/control_reward_tracker/proc/OnJoin(datum/source, mob/living/carbon/human/H, rank)
+	SIGNAL_HANDLER
+	if(!ishuman(H))
+		return FALSE
+	H.adjust_attribute_buff(JUSTICE_ATTRIBUTE, 30)
+	to_chat(H, "<span class='notice'>Control core effects improved your coordination!</span>")
+	return TRUE

--- a/code/modules/suppressions/extraction.dm
+++ b/code/modules/suppressions/extraction.dm
@@ -7,6 +7,7 @@
 	run_text = "The core suppression of Extraction department has begun. The Arbiter has returned."
 	annonce_sound = 'sound/effects/combat_suppression_start.ogg'
 	end_sound = 'sound/effects/combat_suppression_end.ogg'
+	after_midnight = TRUE
 
 /datum/suppression/extraction/Run(run_white = FALSE)
 	..()

--- a/code/modules/suppressions/information.dm
+++ b/code/modules/suppressions/information.dm
@@ -3,9 +3,10 @@
 	name = "Information Core Suppression"
 	desc = "Assignments on the abnormality work consoles will be in random positions.\n\
 			Telecommunications and suit sensors will be negatively impacted."
+	reward_text = "Unique PE gained by working on abnormalities is increased by 25%."
 	run_text = "The core suppression of Information department has begun. The information and sensors will be distorted for its duration."
 
-/datum/suppression/information/Run(run_white = TRUE)
+/datum/suppression/information/Run(run_white = FALSE)
 	. = ..()
 	for(var/obj/machinery/telecomms/processor/P in GLOB.telecomms_list)
 		P.process_mode = 0 // Makes all messages pure gibberish
@@ -13,4 +14,5 @@
 /datum/suppression/information/End()
 	for(var/obj/machinery/telecomms/processor/P in GLOB.telecomms_list)
 		P.process_mode = 1
+	SSlobotomy_corp.box_work_multiplier *= 1.25
 	return ..()

--- a/code/modules/suppressions/safety.dm
+++ b/code/modules/suppressions/safety.dm
@@ -6,7 +6,7 @@
 	reward_text = "All regenerators will receive a permanent +3 boost to healing power."
 	run_text = "The core suppression of Safety department has begun. The regenerators and sleepers will stop operating normally. All personnel will be automatically healed after each meltdown instead."
 
-/datum/suppression/safety/Run(run_white = TRUE)
+/datum/suppression/safety/Run(run_white = FALSE)
 	. = ..()
 	RegisterSignal(SSdcs, COMSIG_GLOB_MELTDOWN_START, .proc/OnMeltdown)
 	for(var/obj/machinery/regenerator/R in GLOB.regenerators)

--- a/code/modules/suppressions/training.dm
+++ b/code/modules/suppressions/training.dm
@@ -5,22 +5,34 @@
 	reward_text = "Employees that survived through the suppression will be awarded with 20 increase and +5 buff to all attributes.\n\
 			All Agents that will join post-suppression will start with higher attributes."
 	run_text = "The core suppression of Training department has begun. All personnel will be suffering from symptoms of work fatigue."
+	/// Mob ref = Current ttribute debuff
 	var/list/affected_mobs = list()
+	// How much your attributes are debuffed after each ordeal
+	var/attribute_debuff_count = -10
+	// Used for new arrivals
+	var/current_debuff_amount
 
-/datum/suppression/training/Run(run_white = TRUE)
+/datum/suppression/training/Run(run_white = FALSE)
 	. = ..()
 	RegisterSignal(SSdcs, COMSIG_GLOB_CREWMEMBER_JOINED, .proc/OnJoin)
+	RegisterSignal(SSdcs, COMSIG_GLOB_MELTDOWN_START, .proc/OnMeltdown)
 	for(var/mob/living/carbon/human/H in GLOB.human_list)
 		if(!H.ckey)
 			continue
-		H.adjust_all_attribute_buffs(-30)
-		affected_mobs += H
+		H.adjust_all_attribute_buffs(attribute_debuff_count)
+		to_chat(H, "<span class='danger'>You feel weaker...</span>")
+		affected_mobs[H] = attribute_debuff_count
+		RegisterSignal(H, COMSIG_PARENT_QDELETING, .proc/RemoveFromAffectedMobs)
+	current_debuff_amount = attribute_debuff_count
 
 /datum/suppression/training/End()
 	UnregisterSignal(SSdcs, COMSIG_GLOB_CREWMEMBER_JOINED)
 	for(var/mob/living/carbon/human/H in affected_mobs)
-		H.adjust_all_attribute_buffs(35)
+		H.adjust_all_attribute_buffs(-affected_mobs[H] + 5)
 		H.adjust_all_attribute_levels(20) // A tiny reward
+		to_chat(H, "<span class='notice'>You feel much better than ever before!</span>")
+		UnregisterSignal(H, COMSIG_PARENT_QDELETING)
+	affected_mobs = null
 	for(var/datum/job/agent/J in SSjob.occupations)
 		J.normal_attribute_level += 5 // This allows agents to spawn with 100 in all stats
 	return ..()
@@ -30,6 +42,26 @@
 	if(!ishuman(L))
 		return FALSE
 	var/mob/living/carbon/human/H = L
-	H.adjust_all_attribute_buffs(-30) // Suffer
-	affected_mobs += H
+	H.adjust_all_attribute_buffs(current_debuff_amount) // Suffer
+	to_chat(H, "<span class='danger'>You feel weaker...</span>")
+	affected_mobs[H] = current_debuff_amount
+	RegisterSignal(H, COMSIG_PARENT_QDELETING, .proc/RemoveFromAffectedMobs)
 	return TRUE
+
+// Whenever an affected mob gets deleted
+/datum/suppression/training/proc/RemoveFromAffectedMobs(mob/M)
+	SIGNAL_HANDLER
+	affected_mobs -= M
+
+// Update debuff amount with each ordeal
+/datum/suppression/training/proc/OnMeltdown(datum/source, ordeal = FALSE)
+	SIGNAL_HANDLER
+	if(!ordeal)
+		return
+	for(var/mob/living/carbon/human/H in GLOB.human_list)
+		if(!H.ckey)
+			continue
+		H.adjust_all_attribute_buffs(attribute_debuff_count)
+		affected_mobs[H] += attribute_debuff_count
+		to_chat(H, "<span class='danger'>You feel weaker...</span>")
+	current_debuff_amount += attribute_debuff_count

--- a/code/modules/suppressions/welfare.dm
+++ b/code/modules/suppressions/welfare.dm
@@ -22,7 +22,7 @@
 		PALE_DAMAGE = 1,
 		)
 
-/datum/suppression/welfare/Run(run_white = TRUE)
+/datum/suppression/welfare/Run(run_white = FALSE)
 	. = ..()
 	RegisterSignal(SSdcs, COMSIG_GLOB_CREWMEMBER_JOINED, .proc/OnJoin)
 	RegisterSignal(SSdcs, COMSIG_GLOB_MELTDOWN_START, .proc/OnMeltdown)
@@ -219,7 +219,7 @@
 	. = ..()
 	RegisterSignal(SSdcs, COMSIG_GLOB_CREWMEMBER_JOINED, .proc/OnJoin)
 
-/datum/suppression/welfare/Destroy()
+/datum/welfare_reward_tracker/Destroy()
 	UnregisterSignal(SSdcs, COMSIG_GLOB_CREWMEMBER_JOINED)
 	return ..()
 

--- a/code/modules/suppressions/white_ordeals.dm
+++ b/code/modules/suppressions/white_ordeals.dm
@@ -1,0 +1,13 @@
+// This isn't a real suppression, it exists only to trigger white ordeals.
+/datum/suppression/white_ordeals
+	name = "White Ordeals"
+	desc = "The facility will trigger white ordeals with 1 meltodwn in-between them. <br>\
+			After clearing dawn, noon and dusk - the agents will have to face off against The Claw."
+	goal_text = "Defeat the Midnight of White - The Claw."
+	run_text = "The Ordeals of White have been introduced into the facility's subroutines. There will be one meltdown in-between each ordeal."
+	annonce_sound = 'sound/effects/combat_suppression_start.ogg'
+	end_sound = 'sound/effects/combat_suppression_end.ogg'
+	after_midnight = TRUE
+
+/datum/suppression/white_ordeals/Run(run_white = TRUE)
+	return ..()

--- a/lobotomy-corp13.dme
+++ b/lobotomy-corp13.dme
@@ -3533,6 +3533,7 @@
 #include "code\modules\suppressions\safety.dm"
 #include "code\modules\suppressions\training.dm"
 #include "code\modules\suppressions\welfare.dm"
+#include "code\modules\suppressions\white_ordeals.dm"
 #include "code\modules\surgery\amputation.dm"
 #include "code\modules\surgery\blood_filter.dm"
 #include "code\modules\surgery\bone_mending.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Core suppressions are available round-start, until dawn started.
Core suppressions end after dusk is finished.
After midnight is over before time limit - "extra core suppressions" are available, in a similar way it worked before rework. Current "extra core suppressions" are "White Ordeals" and Extraction.

Training core suppression has been tweaked slightly to adjust for the rework.
Information core suppression reward added: Each work gives you 25% more unique PE boxes.
Control core suppression reward added: All people, including future late-joins, get +30 justice buff.

## Why It's Good For The Game

The long awaited rework is here. Core suppression rewards finally have a purpose.