### PR TITLE
Hana Intern + Paramedic Crew tracker on spawn

### DIFF
--- a/code/modules/jobs/job_types/city/doctor.dm
+++ b/code/modules/jobs/job_types/city/doctor.dm
@@ -95,6 +95,7 @@
 	maptype = list("city")
 	job_important = "You are an assistant to the town doctor, visit your clinic to the east of town and assist the doctor by bringing bodies in."
 
+
 /datum/outfit/job/doctor/medic
 	name = "Paramedic"
 	jobtype = /datum/job/doctor/medic
@@ -102,3 +103,4 @@
 	uniform = /obj/item/clothing/under/rank/medical/paramedic
 	head = /obj/item/clothing/head/soft/paramedic
 	suit =  /obj/item/clothing/suit/toggle/labcoat/paramedic
+	backpack_contents = list(/obj/item/pinpointer/crew=1)

--- a/code/modules/jobs/job_types/trusted_players/hana.dm
+++ b/code/modules/jobs/job_types/trusted_players/hana.dm
@@ -74,3 +74,34 @@
 
 	ears = /obj/item/radio/headset/heads/headset_association
 	l_hand = /obj/item/clothing/suit/armor/ego_gear/city/hanacombat/paperwork
+
+//Hana
+/datum/job/hana/intern
+	title = "Hana Intern"
+	outfit = /datum/outfit/job/hana/intern
+	total_positions = 4
+	spawn_positions = 4
+	display_order = JOB_DISPLAY_ORDER_INTERN
+	paycheck = 1000
+	trusted_only = FALSE
+
+
+	//Mostly for armor.
+	roundstart_attributes = list(
+								FORTITUDE_ATTRIBUTE = 60,
+								PRUDENCE_ATTRIBUTE = 60,
+								TEMPERANCE_ATTRIBUTE = 60,
+								JUSTICE_ATTRIBUTE = 60
+								)
+
+	job_important = "You are a Intern for the Hana association, Your only job is to assist the higher ups with their duities. \
+		You MUST assist new fixer offices in getting set up, as well as issuing fixer licenses. \
+		All new fixer offices MUST be announced upon creation, including office name and director name. "
+	job_notice = null
+
+
+/datum/outfit/job/hana/intern
+	name = "Hana Intern"
+	jobtype = /datum/job/hana/intern
+
+	l_hand = null

--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -39,6 +39,7 @@ GLOBAL_LIST_INIT(medical_positions, list(
 GLOBAL_LIST_INIT(science_positions, list(
 	"Hana Administrator",
 	"Hana Representative",
+	"Hana Intern",
 	"Association Section Director",
 	"Association Veteran",
 	"Association Fixer",


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR adds the Hana Intern role and also gives the Paramedic the crew pinpointer on spawn.

## Why It's Good For The Game

The Hana Intern role lets non trusted players play as Hana which will help with the paperwork and the crew pinpointer is very much need for Paramedic to do their jobs, So they should start with it.

## Changelog
:cl:
add: Added Hana intern
tweak: Paramedics get a crew pinpointer

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
