### PR TITLE
Nerfs knight of despair

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/waw/despair_knight.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/despair_knight.dm
@@ -92,6 +92,7 @@
 	blessed_human.physiology.white_mod /= 0.5
 	blessed_human.physiology.black_mod /= 0.5
 	blessed_human.physiology.pale_mod /= 2
+	blessed_human.adjust_attribute_bonus(TEMPERANCE_ATTRIBUTE, 100)
 	blessed_human = null
 	BreachEffect()
 	return TRUE
@@ -140,6 +141,7 @@
 		user.physiology.pale_mod *= 2
 		user.add_overlay(mutable_appearance('ModularTegustation/Teguicons/tegu_effects.dmi', "despair", -MUTATIONS_LAYER))
 		playsound(get_turf(user), 'sound/abnormalities/despairknight/gift.ogg', 50, 0, 2)
+		user.adjust_attribute_bonus(TEMPERANCE_ATTRIBUTE, -100)
 	return
 
 /mob/living/simple_animal/hostile/abnormality/despair_knight/BreachEffect(mob/living/carbon/human/user)

--- a/code/modules/paperwork/records/info/waw.dm
+++ b/code/modules/paperwork/records/info/waw.dm
@@ -50,6 +50,7 @@
 	abno_info = list(
 		"The first employee who completes their work with a Good result will receive The Knight of Despair’s blessing. (From then on, the employee will be referred to as O-01-73-1).",
 		"Thanks to the blessing, RED, WHITE, and BLACK damage dealt to O-01-73-1 was halved. However, PALE damage was doubled.",
+		"The blessing caused O-01-73-1 to lose most of their competence when it comes to working on abnormalities.",
 		"The Knight of Despair’s blessing dissipated when O-01-73-1 died or panicked. After the blessing was gone, a new employee could receive it.",
 		"When O-01-73-1 died or panicked, The Knight of Despair escaped from its Containment Unit.")
 	abno_can_breach = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Knight of despair's blessing now causes a -100 reduction in work ability, which translates to about a 20% chance in work reduction and a thorough decrease in work speed.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Knight of despair blessing no longer has no downsides.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Knight of despair's blessing no longer has no downsides.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
