### PR TITLE
Sweeper get diminishing returns from eating other sweepers

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/ordeal/indigo.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/indigo.dm
@@ -1,3 +1,5 @@
+#define SWEEPER_TYPES /mob/living/simple_animal/hostile/ordeal/indigo_dawn || /mob/living/simple_animal/hostile/ordeal/indigo_noon || /mob/living/simple_animal/hostile/ordeal/indigo_dusk || /mob/living/simple_animal/hostile/ordeal/indigo_midnight
+
 /mob/living/simple_animal/hostile/ordeal/indigo_dawn
 	name = "unknown scout"
 	desc = "A tall humanoid with a walking cane. It's wearing indigo armor."
@@ -38,7 +40,11 @@
 	visible_message(
 		"<span class='danger'>[src] devours [L]!</span>",
 		"<span class='userdanger'>You feast on [L], restoring your health!</span>")
-	adjustBruteLoss(-(maxHealth/2))
+	if(istype(L, SWEEPER_TYPES))
+		//Would have made it based on biotypes but that has its own issues.
+		adjustBruteLoss(-20)
+	else
+		adjustBruteLoss(-(maxHealth/2))
 	L.gib()
 	return TRUE
 
@@ -98,7 +104,10 @@
 	visible_message(
 		"<span class='danger'>[src] devours [L]!</span>",
 		"<span class='userdanger'>You feast on [L], restoring your health!</span>")
-	adjustBruteLoss(-(maxHealth/2))
+	if(istype(L, SWEEPER_TYPES))
+		adjustBruteLoss(-20)
+	else
+		adjustBruteLoss(-(maxHealth/2))
 	L.gib()
 	return TRUE
 
@@ -263,7 +272,10 @@
 	visible_message(
 		"<span class='danger'>[src] devours [L]!</span>",
 		"<span class='userdanger'>You feast on [L], restoring your health!</span>")
-	adjustBruteLoss(-(maxHealth/2))
+	if(istype(L, SWEEPER_TYPES))
+		adjustBruteLoss(-20)
+	else
+		adjustBruteLoss(-(maxHealth/2))
 	L.gib()
 	return TRUE
 
@@ -458,7 +470,10 @@
 	visible_message(
 		"<span class='danger'>[src] devours [L]!</span>",
 		"<span class='userdanger'>You feast on [L], restoring your health!</span>")
-	adjustBruteLoss(-(maxHealth*0.3))
+	if(istype(L, SWEEPER_TYPES))
+		adjustBruteLoss(-20)
+	else
+		adjustBruteLoss(-(maxHealth*0.3))
 	L.gib()
 	//Increase the Vore counter by 1
 	belly += 1
@@ -565,6 +580,8 @@
 			all_turfs -= T
 		sleep(delay)
 	slamming = FALSE
+
+#undef SWEEPER_TYPES
 
 /obj/effect/sweeperspawn
 	name = "bloodpool"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Sweepers using the devour ability on other sweepers will result in a 20 hp heal instead of a maximum heal due diminishing returns. Also it sorta makes sense since it would be pre-digested fuel.

## Why It's Good For The Game
Not entirely nessesary for gameplay but there has been a complaint about sentient sweepers doing this.

## Changelog
:cl:
tweak: indigo ordeal devour
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
