### PR TITLE
Speed code unification

### DIFF
--- a/ModularTegustation/tegu_mobs/lc13_outskirtdwellers.dm
+++ b/ModularTegustation/tegu_mobs/lc13_outskirtdwellers.dm
@@ -788,8 +788,7 @@ Mobs that mostly focus on dealing RED damage, they are all a bit more frail than
 	var/counter_threshold = 500 //300 at stage 2
 	var/counter_ready = FALSE //are we ready to counter?
 
-	var/counter_speed = -2 //subtracted from the movedelay when dashing
-	var/original_speed = 6 //used to reset speed after dashing
+	var/counter_speed = 2 //subtracted from the movedelay when dashing
 
 	var/lovewhip_damage = 100
 	var/damage_taken
@@ -799,9 +798,8 @@ Mobs that mostly focus on dealing RED damage, they are all a bit more frail than
 	if(!countering && can_act)
 		icon_state = icon_living
 	current_stage = 2
-	move_to_delay = 4
-	counter_speed = -1
-	original_speed = 4
+	//Speed changed from 6 to 4
+	SpeedChange(-counter_speed)
 	attack_delay = 1 SECONDS
 	counter_threshold = 300
 	playsound(get_turf(src), 'sound/creatures/lc13/lovetown/abomination_stagetransition.ogg', 75, 0, 3)
@@ -838,13 +836,13 @@ Mobs that mostly focus on dealing RED damage, they are all a bit more frail than
 			icon_state = "lovetown_abomination_dash2"
 	countering = TRUE
 	counter_ready = FALSE
-	move_to_delay += counter_speed
+	//Speed becomes 4 or 2 and returns to 6 or 4 after 4 seconds.
+	TemporarySpeedChange(-counter_speed, 4 SECONDS)
 	visible_message("<span class='warning'>[src] sprints toward [target]!</span>", "<span class='notice'>You quickly dash!</span>", "<span class='notice'>You hear heavy footsteps speed up.</span>")
 	addtimer(CALLBACK(src, .proc/DisableCounter), 4 SECONDS) //disables the counter after 4 seconds
 
-/mob/living/simple_animal/hostile/lovetown/abomination/proc/DisableCounter() //resets the speed
+/mob/living/simple_animal/hostile/lovetown/abomination/proc/DisableCounter() //resets the counter
 	if(countering)
-		move_to_delay = original_speed
 		countering = FALSE
 		playsound(get_turf(src), 'sound/creatures/lc13/lovetown/abomination_counter_end.ogg', 75, 0, 3)
 		SLEEP_CHECK_DEATH(10)

--- a/code/modules/mob/living/simple_animal/abnormality/_abnormality.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_abnormality.dm
@@ -82,7 +82,6 @@
 
 /mob/living/simple_animal/hostile/abnormality/Initialize(mapload)
 	. = ..()
-	UpdateSpeed()
 	if(!(type in GLOB.cached_abno_work_rates))
 		GLOB.cached_abno_work_rates[type] = work_chances.Copy()
 	if(!(type in GLOB.cached_abno_resistances))

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/melting_love.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/melting_love.dm
@@ -206,7 +206,7 @@
 	return TRUE
 
 /mob/living/simple_animal/hostile/abnormality/melting_love/proc/Empower()
-	move_to_delay -= 0.5
+	SpeedChange(-0.5)
 	melee_damage_lower = 80
 	melee_damage_upper = 85
 	projectiletype = /obj/projectile/melting_blob/enraged

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/mountain.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/mountain.dm
@@ -224,15 +224,12 @@
 				if(CheckCombat())
 					phase = 2
 					return
-
 				icon_living = "mosb_breach2"
-				speed = 1
-				move_to_delay = 5
+				SpeedChange(1)
 				patrol_cooldown_time = 30 SECONDS
 			if(phase == 2)
 				icon_living = "mosb_breach"
-				speed = 0.5
-				move_to_delay = 4
+				SpeedChange(2)
 				patrol_cooldown_time = 20 SECONDS
 			icon_state = icon_living
 			update_simplemob_varspeed()
@@ -250,15 +247,13 @@
 		icon = 'ModularTegustation/Teguicons/64x64.dmi'
 		pixel_x = -16
 		base_pixel_x = -16
-		speed = -0.5
-		move_to_delay = 2
+		SpeedChange(-2)
 		patrol_cooldown_time = 10 SECONDS
 	if(phase == 2)
 		icon = 'ModularTegustation/Teguicons/96x96.dmi'
 		pixel_x = -32
 		base_pixel_x = -32
