### PR TITLE
Realized armor reballanced

### DIFF
--- a/code/modules/clothing/suits/ego_gear/realized.dm
+++ b/code/modules/clothing/suits/ego_gear/realized.dm
@@ -353,6 +353,8 @@
 	//goonchem_vortex(get_turf(src), 1, 3)
 	if(!canSUCC)
 		return
+	if(user.is_working)
+		return
 	canSUCC = FALSE
 	addtimer(CALLBACK(src, .proc/Reset), 2 SECONDS)
 	for(var/turf/T in view(3, user))

--- a/code/modules/spells/ability_types/realized.dm
+++ b/code/modules/spells/ability_types/realized.dm
@@ -61,7 +61,8 @@
 	cooldown_time = 30 SECONDS
 
 	var/debuff_range = 8
-	var/debuff_slowdown = 0.2 // Slowdown per use(funfact this was meant to be an 80% slow but I accidentally made it 20%)
+	var/debuff_slowdown = 0.5 // Slowdown per use(funfact this was meant to be an 80% slow but I accidentally made it 20%)
+
 /obj/effect/proc_holder/ability/lamp/Perform(target, mob/user)
 	cooldown = world.time + (2 SECONDS)
 	if(!do_after(user, 1.5 SECONDS))
@@ -76,7 +77,8 @@
 		new /obj/effect/temp_visual/revenant(get_turf(L))
 		if(ishostile(L))
 			var/mob/living/simple_animal/hostile/H = L
-			H.TemporarySpeedChange(debuff_slowdown , 15 SECONDS) // Slow down_status_effect(/datum/status_effect/salvation)
+			H.apply_status_effect(/datum/status_effect/salvation)
+			H.TemporarySpeedChange(H.move_to_delay*debuff_slowdown , 15 SECONDS) // Slow down_status_effect(/datum/status_effect/salvation)
 	return ..()
 
 /datum/status_effect/salvation

--- a/code/modules/spells/ability_types/realized.dm
+++ b/code/modules/spells/ability_types/realized.dm
@@ -61,7 +61,7 @@
 	cooldown_time = 30 SECONDS
 
 	var/debuff_range = 8
-	var/debuff_slowdown = 0.5 // Slowdown per use(funfact this was meant to be an 80% slow but I accidentally made it 20%)
+	var/debuff_slowdown = 0.2 // Slowdown per use(funfact this was meant to be an 80% slow but I accidentally made it 20%)
 /obj/effect/proc_holder/ability/lamp/Perform(target, mob/user)
 	cooldown = world.time + (2 SECONDS)
 	if(!do_after(user, 1.5 SECONDS))
@@ -551,7 +551,7 @@
 	id = "EGO_P2"
 	status_type = STATUS_EFFECT_UNIQUE
 	alert_type = /atom/movable/screen/alert/status_effect/punishment
-	duration = 2 SECONDS
+	duration = 5 SECONDS
 
 /atom/movable/screen/alert/status_effect/punishment
 	name = "Ready to punish"
@@ -570,7 +570,7 @@
 	H.remove_status_effect(/datum/status_effect/punishment)
 	to_chat(H, "<span class='userdanger'>You strike back at the wrong doer!</span>")
 	playsound(H, 'sound/abnormalities/apocalypse/beak.ogg', 100, FALSE, 12)
-	for(var/turf/T in view(1, H))
+	for(var/turf/T in view(2, H))
 		new /obj/effect/temp_visual/beakbite(T)
 		for(var/mob/living/L in T)
 			if(H.faction_check_mob(L, FALSE))
@@ -585,7 +585,7 @@
 	id = "EGO_PBIRD"
 	status_type = STATUS_EFFECT_UNIQUE
 	alert_type = /atom/movable/screen/alert/status_effect/pbird
-	duration = 15 SECONDS
+	duration = 20 SECONDS
 
 /atom/movable/screen/alert/status_effect/pbird
 	name = "Punishment"
@@ -609,7 +609,7 @@
 	desc = "Creates a big area of healing at the cost of double damage taken for a short period of time."
 	action_icon_state = "petalblizzard0"
 	base_icon_state = "petalblizzard"
-	cooldown_time = 45 SECONDS
+	cooldown_time = 30 SECONDS
 	var/healing_amount = 70 // Amount of healing to plater per "pulse".
 	var/healing_range = 8
 

