### PR TITLE
Add COMSIG_GLOB_PATROL_START

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -560,6 +560,9 @@
 // /mob/living/simple_animal/hostile signals
 #define COMSIG_HOSTILE_ATTACKINGTARGET "hostile_attackingtarget"
 	#define COMPONENT_HOSTILE_NO_ATTACK (1<<0)
+/// a hostile has started their patrol (datum/source, mob/living/simple_animal/hostile/mover, turf/target_location)
+#define COMSIG_GLOB_PATROL_START "!patrol_start"
+#define COMSIG_PATROL_START "patrol_start"
 
 // /obj signals
 

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -738,6 +738,8 @@
 		target_center = pick(potential_centers)
 	else
 		target_center = pick(GLOB.department_centers)
+	SEND_SIGNAL(src, COMSIG_PATROL_START, src, target_center)
+	SEND_GLOBAL_SIGNAL(src, COMSIG_GLOB_PATROL_START, src, target_center)
 	patrol_path = get_path_to(src, target_center, /turf/proc/Distance_cardinal, 0, 200)
 
 /mob/living/simple_animal/hostile/proc/patrol_reset()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds patrol signal since im making a component that has a check that only happens when the hostile is beginning a patrol. May also have other uses.

Im worried about the lag a bunch of mobs all patrolling at once would cause if they send signals but im concerned about the lag caused by a bunch of mobs all patrolling anyways.

## Why It's Good For The Game
I'm making a component that could use it but if its deemed unnecessary ill use some other method.

## Changelog
:cl:
add: Signals COMSIG_GLOB_PATROL_START and COMSIG_PATROL_START
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
