### PR TITLE
Fixes Mob Spawner Factions to allow lists & attributes

### DIFF
--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -1,4 +1,5 @@
-//Objects that spawn ghosts in as a certain role when they click on it, i.e. away mission bartenders.
+/*Objects that spawn ghosts in as a certain role when they click on it, i.e. away mission bartenders.
+	Origin Procs are in code/module/awaymissions/corpse.dm */
 
 //Preserved terrarium/seed vault: Spawns in seed vault structures in lavaland. Ghosts become plantpeople and are advised to begin growing plants in the room near them.
 /obj/effect/mob_spawn/human/seed_vault
@@ -859,7 +860,7 @@
 	name = "sleeper"
 	icon = 'icons/obj/machines/sleeper.dmi'
 	icon_state = "sleeper"
-	faction = "nanotrasenprivate"
+	faction = list("nanotrasenprivate")
 	short_desc = "You are a Nanotrasen Private Security Officer!"
 
 /obj/effect/mob_spawn/human/commander/alive
@@ -1056,6 +1057,11 @@
 	outfit = /datum/outfit/centcom/ert/security/rabbit
 	assignedrole = "Specialist"
 
+/obj/effect/mob_spawn/human/supplypod/r_corp/rabbit_call/special(mob/living/new_spawn)
+	..()
+	var/mob/living/carbon/human/H = new_spawn
+	H.adjust_all_attribute_levels(60)
+
 //Raven Mobspawner
 /obj/effect/mob_spawn/human/supplypod/r_corp/raven_call
 	name = "raven teleport zone"
@@ -1063,6 +1069,12 @@
 	mob_name = "raven team scout"
 	outfit = /datum/outfit/job/raven
 	assignedrole = "SPC"
+
+/obj/effect/mob_spawn/human/supplypod/r_corp/raven_call/special(mob/living/new_spawn)
+	..()
+	var/mob/living/carbon/human/H = new_spawn
+	H.adjust_all_attribute_levels(40)
+	H.adjust_attribute_level(JUSTICE_ATTRIBUTE, 60)
 
 //Rhino Mobspawner
 /obj/effect/mob_spawn/human/supplypod/r_corp/rhino_call
@@ -1072,6 +1084,11 @@
 	outfit = /datum/outfit/centcom/ert/security/rhino
 	assignedrole = "Sergeant"
 	uses = 2
+
+/obj/effect/mob_spawn/human/supplypod/r_corp/rhino_call/special(mob/living/new_spawn)
+	..()
+	var/mob/living/carbon/human/H = new_spawn
+	H.adjust_all_attribute_levels(40)
 
 /obj/effect/mob_spawn/human/supplypod/r_corp/rhino_call/PrepareForHellDiving(mob/living/user)
 	var/obj/vehicle/sealed/mecha/combat/rhino/mech = new

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -20,7 +20,6 @@
 	var/short_desc = "The mapper forgot to set this!"
 	var/flavour_text = ""
 	var/important_info = ""
-	var/faction = null
 	var/permanent = FALSE	//If true, the spawner will not disappear upon running out of uses.
 	var/random = FALSE		//Don't set a name or gender, just go random
 	var/antagonist_type
@@ -35,6 +34,7 @@
 	var/show_flavour = TRUE
 	var/banType = ROLE_LAVALAND
 	var/ghost_usable = TRUE
+	var/list/faction
 
 /obj/effect/mob_spawn/proc/spawn_user_as_role(mob/user)
 	if(!SSticker.HasRoundStarted() || !loc)
@@ -102,7 +102,12 @@
 			var/mob/living/carbon/human/hoomie = M
 			hoomie.body_type = mob_gender
 	if(faction)
-		M.faction = list(faction)
+		/*This used to be list(faction) replacing the entire mob faction
+			with ONE faction, but now the faction is a list...
+			I considered making this a LAZYADD(M.faction, faction)
+			but there may be some roles that dont want a mob to be
+			neutral automatically. -IP */
+		M.faction = faction
 	if(disease)
 		M.ForceContractDisease(new disease)
 	if(death)

--- a/code/modules/clothing/outfits/ert.dm
+++ b/code/modules/clothing/outfits/ert.dm
@@ -505,7 +505,10 @@
 	belt = /obj/item/storage/belt/utility/full
 	l_pocket = null
 	r_pocket = null
-	backpack_contents = list(/obj/item/storage/box/survival/engineer=1)
+	backpack_contents = list(
+		/obj/item/storage/box/survival/engineer=1,
+		/obj/item/clothing/glasses/welding=1
+		)
 
 /datum/outfit/centcom/ert/security/rhino/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	if(visualsOnly)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
So... before this update no mobspawned mob could have more than one faction.
Because it was 
`M.faction = faction`
and faction would just be "syndicate"
In order to make sure i didnt break anything i have to touch all these ghost roles.
![image](https://github.com/vlggms/lobotomy-corp13/assets/109536843/f40cb318-05df-40eb-8022-ee1b36b3878f)
Everything seems to be in order. The only thing missing from the faction is the mobs "[mob_tag]" but i dont know if ANYTHING uses that.
![image](https://github.com/vlggms/lobotomy-corp13/assets/109536843/2fb5b41b-9e43-441e-bac1-746ca1a5bb12)

Also added attributes to r corp spawns since they are supposed to have them.

## Why It's Good For The Game
I feel like we should be allowed to have more than one faction on mob spawn.

## Changelog
:cl:
fix: corpses.dm
fix: attributes not being on r corp people.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