-		speed = 0.5
-		move_to_delay = 4
+		SpeedChange(-1)
 		patrol_cooldown_time = 20 SECONDS
 	icon_state = icon_living
 	UpdateSpeed()

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/nothing_there.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/nothing_there.dm
@@ -259,8 +259,7 @@
 	if(!istype(disguise))
 		return
 	next_transform = world.time + rand(30 SECONDS, 40 SECONDS)
-	move_to_delay = initial(move_to_delay)
-	UpdateSpeed()
+	SpeedChange(1.5)
 	appearance = saved_appearance
 	disguise.forceMove(get_turf(src))
 	disguise.gib()
@@ -292,7 +291,7 @@
 			can_act = TRUE
 			melee_damage_lower = 65
 			melee_damage_upper = 75
-			move_to_delay = 4.5
+			SpeedChange(1.5)
 			heartbeat.stop()
 			breachloop.start()
 	UpdateSpeed()
@@ -391,7 +390,7 @@
 		return
 	// Teleport us somewhere where nobody will see us at first
 	fear_level = 0 // So it doesn't inflict fear to those around them
-	move_to_delay = 1.2 // This will make them move at a speed similar to normal players
+	SpeedChange(-1.5) // This will make them move at a speed similar to normal players
 	UpdateSpeed()
 	var/list/priority_list = list()
 	for(var/turf/T in GLOB.xeno_spawn)

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/titania.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/titania.dm
@@ -79,8 +79,7 @@
 	. = ..()
 
 	if(H.stat == DEAD && target == nemesis)		//Does she slay Oberon personally? If so, get buffed.
-		move_to_delay = 3
-		UpdateSpeed()
+		SpeedChange(-1)
 		melee_damage_lower = 110
 		melee_damage_upper = 140
 		adjustBruteLoss(-maxHealth) // Round 2, baby

--- a/code/modules/mob/living/simple_animal/abnormality/he/blue_shepherd.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/blue_shepherd.dm
@@ -238,8 +238,7 @@
 		slash_damage = 50
 		melee_damage_lower = 30
 		melee_damage_upper = 40
-		move_to_delay = 2.5
-		UpdateSpeed()
+		SpeedChange(-0.5)
 		maxHealth = maxHealth * 4 //5000 health, will get hurt by buddy's howl to make up for the high health
 		set_health(health * 4)
 		med_hud_set_health()

--- a/code/modules/mob/living/simple_animal/abnormality/he/red_buddy.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/red_buddy.dm
@@ -167,7 +167,7 @@
 		awoo_cooldown = 0 //resets the awoo cooldown too
 		melee_damage_lower = 60
 		melee_damage_upper = 80
-		move_to_delay = 4 //this doesn't matter as much as you'd think because he can't move before shepherd
+		SpeedChange(-1) //this doesn't matter as much as you'd think because he can't move before shepherd
 		UpdateSpeed()
 		vision_range = 3
 		aggro_vision_range = 3 //red buddy should only move for things it can actually reach, in this case somewhat within shepherd's reach
@@ -236,8 +236,7 @@
 		awakened_master.melee_damage_lower = 10
 		awakened_master.melee_damage_upper = 15
 		awakened_master.slash_damage = 20
-		awakened_master.move_to_delay = 1.7 //we severely nerf shepherd's damage but make him way faster on buddy's death, it's last one tango.
-		UpdateSpeed()
+		awakened_master.SpeedChange(-0.8) //we severely nerf shepherd's damage but make him way faster on buddy's death, it's last one tango.
 		awakened_master.say("A wolf. A wolf. Why won't you believe me? it's right there. IT WAS RIGHT THERE!")
 	awakened_master = null
 	density = FALSE

--- a/code/modules/mob/living/simple_animal/abnormality/he/you_strong.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/you_strong.dm
@@ -235,6 +235,8 @@
 	var/gear = 2
 	COOLDOWN_DECLARE(gear_shift)
 	var/gear_cooldown = 1 MINUTES
+	//tracks speed change even if altered by other speed modifiers.
+	var/gear_speed = 0
 
 /mob/living/simple_animal/hostile/grown_strong/Move(atom/newloc, dir, step_x, step_y)
 	if(status_flags & GODMODE)
@@ -256,8 +258,12 @@
 	manual_emote("shifts into [gear]\th gear!")
 	melee_damage_lower = 3*gear
 	melee_damage_upper = 5*gear
-	move_to_delay = 5 - FLOOR(gear / 3, 1)
-	UpdateSpeed()
+	//Reset the speed. First proc changes this only with 0.
+	SpeedChange(gear_speed)
+	//Calculate speed change.
+	gear_speed = FLOOR(gear / 3, 1)
+	//CRANK UP THE SPEED.
+	SpeedChange(-gear_speed)
 	rapid_melee = gear > 7 ? 2 : 1
 
 /mob/living/simple_animal/hostile/grown_strong/Life()

