### PR TITLE
Lovetown Nerf

### DIFF
--- a/ModularTegustation/tegu_mobs/lc13_outskirtdwellers.dm
+++ b/ModularTegustation/tegu_mobs/lc13_outskirtdwellers.dm
@@ -479,6 +479,7 @@ Mobs that mostly focus on dealing RED damage, they are all a bit more frail than
 	mob_size = MOB_SIZE_HUGE
 	a_intent = INTENT_HARM
 	var/mob_spawn_amount = 1 //the weakest will spawn just one suicidal, higher tiers will spawn more
+	var/spawn_prob = 66 //chance to spawn suicials on death, default is 33%
 
 //Proc below is a modified crimson DeathExplosion()
 /mob/living/simple_animal/hostile/lovetown/proc/SpawnSuicidal() //all mobs spawn at least 1 suicidal on death, except the suicidals themselves
@@ -494,6 +495,8 @@ Mobs that mostly focus on dealing RED damage, they are all a bit more frail than
 		if(!TF.is_blocked_turf(TRUE))
 			valid_directions += d
 	for(var/i = 1 to mob_spawn_amount)
+		if(prob(spawn_prob))
+			continue
 		var/turf/T = get_step(get_turf(src), pick(valid_directions))
 		new/mob/living/simple_animal/hostile/lovetown/suicidal(T)
 	gib()
@@ -518,7 +521,7 @@ Mobs that mostly focus on dealing RED damage, they are all a bit more frail than
 
 	var/can_act = TRUE
 	var/scream_cooldown
-	var/scream_cooldown_time = 4 SECONDS
+	var/scream_cooldown_time = 6 SECONDS
 
 /mob/living/simple_animal/hostile/lovetown/suicidal/AttackingTarget()
 	return OpenFire()
@@ -537,13 +540,13 @@ Mobs that mostly focus on dealing RED damage, they are all a bit more frail than
 	scream_cooldown = world.time + scream_cooldown_time
 	can_act = FALSE
 	playsound(get_turf(src), 'sound/creatures/lc13/lovetown/scream.ogg', 50, TRUE, 3)
-	for(var/i = 1 to 2)
+	for(var/i = 1 to 3)
 		var/obj/effect/temp_visual/decoy/D = new /obj/effect/temp_visual/decoy(get_turf(src), src)
-		animate(D, alpha = 0, transform = matrix()*1.5, time = 2)
-		SLEEP_CHECK_DEATH(3)
-	for(var/mob/living/L in view(4, src))
+		animate(D, alpha = 0, transform = matrix()*1.5, time = 4)
+		SLEEP_CHECK_DEATH(6)
+	for(var/mob/living/L in view(3, src))
 		if(!faction_check_mob(L))
-			L.apply_damage(10, WHITE_DAMAGE, null, L.run_armor_check(null, WHITE_DAMAGE))
+			L.apply_damage(5, WHITE_DAMAGE, null, L.run_armor_check(null, WHITE_DAMAGE))
 	can_act = TRUE
 
 //Love Town Slasher - TETH goons, not much of a threat
@@ -613,6 +616,7 @@ Mobs that mostly focus on dealing RED damage, they are all a bit more frail than
 	damage_coeff = list(BRUTE = 1, RED_DAMAGE = 1.4, WHITE_DAMAGE = 0.6, BLACK_DAMAGE = 0.8, PALE_DAMAGE = 2)
 	move_resist = MOVE_FORCE_OVERPOWERING
 	mob_spawn_amount = 4 //on death explodes into 4 suicidals
+	spawn_prob = 33 //66% chance to spawn suicidals, higher than normal
 
 	var/scream_cooldown
 	var/scream_cooldown_time = 7 SECONDS
@@ -635,13 +639,13 @@ Mobs that mostly focus on dealing RED damage, they are all a bit more frail than
 	can_act = FALSE
 	scream_cooldown = world.time + scream_cooldown_time
 	playsound(get_turf(src), 'sound/creatures/lc13/lovetown/scream.ogg', 75, TRUE, 3)
-	for(var/i = 1 to 3)
+	for(var/i = 1 to 4)
 		var/obj/effect/temp_visual/decoy/D = new /obj/effect/temp_visual/decoy(get_turf(src), src)
-		animate(D, alpha = 0, transform = matrix()*1.5, time = 2)
-		SLEEP_CHECK_DEATH(3)
-	for(var/mob/living/L in view(6, src))
+		animate(D, alpha = 0, transform = matrix()*1.5, time = 3)
+		SLEEP_CHECK_DEATH(6)
+	for(var/mob/living/L in view(4, src))
 		if(!faction_check_mob(L))
-			L.apply_damage(40, WHITE_DAMAGE, null, L.run_armor_check(null, WHITE_DAMAGE))
+			L.apply_damage(33, WHITE_DAMAGE, null, L.run_armor_check(null, WHITE_DAMAGE))
 	can_act = TRUE
 
 // Love Town Slumberer - HE threat,, quite damaging and can grab you, stuns you for some time.
@@ -753,6 +757,7 @@ Mobs that mostly focus on dealing RED damage, they are all a bit more frail than
 	footstep_type = FOOTSTEP_MOB_HEAVY
 	move_resist = MOVE_FORCE_OVERPOWERING
 	mob_spawn_amount = 2 //:(
+	spawn_prob = 0 //100%, always spawn them
 
 	var/can_act = TRUE
 	var/current_stage = 1 //changes behaviour slightly on phase 2


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Rebalances Rcorp White screechers and the spawn rates of them when other mobs die.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
LoveTown sweeped too hard, and not in a good way for the players
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: changes how lovetown spawns suicidals (uses chance now)
balance: rebalances lovetown
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
