### PR TITLE
Work Type Sublist

### DIFF
--- a/code/datums/abnormality/datum/abnormality.dm
+++ b/code/datums/abnormality/datum/abnormality.dm
@@ -144,7 +144,7 @@
 	if(!console?.recorded && !console?.tutorial) //only training rabbit should not train stats
 		return
 	if(pe > 0) // Work did not fail
-		var/attribute_type = WORK_TO_ATTRIBUTE[work_type]
+		var/attribute_type = current.work_attribute_types[work_type]
 		var/maximum_attribute_level = 0
 		switch(threat_level)
 			if(ZAYIN_LEVEL)

--- a/code/datums/abnormality/datum/abnormality.dm
+++ b/code/datums/abnormality/datum/abnormality.dm
@@ -158,18 +158,17 @@
 			if(ALEPH_LEVEL)
 				maximum_attribute_level = 130
 		var/datum/attribute/user_attribute = user.attributes[attribute_type]
-		if(!user_attribute) //To avoid runtime if it's a custom work type like "Release".
-			return
-		var/user_attribute_level = max(1, user_attribute.level)
-		var/attribute_given = clamp(((maximum_attribute_level / (user_attribute_level * 0.25)) * (0.25 + (pe / max_boxes))), 0, 16)
-		if((user_attribute_level + attribute_given + 1) >= maximum_attribute_level) // Already/Will/Should be at maximum.
-			attribute_given = max(0, maximum_attribute_level - user_attribute_level)
-		if(attribute_given == 0)
-			if(was_melting)
-				attribute_given = threat_level //pity stats on meltdowns
-			else
-				to_chat(user, "<span class='warning'>You don't feel like you've learned anything from this!</span>")
-		user.adjust_attribute_level(attribute_type, attribute_given)
+		if(user_attribute) //To avoid runtime if it's a custom work type like "Release".
+			var/user_attribute_level = max(1, user_attribute.level)
+			var/attribute_given = clamp(((maximum_attribute_level / (user_attribute_level * 0.25)) * (0.25 + (pe / max_boxes))), 0, 16)
+			if((user_attribute_level + attribute_given + 1) >= maximum_attribute_level) // Already/Will/Should be at maximum.
+				attribute_given = max(0, maximum_attribute_level - user_attribute_level)
+			if(attribute_given == 0)
+				if(was_melting)
+					attribute_given = threat_level //pity stats on meltdowns
+				else
+					to_chat(user, "<span class='warning'>You don't feel like you've learned anything from this!</span>")
+			user.adjust_attribute_level(attribute_type, attribute_given)
 	if(console?.tutorial) //don't run logging-related code if tutorial console
 		return
 	var/user_job_title = "Unidentified Employee"

--- a/code/modules/mob/living/simple_animal/abnormality/_abnormality.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_abnormality.dm
@@ -47,6 +47,8 @@
 							ABNORMALITY_WORK_ATTACHMENT = list(50, 55, 60, 65, 70),
 							ABNORMALITY_WORK_REPRESSION = list(50, 55, 60, 65, 70)
 							)
+	/// Work Types and corresponding their attributes
+	var/list/work_attribute_types = WORK_TO_ATTRIBUTE
 	/// How much damage is dealt to user on each work failure
 	var/work_damage_amount = 2
 	/// What damage type is used for work failures


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a new variable to abnormalities that goes along-side their Work Chances, it's a list that associates work type with attribute type. This list defaults to the one that's always been used.
Also changes a little bit of logic so that works that don't have an attribute still do the following:
* Produce PE
* Get Logged
* Increase Overload
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This allows for custom works to train attributes if they're supposed to, as well as allowing for logging of all work types. The only real issues that would exist is if someone makes a work that actually has a 100% success rate with 0 effect outside of simply being a work, which does not currently exist. The closest we have is Shepard and he breaches when Release work is performed.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->


<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
