### PR TITLE
Reduces starter fishing gear cost and Fishing Nets cant be Harvested with your mind

### DIFF
--- a/ModularTegustation/fishing/code/fish_market.dm
+++ b/ModularTegustation/fishing/code/fish_market.dm
@@ -9,13 +9,13 @@
 	var/list/order_list = list( //if you add something to this, please, for the love of god, sort it by price/type. use tabs and not spaces.
 		//Gadgets - More Technical Equipment, Usually active
 		new /datum/data/extraction_cargo("Discount Quality Suture ",	/obj/item/stack/medical/suture/emergency,			100) = 1,
+		new /datum/data/extraction_cargo("Fishin Starting Pack ",		/obj/item/storage/box/fishing,						200) = 1,
 		new /datum/data/extraction_cargo("Aquarium Rocks ",				/obj/item/aquarium_prop/rocks,						250) = 1,
 		new /datum/data/extraction_cargo("Aquarium Seaweed ",			/obj/item/aquarium_prop/seaweed,					250) = 1,
 		new /datum/data/extraction_cargo("Sinew Fishing Line ",			/obj/item/fishing_component/line/sinew,				250) = 1,
 		new /datum/data/extraction_cargo("Bone Fishing Hook ",			/obj/item/fishing_component/hook/bone,				250) = 1,
 		new /datum/data/extraction_cargo("Water Sprayer Backpack ",		/obj/item/watertank,								400) = 1,
 		new /datum/data/extraction_cargo("Dock Worker Lantern ",		/obj/item/flashlight/lantern,						400) = 1,
-		new /datum/data/extraction_cargo("Fishin Starting Pack ",		/obj/item/storage/box/fishing,						450) = 1,
 		new /datum/data/extraction_cargo("Weighted Fishing Hook ", 		/obj/item/fishing_component/hook/weighted,			500) = 1,
 		new /datum/data/extraction_cargo("Reinforced Fishing Line ", 	/obj/item/fishing_component/line/reinforced,		500) = 1,
 		new /datum/data/extraction_cargo("Fishing Hat ",		 		/obj/item/clothing/head/beret/tegu/fishing_hat,		500) = 1,

--- a/ModularTegustation/fishing/code/fishing_items/fishing_net.dm
+++ b/ModularTegustation/fishing/code/fishing_items/fishing_net.dm
@@ -37,6 +37,8 @@
 
 /obj/structure/destructible/fishing_net/AltClick(mob/user)
 	. = ..()
+	if(!user.canUseTopic(src, BE_CLOSE))
+		return
 	EmptyNet(get_turf(user))
 
 /obj/structure/destructible/fishing_net/proc/EmptyNet(turf/dropoff)


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Reduces 450 fishing starter pack to 200. Fixes net alt click from activating when your a far distance away.

## Why It's Good For The Game
Fishing starting gear should be sorta affordable.

## Changelog
:cl:
tweak: fishing market
fix: fishing_nets
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
