### PR TITLE
3 New random carriages

### DIFF
--- a/_maps/map_files/Event/wcorp-carriage1.dmm
+++ b/_maps/map_files/Event/wcorp-carriage1.dmm
@@ -1,0 +1,388 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/turf/closed/wall/r_wall/syndicate,
+/area/city/outskirts)
+"b" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/carpet/blue,
+/area/city/outskirts)
+"c" = (
+/turf/closed/indestructible/wood,
+/area/city/outskirts)
+"e" = (
+/obj/machinery/vending/boozeomat,
+/turf/closed/indestructible/wood,
+/area/city/outskirts)
+"f" = (
+/turf/open/floor/wood,
+/area/city/outskirts)
+"g" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/city/outskirts)
+"h" = (
+/obj/structure/table/rolling,
+/obj/item/reagent_containers/food/drinks/beer,
+/turf/open/floor/carpet/blue,
+/area/city/outskirts)
+"i" = (
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/carpet/blue,
+/area/city/outskirts)
+"j" = (
+/obj/structure/chair/stool/bar,
+/turf/open/floor/carpet/blue,
+/area/city/outskirts)
+"k" = (
+/obj/structure/table/wood,
+/turf/open/floor/carpet/blue,
+/area/city/outskirts)
+"l" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/city/outskirts)
+"m" = (
+/obj/effect/decal/cleanable/xenoblood/xgibs,
+/turf/open/floor/wood,
+/area/city/outskirts)
+"n" = (
+/obj/structure/table/rolling,
+/turf/open/floor/carpet/blue,
+/area/city/outskirts)
+"o" = (
+/obj/structure/chair/wood,
+/turf/open/floor/carpet/blue,
+/area/city/outskirts)
+"p" = (
+/obj/item/chair/wood,
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/wood,
+/area/city/outskirts)
+"q" = (
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/wood,
+/area/city/outskirts)
+"r" = (
+/obj/structure/displaycase,
+/turf/open/floor/carpet/blue,
+/area/city/outskirts)
+"t" = (
+/obj/structure/table/rolling,
+/obj/item/reagent_containers/food/drinks/bottle/whiskey,
+/turf/open/floor/carpet/blue,
+/area/city/outskirts)
+"u" = (
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/carpet/blue,
+/area/city/outskirts)
+"v" = (
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/wood,
+/area/city/outskirts)
+"x" = (
+/obj/structure/table/wood,
+/obj/item/candle/infinite,
+/turf/open/floor/carpet/blue,
+/area/city/outskirts)
+"y" = (
+/obj/structure/bookcase,
+/turf/open/floor/wood,
+/area/city/outskirts)
+"z" = (
+/obj/item/chair/wood,
+/turf/open/floor/carpet/blue,
+/area/city/outskirts)
+"A" = (
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/wood,
+/area/city/outskirts)
+"B" = (
+/obj/structure/chair/wood{
+	dir = 1
+	},
+/turf/open/floor/carpet/blue,
+/area/city/outskirts)
+"D" = (
+/obj/structure/table/wood,
+/obj/effect/decal/cleanable/ash,
+/obj/item/clothing/mask/cigarette/cigar,
+/turf/open/floor/carpet/blue,
+/area/city/outskirts)
+"E" = (
+/obj/structure/table/rolling,
+/obj/structure/table/rolling,
+/obj/item/flashlight/lamp,
+/turf/open/floor/carpet/blue,
+/area/city/outskirts)
+"F" = (
+/obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/wood,
+/area/city/outskirts)
+"H" = (
+/obj/effect/decal/cleanable/xenoblood,
+/turf/open/floor/wood,
+/area/city/outskirts)
+"I" = (
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/crude,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/wood,
+/area/city/outskirts)
+"L" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/city/outskirts)
+"M" = (
+/turf/open/floor/carpet/blue,
+/area/city/outskirts)
+"N" = (
+/obj/item/chair/wood,
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/carpet/blue,
+/area/city/outskirts)
+"P" = (
+/obj/machinery/light,
+/turf/open/floor/wood,
+/area/city/outskirts)
+"Q" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/beer,
+/turf/open/floor/carpet/blue,
+/area/city/outskirts)
+"R" = (
+/obj/item/chair/wood{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/carpet/blue,
+/area/city/outskirts)
+"S" = (
+/obj/item/chair/stool/bar,
+/turf/open/floor/carpet/blue,
+/area/city/outskirts)
+"T" = (
+/obj/structure/table/rolling,
+/obj/item/flashlight/lamp,
+/turf/open/floor/carpet/blue,
+/area/city/outskirts)
+"U" = (
+/obj/item/chair/wood,
+/turf/open/floor/wood,
+/area/city/outskirts)
+"V" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/bottle/whiskey,
+/obj/item/clothing/mask/cigarette/cigar{
+	pixel_x = 9;
+	pixel_y = 7
+	},
+/turf/open/floor/carpet/blue,
+/area/city/outskirts)
+"Z" = (
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/crude,
+/turf/open/floor/wood,
+/area/city/outskirts)
+
+(1,1,1) = {"
+a
+a
+m
+f
+I
+H
+A
+I
+I
+a
+a
+"}
+(2,1,1) = {"
+a
+q
+f
+f
+f
+f
+f
+f
+f
+y
+a
+"}
+(3,1,1) = {"
+a
+L
+f
+f
+j
+S
+S
+f
+A
+P
+a
+"}
+(4,1,1) = {"
+a
+p
+f
+f
+n
+h
+E
+f
+f
+g
+a
+"}
+(5,1,1) = {"
+a
+Q
+B
+M
+S
+j
+j
+M
+R
+x
+a
+"}
+(6,1,1) = {"
+a
+r
+M
+M
+u
+u
+i
+M
+M
+r
+a
+"}
+(7,1,1) = {"
+a
+x
+N
+M
+M
+M
+M
+M
+o
+k
+a
+"}
+(8,1,1) = {"
+a
+U
+f
+f
+e
+c
+e
+f
+f
+f
+a
+"}
+(9,1,1) = {"
+a
+k
+B
+M
+M
+M
+M
+M
+z
+V
+a
+"}
+(10,1,1) = {"
+a
+r
+M
+M
+M
+b
+M
+u
+M
+r
+a
+"}
+(11,1,1) = {"
+a
+k
+M
+M
+j
+j
+j
+M
+N
+D
+a
+"}
+(12,1,1) = {"
+a
+l
+f
+f
+T
+t
+n
+f
+f
+l
+a
+"}
+(13,1,1) = {"
+a
+L
+F
+f
+S
+j
+j
+f
+A
+P
+a
+"}
+(14,1,1) = {"
+a
+v
+f
+f
+f
+f
+f
+f
+f
+y
+a
+"}
+(15,1,1) = {"
+a
+a
+Z
+Z
+m
+A
+Z
+f
+H
+a
+a
+"}

--- a/_maps/map_files/Event/wcorp-firstclass.dmm
+++ b/_maps/map_files/Event/wcorp-firstclass.dmm
@@ -1,0 +1,539 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"ax" = (
+/obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/glass/plasma,
+/turf/open/floor/circuit/red,
+/area/city/outskirts)
+"aQ" = (
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 10
+	},
+/obj/machinery/atmospherics/components/unary/thermomachine,
+/turf/open/floor/mineral/plastitanium,
+/area/city/outskirts)
+"bV" = (
+/obj/effect/decal/cleanable/glass,
+/obj/machinery/light{
+	dir = 2
+	},
+/turf/open/floor/carpet/blue,
+/area/city/outskirts)
+"cD" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 9
+	},
+/turf/open/floor/carpet/blue,
+/area/city/outskirts)
+"eX" = (
+/obj/structure/window/shuttle/survival_pod,
+/turf/open/floor/circuit/red,
+/area/city/outskirts)
+"fa" = (
+/obj/structure/window/shuttle/survival_pod,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/circuit,
+/area/city/outskirts)
+"hQ" = (
+/obj/machinery/clonepod,
+/turf/open/floor/plating,
+/area/city/outskirts)
+"hX" = (
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/city/outskirts)
+"ic" = (
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 8
+	},
+/turf/open/floor/circuit,
+/area/city/outskirts)
+"iU" = (
+/turf/closed/wall/r_wall/syndicate,
+/area/city/outskirts)
+"jO" = (
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 4
+	},
+/turf/open/floor/circuit,
+/area/city/outskirts)
+"kR" = (
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 8
+	},
+/obj/structure/barricade/security,
+/turf/open/floor/mineral/plastitanium,
+/area/city/outskirts)
+"lW" = (
+/obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/glass/plasma,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/circuit/red,
+/area/city/outskirts)
+"mu" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/carpet/blue,
+/area/city/outskirts)
+"ns" = (
+/obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/glass/plasma,
+/obj/effect/decal/cleanable/blood/gibs,
+/turf/open/floor/circuit/red,
+/area/city/outskirts)
+"nA" = (
+/obj/structure/window/shuttle/survival_pod,
+/obj/structure/window/shuttle/survival_pod,
+/turf/open/floor/circuit/red,
+/area/city/outskirts)
+"nF" = (
+/obj/machinery/light/broken,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/carpet/blue,
+/area/city/outskirts)
+"oy" = (
+/obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/glass/plasma,
+/obj/effect/decal/cleanable/blood/gibs/up,
+/turf/open/floor/circuit/red,
+/area/city/outskirts)
+"pb" = (
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 9
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/city/outskirts)
+"qB" = (
+/obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/glass/plasma,
+/obj/effect/decal/cleanable/blood/gibs/down,
+/turf/open/floor/circuit/red,
+/area/city/outskirts)
+"ra" = (
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/thermomachine,
+/turf/open/floor/mineral/plastitanium,
+/area/city/outskirts)
+"rH" = (
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 4
+	},
+/obj/structure/barricade/security,
+/turf/open/floor/circuit,
+/area/city/outskirts)
+"rM" = (
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 10
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/city/outskirts)
+"sX" = (
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/mineral/plastitanium,
+/area/city/outskirts)
+"um" = (
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 9
+	},
+/obj/machinery/atmospherics/components/unary/thermomachine,
+/turf/open/floor/mineral/plastitanium,
+/area/city/outskirts)
+"wx" = (
+/obj/effect/decal/cleanable/glass,
+/obj/machinery/light,
+/turf/open/floor/carpet/blue,
+/area/city/outskirts)
+"wH" = (
+/turf/open/floor/circuit,
+/area/city/outskirts)
+"xk" = (
+/obj/effect/decal/cleanable/blood/gibs,
+/turf/open/floor/circuit/red,
+/area/city/outskirts)
+"ya" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 8
+	},
+/obj/machinery/light/broken,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/carpet/blue,
+/area/city/outskirts)
+"Bp" = (
+/obj/effect/decal/cleanable/glass,
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 6
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/city/outskirts)
+"Bu" = (
+/obj/effect/decal/cleanable/glass,
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 5
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/city/outskirts)
+"Cn" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/circuit/red,
+/area/city/outskirts)
+"Du" = (
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 5
+	},
+/obj/machinery/atmospherics/components/unary/thermomachine,
+/turf/open/floor/mineral/plastitanium,
+/area/city/outskirts)
+"Ew" = (
+/obj/machinery/door/poddoor/shutters/window/preopen,
+/obj/effect/decal/cleanable/blood/tracks,
+/turf/open/floor/circuit/red,
+/area/city/outskirts)
+"EN" = (
+/obj/effect/decal/cleanable/blood/gibs,
+/obj/effect/decal/cleanable/blood/tracks,
+/turf/open/floor/circuit/red,
+/area/city/outskirts)
+"Fc" = (
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 4
+	},
+/obj/structure/barricade/security,
+/turf/open/floor/mineral/plastitanium,
+/area/city/outskirts)
+"Fn" = (
+/obj/machinery/light,
+/turf/open/floor/carpet/blue,
+/area/city/outskirts)
+"FB" = (
+/turf/open/floor/carpet/blue,
+/area/city/outskirts)
+"Gi" = (
+/obj/machinery/door/poddoor/shutters/window,
+/turf/open/floor/circuit,
+/area/city/outskirts)
+"GJ" = (
+/obj/structure/window/shuttle/survival_pod,
+/turf/open/floor/circuit,
+/area/city/outskirts)
+"Mz" = (
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/circuit/red,
+/area/city/outskirts)
+"Oa" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 8
+	},
+/obj/machinery/light,
+/turf/open/floor/carpet/blue,
+/area/city/outskirts)
+"Qg" = (
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/circuit/red,
+/area/city/outskirts)
+"RJ" = (
+/obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/glass/plasma,
+/obj/effect/decal/cleanable/blood/gibs,
+/turf/open/floor/circuit/red,
+/area/city/outskirts)
+"Sx" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/carpet/blue,
+/area/city/outskirts)
+"Te" = (
+/obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/machinery/atmospherics/components/unary/thermomachine,
+/turf/open/floor/mineral/plastitanium,
+/area/city/outskirts)
+"Uj" = (
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 8
+	},
+/obj/structure/barricade/security,
+/turf/open/floor/circuit,
+/area/city/outskirts)
+"Uw" = (
+/turf/open/floor/mineral/plastitanium,
+/area/city/outskirts)
+"UG" = (
+/obj/effect/decal/cleanable/blood/gibs/torso,
+/turf/open/floor/circuit/red,
+/area/city/outskirts)
+"UY" = (
+/obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/blood/gibs/down,
+/turf/open/floor/mineral/plastitanium,
+/area/city/outskirts)
+"VY" = (
+/obj/effect/decal/cleanable/glass,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/carpet/blue,
+/area/city/outskirts)
+"WZ" = (
+/obj/effect/decal/cleanable/glass/plasma,
+/obj/effect/decal/cleanable/blood/innards,
+/turf/open/floor/circuit/red,
+/area/city/outskirts)
+"Xz" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 6
+	},
+/turf/open/floor/carpet/blue,
+/area/city/outskirts)
+"XK" = (
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 6
+	},
+/obj/machinery/atmospherics/components/unary/thermomachine,
+/turf/open/floor/mineral/plastitanium,
+/area/city/outskirts)
+"Yc" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/city/outskirts)
+"Ym" = (
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/city/outskirts)
+"Yz" = (
+/obj/machinery/clonepod{
+	pixel_y = 0
+	},
+/turf/open/floor/plating,
+/area/city/outskirts)
+"YR" = (
+/obj/effect/decal/cleanable/glass,
+/obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/machinery/atmospherics/components/unary/thermomachine,
+/turf/open/floor/mineral/plastitanium,
+/area/city/outskirts)
+"Zm" = (
+/obj/effect/decal/cleanable/blood,
+/obj/structure/barricade/security,
+/turf/open/floor/circuit/red,
+/area/city/outskirts)
+"ZX" = (
+/obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/glass/plasma,
+/obj/effect/decal/cleanable/blood,
+/obj/structure/barricade/security,
+/turf/open/floor/circuit/red,
+/area/city/outskirts)
+
+(1,1,1) = {"
+iU
+iU
+pb
+kR
+ic
+ic
+Uj
+hX
+rM
+iU
+iU
+"}
+(2,1,1) = {"
+iU
+um
+Uw
+UY
+wH
+wH
+wH
+Uw
+Uw
+aQ
+iU
+"}
+(3,1,1) = {"
+iU
+eX
+iU
+ya
+iU
+lW
+RJ
+Fn
+iU
+GJ
+iU
+"}
+(4,1,1) = {"
+iU
+hQ
+Ew
+Xz
+ns
+qB
+ZX
+FB
+Gi
+Yz
+iU
+"}
+(5,1,1) = {"
+iU
+eX
+iU
+nF
+iU
+eX
+ax
+Fn
+iU
+GJ
+iU
+"}
+(6,1,1) = {"
+iU
+ra
+Uw
+Uw
+wH
+wH
+wH
+Uw
+sX
+Te
+iU
+"}
+(7,1,1) = {"
+iU
+GJ
+iU
+bV
+iU
+eX
+Cn
+FB
+iU
+nA
+iU
+"}
+(8,1,1) = {"
+iU
+hQ
+Gi
+FB
+xk
+oy
+WZ
+cD
+Ew
+hQ
+iU
+"}
+(9,1,1) = {"
+iU
+GJ
+iU
+FB
+Mz
+eX
+iU
+mu
+iU
+eX
+iU
+"}
+(10,1,1) = {"
+iU
+ra
+Uw
+sX
+wH
+wH
+wH
+Yc
+Uw
+YR
+iU
+"}
+(11,1,1) = {"
+iU
+GJ
+iU
+Sx
+Cn
+eX
+iU
+Oa
+iU
+fa
+iU
+"}
+(12,1,1) = {"
+iU
+hQ
+Gi
+FB
+Zm
+UG
+EN
+Xz
+Gi
+hQ
+iU
+"}
+(13,1,1) = {"
+iU
+GJ
+iU
+VY
+UG
+Qg
+iU
+wx
+iU
+GJ
+iU
+"}
+(14,1,1) = {"
+iU
+Du
+Uw
+Uw
+wH
+wH
+wH
+Uw
+Uw
+XK
+iU
+"}
+(15,1,1) = {"
+iU
+iU
+Bu
+Ym
+rH
+jO
+jO
+Fc
+Bp
+iU
+iU
+"}

--- a/_maps/map_files/Event/wcorp-passenger1.dmm
+++ b/_maps/map_files/Event/wcorp-passenger1.dmm
@@ -1,0 +1,526 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"ah" = (
+/obj/machinery/light{
+	dir = 2
+	},
+/turf/open/floor/plasteel/dark,
+/area/city/outskirts)
+"bH" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
+/area/city/outskirts)
+"cn" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/royalblue,
+/area/city/outskirts)
+"eo" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 8
+	},
+/turf/open/floor/carpet/royalblue,
+/area/city/outskirts)
+"eZ" = (
+/obj/effect/decal/cleanable/blood/gibs/up,
+/obj/effect/decal/cleanable/blood/bubblegum,
+/turf/open/floor/plasteel/dark,
+/area/city/outskirts)
+"fV" = (
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/floor/carpet/royalblue,
+/area/city/outskirts)
+"hz" = (
+/obj/effect/decal/cleanable/xenoblood/xsplatter,
+/turf/open/floor/carpet/royalblue,
+/area/city/outskirts)
+"hN" = (
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/crude,
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
+/area/city/outskirts)
+"hQ" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 8
+	},
+/turf/open/floor/carpet/royalblue,
+/area/city/outskirts)
+"iO" = (
+/turf/open/floor/carpet/royalblue,
+/area/city/outskirts)
+"kt" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
+/area/city/outskirts)
+"lu" = (
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 6
+	},
+/turf/open/floor/carpet/royalblue,
+/area/city/outskirts)
+"lz" = (
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/crude,
+/turf/open/floor/plasteel/dark/side,
+/area/city/outskirts)
+"mH" = (
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
+/area/city/outskirts)
+"mU" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/royalblue,
+/area/city/outskirts)
+"nj" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/city/outskirts)
+"nL" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/closed/wall/r_wall/syndicate,
+/area/city/outskirts)
+"nO" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/plasteel/dark,
+/area/city/outskirts)
+"nX" = (
+/turf/closed/wall/r_wall/syndicate,
+/area/city/outskirts)
+"pa" = (
+/obj/effect/decal/cleanable/blood/gibs/down,
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 8
+	},
+/turf/open/floor/carpet/royalblue,
+/area/city/outskirts)
+"qc" = (
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/floor/plasteel/dark,
+/area/city/outskirts)
+"qh" = (
+/turf/open/floor/plasteel/dark/side,
+/area/city/outskirts)
+"rQ" = (
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 8
+	},
+/turf/open/floor/carpet/royalblue,
+/area/city/outskirts)
+"tR" = (
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/plasteel/dark,
+/area/city/outskirts)
+"tV" = (
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/crude,
+/turf/open/floor/plasteel/dark/corner{
+	dir = 4
+	},
+/area/city/outskirts)
+"vr" = (
+/turf/open/floor/plasteel/dark/corner,
+/area/city/outskirts)
+"wj" = (
+/obj/effect/decal/cleanable/blood/gibs/old,
+/turf/open/floor/plasteel/dark,
+/area/city/outskirts)
+"xn" = (
+/turf/open/floor/plasteel/dark/corner{
+	dir = 8
+	},
+/area/city/outskirts)
+"xF" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/floor/plasteel/dark,
+/area/city/outskirts)
+"yl" = (
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/crude,
+/turf/open/floor/carpet/royalblue,
+/area/city/outskirts)
+"yw" = (
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
+/area/city/outskirts)
+"zE" = (
+/obj/structure/displaycase/trophy,
+/turf/open/floor/plasteel/dark,
+/area/city/outskirts)
+"AD" = (
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/crude,
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/city/outskirts)
+"Bk" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/city/outskirts)
+"Bz" = (
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/crude,
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
+/area/city/outskirts)
+"Ci" = (
+/obj/effect/decal/cleanable/xenoblood/xgibs,
+/turf/open/floor/carpet/royalblue,
+/area/city/outskirts)
+"Cr" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 8
+	},
+/turf/open/floor/carpet/royalblue,
+/area/city/outskirts)
+"Cx" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark/side,
+/area/city/outskirts)
+"CV" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/royalblue,
+/area/city/outskirts)
+"Eu" = (
+/turf/open/floor/plasteel/dark,
+/area/city/outskirts)
+"Fv" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/city/outskirts)
+"HE" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
+/area/city/outskirts)
+"JY" = (
+/obj/structure/railing{
+	dir = 2
+	},
+/turf/open/floor/plasteel/dark/side,
+/area/city/outskirts)
+"KK" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/floor/plasteel/dark,
+/area/city/outskirts)
+"KM" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/carpet/royalblue,
+/area/city/outskirts)
+"Lw" = (
+/obj/effect/decal/cleanable/blood/gibs/bubblegum,
+/obj/effect/decal/cleanable/blood/gibs/body,
+/obj/effect/decal/cleanable/blood/tracks,
+/turf/open/floor/carpet/royalblue,
+/area/city/outskirts)
+"Nm" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
+/area/city/outskirts)
+"NN" = (
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/plasteel/dark/side,
+/area/city/outskirts)
+"PA" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 9
+	},
+/turf/open/floor/carpet/royalblue,
+/area/city/outskirts)
+"Ri" = (
+/obj/structure/displaycase/trophy,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/dark,
+/area/city/outskirts)
+"Rw" = (
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/city/outskirts)
+"RK" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/city/outskirts)
+"SY" = (
+/obj/structure/railing{
+	dir = 2
+	},
+/turf/open/floor/plasteel/dark,
+/area/city/outskirts)
+"SZ" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/city/outskirts)
+"Ui" = (
+/obj/machinery/light{
+	dir = 2
+	},
+/obj/effect/decal/cleanable/blood/gibs/old,
+/turf/open/floor/plasteel/dark,
+/area/city/outskirts)
+"Wd" = (
+/obj/effect/decal/cleanable/blood/gibs/bubblegum,
+/turf/open/floor/plasteel/dark,
+/area/city/outskirts)
+"Xh" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/plasteel/dark,
+/area/city/outskirts)
+"Xn" = (
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/floor/plasteel/dark/side,
+/area/city/outskirts)
+"Yt" = (
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/crude,
+/turf/open/floor/plasteel/dark/corner{
+	dir = 1
+	},
+/area/city/outskirts)
+
+(1,1,1) = {"
+nX
+nX
+Rw
+tV
+iO
+yl
+iO
+vr
+AD
+nX
+nX
+"}
+(2,1,1) = {"
+nX
+Xh
+Nm
+yw
+Ci
+rQ
+cn
+Xn
+Eu
+ah
+nX
+"}
+(3,1,1) = {"
+nX
+RK
+RK
+yw
+yl
+rQ
+iO
+qh
+RK
+RK
+nX
+"}
+(4,1,1) = {"
+nX
+Eu
+Wd
+yw
+iO
+hQ
+iO
+NN
+xF
+wj
+nX
+"}
+(5,1,1) = {"
+nX
+bH
+RK
+yw
+fV
+mU
+iO
+Cx
+KK
+RK
+nX
+"}
+(6,1,1) = {"
+nX
+SZ
+qc
+yw
+iO
+pa
+iO
+qh
+eZ
+Ui
+nX
+"}
+(7,1,1) = {"
+nX
+Eu
+Fv
+yw
+iO
+hz
+iO
+lz
+Fv
+Nm
+nL
+"}
+(8,1,1) = {"
+nX
+SY
+Ri
+kt
+iO
+yl
+iO
+JY
+zE
+Bk
+nL
+"}
+(9,1,1) = {"
+nX
+Eu
+nj
+hN
+iO
+iO
+iO
+qh
+HE
+Eu
+nX
+"}
+(10,1,1) = {"
+nX
+SZ
+tR
+yw
+CV
+iO
+KM
+qh
+Eu
+ah
+nX
+"}
+(11,1,1) = {"
+nX
+bH
+RK
+yw
+iO
+PA
+Lw
+qh
+RK
+RK
+nX
+"}
+(12,1,1) = {"
+nX
+Eu
+qc
+yw
+PA
+lu
+iO
+qh
+Eu
+Wd
+nX
+"}
+(13,1,1) = {"
+nX
+RK
+bH
+yw
+eo
+iO
+yl
+Xn
+RK
+RK
+nX
+"}
+(14,1,1) = {"
+nX
+nO
+Eu
+yw
+eo
+iO
+iO
+qh
+Eu
+ah
+nX
+"}
+(15,1,1) = {"
+nX
+nX
+mH
+Yt
+Cr
+yl
+iO
+xn
+Bz
+nX
+nX
+"}


### PR DESCRIPTION
Adds 3 random carriages for later use and testing (Each carriage is 15x11 for future reference)

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds in the 3 random carriages (after a bit of strife) that will be later used in the randomly generated trains coming down the road.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

These designs make a baseline for what the future train maps should theoretically be, the dimensions can be carried over to any future designs made by other people

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added new Wcorp maps
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
