### PR TITLE
Injector fix

### DIFF
--- a/ModularTegustation/tegu_items/associations/items.dm
+++ b/ModularTegustation/tegu_items/associations/items.dm
@@ -59,7 +59,7 @@
 
 /obj/item/attribute_increase_small/attack_self(mob/living/carbon/human/user)
 	//max stats can't gain stats
-	if(get_attribute_level(user, TEMPERANCE_ATTRIBUTE)<=130)
+	if(get_attribute_level(user, TEMPERANCE_ATTRIBUTE)>=130)
 		to_chat(user, "<span class='danger'>You feel like you won't gain anything.</span>")
 		return
 


### PR DESCRIPTION
Swaps a sign around

## Changelog
:cl:
fix: fixed stat injectors
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
