### PR TITLE
Steel Manager Health and Black Defense reduction

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/ordeal/steel.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/steel.dm
@@ -199,8 +199,8 @@
 	mob_biotypes = MOB_ORGANIC|MOB_HUMANOID|MOB_BUG
 	ranged_cooldown_time = 15 SECONDS
 	a_intent = INTENT_HELP
-	maxHealth = 2000
-	health = 2000
+	maxHealth = 1300
+	health = 1300
 	melee_damage_lower = 40
 	melee_damage_upper = 57
 	vision_range = 12
@@ -208,7 +208,7 @@
 	ranged = TRUE
 	retreat_distance = 2
 	minimum_distance = 2
-	damage_coeff = list(BRUTE = 1, RED_DAMAGE = 0.8, WHITE_DAMAGE = 0.8, BLACK_DAMAGE = 1.2, PALE_DAMAGE = 1)
+	damage_coeff = list(BRUTE = 1, RED_DAMAGE = 0.8, WHITE_DAMAGE = 0.8, BLACK_DAMAGE = 1.4, PALE_DAMAGE = 1)
 	can_patrol = TRUE
 	wander = FALSE
 	patrol_cooldown_time = 1 MINUTES


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Reduces Steel Managers health and increases their vulnerability to black.
So dawn health is 220 and noons are 750, a 530hp increase from their dawn counterparts. 
Steel dusk is currently 2000, the same a big bird and a 1250 hp increase for a creature that is generally a heavy white hitter/support class. Im going to reduce it to 1300 since then the health increase is 550 hp.  
Also changing black resistance from 1.2 to 1.4 since people where having issue killing them.

I know Steel is a mess. Its kind of the curse of ordeals.

## Why It's Good For The Game
It is weird steel managers have as much health as big bird. We really need to standardize what is alot of health and what is little.

## Changelog
:cl:
tweak: Steel Dusk health
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
