### PR TITLE
Sweepers gib now leaves only items and gibs

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/ordeal/indigo.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/indigo.dm
@@ -39,7 +39,7 @@
 		"<span class='danger'>[src] devours [L]!</span>",
 		"<span class='userdanger'>You feast on [L], restoring your health!</span>")
 	adjustBruteLoss(-(maxHealth/2))
-	L.gib()
+	L.gib(FALSE, TRUE, TRUE)
 	return TRUE
 
 /mob/living/simple_animal/hostile/ordeal/indigo_noon
@@ -99,7 +99,7 @@
 		"<span class='danger'>[src] devours [L]!</span>",
 		"<span class='userdanger'>You feast on [L], restoring your health!</span>")
 	adjustBruteLoss(-(maxHealth/2))
-	L.gib()
+	L.gib(FALSE, TRUE, TRUE)
 	return TRUE
 
 /mob/living/simple_animal/hostile/ordeal/indigo_noon/PickTarget(list/Targets)
@@ -264,7 +264,7 @@
 		"<span class='danger'>[src] devours [L]!</span>",
 		"<span class='userdanger'>You feast on [L], restoring your health!</span>")
 	adjustBruteLoss(-(maxHealth/2))
-	L.gib()
+	L.gib(FALSE, TRUE, TRUE)
 	return TRUE
 
 
@@ -425,7 +425,7 @@
 		"<span class='danger'>[src] devours [L]!</span>",
 		"<span class='userdanger'>You feast on [L], restoring your health!</span>")
 	adjustBruteLoss(-(maxHealth*0.3))
-	L.gib()
+	L.gib(FALSE, TRUE, TRUE)
 	//Increase the Vore counter by 1
 	belly += 1
 	pulse_damage += 2


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This basically makes sweeper gibs not drop organs or bodyparts but still leave gibs and items.

## Why It's Good For The Game
Like the green ordeal gib sprite change this is a low priority PR that i would understand if it gets denied. The removal of bodyparts and organs is mostly to make the map cleaner since we already have issues with sparks and blood.

## Changelog
:cl:
tweak: sweeper gib() becomes gib(TRUE, TRUE, TRUE)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
