### PR TITLE
KCorp Drone Tweaks

### DIFF
--- a/ModularTegustation/tegu_mobs/lc13_outskirtdwellers.dm
+++ b/ModularTegustation/tegu_mobs/lc13_outskirtdwellers.dm
@@ -431,10 +431,8 @@
 	SLEEP_CHECK_DEATH(2 SECONDS) //Enough to run away, but not easily
 	playsound(src, 'sound/weapons/flash.ogg', 100, TRUE)
 
-	for (var/mob/living/L in viewers(src, null)) //The actual flashing
+	for (var/mob/living/L in viewers(flash_range,src)) //The actual flashing
 		if (!ishuman(L))
-			continue
-		if (get_dist(src, L) > flash_range)
 			continue
 		L.Paralyze(5 SECONDS) //you better dodge it
 		var/obj/item/held = L.get_active_held_item()

--- a/ModularTegustation/tegu_mobs/lc13_outskirtdwellers.dm
+++ b/ModularTegustation/tegu_mobs/lc13_outskirtdwellers.dm
@@ -380,7 +380,6 @@
 	deathmessage = "screeches as it falls over." // |MESSAGE ABOVE|
 	density = TRUE
 	search_objects = 1
-	var/current_size = RESIZE_DEFAULT_SIZE
 	del_on_death = TRUE
 
 /mob/living/simple_animal/hostile/ordeal/bigBirdEye/Life()
@@ -400,6 +399,7 @@
 	icon = 'ModularTegustation/Teguicons/tegumobs.dmi'
 	icon_state = "kcorp_drone_idle"
 	icon_living = "kcorp_drone_idle"
+	icon_dead = "kcorp_drone_idle"
 	faction = list("hostile") // should target humanoids only and annoy them to no end
 	response_disarm_continuous = "pushes aside"
 	response_disarm_simple = "push aside"
@@ -416,25 +416,47 @@
 	butcher_difficulty = 3
 	butcher_results = list(/obj/item/ksyringe = 1, /obj/item/assembly/flash/handheld = 1)
 	deathmessage = "buzzes as he falls out of the air."
-	density = TRUE
+	density = FALSE
 	search_objects = 1
-	var/current_size = RESIZE_DEFAULT_SIZE
 	del_on_death = TRUE
 
-/mob/living/simple_animal/hostile/kcorp/drone/AttackingTarget()
-	. = ..()
-	if(ishuman(target))
-		var/mob/living/carbon/human/L = target
-		icon_state = "kcorp_drone_angry"
-		icon_living = "kcorp_drone_angry"
-		animate(src, time = 1, loop = 0)
-		playsound(src, 'sound/weapons/flash.ogg', 100, TRUE)
-		L.Paralyze(3 SECONDS)
+	var/can_act = TRUE //If flashing, turns FALSE so we don't attack/move
+	var/flash_cooldown
+	var/flash_cooldown_time = 8 SECONDS
+	var/flash_range = 5 //Range that the flash hits
+
+/mob/living/simple_animal/hostile/kcorp/drone/proc/Flash()
+	icon_state = "kcorp_drone_angry"
+	can_act = FALSE
+	SLEEP_CHECK_DEATH(2 SECONDS) //Enough to run away, but not easily
+	playsound(src, 'sound/weapons/flash.ogg', 100, TRUE)
+
+	for (var/mob/living/L in viewers(src, null)) //The actual flashing
+		if (!ishuman(L))
+			continue
+		if (get_dist(src, L) > flash_range)
+			continue
+		L.Paralyze(5 SECONDS) //you better dodge it
 		var/obj/item/held = L.get_active_held_item()
-		L.dropItemToGround(held)
-		SLEEP_CHECK_DEATH(10)
-		icon_state = "kcorp_drone_idle"
-		icon_living = "kcorp_drone_idle"
+		L.dropItemToGround(held) //Drops everyone's weapons
+		to_chat(L, "<span class='danger'>[src] shines a blinding light!</span>")
+
+	SLEEP_CHECK_DEATH(1 SECONDS)
+	icon_state = "kcorp_drone_idle"
+	can_act = TRUE
+
+/mob/living/simple_animal/hostile/kcorp/drone/Move()
+	if (!can_act)
+		return FALSE
+	. = ..()
+
+/mob/living/simple_animal/hostile/kcorp/drone/AttackingTarget(target)
+	if (!can_act)
+		return
+	. = ..()
+	if(flash_cooldown <= world.time)
+		flash_cooldown = world.time + flash_cooldown_time
+		Flash()
 
 /mob/living/simple_animal/hostile/kcorp/drone/Aggro() //flash and push people, then run away |FLASH IS ANIMATED|
 	..()

--- a/ModularTegustation/tegu_mobs/lc13_outskirtdwellers.dm
+++ b/ModularTegustation/tegu_mobs/lc13_outskirtdwellers.dm
@@ -422,7 +422,7 @@
 
 	var/can_act = TRUE //If flashing, turns FALSE so we don't attack/move
 	var/flash_cooldown
-	var/flash_cooldown_time = 8 SECONDS
+	var/flash_cooldown_time = 10 SECONDS
 	var/flash_range = 5 //Range that the flash hits
 
 /mob/living/simple_animal/hostile/kcorp/drone/proc/Flash()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Small tweak to KCorp Drones that spawn rarely in some backstreets rooms, now they flash in an AoE on a cooldown, instead of on every hit. Also makes them non dense. Also removes two redundant lines of code from drones and eye mobs.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
KCorp drones were cancerous at best to fight when two caught you at once, now you have some amount of counterplay, but the danger is still there.
Density doesnt really make sense, they are small flying pricks.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: tweaks Kcorp drones
balance: Kcorp drone rebalance
code: removes redundant code
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
