### PR TITLE
Adjusts some abnormalities

### DIFF
--- a/code/__DEFINES/sound.dm
+++ b/code/__DEFINES/sound.dm
@@ -7,6 +7,7 @@
 #define CHANNEL_AMBIENCE 1019
 #define CHANNEL_BUZZ 1018
 #define CHANNEL_BICYCLE 1017
+#define CHANNEL_SIREN 1016 //used to stop siren from blaring music while turned off
 
 ///Default range of a sound.
 #define SOUND_RANGE 17

--- a/code/datums/looping_sounds/_looping_sound.dm
+++ b/code/datums/looping_sounds/_looping_sound.dm
@@ -34,6 +34,7 @@
 	var/falloff_exponent
 	var/timerid
 	var/falloff_distance
+	var/channel = 0
 
 /datum/looping_sound/New(list/_output_atoms=list(), start_immediately=FALSE, _direct=FALSE)
 	if(!mid_sounds)
@@ -87,7 +88,7 @@
 		if(direct)
 			SEND_SOUND(thing, S)
 		else
-			playsound(thing, S, volume, vary, extra_range, falloff_exponent = falloff_exponent, falloff_distance = falloff_distance)
+			playsound(thing, S, volume, vary, extra_range, falloff_exponent = falloff_exponent, falloff_distance = falloff_distance, channel = channel)
 
 /datum/looping_sound/proc/get_sound(starttime, _mid_sounds)
 	. = _mid_sounds || mid_sounds

--- a/code/datums/looping_sounds/abnormalities.dm
+++ b/code/datums/looping_sounds/abnormalities.dm
@@ -86,6 +86,7 @@
 	extra_range = 40
 	falloff_distance = 35 //minimal falloff due to being a long sound
 	end_sound = 'sound/abnormalities/siren/needle2.ogg'
+	channel = CHANNEL_SIREN
 
 /datum/looping_sound/clown_ambience
 	mid_sounds = 'sound/abnormalities/clownsmiling/clownloop.ogg'

--- a/code/game/objects/items/ego_weapons/teth.dm
+++ b/code/game/objects/items/ego_weapons/teth.dm
@@ -522,7 +522,7 @@
 /obj/item/ego_weapon/zauberhorn
 	name = "zauberhorn"
 	desc = "Falada, Falada, thou art dead, and all the joy in my life has fled."
-	special = "This E.G.O. functions as both a gun and a mele weapon."
+	special = "This E.G.O. functions as both a gun and a melee weapon."
 	icon_state = "zauberhorn"
 	force = 10
 	damtype = BLACK_DAMAGE

--- a/code/modules/mob/living/simple_animal/abnormality/he/headless_ichthys.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/headless_ichthys.dm
@@ -153,6 +153,8 @@
 					continue
 				if(L.stat == DEAD)
 					continue
+				if(faction_check_mob(L))
+					continue
 				if(!(is_A_facing_B(src,L))) //so it doesn't hit people behind the mob
 					continue
 				already_hit += L

--- a/code/modules/mob/living/simple_animal/abnormality/he/jangsan.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/jangsan.dm
@@ -266,7 +266,7 @@
 	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/jangsan/bullet_act(obj/projectile/P)
-	if(prob(90)) //guns are ineffective
+	if(P.damage <= 40)
 		visible_message("<span class='userdanger'>[P] is caught in [src]'s thick fur!</span>")
 		P.Destroy()
 		return

--- a/code/modules/mob/living/simple_animal/abnormality/he/missed_reaper.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/missed_reaper.dm
@@ -87,7 +87,7 @@
 
 // Breach
 /mob/living/simple_animal/hostile/abnormality/missed_reaper/ZeroQliphoth(mob/living/carbon/human/user)
-	datum_reference.qliphoth_change(1) //no need for qliphoth to be stuck at 0
+	datum_reference.qliphoth_change(2) //no need for qliphoth to be stuck at 0
 	if(meltdown_cooldown > world.time)
 		return
 	meltdown_cooldown = world.time + meltdown_cooldown_time

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/hammer_light.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/hammer_light.dm
@@ -11,6 +11,7 @@
 	pixel_y = -8
 	base_pixel_y = -8
 	threat_level = ZAYIN_LEVEL
