### PR TITLE
Sparks fix with some TG port

### DIFF
--- a/code/controllers/subsystem/atoms.dm
+++ b/code/controllers/subsystem/atoms.dm
@@ -9,6 +9,8 @@ SUBSYSTEM_DEF(atoms)
 	flags = SS_NO_FIRE
 
 	var/old_initialized
+	/// A count of how many initalize changes we've made. We want to prevent old_initialize being overriden by some other value, breaking init code
+	var/initialized_changed = 0
 
 	var/list/late_loaders = list()
 
@@ -16,7 +18,13 @@ SUBSYSTEM_DEF(atoms)
 
 	///initAtom() adds the atom its creating to this list iff InitializeAtoms() has been given a list to populate as an argument
 	var/list/created_atoms
-	// ^ if this is not null after InitializeAtoms() is done, this list will fill up with every atom in the world initialized afterwards!
+
+	/// Atoms that will be deleted once the subsystem is initialized
+	var/list/queued_deletions = list()
+
+	#ifdef PROFILE_MAPLOAD_INIT_ATOM
+	var/list/mapload_init_times = list()
+	#endif
 
 	initialized = INITIALIZATION_INSSATOMS
 
@@ -27,15 +35,53 @@ SUBSYSTEM_DEF(atoms)
 	initialized = INITIALIZATION_INNEW_MAPLOAD
 	InitializeAtoms()
 	initialized = INITIALIZATION_INNEW_REGULAR
+
 	return ..()
 
-/datum/controller/subsystem/atoms/proc/InitializeAtoms(list/atoms, list/atoms_to_return = null)
+#ifdef PROFILE_MAPLOAD_INIT_ATOM
+#define PROFILE_INIT_ATOM_BEGIN(...) var/__profile_stat_time = TICK_USAGE
+#define PROFILE_INIT_ATOM_END(atom) mapload_init_times[##atom.type] += TICK_USAGE_TO_MS(__profile_stat_time)
+#else
+#define PROFILE_INIT_ATOM_BEGIN(...)
+#define PROFILE_INIT_ATOM_END(...)
+#endif
+
+/datum/controller/subsystem/atoms/proc/InitializeAtoms(list/atoms, list/atoms_to_return)
 	if(initialized == INITIALIZATION_INSSATOMS)
 		return
 
-	old_initialized = initialized
-	initialized = INITIALIZATION_INNEW_MAPLOAD
+	set_tracked_initalized(INITIALIZATION_INNEW_MAPLOAD)
 
+	// This may look a bit odd, but if the actual atom creation runtimes for some reason, we absolutely need to set initialized BACK
+	CreateAtoms(atoms, atoms_to_return)
+	clear_tracked_initalize()
+
+	if(late_loaders.len)
+		for(var/I in 1 to late_loaders.len)
+			var/atom/A = late_loaders[I]
+			//I hate that we need this
+			if(QDELETED(A))
+				continue
+			A.LateInitialize()
+		testing("Late initialized [late_loaders.len] atoms")
+		late_loaders.Cut()
+
+	if (created_atoms)
+		atoms_to_return += created_atoms
+		created_atoms = null
+
+	for (var/queued_deletion in queued_deletions)
+		qdel(queued_deletion)
+
+	testing("[queued_deletions.len] atoms were queued for deletion.")
+	queued_deletions.Cut()
+
+	#ifdef PROFILE_MAPLOAD_INIT_ATOM
+	rustg_file_write(json_encode(mapload_init_times), "[GLOB.log_directory]/init_times.json")
+	#endif
+
+/// Actually creates the list of atoms. Exists soley so a runtime in the creation logic doesn't cause initalized to totally break
+/datum/controller/subsystem/atoms/proc/CreateAtoms(list/atoms, list/atoms_to_return = null)
 	if (atoms_to_return)
 		LAZYINITLIST(created_atoms)
 
@@ -47,34 +93,25 @@ SUBSYSTEM_DEF(atoms)
 		for(var/I in 1 to count)
 			var/atom/A = atoms[I]
 			if(!(A.flags_1 & INITIALIZED_1))
-				InitAtom(A, mapload_arg)
 				CHECK_TICK
+				PROFILE_INIT_ATOM_BEGIN()
+				InitAtom(A, TRUE, mapload_arg)
+				PROFILE_INIT_ATOM_END(A)
 	else
 		count = 0
 		for(var/atom/A in world)
 			if(!(A.flags_1 & INITIALIZED_1))
-				InitAtom(A, mapload_arg)
+				PROFILE_INIT_ATOM_BEGIN()
+				InitAtom(A, FALSE, mapload_arg)
+				PROFILE_INIT_ATOM_END(A)
 				++count
 				CHECK_TICK
 
 	testing("Initialized [count] atoms")
 	pass(count)
 
