### PR TITLE
Carnival Shop Location

### DIFF
--- a/_maps/map_files/Event/city.dmm
+++ b/_maps/map_files/Event/city.dmm
@@ -4626,10 +4626,6 @@
 /obj/machinery/computer/arcade/battle,
 /turf/open/floor/eighties,
 /area/city/fixers)
-"Oe" = (
-/obj/item/kirbyplants,
-/turf/open/floor/facility/dark,
-/area/city/backstreets_room)
 "Og" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 32
@@ -27902,7 +27898,7 @@ Oq
 Oq
 XQ
 IA
-Oe
+vY
 XQ
 iE
 XQ

--- a/_maps/map_files/Event/city.dmm
+++ b/_maps/map_files/Event/city.dmm
@@ -30,6 +30,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/city)
+"ay" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/turf/open/floor/facility/dark,
+/area/city/backstreets_room)
 "aB" = (
 /obj/structure/fluff/beach_umbrella/syndi,
 /turf/open/floor/plating/beach/sand,
@@ -336,6 +342,29 @@
 /obj/item/choice_beacon/association,
 /turf/open/floor/carpet/black,
 /area/city/fixers)
+"cG" = (
+/obj/structure/closet/crate,
+/obj/item/storage/box/papersack{
+	pixel_x = -6
+	},
+/obj/item/storage/box/papersack{
+	pixel_x = -6
+	},
+/obj/item/storage/box/papersack{
+	pixel_x = -6
+	},
+/obj/item/storage/box/papersack{
+	pixel_x = -6
+	},
+/obj/item/storage/box/papersack{
+	pixel_x = -6
+	},
+/obj/item/storage/box/papersack{
+	pixel_x = -6
+	},
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/facility/dark,
+/area/city/backstreets_room)
 "cJ" = (
 /obj/structure/fluff/bus/passable,
 /turf/open/floor/carpet/black,
@@ -679,6 +708,13 @@
 	},
 /turf/open/floor/plating/asteroid/basalt,
 /area/city/backstreets_alley)
+"fK" = (
+/obj/effect/turf_decal/loading_area/red{
+	dir = 1
+	},
+/obj/structure/chair,
+/turf/open/floor/facility/dark,
+/area/city/backstreets_room)
 "fP" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -1026,6 +1062,14 @@
 	},
 /turf/open/floor/wood,
 /area/city/shop)
+"iA" = (
+/obj/effect/decal/cleanable/blood/drip{
+	pixel_x = 12;
+	pixel_y = 12
+	},
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/floor/facility/dark,
+/area/city/backstreets_room)
 "iB" = (
 /obj/effect/spawner/room/backstreets/pointofinterest,
 /turf/closed/indestructible/reinforced,
@@ -1037,6 +1081,10 @@
 	},
 /turf/open/floor/wood,
 /area/city/fixers)
+"iE" = (
+/obj/machinery/door/airlock/hatch,
+/turf/open/floor/facility/dark,
+/area/city/backstreets_room)
 "iF" = (
 /obj/machinery/door/poddoor/shutters/indestructible{
 	name = "Malfunctioning Backstreets Shutters"
@@ -1443,6 +1491,10 @@
 /obj/item/storage/toolbox/emergency,
 /turf/open/floor/wood,
 /area/city/shop)
+"nt" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/facility/dark,
+/area/city/backstreets_room)
 "nu" = (
 /obj/effect/spawner/randomcolavend,
 /turf/open/floor/plating/ashplanet/rocky,
@@ -1465,6 +1517,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/city/house)
+"nK" = (
+/obj/structure/table/reinforced,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/facility/dark,
+/area/city/backstreets_room)
 "nQ" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -1586,6 +1647,13 @@
 /obj/effect/spawner/randomsnackvend,
 /turf/open/floor/facility,
 /area/city/shop)
+"pe" = (
+/obj/machinery/light,
+/obj/effect/turf_decal/box/red/corners{
+	dir = 8
+	},
+/turf/open/floor/facility/dark,
+/area/city/backstreets_room)
 "pg" = (
 /obj/structure/closet/cabinet,
 /obj/item/reagent_containers/food/drinks/bottle/wine/unlabeled{
@@ -1626,6 +1694,14 @@
 "pO" = (
 /turf/open/floor/plating/asteroid/basalt,
 /area/city/backstreets_alley)
+"pQ" = (
+/obj/structure/table/reinforced,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/facility/dark,
+/area/city/backstreets_room)
 "pS" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -1672,6 +1748,13 @@
 /obj/structure/window/reinforced/survival_pod,
 /turf/open/floor/mineral/silver,
 /area/city/shop)
+"qq" = (
+/obj/machinery/door/airlock/hatch,
+/obj/effect/turf_decal/trimline/red/filled/shrink_cw{
+	dir = 8
+	},
+/turf/open/floor/facility/dark,
+/area/city/backstreets_room)
 "qu" = (
 /obj/machinery/light{
 	dir = 1
@@ -3485,6 +3568,13 @@
 /obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/city/fixers)
+"EE" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/facility/dark,
+/area/city/backstreets_room)
 "EF" = (
 /obj/structure/chair/sofa/corner{
 	dir = 4
@@ -3649,6 +3739,16 @@
 /obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/city/shop)
+"Gf" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/closet/crate,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/turf/open/floor/facility/dark,
+/area/city/backstreets_room)
 "Gh" = (
 /obj/structure/table,
 /turf/open/floor/wood,
@@ -3991,6 +4091,12 @@
 /obj/structure/fireplace,
 /turf/open/floor/wood,
 /area/city/fixers)
+"IA" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/turf/open/floor/facility/dark,
+/area/city/backstreets_room)
 "IB" = (
 /obj/item/bodypart/chest/robot,
 /obj/item/bodypart/head/robot,
@@ -4226,6 +4332,13 @@
 /obj/structure/bed/pod,
 /turf/open/floor/wood,
 /area/city/shop)