--- a/code/modules/mob/living/simple_animal/abnormality/teth/void_dream.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/void_dream.dm
@@ -69,8 +69,7 @@
 		return
 	icon = 'ModularTegustation/Teguicons/32x64.dmi'
 	punched = TRUE
-	move_to_delay = 4
-	UpdateSpeed()
+	SpeedChange(-2)
 	ability_cooldown_time = 8 SECONDS
 	ability_cooldown = 0
 	REMOVE_TRAIT(src, TRAIT_MOVE_FLYING, ROUNDSTART_TRAIT)

--- a/code/modules/mob/living/simple_animal/abnormality/waw/nosferatu.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/nosferatu.dm
@@ -154,8 +154,7 @@
 	animate(src, transform = matrix()*1.2, color = "#FF0000", time = 10)
 	playsound(get_turf(src), 'sound/abnormalities/nosferatu/transform.ogg', 35, 8)
 	bloodlust_cooldown = clamp(bloodlust_cooldown - 2, 0, 4)
-	move_to_delay -= 1
-	UpdateSpeed()
+	SpeedChange(-1)
 	berzerk = TRUE
 
 /mob/living/simple_animal/hostile/abnormality/nosferatu/add_splatter_floor(turf/T, small_drip) //no spilling blood, it just works.

--- a/code/modules/mob/living/simple_animal/abnormality/waw/warden.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/warden.dm
@@ -62,8 +62,7 @@
 
 			// it gets faster.
 			if(move_to_delay>1)
-				move_to_delay -= move_to_delay*0.25
-				UpdateSpeed()
+				SpeedChange(-move_to_delay*0.25)
 				if(melee_damage_lower > 30)
 					melee_damage_lower -=5
 

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -78,8 +78,11 @@
 
 	if(!targets_from)
 		targets_from = src
+	/*Update Speed overrides set speed and sets it
+		to the equivilent of move_to_delay. Basically
+		move_to_delay - 2 = speed. */
+	UpdateSpeed()
 	wanted_objects = typecacheof(wanted_objects)
-
 
 /mob/living/simple_animal/hostile/Destroy()
 	targets_from = null

--- a/code/modules/mob/living/simple_animal/hostile/ordeal/indigo.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/indigo.dm
@@ -320,8 +320,7 @@
 	var/pissed_threshold = 16
 
 	//phase speedchange
-	var/phase2speed = 2.4
-	var/phase3speed = 1.8
+	var/phasespeedchange = -0.6
 
 
 /mob/living/simple_animal/hostile/ordeal/indigo_midnight/Move()
@@ -512,8 +511,7 @@
 
 	maxHealth = 4000
 	damage_coeff = list(BRUTE = 1, RED_DAMAGE = 0.4, WHITE_DAMAGE = 0.6, BLACK_DAMAGE = 0.25, PALE_DAMAGE = 0.8)
-	move_to_delay = phase2speed
-	UpdateSpeed()
+	SpeedChange(phasespeedchange)
 	rapid_melee +=1
 	melee_damage_lower -= 10
 	melee_damage_upper -= 10
@@ -531,8 +529,7 @@
 
 	maxHealth = 3000
 	damage_coeff = list(BRUTE = 1, RED_DAMAGE = 0.5, WHITE_DAMAGE = 0.8, BLACK_DAMAGE = 0.3, PALE_DAMAGE = 1)
-	move_to_delay = phase3speed
-	UpdateSpeed()
+	SpeedChange(phasespeedchange)
 	rapid_melee += 2
 	melee_damage_lower -= 15
 	melee_damage_upper -= 15


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
changed the move_to_delay defines with a speed change proc.
I have to test 

- [x] Melting Love
- [x] Mountain of Smiling Bodies
- [x] Blue Shepherd
- [x] Red Buddy
- [x] Titania
- [x] You Strong
- [x] Void Dream
- [x] Nosferatu
- [x] Warden
- [x] Indigo Midnight Matriarch
- [x] Lovetown Abomination
![image](https://github.com/vlggms/lobotomy-corp13/assets/109536843/4a69ecb9-1398-4ebc-ac9e-69fa0c04f714)
Tests of the lovetown dash show that it doesnt break when lovewhip and dash both happen one after another.
Will need @TaculoTaculo to approve lovetown abomination edits.

## Why It's Good For The Game
Slowdown bullets wont make them go extremely fast anymore.

## Changelog
:cl:
fix: Speed Define super speed bug
fix: Some runtime errors that rendered speed changes inactive.
tweak: moves UpdateSpeed proc from abnormalitiy initialize to hostile so all hostile subtypes auto set their speed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
