### PR TITLE
Fix missing bar codes on wolf and baba yaga

### DIFF
--- a/code/modules/paperwork/records/info/waw.dm
+++ b/code/modules/paperwork/records/info/waw.dm
@@ -449,7 +449,7 @@
 //Baba Yaga
 /obj/item/paper/fluff/info/waw/babayaga
 	abno_type = /mob/living/simple_animal/hostile/abnormality/babayaga
-	name = "M-04-166"
+	abno_code = "M-04-166"
 	abno_info = list(
 		"When the work result was Normal, the Qliphoth Counter lowered with a normal probability.",
 		"When the work result was Bad, the Qliphoth Counter lowered. In addition, the employee was attacked by a group of frozen slaves.",
@@ -462,7 +462,7 @@
 //Big and Will be Bad Wolf
 /obj/item/paper/fluff/info/waw/big_wolf
 	abno_type = /mob/living/simple_animal/hostile/abnormality/big_wolf
-	name = "F-02-58"
+	abno_code = "F-02-58"
 	abno_info = list(
 		"When the work result was Bad, the Qliphoth Counter lowered and the employee working on F-02-58 was consumed.",
 		"When the employee had a good result while preforming instinct work F-02-58 vomited all of the previously consumed employees.",


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Turns out the bar codes were listed under name instead of abno_code

## Changelog
:cl:
fix: big_wolf and babayaga bar codes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
