### PR TITLE
Slowdown Bullet Rework

### DIFF
--- a/ModularTegustation/tegu_items/gadgets/powered.dm
+++ b/ModularTegustation/tegu_items/gadgets/powered.dm
@@ -165,7 +165,7 @@
 
 /obj/structure/slowingmk1/Crossed(atom/movable/AM)
 	. = ..()
-	if(isabnormalitymob(AM))
+	if(ishostile(AM))
 		var/mob/living/simple_animal/hostile/L = AM
 		L.apply_status_effect(/datum/status_effect/qliphothoverload)
 		QDEL_IN(src, 2)
@@ -296,7 +296,7 @@
 		user.visible_message(hit_message)
 		return
 	hit_message = "<span class='userdanger'>[user] smashes the taser into [T].</span>"
-	if(isabnormalitymob(T) && cell.charge >= batterycost_slow)
+	if(ishostile(T) && cell.charge >= batterycost_slow)
 		cell.charge = cell.charge - batterycost_slow
 		user.visible_message(hit_message)
 		T.apply_status_effect(/datum/status_effect/qliphothoverload)

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -981,21 +981,23 @@
 
 
 //~~~LC13 General Debuffs~~~
-
+#define CARBON_HALFSPEED /datum/movespeed_modifier/qliphothoverload
 /datum/status_effect/qliphothoverload
 	id = "qliphoth intervention field"
 	duration = 10 SECONDS
 	alert_type = null
 	status_type = STATUS_EFFECT_REFRESH
 	var/statuseffectvisual
-	var/originalstamina = 0
 
 /datum/status_effect/qliphothoverload/on_apply()
 	. = ..()
-	var/mob/living/simple_animal/hostile/L = owner
-	L.adjustStaminaLoss(160, TRUE, TRUE)
-	L.stamina_recovery *= 0.01 //anything with below 10 stamina recovery will continue to lose stamina
-	L.update_stamina()
+	if(ishostile(owner))
+		var/mob/living/simple_animal/hostile/L = owner
+		L.TemporarySpeedChange(4, duration)
+	if(iscarbon(owner))
+		var/mob/living/carbon/M = owner
+		M.add_movespeed_modifier(CARBON_HALFSPEED)
+
 	var/mutable_appearance/effectvisual = mutable_appearance('icons/obj/clockwork_objects.dmi', "vanguard")
 	effectvisual.pixel_x = -owner.pixel_x
 	effectvisual.pixel_y = -owner.pixel_y
@@ -1003,15 +1005,12 @@
 	owner.add_overlay(statuseffectvisual)
 
 /datum/status_effect/qliphothoverload/on_remove()
-	var/mob/living/simple_animal/hostile/L = owner
-	L.adjustStaminaLoss(-160, TRUE, TRUE)
-	L.stamina_recovery /= 0.01
-	L.update_stamina()
+	if(iscarbon(owner))
+		var/mob/living/carbon/M = owner
+		M.remove_movespeed_modifier(CARBON_HALFSPEED)
+
 	owner.cut_overlay(statuseffectvisual)
 	return ..()
-
-//update_stamina() is move_to_delay = (initial(move_to_delay) + (staminaloss * 0.06))
-// 100 stamina damage equals 6 additional move_to_delay. So 167*0.06 = 10.02
 
 /datum/status_effect/sunder_red
 	id = "sunder red armor"
@@ -1068,3 +1067,5 @@
 	. = ..()
 	var/mob/living/simple_animal/M = owner
 	M.damage_coeff[BLACK_DAMAGE] /= 1.2
+
+#undef CARBON_HALFSPEED

--- a/code/game/machinery/computer/manager_camera.dm
+++ b/code/game/machinery/computer/manager_camera.dm
@@ -104,7 +104,7 @@
 	if(ishuman(clicked_atom))
 		clickedemployee(source, clicked_atom)
 		return
-	if(isabnormalitymob(clicked_atom))
+	if(ishostile(clicked_atom))
 		clickedabno(source, clicked_atom)
 		return
 
@@ -124,6 +124,12 @@
 				H.apply_status_effect(/datum/status_effect/interventionshield/black)
 			if(PALE_BULLET)
 				H.apply_status_effect(/datum/status_effect/interventionshield/pale)
+			if(YELLOW_BULLET)
+				if(!owner.faction_check_mob(H))
+					H.apply_status_effect(/datum/status_effect/qliphothoverload)
+				else
+					to_chat(owner, "<span class='warning'>WELFARE SAFETY SYSTEM ERROR: TARGET SHARES CORPORATE FACTION.</span>")
+					return
 			else
 				to_chat(owner, "<span class='warning'>ERROR: BULLET INITIALIZATION FAILURE.</span>")
 				return