+	can_breach = FALSE
 	work_chances = list(
 						ABNORMALITY_WORK_INSTINCT = 70,
 						ABNORMALITY_WORK_INSIGHT = 70,
@@ -39,7 +40,7 @@
 	var/points
 	var/points_threshold = 150
 	var/usable_cooldown
-	var/usable_cooldown_time = 10 SECONDS //change to 5m
+	var/usable_cooldown_time = 5 MINUTES
 
 	var/list/lock_sounds = list(
 	'sound/abnormalities/lighthammer/hammer_filterOut1.ogg','sound/abnormalities/lighthammer/hammer_filterOut2.ogg'
@@ -172,21 +173,24 @@
 	hammer_present = FALSE
 	sealed = FALSE
 	update_icon()
+	var/mob/living/simple_animal/hostile/ordeal/pink_midnight/mob_to_copy = null
 	var/turf/destination
 	for(var/mob/living/simple_animal/hostile/ordeal/pink_midnight/P in GLOB.ordeal_list)
 		destination = get_turf(P)
+		mob_to_copy = P
+	if(!mob_to_copy)
+		return
 	var/turf/W = pick(GLOB.department_centers) //spawn hammers at a random department
 	for(var/turf/T in orange(1, W))
 		new /obj/effect/temp_visual/dir_setting/cult/phase
 		if(prob(50))
 			var/mob/living/simple_animal/hostile/lighthammer/V = new(T)
 			new /obj/effect/temp_visual/beam_in(T)
-			V.faction = src.faction.Copy()
+			V.faction = mob_to_copy.faction.Copy()
 			if(!destination)
 				continue
 			if(!V.patrol_to(destination)) //Move them to pink midnight
 				V.forceMove(destination)
-
 	addtimer(CALLBACK(src, .proc/UserDeath), usable_cooldown_time)
 
 //Item version
@@ -370,7 +374,7 @@
 	attack_sound = 'sound/abnormalities/lighthammer/hammer_filter.ogg'
 	health = 1000
 	maxHealth = 1000
-	faction = list("lighthammer", "pink_midnight") //Overridden in summoning code, evil during pink midnight
+	faction = list("neutral") //Should always be overridden
 	obj_damage = 300
 	damage_coeff = list(BRUTE = 1, RED_DAMAGE = 1, WHITE_DAMAGE = 1, BLACK_DAMAGE = 1, PALE_DAMAGE = 1)
 	melee_damage_type = PALE_DAMAGE

--- a/code/modules/paperwork/records/info/he.dm
+++ b/code/modules/paperwork/records/info/he.dm
@@ -278,9 +278,9 @@
 		"When the Qliphoth Counter reached 0, a strange sound came from the abnormality.",
 		"Other abnormalities became agitated if the sound did not cease.",
 		"When the abnormality was turned off manually, the Qliphoth counter raised.",
-		"When work was performed on the abnormality, the Qliphoth counter raised higher.",
-		"When insight work was performed on the abnormality, time seemed to distort.",
-		"Performing insight work multiple times, the employee occasionally perished inexplicably.",
+		"When work was performed on the abnormality, the Qliphoth counter was raised to its maximum.",
+		"When insight work was performed on the abnormality while the Qliphoth counter was below 2, a mentally soothing song was played.",
+		"Insight work was ineffective when the Qliphoth counter was high. If the Qliphoth counter was at 5, the employee performing work was turned into dust.",
 		"Some agents have reported relief from certain symptoms after performing insight work.")
 
 //Jangsan Tiger
@@ -292,6 +292,7 @@
 		"When powerful employees performed work, the Qliphoth Counter increased.",
 		"For every stat at or above level 3, the work chance was reduced.",
 		"When all stats were at level 1, the Qliphoth counter decreased upon completion of work.",
+		"This abnormality has a thick hide that only high-impact projectiles or melee attacks can penetrate.",
 		"Agents with all stats below level 2 perish with alarming frequency near this abnormality.")
 
 //Golden False Apple


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Buffs Siren and changes how Jangsan tiger's resistance works to be more in line with my original idea

- Jangsan tiger now ignores projectiles that deal less than 40 damage. Projectiles that deal more always hit. This is better overall than %-based reduction because it fulfills my original intention of preventing clerks from damaging it.
- Siren no longer kills you when performing insight work at a random chance. Instead, it simply kills you if you perform insight work at max Qliphoth, and performing insight work successfully at low Qliphoth causes it to play sanity-healing music for 60 seconds.
- In addition, I have made use of sound channels to make siren's music a bit more robust in how it can stop and start.
- Adds "channel" variable to looping sounds. For some reason, tg did not feel that having this was important.
- Fixes a minor spelling mistake in E.G.O.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Less jank, and buffs an unpopular abnormality.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: siren can now heal sanity in a large area
balance: jangsan tiger now only ignores low-caliber projectiles
soundadd: added a new sound channel for siren
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
