### PR TITLE
Fishin Fixes 3.1 Fishin Rods Now Bonk Off of Walls.

### DIFF
--- a/ModularTegustation/fishing/code/fishing_items/fishing_net.dm
+++ b/ModularTegustation/fishing/code/fishing_items/fishing_net.dm
@@ -15,6 +15,8 @@
 	break_message = "<span class='notice'>The net falls apart!</span>"
 	break_sound = 'sound/items/wirecutter.ogg'
 	debris = list(/obj/item/fishing_net = 1)
+	var/fishin_cooldown = 25 SECONDS
+	var/fishin_cooldown_delay = 1 SECONDS
 	var/list/stuff_to_catch
 	var/turf/open/water/deep/open_waters
 
@@ -25,11 +27,12 @@
 		qdel(src)
 		return
 	stuff_to_catch = open_waters.ReturnChanceList()
-	RegisterSignal(SSdcs, COMSIG_GLOB_MELTDOWN_START, .proc/CatchFish)
+	//will proc at least 5 times before the loop stops.
+	addtimer(CALLBACK(src, .proc/CatchFish), fishin_cooldown + fishin_cooldown_delay)
 
 /obj/structure/destructible/fishing_net/examine(mob/user)
 	. = ..()
-	if(contents.len >= 5)
+	if(contents.len > 0)
 		. += "<span class='notice'>[contents.len]/5 things are caught in the [src].</span>"
 
 /obj/structure/destructible/fishing_net/AltClick(mob/user)
@@ -43,10 +46,11 @@
 	qdel(src)
 
 /obj/structure/destructible/fishing_net/proc/CatchFish()
-	SIGNAL_HANDLER
 	if(contents.len >= 5 || !open_waters)
 		return
 	var/atom/thing_caught = pickweight(stuff_to_catch)
 	new thing_caught(src)
 	icon_state = "trawling_net_full"
 	update_icon()
+	fishin_cooldown_delay = rand(0, 5) SECONDS
+	addtimer(CALLBACK(src, .proc/CatchFish), fishin_cooldown + fishin_cooldown_delay)

--- a/ModularTegustation/fishing/code/fishing_items/fishing_rod.dm
+++ b/ModularTegustation/fishing/code/fishing_items/fishing_rod.dm
@@ -53,6 +53,8 @@
 		//Multicasting is too chaotic
 		if(isfishing == TRUE)
 			return
+		if(!BobberThrow(user, target))
+			return
 		StartFishing(user, target) //Maybe we can make it call something else with this proc.
 		return
 	. = ..()
@@ -98,6 +100,42 @@
 		//Fishing successful
 		FishLoot(pickweight(things_to_fish), user, get_turf(fishing_spot))
 	return StopFishing()
+
+/*Tgstation uses signals and projectiles for their fishing rods
+	but im not too familiar with signals so for now
+	Bobber throw for checking if there is anything blocking the turf we fish. */
+/obj/item/fishing_rod/proc/BobberThrow(mob/living/user, bobber_target)
+	var/turf/target_turf = get_turf(bobber_target)
+	var/fish_distance = get_dist_euclidian(get_turf(target_turf), get_turf(src))
+	if(fish_distance >= 7)
+		to_chat(user, "<span class='notice'>The bobber is [round(fish_distance - 7)] tiles short of its destination.</span>")
+		return FALSE
+	/*Cycles 7 times until it returns. Wallcheck checks the turf after
+		this turf and if that turf equals the target turf we return TRUE.
+		If the Wallcheck returns a false proc on ClearSky then we return FALSE.
+		Clearsky checks if the turf has a window in it or a solid wall. */
+	var/turf/this_turf = get_turf(src)
+	var/turf/wallcheck
+	for(var/i=0 to 7)
+		if(this_turf == target_turf)
+			return TRUE
+		wallcheck = get_step(this_turf, get_dir(this_turf, target_turf))
+		if(!ClearSky(wallcheck))
+			to_chat(user, "<span class='notice'>The bobber donks off of an obstacle.</span>")
+			return FALSE
+		this_turf = wallcheck
+
+/*For checking turf to where the bobber lands. Same check as
+	/mob/living/simple_animal/hostile/ordeal/steel_dawn/steel_noon/flying. -IP */
+/obj/item/fishing_rod/proc/ClearSky(turf/T)
+	if(!T || isclosedturf(T) || T == loc)
+		return FALSE
+	if(locate(/obj/structure/window) in T.contents)
+		return FALSE
+	for(var/obj/machinery/door/D in T.contents)
+		if(D.density)
+			return FALSE
+	return TRUE
 
 //Unique Fish Retrieval
 /obj/item/fishing_rod/proc/FishLoot(obj/item/fished_thing, mob/living/user, turf/fish_land)

--- a/ModularTegustation/fishing/code/turfs.dm
+++ b/ModularTegustation/fishing/code/turfs.dm
@@ -1,4 +1,5 @@
-/turf/open/water/deep //you will sink in this. collective branch for both saltwater and freshwater turfs.
+//you will sink in this. collective branch for both saltwater and freshwater turfs.
+/turf/open/water/deep
 	name = "water"
 	desc = "Deep Water."
 	icon = 'ModularTegustation/Teguicons/32x32.dmi'
@@ -8,8 +9,12 @@
 	density = TRUE
 	bullet_sizzle = TRUE
 	bullet_bounce_sound = 'sound/effects/footstep/water1.ogg'
-	//Turf that living mobs like hostiles and humans are dropped off at.
+	/*Turf that living mobs like hostiles and humans are dropped off at.
+		This is a variable because some people may want water to work as
+		a portal to somewhere.*/
 	var/turf/target_turf
+	//If the target_turf is randomized.
+	var/static_target = FALSE
 	//Sound delay so we dont get splash spam.
 	var/sound_delay = 0
 	//Lootlist of things for fishing.
@@ -36,12 +41,13 @@
 
 /turf/open/water/deep/Initialize()
 	. = ..()
-	target_turf = pick(GLOB.department_centers)
+	WashedOnTheShore()
 
 /turf/open/water/deep/CanAllowThrough(atom/movable/AM, turf/target)
 	. = ..()
 	return TRUE
 
+//For fishing nets.
 /turf/open/water/deep/attackby(obj/item/C, mob/user, params)
 	if(istype(C, /obj/item/fishing_net) && params)
 		to_chat(user, "<span class='notice'>You start setting up the [C].</span>")
@@ -78,7 +84,16 @@
 	if(sound_delay <= world.time)
 		playsound(get_turf(src), 'sound/abnormalities/piscinemermaid/waterjump.ogg', 20, 0, 3)
 		sound_delay = world.time + (3 SECONDS)
+		WashedOnTheShore()
 	thing.forceMove(target_turf)
+
+//Proc to randomize target_turf
+/turf/open/water/deep/proc/WashedOnTheShore()
+	if(!static_target)
+		if(GLOB.department_centers.len > 0)
+			target_turf = pick(GLOB.department_centers)
+		else
+			target_turf = get_turf(src)
 
 	//How this works is that it returns a list with a divided chance for anything lower than the maximum
 /turf/open/water/deep/proc/ReturnChanceList(maximum = FISH_RARITY_BASIC)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fishin nets now work on a callback timer instead of meltdown, Fishing rods now check the line towards its destination for obstacles, and deep water turf now defaults its teleport target to itself if the department centers list is empty (lifeguards may be able to save them on the beach). 

## Changelog
:cl:
fix: fishing rods, fishin turf
tweak: fishing nets
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