+"KG" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/facility/dark,
+/area/city/backstreets_room)
 "KK" = (
 /obj/machinery/vending/city_clothing,
 /obj/machinery/light,
@@ -4386,6 +4499,13 @@
 /obj/item/food/meat/slab,
 /turf/open/indestructible/hoteltile,
 /area/city/house)
+"Ms" = (
+/obj/machinery/door/airlock/hatch,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/turf/open/floor/facility/dark,
+/area/city/backstreets_room)
 "My" = (
 /obj/structure/potential,
 /turf/open/floor/facility/white,
@@ -4506,6 +4626,10 @@
 /obj/machinery/computer/arcade/battle,
 /turf/open/floor/eighties,
 /area/city/fixers)
+"Oe" = (
+/obj/item/kirbyplants,
+/turf/open/floor/facility/dark,
+/area/city/backstreets_room)
 "Og" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 32
@@ -4540,6 +4664,13 @@
 "Ot" = (
 /turf/closed/indestructible/reinforced,
 /area/city/backstreets_checkpoint)
+"Ov" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/turf/open/floor/facility/dark,
+/area/city/backstreets_room)
 "Ox" = (
 /obj/structure/barricade/wooden,
 /obj/effect/decal/cleanable/dirt,
@@ -4920,6 +5051,19 @@
 	},
 /turf/open/floor/plating/asteroid/basalt,
 /area/city/backstreets_alley)
+"TQ" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/item/storage/box/papersack{
+	pixel_x = -6
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/turf/open/floor/facility/dark,
+/area/city/backstreets_room)
 "TS" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/hypospray/medipen/mental,
@@ -5027,6 +5171,12 @@
 /obj/structure/closet/crate/bin,
 /turf/open/floor/facility/dark,
 /area/city/backstreets_checkpoint)
+"UZ" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/turf/open/floor/facility/dark,
+/area/city/backstreets_room)
 "Vb" = (
 /turf/open/indestructible/hoteltile,
 /area/city/house)
@@ -5144,6 +5294,15 @@
 	},
 /turf/open/floor/plating/asteroid/basalt,
 /area/city/backstreets_alley)
+"VS" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 9
+	},
+/turf/open/floor/facility/dark,
+/area/city/backstreets_room)
 "VV" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood,
@@ -5252,6 +5411,22 @@
 "Xr" = (
 /turf/open/floor/plating/beach/sand,
 /area/city)
+"Xs" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table/reinforced,
+/obj/item/storage/box/bodybags{
+	pixel_y = -4;
+	pixel_x = -5
+	},
+/obj/item/storage/firstaid{
+	pixel_x = 9;
+	pixel_y = -7
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/turf/open/floor/facility/dark,
+/area/city/backstreets_room)
 "Xt" = (
 /obj/structure/toilet,
 /obj/machinery/light{
@@ -5291,6 +5466,10 @@
 "XK" = (
 /turf/open/space/basic,
 /area/space)
+"XP" = (
+/obj/effect/turf_decal/box/red/corners,
+/turf/open/floor/facility/dark,
+/area/city/backstreets_room)
 "XQ" = (
 /turf/closed/indestructible/reinforced,
 /area/city/backstreets_room)
@@ -5324,6 +5503,13 @@
 	},
 /turf/open/floor/plating/dirt/jungle/dark,
 /area/city/backstreets_alley)
+"Yl" = (
+/obj/machinery/door/airlock/hatch,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
+	},
+/turf/open/floor/facility/dark,
+/area/city/backstreets_room)
 "Ym" = (
 /mob/living/simple_animal/hostile/ordeal/green_bot{
 	name = "spear bot"
@@ -5334,6 +5520,14 @@
 /obj/effect/spawner/lootdrop/garbage_spawner,
 /turf/open/floor/plating/beach/sand,
 /area/city)
+"Yp" = (
+/obj/structure/closet/crate,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
+	},
+/turf/open/floor/facility/dark,
+/area/city/backstreets_room)
 "Yq" = (
 /obj/structure/table/wood,
 /obj/item/storage/backpack/duffelbag/med/surgery,
@@ -5362,6 +5556,10 @@
 /obj/item/ego_weapon/city/yun/fist,
 /turf/open/floor/wood,
 /area/city)
+"Yx" = (
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/facility/dark,
+/area/city/backstreets_room)
 "Yy" = (
 /turf/open/water/deep/polluted,
 /area/city)
