### PR TITLE
Unaimed shots miss cloaked Apex Predator

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/waw/apex_predator.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/apex_predator.dm
@@ -10,6 +10,7 @@
 
 	maxHealth = 1600
 	health = 1600
+	density = FALSE
 	damage_coeff = list(BRUTE = 1, RED_DAMAGE = 0.2, WHITE_DAMAGE = 1, BLACK_DAMAGE = 1, PALE_DAMAGE = 1)
 	ranged = TRUE
 	melee_damage_lower = 30
@@ -132,10 +133,12 @@
 /mob/living/simple_animal/hostile/abnormality/apex_predator/proc/Cloak()
 	alpha = 10
 	revealed = FALSE
+	density = FALSE
 
 /mob/living/simple_animal/hostile/abnormality/apex_predator/proc/Decloak()
 	alpha = 255
 	revealed = TRUE
+	density = TRUE
 
 /mob/living/simple_animal/hostile/abnormality/apex_predator/OpenFire()
 	if(!revealed)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Shots not aimed at Apex Predator will now pass over it whilst it is cloaked (except magic bullet which hits non-dense entities). Decloaked, it will be hit by stray and unaimed shots as before.

This will also let cloaked Apex occupy the same tile as other abnormalities but I don't anticipate this causing balance concerns.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It probably isn't 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Unaimed shots now miss Apex Predator
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