-	initialized = old_initialized
-
-	if(late_loaders.len)
-		for(var/I in 1 to late_loaders.len)
-			var/atom/A = late_loaders[I]
-			A.LateInitialize()
-		testing("Late initialized [late_loaders.len] atoms")
-		late_loaders.Cut()
-
-	if (created_atoms)
-		atoms_to_return += created_atoms
-		created_atoms = null
-
 /// Init this specific atom
-/datum/controller/subsystem/atoms/proc/InitAtom(atom/A, list/arguments)
+/datum/controller/subsystem/atoms/proc/InitAtom(atom/A, from_template = FALSE, list/arguments)
 	var/the_type = A.type
 	if(QDELING(A))
 		BadInitializeCalls[the_type] |= BAD_INIT_QDEL_BEFORE
@@ -92,7 +129,7 @@ SUBSYSTEM_DEF(atoms)
 	if(result != INITIALIZE_HINT_NORMAL)
 		switch(result)
 			if(INITIALIZE_HINT_LATELOAD)
-				if(arguments[1])	//mapload
+				if(arguments[1]) //mapload
 					late_loaders += A
 				else
 					A.LateInitialize()
@@ -102,24 +139,36 @@ SUBSYSTEM_DEF(atoms)
 			else
 				BadInitializeCalls[the_type] |= BAD_INIT_NO_HINT
 
-	if(!A)	//possible harddel
+	if(!A) //possible harddel
 		qdeleted = TRUE
 	else if(!(A.flags_1 & INITIALIZED_1))
 		BadInitializeCalls[the_type] |= BAD_INIT_DIDNT_INIT
 	else
 		SEND_SIGNAL(A,COMSIG_ATOM_AFTER_SUCCESSFUL_INITIALIZE)
-
-	if (created_atoms)
-		created_atoms += A
+		if(created_atoms && from_template && ispath(the_type, /atom/movable))//we only want to populate the list with movables
+			created_atoms += A.get_all_contents()
 
 	return qdeleted || QDELING(A)
 
 /datum/controller/subsystem/atoms/proc/map_loader_begin()
-	old_initialized = initialized
-	initialized = INITIALIZATION_INSSATOMS
+	set_tracked_initalized(INITIALIZATION_INSSATOMS)
 
 /datum/controller/subsystem/atoms/proc/map_loader_stop()
-	initialized = old_initialized
+	clear_tracked_initalize()
+
+/// Use this to set initialized to prevent error states where old_initialized is overriden. It keeps happening and it's cheesing me off
+/datum/controller/subsystem/atoms/proc/set_tracked_initalized(value)
+	if(!initialized_changed)
+		old_initialized = initialized
+		initialized = value
+	else
+		stack_trace("We started maploading while we were already maploading. You doing something odd?")
+	initialized_changed += 1
+
+/datum/controller/subsystem/atoms/proc/clear_tracked_initalize()
+	initialized_changed -= 1
+	if(!initialized_changed)
+		initialized = old_initialized
 
 /datum/controller/subsystem/atoms/Recover()
 	initialized = SSatoms.initialized
@@ -157,13 +206,21 @@ SUBSYSTEM_DEF(atoms)
 		. += "Path : [path] \n"
 		var/fails = BadInitializeCalls[path]
 		if(fails & BAD_INIT_DIDNT_INIT)
-			. += "- Didn't call atom/Initialize()\n"
+			. += "- Didn't call atom/Initialize(mapload)\n"
 		if(fails & BAD_INIT_NO_HINT)
 			. += "- Didn't return an Initialize hint\n"
 		if(fails & BAD_INIT_QDEL_BEFORE)
 			. += "- Qdel'd in New()\n"
 		if(fails & BAD_INIT_SLEPT)
 			. += "- Slept during Initialize()\n"
+
+/// Prepares an atom to be deleted once the atoms SS is initialized.
+/datum/controller/subsystem/atoms/proc/prepare_deletion(atom/target)
+	if (initialized == INITIALIZATION_INNEW_REGULAR)
+		// Atoms SS has already completed, just kill it now.
+		qdel(target)
+	else
+		queued_deletions += WEAKREF(target)
 
 /datum/controller/subsystem/atoms/Shutdown()
 	var/initlog = InitLog()

--- a/code/game/objects/effects/effect_system/effect_system.dm
+++ b/code/game/objects/effects/effect_system/effect_system.dm
@@ -20,12 +20,13 @@ would spawn and follow the beaker, even if it is carried or thrown.
 	GLOB.cameranet.updateVisibility(src)
 	return ..()
 
-/obj/effect/particle_effect/newtonian_move() // Prevents effects from getting registered for SSspacedrift
+// Prevents effects from getting registered for SSspacedrift
+/obj/effect/particle_effect/newtonian_move(direction, instant = FALSE, start_delay = 0)
 	return TRUE
 
 /datum/effect_system
 	var/number = 3
-	var/cardinals = FALSE
+	var/cardinals_only = FALSE
 	var/turf/location
 	var/atom/holder
 	var/effect_type