@@ -27197,7 +27395,7 @@ XQ
 XQ
 XQ
 XQ
-dD
+XQ
 Oq
 Oq
 Oq
@@ -27446,14 +27644,14 @@ Oq
 Oq
 Oq
 XQ
-XQ
-XQ
-XQ
-XQ
-XQ
-XQ
-XQ
-XQ
+VS
+EE
+Ms
+Ov
+ay
+ay
+TQ
+Xs
 XQ
 Oq
 Oq
@@ -27703,14 +27901,14 @@ Oq
 Oq
 Oq
 XQ
+IA
+Oe
 XQ
+iE
 XQ
-XQ
-XQ
-XQ
-XQ
-XQ
-XQ
+vY
+iA
+Yx
 XQ
 Oq
 Oq
@@ -27960,14 +28158,14 @@ zr
 zr
 zr
 XQ
+IA
+fK
+nK
+pe
 XQ
-XQ
-XQ
-XQ
-XQ
-XQ
-XQ
-XQ
+nt
+vY
+cG
 XQ
 Oq
 Oq
@@ -28217,14 +28415,14 @@ zr
 Ua
 RZ
 XQ
-XQ
-XQ
-XQ
-XQ
-XQ
-XQ
-XQ
-XQ
+KG
+fK
+pQ
+XP
+qq
+UZ
+Gf
+Yp
 XQ
 Oq
 Oq
@@ -28474,7 +28672,7 @@ kG
 RZ
 RZ
 XQ
-XQ
+Yl
 XQ
 XQ
 XQ

--- a/_maps/map_files/Event/city.dmm
+++ b/_maps/map_files/Event/city.dmm
@@ -321,6 +321,10 @@
 	},
 /turf/open/floor/plating/dirt/jungle/dark,
 /area/city/backstreets_alley)
+"cq" = (
+/obj/machinery/vending/weaving,
+/turf/closed/indestructible/reinforced,
+/area/city/backstreets_room)
 "cr" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 5
@@ -1082,7 +1086,9 @@
 /turf/open/floor/wood,
 /area/city/fixers)
 "iE" = (
-/obj/machinery/door/airlock/hatch,
+/obj/machinery/door/airlock/hatch{
+	req_access_txt = "ACCESS_CARGO"
+	},
 /turf/open/floor/facility/dark,
 /area/city/backstreets_room)
 "iF" = (
@@ -1749,7 +1755,9 @@
 /turf/open/floor/mineral/silver,
 /area/city/shop)
 "qq" = (
-/obj/machinery/door/airlock/hatch,
+/obj/machinery/door/airlock/hatch{
+	req_access_txt = "ACCESS_CARGO"
+	},
 /obj/effect/turf_decal/trimline/red/filled/shrink_cw{
 	dir = 8
 	},
@@ -3747,6 +3755,12 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
+/obj/item/clothing/suit/armor/ego_gear/city/carnival_robes,
+/obj/item/clothing/suit/armor/ego_gear/city/carnival_robes,
+/obj/item/clothing/suit/armor/ego_gear/city/carnival_robes,
+/obj/item/clothing/mask/carnival_mask,
+/obj/item/clothing/mask/carnival_mask,
+/obj/item/clothing/mask/carnival_mask,
 /turf/open/floor/facility/dark,
 /area/city/backstreets_room)
 "Gh" = (
@@ -4500,7 +4514,10 @@
 /turf/open/indestructible/hoteltile,
 /area/city/house)
 "Ms" = (
-/obj/machinery/door/airlock/hatch,
+/obj/machinery/door/airlock/hatch{
+	req_access_txt = "ACCESS_CARGO";
+	name = "Staff Only"
+	},
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
@@ -5052,12 +5069,10 @@
 	dir = 8
 	},
 /obj/structure/table/reinforced,
-/obj/item/storage/box/papersack{
-	pixel_x = -6
-	},
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
+/obj/item/ego_weapon/city/carnival_spear,
 /turf/open/floor/facility/dark,
 /area/city/backstreets_room)
 "TS" = (
@@ -5421,6 +5436,9 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
+/obj/item/ego_weapon/city/carnival_spear{
+	pixel_y = 17
+	},
 /turf/open/floor/facility/dark,
 /area/city/backstreets_room)
 "Xt" = (
@@ -5500,7 +5518,9 @@
 /turf/open/floor/plating/dirt/jungle/dark,
 /area/city/backstreets_alley)
 "Yl" = (
-/obj/machinery/door/airlock/hatch,
+/obj/machinery/door/airlock/hatch{
+	name = "Carnival"
+	},
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 5
 	},
@@ -27901,7 +27921,7 @@ IA
 vY
 XQ
 iE
-XQ
+cq
 vY
 iA
 Yx


### PR DESCRIPTION
Removes the "Medium West Spawner" in the nest and replaces it with the soon to be used Carnival location

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Another person is developing the Carnival and requested a quick shop that they can use, so here it is.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
Removed the Medium Spawner West in the nest and replaced it with the "Carnival" shop which will inevitably be used to house the Carnival
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