--- a/code/modules/mob/living/simple_animal/abnormality/_abnormality.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_abnormality.dm
@@ -79,24 +79,8 @@
 	var/list/dummy_chems = list(/datum/reagent/abnormality/nutrition, /datum/reagent/abnormality/cleanliness, /datum/reagent/abnormality/consensus, /datum/reagent/abnormality/amusement, /datum/reagent/abnormality/violence)
 
 /mob/living/simple_animal/hostile/abnormality/Initialize(mapload)
-	//Speed is checked before everything else.
-	//This has literally no easy calculation I could find so I will be doing it manually
-	switch(move_to_delay)
-		if(5 to INFINITY)
-			speed = 1.5
-		if(4 to 5)
-			speed = 1
-		if(3 to 4)
-			speed = 0.5
-		if(-INFINITY to 2)
-			speed = -1
-		if(2 to 3)
-			speed = -0.5
-		if(3)	//3 is the default
-			speed = 0
-
-
 	. = ..()
+	UpdateSpeed()
 	if(!(type in GLOB.cached_abno_work_rates))
 		GLOB.cached_abno_work_rates[type] = work_chances.Copy()
 	if(!(type in GLOB.cached_abno_resistances))

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -130,9 +130,11 @@
 /mob/living/simple_animal/hostile/update_stamina()
 	. = ..()
 	move_to_delay = (initial(move_to_delay) + (staminaloss * 0.06))
+	UpdateSpeed()
 
 /mob/living/simple_animal/hostile/proc/SpeedChange(amount = 0)
 	move_to_delay += amount
+	UpdateSpeed()
 
 /mob/living/simple_animal/hostile/proc/TemporarySpeedChange(amount = 0, time = 0)
 	if(time <= 0)
@@ -170,6 +172,21 @@
 			FindTarget(list(P.firer), 1)
 		Goto(P.starting, move_to_delay, 3)
 	return ..()
+
+/*Used in LC13 abnormality calculations.
+	Moved here so we can use it for all hostiles.
+	So this took me a while to figure out,
+	player controlled mob speed is default
+	2 when in running mode. The "speed" variable
+	isnt actually adding it up from 0. Its a
+	multiplication of a 1 that is added to the 2.
+	move_to_delay is the lag in deciseconds. So
+	to fix this the speed should be move_to_delay -2.
+	Also this doesnt fix Stamina Update since it uses
+	initial - IP*/
+//Also is it frowned upon to make a proc just a single proc but with a unique var
+/mob/living/simple_animal/hostile/proc/UpdateSpeed()
+	set_varspeed(move_to_delay - 2)
 
 //////////////HOSTILE MOB TARGETTING AND AGGRESSION////////////
 

--- a/code/modules/movespeed/modifiers/mobs.dm
+++ b/code/modules/movespeed/modifiers/mobs.dm
@@ -118,6 +118,10 @@
 /datum/movespeed_modifier/metabolicboost
 	multiplicative_slowdown = -1.5
 
+//LC13 Movespeeds
 /datum/movespeed_modifier/justice_attribute
 	variable = TRUE
 	multiplicative_slowdown = 0
+
+/datum/movespeed_modifier/qliphothoverload
+	multiplicative_slowdown = 4


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Reworks slowdown bullets and mob speeds.
Replaces abnormality auto speed calculation with a proc.
Discovered move_to_delay was the lag in deciseconds while speed was a multiplication of the users speed.
Slowdown Bullets now work on all mobs but managers can only fire slowdown on mobs that dont match their faction.
Slowdown bullets now work on carbons as well as abnormalities without relying on stamina damage.

> Big bird has 3.5 Cache_move_delay but it should have 1.5 move_delay. 
> Nosferatu and Titania is 3 but it should be 1
> Golden Apple, Blue Shep, and All Around Helper is 2.5 but should be 0.5
> Picene Mermaid is 1.5 but should be -0.5
> 
> is the basis of speed 2 and the speed is just added onto that?
> 2 + 1.5 = 3.5 
> 2 + 1 = 3
> 2 - 1 = 2.5 

## Why It's Good For The Game
People have been reporting a bug where abnormalities will speed up or slow down after being slowed.

## Changelog
:cl:
tweak: Slowdown Bullets
tweak: Auto Abnormality Speed Calculation
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
