### PR TITLE
Thumb Buff and Ncorp Nerf

### DIFF
--- a/_maps/templates/syndicate_office/ncorp.dmm
+++ b/_maps/templates/syndicate_office/ncorp.dmm
@@ -52,6 +52,12 @@
 /area/city/backstreets_room)
 "hG" = (
 /obj/structure/rack,
+/obj/item/storage/belt/ego,
+/obj/item/storage/belt/ego,
+/obj/item/storage/belt/ego,
+/obj/item/storage/belt/ego,
+/obj/item/storage/belt/ego,
+/obj/item/storage/belt/ego,
 /turf/open/floor/wood,
 /area/city/backstreets_room)
 "iw" = (
@@ -275,7 +281,6 @@
 /obj/item/ego_weapon/city/ncorp_mark/black,
 /obj/item/ego_weapon/city/ncorp_mark/black,
 /obj/item/ego_weapon/city/ncorp_mark/black,
-/obj/item/ego_weapon/city/ncorp_mark/pale,
 /obj/item/ego_weapon/city/ncorp_brassnail/rose,
 /turf/open/floor/wood,
 /area/city/backstreets_room)

--- a/code/game/objects/items/ego_weapons/non_abnormality/weak_edits/city.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/weak_edits/city.dm
@@ -97,8 +97,8 @@
 
 //Thumb
 /obj/item/gun/ego_gun/city/thumb/weak
-	force = 15
-	projectile_damage_multiplier = 1.5		//15 damage per bullet
+	force = 20
+	projectile_damage_multiplier = 2		//20 damage per bullet
 	attribute_requirements = list(
 							FORTITUDE_ATTRIBUTE = 60,
 							PRUDENCE_ATTRIBUTE = 60,
@@ -108,8 +108,8 @@
 
 //Capo
 /obj/item/gun/ego_gun/city/thumb/capo/weak
-	force = 20
-	projectile_damage_multiplier = 2.5		//25 damage per bullet
+	force = 25
+	projectile_damage_multiplier = 3		//30 damage per bullet
 	attribute_requirements = list(
 							FORTITUDE_ATTRIBUTE = 80,
 							PRUDENCE_ATTRIBUTE = 80,
@@ -120,8 +120,8 @@
 //Sottoacpo
 /obj/item/gun/ego_gun/city/thumb/sottocapo/weak
 	force = 10	//It's a pistol
-	projectile_damage_multiplier = 0.5		//5 damage per bullet
-	ammo_type = /obj/item/ammo_casing/caseless/thumbshell	//Does 8 shells at 5 damage, total 40
+	projectile_damage_multiplier = 0.7		//5 damage per bullet
+	ammo_type = /obj/item/ammo_casing/caseless/thumbshell	//Does 8 shells at 7 damage, total 56
 	attribute_requirements = list(
 							FORTITUDE_ATTRIBUTE = 100,
 							PRUDENCE_ATTRIBUTE = 100,
@@ -131,7 +131,7 @@
 
 //wepaons are kinda uninteresting
 /obj/item/ego_weapon/city/thumbmelee/weak
-	force = 30
+	force = 35
 	attribute_requirements = list(
 							FORTITUDE_ATTRIBUTE = 80,
 							PRUDENCE_ATTRIBUTE = 80,
@@ -140,7 +140,7 @@
 							)
 
 /obj/item/ego_weapon/city/thumbcane/weak
-	force = 40
+	force = 45
 	attribute_requirements = list(
 							FORTITUDE_ATTRIBUTE = 100,
 							PRUDENCE_ATTRIBUTE = 100,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Buffs all thumb weapons by about 5 damage
Removes NCorp Pale seal
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Thumb didn't do enough damage; and Ncorp killed you in one hit.
This makes both of those scenarios less likely.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Buffs Thumb damage
balance: Nerf NCorp Damage

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
