### PR TITLE
Adds Apex, RBA, Alriune to RCorp gamemode

### DIFF
--- a/ModularTegustation/tegu_items/rcorp/landmarks.dm
+++ b/ModularTegustation/tegu_items/rcorp/landmarks.dm
@@ -3,13 +3,15 @@ GLOBAL_LIST_INIT(easycombat, list(
 	/mob/living/simple_animal/hostile/abnormality/blue_shepherd,
 	/mob/living/simple_animal/hostile/abnormality/kqe,
 	/mob/living/simple_animal/hostile/abnormality/dimensional_refraction,
-	/mob/living/simple_animal/hostile/abnormality/helper))
+	/mob/living/simple_animal/hostile/abnormality/helper,
+	/mob/living/simple_animal/hostile/abnormality/apex_predator))
 
 GLOBAL_LIST_INIT(easysupport, list(/mob/living/simple_animal/hostile/abnormality/fragment,
 	/mob/living/simple_animal/hostile/abnormality/funeral,
 	/mob/living/simple_animal/hostile/abnormality/voiddream,
 	/mob/living/simple_animal/hostile/abnormality/pisc_mermaid,
-	/mob/living/simple_animal/hostile/abnormality/rudolta,))
+	/mob/living/simple_animal/hostile/abnormality/rudolta,
+	/mob/living/simple_animal/hostile/abnormality/redblooded))
 
 GLOBAL_LIST_INIT(easytank, list(/mob/living/simple_animal/hostile/abnormality/jangsan,
 	/mob/living/simple_animal/hostile/abnormality/schadenfreude,
@@ -26,7 +28,8 @@ GLOBAL_LIST_INIT(hardsupport, list(/mob/living/simple_animal/hostile/abnormality
 	/mob/living/simple_animal/hostile/abnormality/judgement_bird,
 	/mob/living/simple_animal/hostile/abnormality/ebony_queen,
 	/mob/living/simple_animal/hostile/abnormality/thunder_bird,
-	/mob/living/simple_animal/hostile/abnormality/despair_knight,))
+	/mob/living/simple_animal/hostile/abnormality/despair_knight,
+	/mob/living/simple_animal/hostile/abnormality/alriune))
 
 GLOBAL_LIST_INIT(hardtank, list(/mob/living/simple_animal/hostile/abnormality/melting_love,
 	/mob/living/simple_animal/hostile/abnormality/nothing_there,

--- a/code/modules/mob/living/simple_animal/abnormality/waw/alriune.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/alriune.dm
@@ -49,6 +49,8 @@
 /* Combat */
 
 /mob/living/simple_animal/hostile/abnormality/alriune/Move()
+	if(CheckCombat())
+		return ..()
 	return FALSE
 
 /mob/living/simple_animal/hostile/abnormality/alriune/Life()
@@ -96,6 +98,8 @@
 
 
 /mob/living/simple_animal/hostile/abnormality/alriune/proc/TeleportAway()
+	if(CheckCombat())
+		return
 	var/list/potential_turfs = list()
 	for(var/turf/T in GLOB.xeno_spawn)
 		if(get_dist(src, T) < 7)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds Apex, RBA, Alriune to RCorp, gives Alriune legs and neuters her TP when on the gamemode.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
**RBA**: neat little TETH for the easy team, takes a support slot, taking more of a ranged supressive fire role with easy to hit shots.

**Apex**: assassin type abnormality, has extreme damage on backstabs, will shine when given the change to attack targets with little armor, like the commander, performance may not be the best when uncloaked though.

**Alriune**: AoE area denial abnormality that has an insane amount of burst telegraphed by sound, it can be heard from afar but has a scary amount of damage in a big area.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: changes abnormality spawn landmarks for rcorp
tweak: changes alriune to work on Rcorp
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
