### PR TITLE
melee_reach Variable and controlled mob attack rate fix

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/he/porccubus.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/porccubus.dm
@@ -18,9 +18,11 @@
 			) //for some reason all its work rates are uniform through attribute levels in LC
 	damage_coeff = list(BRUTE = 1, RED_DAMAGE = 1, WHITE_DAMAGE = 0.5, BLACK_DAMAGE = 1, PALE_DAMAGE = 1.5)
 	ranged = TRUE
+	ranged_cooldown_time = 15 SECONDS //will dash at people if they get out of range but not too often
 	melee_damage_lower = 15
 	melee_damage_upper = 20
 	rapid_melee = 3 //you can withdraw out of its range very easily so it needs to be a little harder to melee it
+	melee_reach = 2
 	work_damage_amount = 12
 	can_patrol = FALSE //it can't move anyway but why not
 	stat_attack = HARD_CRIT
@@ -44,8 +46,6 @@
 
 	//the agent that started work on porccubus
 	var/agent_ckey
-	var/dash_cooldown_time = 15 SECONDS //will dash at people if they get out of range but not too often
-	var/dash_cooldown
 	var/teleport_cooldown_time = 5 MINUTES
 	var/teleport_cooldown
 	var/damage_taken = FALSE
@@ -126,7 +126,7 @@
 	icon_state = icon_living
 	var/turf/T = pick(GLOB.xeno_spawn)
 	forceMove(T)
-	dash_cooldown = world.time + dash_cooldown_time
+	ranged_cooldown = world.time + ranged_cooldown_time
 	teleport_cooldown = world.time + teleport_cooldown_time
 
 /mob/living/simple_animal/hostile/abnormality/porccubus/Move()
@@ -150,21 +150,15 @@
 	if(amount > 0)
 		damage_taken = TRUE
 
-/mob/living/simple_animal/hostile/abnormality/porccubus/CheckAndAttack()//we give porccubus a 2 tile range because it can't move and has no ranged attacks
-	if(!target)
-		return
-
-	if(targets_from && isturf(targets_from.loc) && get_dist(target, src) <= 2 && !incapacitated()) //a slightly modified check that includes people on a 2 tile radius
-		AttackingTarget()
-		return
-
 /mob/living/simple_animal/hostile/abnormality/porccubus/bullet_act(obj/projectile/P)
 	visible_message("<span class='warning'>Porccubus playfully swat [P] projectile away!</span>")
 	return FALSE //COME CLOSER AND GET DRUGGED COWARD
 
 //Breach Code Attacks
-/mob/living/simple_animal/hostile/abnormality/porccubus/OpenFire()
+/mob/living/simple_animal/hostile/abnormality/porccubus/OpenFire(atom/A)
 	if(client)
+		if(ranged_cooldown > world.time || chosen_attack != 1)
+			RangedAttack(A)
 		switch(chosen_attack)
 			if(1)
 				PorcDash(target)
@@ -178,7 +172,7 @@
 	if(!istype(target))
 		return
 	var/dist = get_dist(target, src)
-	if(dist > 2 && dash_cooldown < world.time)
+	if(dist > 2 && ranged_cooldown < world.time)
 		var/list/dash_line = getline(src, target)
 		for(var/turf/line_turf in dash_line) //checks if there's a valid path between the turf and the friend
 			if(line_turf.is_blocked_turf(exclude_mobs = TRUE))
@@ -186,7 +180,7 @@
 			forceMove(line_turf)
 			SLEEP_CHECK_DEATH(0.8)
 		playsound(src, 'sound/abnormalities/porccubus/head_explode_laugh.ogg', 50, FALSE, 4)
-		dash_cooldown = world.time + dash_cooldown_time
+		ranged_cooldown = world.time + ranged_cooldown_time
 
 /mob/living/simple_animal/hostile/abnormality/porccubus/AttackingTarget()
 	var/mob/living/carbon/human/H
@@ -204,14 +198,6 @@
 		DrugOverdose(H, H.ckey, nirvana)
 		LoseTarget()
 		H.faction += "porccubus" //that guy's already fucked, even if they can kill porccubus safely now, porccubus has done its job of being a cunt
-
-/mob/living/simple_animal/hostile/abnormality/porccubus/RangedAttack(atom/A, params) //Ranged melee code for a client
-	if(!client)
-		return ..()
-	CheckAndAttack(A)
-	if(ismob(A))
-		changeNext_move(CLICK_CD_MELEE)
-	return ..()
 
 //Drug Item
 //this is only obtainable if someone else dies from the addiction, but it's the only way to get drugged without working on porccubus


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds the "melee_reach" variable that lets mobs perform melee attacks at a range. Used in Porccubus, to be NoriNori, and potentially one of the LOVE bois.
Switches Porccubus to used `ranged_cooldown` and `ranged_cooldown_time` instead of the dash variants because it's simply better.
Makes client-occupied mobs have a attack-cooldown equal to the normal version and gives them an equal attack rate when they have rapid melee.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
1. We're adding things that do this and it expands on it for further things that want to.
2. Code Improvement
3. Balancing admin bussing and playables.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