--- a/code/modules/spells/ability_types/realized_aimed.dm
+++ b/code/modules/spells/ability_types/realized_aimed.dm
@@ -91,13 +91,13 @@
 
 /obj/effect/proc_holder/ability/aimed/despair_swords
 	name = "Blades Whetted with Tears"
-	desc = "An ability that summons 3 swords to attack and slow nearby enemies. \
+	desc = "An ability that summons 2 swords to attack and slow nearby enemies. \
 		Each sword deals damage equal to 5% of the target's max HP as Pale, to a minimum of 120."
 	action_icon_state = "despair0"
 	base_icon_state = "despair"
 	cooldown_time = 20 SECONDS
 
-	var/swords = 3
+	var/swords = 2
 
 /obj/effect/proc_holder/ability/aimed/despair_swords/Perform(target, mob/user)
 	var/turf/target_turf = get_turf(target)

--- a/code/modules/spells/ability_types/realized_aimed.dm
+++ b/code/modules/spells/ability_types/realized_aimed.dm
@@ -92,7 +92,7 @@
 /obj/effect/proc_holder/ability/aimed/despair_swords
 	name = "Blades Whetted with Tears"
 	desc = "An ability that summons 3 swords to attack and slow nearby enemies. \
-		Each sword deals damage equal to 2% of the target's max HP as Pale, to a minimum of 150."
+		Each sword deals damage equal to 5% of the target's max HP as Pale, to a minimum of 120."
 	action_icon_state = "despair0"
 	base_icon_state = "despair"
 	cooldown_time = 20 SECONDS
@@ -133,7 +133,7 @@
 	if(ishostile(target))
 		var/mob/living/simple_animal/hostile/H = target
 		H.TemporarySpeedChange(1, 10 SECONDS)
-		damage = max(0.02*H.maxHealth, 150)
+		damage = max(0.05*H.maxHealth, 120)
 	..()
 	qdel(src)
 

--- a/code/modules/spells/ability_types/realized_aimed.dm
+++ b/code/modules/spells/ability_types/realized_aimed.dm
@@ -91,13 +91,13 @@
 
 /obj/effect/proc_holder/ability/aimed/despair_swords
 	name = "Blades Whetted with Tears"
-	desc = "An ability that summons 2 swords to attack and slow nearby enemies. \
-		Each sword deals damage equal to 2% of the target's max HP as Pale, to a minimum of 40."
+	desc = "An ability that summons 3 swords to attack and slow nearby enemies. \
+		Each sword deals damage equal to 2% of the target's max HP as Pale, to a minimum of 150."
 	action_icon_state = "despair0"
 	base_icon_state = "despair"
 	cooldown_time = 20 SECONDS
 
-	var/swords = 2
+	var/swords = 3
 
 /obj/effect/proc_holder/ability/aimed/despair_swords/Perform(target, mob/user)
 	var/turf/target_turf = get_turf(target)
@@ -116,6 +116,8 @@
 		RP.original = target_turf
 		RP.preparePixelProjectile(target_turf, T)
 		addtimer(CALLBACK (RP, .obj/projectile/proc/fire), 3)
+	sleep(3)
+	playsound(target_turf, 'sound/abnormalities/despairknight/attack.ogg', 50, 0, 4)
 	return ..()
 
 /obj/projectile/despair_rapier/ego
@@ -131,7 +133,7 @@
 	if(ishostile(target))
 		var/mob/living/simple_animal/hostile/H = target
 		H.TemporarySpeedChange(1, 10 SECONDS)
-		damage = max(0.02*H.maxHealth, 40)
+		damage = max(0.02*H.maxHealth, 150)
 	..()
 	qdel(src)
 
@@ -338,8 +340,8 @@
 	icon_state = "cocoon_large2"
 	icon_living = "cocoon_large2"
 	faction = list("neutral")
-	health = 300	//They're here to help
-	maxHealth = 300
+	health = 250	//They're here to help
+	maxHealth = 250
 	speed = 0
 	turns_per_move = 10000000000000
 	generic_canpass = FALSE
@@ -351,10 +353,8 @@
 /mob/living/simple_animal/cocoonability/Initialize()
 	. = ..()
 	QDEL_IN(src, (30 SECONDS))
