### PR TITLE
Liver Parasites get blended in Cybernetic Liver 2.0

### DIFF
--- a/code/datums/diseases/parasitic_infection.dm
+++ b/code/datums/diseases/parasitic_infection.dm
@@ -13,16 +13,31 @@
 	spread_flags = DISEASE_SPREAD_NON_CONTAGIOUS
 	required_organs = list(/obj/item/organ/liver)
 	bypasses_immunity = TRUE
+	var/obj/item/organ/liver/affected_liver
 
 
 /datum/disease/parasite/stage_act()
 	. = ..()
 	if(!.)
 		return
-
-	var/obj/item/organ/liver/affected_liver = affected_mob.getorgan(/obj/item/organ/liver)
+	//If no liver check the organ slot.
 	if(!affected_liver)
+		affected_liver = affected_mob.getorganslot(ORGAN_SLOT_LIVER)
+	/* If still no liver cure ourselves.
+		Check twice cut once. */
+	if(!affected_liver)
+		cure()
+		return FALSE
+	//We have a liver. Cool. Is that liver inside the person who has the parasite?
+	if(affected_liver.owner != affected_mob)
 		affected_mob.visible_message("<span class='notice'><B>[affected_mob]'s liver is covered in tiny larva! They quickly shrivel and die after being exposed to the open air.</B></span>")
+		cure()
+		return FALSE
+	//Thats not a liver thats a hunk of plastic.
+	if(affected_liver.organ_flags & ORGAN_SYNTHETIC)
+		to_chat(affected_mob, "<span class='nicegreen'>Your liver starts whirring and making noises like someone threw popcorn into a blender.</span>")
+		//That cant be good for your liver.
+		affected_mob.adjustOrganLoss(ORGAN_SLOT_LIVER, 20, 200)
 		cure()
 		return FALSE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Liver Parasites will now check if you have a cybernetic liver and instead of persisting deal a one time 20 liver damage and be cured. The logic behind the liver being damaged is that the blender function is not perfect. Coder logic is that people should not be drinking vile fluid even if they got cogs instead of guts.

update: turns out removing the liver does not remove parasites AT ALL. 
I have to fix this now.

## Why It's Good For The Game
Its only fair that a cybernetic liver has a blending function.

## Changelog
:cl:
fix: Parasitic Infection
tweak: Parasitic Infection
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