@@ -37,15 +38,10 @@ would spawn and follow the beaker, even if it is carried or thrown.
 	location = null
 	return ..()
 
-/datum/effect_system/proc/set_up(n = 3, c = FALSE, loca)
-	if(n > 10)
-		n = 10
-	number = n
-	cardinals = c
-	if(isturf(loca))
-		location = loca
-	else
-		location = get_turf(loca)
+/datum/effect_system/proc/set_up(number = 3, cardinals_only = FALSE, location)
+	src.number = min(number, 10)
+	src.cardinals_only = cardinals_only
+	src.location = get_turf(location)
 
 /datum/effect_system/proc/attach(atom/atom)
 	holder = atom
@@ -64,7 +60,7 @@ would spawn and follow the beaker, even if it is carried or thrown.
 	var/obj/effect/E = new effect_type(location)
 	total_effects++
 	var/direction
-	if(cardinals)
+	if(cardinals_only)
 		direction = pick(GLOB.cardinals)
 	else
 		direction = pick(GLOB.alldirs)
@@ -75,7 +71,8 @@ would spawn and follow the beaker, even if it is carried or thrown.
 	if(!QDELETED(src))
 		addtimer(CALLBACK(src, .proc/decrement_total_effect), 20)
 
-/datum/effect_system/proc/decrement_total_effect()
+/datum/effect_system/proc/decrement_total_effect(datum/source)
 	total_effects--
-	if(autocleanup && total_effects <= 0)
-		qdel(src)
+	if(!autocleanup || total_effects > 0)
+		return
+	QDEL_IN(src, 2 SECONDS)

--- a/code/game/objects/effects/effect_system/effects_sparks.dm
+++ b/code/game/objects/effects/effect_system/effects_sparks.dm
@@ -22,7 +22,6 @@
 
 /obj/effect/particle_effect/sparks/Initialize(mapload)
 	..()
-	autoDelete()
 	return INITIALIZE_HINT_LATELOAD
 
 /obj/effect/particle_effect/sparks/LateInitialize()

--- a/code/game/objects/effects/effect_system/effects_sparks.dm
+++ b/code/game/objects/effects/effect_system/effects_sparks.dm
@@ -5,13 +5,9 @@
 // will always spawn at the items location.
 /////////////////////////////////////////////
 
-/proc/do_sparks(n, c, source)
-	// n - number of sparks
-	// c - cardinals, bool, do the sparks only move in cardinal directions?
-	// source - source of the sparks.
-
+/proc/do_sparks(number, cardinal_only, datum/source)
 	var/datum/effect_system/spark_spread/sparks = new
-	sparks.set_up(n, c, source)
+	sparks.set_up(number, cardinal_only, source)
 	sparks.autocleanup = TRUE
 	sparks.start()
 
@@ -20,13 +16,13 @@
 	name = "sparks"
 	icon_state = "sparks"
 	anchored = TRUE
-	light_system = MOVABLE_LIGHT
 	light_range = 2
 	light_power = 0.5
 	light_color = LIGHT_COLOR_FIRE
 
-/obj/effect/particle_effect/sparks/Initialize()
+/obj/effect/particle_effect/sparks/Initialize(mapload)
 	..()
+	autoDelete()
 	return INITIALIZE_HINT_LATELOAD
 
 /obj/effect/particle_effect/sparks/LateInitialize()
@@ -35,19 +31,17 @@
 	var/turf/T = loc
 	if(isturf(T))
 		T.hotspot_expose(1000,100)
-	QDEL_IN(src, 20)
-
-/obj/effect/particle_effect/sparks/Destroy()
-	var/turf/T = loc
-	if(isturf(T))
-		T.hotspot_expose(1000,100)
-	return ..()
+	QDEL_IN(src, 2 SECONDS)
 
 /obj/effect/particle_effect/sparks/Move()
 	..()
 	var/turf/T = loc
 	if(isturf(T))
 		T.hotspot_expose(1000,100)
+
+/// I feel shame that this noodle code is my solution -IP
+/obj/effect/particle_effect/sparks/proc/autoDelete()
+	QDEL_IN(src, 2 SECONDS)
 
 /datum/effect_system/spark_spread
 	effect_type = /obj/effect/particle_effect/sparks


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
For some reason the LateInitialize on sparks is not proccing on LOR13 map. I cant tell why but if i move QDEL_IN from lateinitialize to initialize it seems to fix itself.
![image](https://media.discordapp.net/attachments/982658750391406629/1154261383463055360/image.png)
![image](https://github.com/vlggms/lobotomy-corp13/assets/109536843/a4f6bc6f-7a91-4bfd-98dc-38dc5aa72cf1)

UPDATE: I made a shameful proc called autoDelete which just has qdel_in in it.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes it so that 1000 sparks, all with their own individual light dont clog up the server.

## Changelog
:cl:
tweak: particle_effect/sparks
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