-
-/mob/living/simple_animal/cocoonability/Life()
-	if(..())
-		SplashEffect()
+	for(var/i = 1 to 10)
+		addtimer(CALLBACK(src, .proc/SplashEffect), i * 3 SECONDS)
 
 /mob/living/simple_animal/cocoonability/proc/SplashEffect()
 	for(var/turf/T in view(damage_range, src))
@@ -367,7 +367,7 @@
 		L.apply_damage(ishuman(L) ? damage_amount*0.5 : damage_amount, RED_DAMAGE, null, L.run_armor_check(null, RED_DAMAGE), spread_damage = TRUE)
 		if(ishostile(L))
 			var/mob/living/simple_animal/hostile/H = L
-			H.TemporarySpeedChange(damage_slowdown, 2 SECONDS) // Slow down
+			H.TemporarySpeedChange(damage_slowdown, 3 SECONDS) // Slow down
 
 
 /obj/effect/proc_holder/ability/aimed/blackhole
@@ -397,7 +397,7 @@
 	flag = BLACK_DAMAGE
 	projectile_piercing = PASSMOB
 	hit_nondense_targets = TRUE
-	var/damage_amount = 100 // Amount of black damage dealt to enemies in the epicenter.
+	var/damage_amount = 200 // Amount of black damage dealt to enemies in the epicenter.
 	var/damage_range = 3
 
 /obj/projectile/black_hole_realized/Initialize()
@@ -411,7 +411,7 @@
 	for(var/turf/T in view(damage_range, src))
 		new /obj/effect/temp_visual/revenant(T)
 	for(var/mob/living/L in view(damage_range, src))
-		var/distance_decrease = get_dist(src, L) * 30
+		var/distance_decrease = get_dist(src, L) * 40
 		L.apply_damage(ishuman(L) ? (damage_amount - distance_decrease)*0.5 : (damage_amount - distance_decrease), BLACK_DAMAGE, null, L.run_armor_check(null, BLACK_DAMAGE), spread_damage = TRUE)
 		var/atom/throw_target = get_edge_target_turf(L, get_dir(L, get_step_towards(L, get_turf(src))))
 		L.throw_at(throw_target, 1, 2)


### PR DESCRIPTION
## About The Pull Request

Buffed quenched with blood's ability  with a damage floor of 120, and buffed the % damage to 5%(and added the sword sounds kod makes)

Make fallen color's ability's damage higher(200 black with 40 fall off per tile) making it more of the chaotic cluster fuck it was meant to be

Buff mouth of god's abilities heavily. the counter time is increased from 2 seconds to 5 seconds, area of the counter is bigger, and increased the justice buff's duration to 20 seconds from 15

Buff sakura bloom's ability cooldown back to how it was(30 seconds)

Buff eye's of god's ability to actually function and make the slow a 50% slow

Nerfed death stare's ability heath to 250 and attack speed to every 3 seconds(slowdown buffed to 3 seconds to compinsate)

##Why It's Good For The Game

quenched with blood's sortof struggled as an ability when head of god's ability did 150 pale to an area and makes them take 50% more pale with the same cooldown. making quenched with blood's ability by buffing the min damage and % damage helps it be a more single target version of head of god's ability. 

Fallen color's ability was meant to be more destructive so buffing the max amount of damage it could do will help it being high risk high reward. Also fixed it's passive ability being able to go off during work damage.

Mouth of god's ability kind of sucked to use so giving it a bigger window, buffing its range, and making the justice buff last longer will help it be more useful and increases the reward.

Sakura bloom's was too strong before since it had a constant rate of healing instead of burst healing so I felt that it could have its old cooldown of 30 seconds back since the burst healing is a lot less useful.

Eye's of god was always meant to have a % slow, this change fixes that same with the 1.1x damage debuff to the slowed.

Death's stare's ability was broken before, not sure if a 16% health nerf and a 50% decreased attack speed will make it balanced or if it will be op even with this nerf.

## Changelog
:cl:
tweak: makes fallen color's passive not go off during work
balance: buffed the abilities of quenched with blood, fallen colors, sakura bloom, mouth of god, and eyes of god, and nerfed the ability of death's stare
fix: fixed a few things
soundadd: gave quenched with blood's ability sound
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
