### PR TITLE
[LoR13] Adds more shutters to bus room.

### DIFF
--- a/_maps/map_files/Event/city.dmm
+++ b/_maps/map_files/Event/city.dmm
@@ -2043,6 +2043,12 @@
 	},
 /turf/open/floor/mineral/titanium,
 /area/city/house)
+"ua" = (
+/obj/machinery/button/door{
+	id = "Garage"
+	},
+/turf/closed/indestructible/reinforced,
+/area/city/shop)
 "ub" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/condiment/flour,
@@ -4786,6 +4792,12 @@
 	},
 /turf/open/floor/plating/ashplanet/rocky,
 /area/city/backstreets_checkpoint)
+"Sf" = (
+/obj/machinery/door/poddoor/shutters/indestructible{
+	id = "Garage"
+	},
+/turf/open/floor/wood,
+/area/city/shop)
 "Sg" = (
 /obj/structure/fence{
 	dir = 4
@@ -35191,7 +35203,7 @@ lk
 lk
 lk
 Gz
-OT
+ua
 pg
 qy
 OT
@@ -35445,9 +35457,9 @@ NJ
 NJ
 NJ
 OT
-OT
-OT
-OT
+Sf
+Sf
+Sf
 OT
 OT
 OT


### PR DESCRIPTION
## About The Pull Request
![(null)scrnshot1](https://github.com/vlggms/lobotomy-corp13/assets/48499004/884d28ca-4929-4dc0-835e-f599b99c2107)
Adds an additional set of invincible shutters (with a linked button) to the bus room.

## Why It's Good For The Game
Opens up the Molar Office room for food truck shenanigans.

## Changelog
:cl:
add: Added new shutters + button to Molar Office room.
/:cl:
