### PR TITLE
Nerfs sea-pushing

### DIFF
--- a/ModularTegustation/fishing/code/turfs.dm
+++ b/ModularTegustation/fishing/code/turfs.dm
@@ -67,14 +67,13 @@
 		var/mob/living/L = thing
 		if(L.movement_type & FLYING)
 			return
-		//100 brute damage to living mobs. If they are human add 50 oxygen damage to them.
-		L.adjustBruteLoss(100)
+		//20 brute damage to living mobs. Adds up pretty quick if you're not warped away.
+		L.adjustBruteLoss(30)
 		if(ishuman(L))
 			var/mob/living/carbon/human/H = L
-			H.Paralyze(30)
-			H.adjustOxyLoss(50)
-			visible_message("<span class='boldwarning'>[H] sinks into the deep!</span>")
-			to_chat(H, pick("<span class='userdanger'>Something in the [src] grabs you and pulls you into the darkness. Your eyes burn as the light becomes fainter and the deep darkness begins circle around you.</span>", "<span class='userdanger'>The fluid around you starts crawling into your mouth.</span>", "<span class='userdanger'>You feel a sudden sting, then everything goes numb.</span>"))
+			H.Knockdown(10)
+			visible_message("<span class='boldwarning'>[H] struggles to remain afloat!</span>")
+			to_chat(H, pick("<span class='boldwarning'>You struggle to remain afloat, your lungs burning from holding your breath!.</span>", "<span class='boldwarning'>The water around you is too turbulent to swim in, you're drowning!</span>", "<span class='boldwarning'>You flail around as water enters your lungs!</span>"))
 		//Things that become lost in the deep. Objects like fish can be thrown into the deep. However some objects result in pollution.
 	else if(isitem(thing) || istype(thing, /obj/effect/decal/cleanable))
 		if(istype(thing, /obj/item/food/fish/emulsijack) && !istype(src, /turf/open/water/deep/polluted))

--- a/ModularTegustation/fishing/code/turfs.dm
+++ b/ModularTegustation/fishing/code/turfs.dm
@@ -67,8 +67,8 @@
 		var/mob/living/L = thing
 		if(L.movement_type & FLYING)
 			return
-		//20 brute damage to living mobs. Adds up pretty quick if you're not warped away.
-		L.adjustBruteLoss(30)
+		//10 brute damage to living mobs. Adds up pretty quick if you're not warped away.
+		L.adjustBruteLoss(10)
 		if(ishuman(L))
 			var/mob/living/carbon/human/H = L
 			H.Knockdown(10)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This might be a scuffed way to do this, i'll admit, but such is the way of answering a WYCI. 

Deep water deals hilariously high damage capable of putting most players into softcrit instantly, on top of inflicting paralysis just long enough for anyone who survives the initial damage to be finished off regardless. This isn't much of an issue in LC13 where PvP is a rare occurence, but with the addition of LOR13 this has become an issue and has been to instantly dispatch people regardless of attributes and gear.

This is a problem on its own, but water has also been used as a way to keep dead people permanently out of reach of revival by throwing the corpse away from shore, as its near-fatal properties make wading in it to retrieve a body impossible unless the body is next to solid ground.

Perma-kills are fine, we wouldn't have a gibber otherwise, but this specific method takes no effort outside of activating harm intent and running into someone until they are pushed in a water tile, while the gibber requires you to have already killed or critted the unlucky victim beforehand. Moreover, we've been trying to move away from so-called "cheap" SS13 tactics that allow someone to gain a severe combat advantage with low effort such as wallshoves (#1369), and sea-pushing fits that category.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Stops rats from being able to win 1v1s with every character under the sun and making them unreviveable by inviting them to dip their toes in the ocean.

## Changelog
:cl:
balance: Deep water damage reduced from 100 brute and 50 oxy per step to 10 brute per step, and knocks players instead of paralyzing them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
