### PR TITLE
Planetary Atmos Default on Turf/Open Parent

### DIFF
--- a/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
+++ b/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
@@ -29,7 +29,7 @@
 	var/datum/gas_mixture/turf/air
 
 	var/obj/effect/hotspot/active_hotspot
-	var/planetary_atmos = FALSE //air will revert to initial_gas_mix
+	var/planetary_atmos = TRUE //air will revert to initial_gas_mix
 
 	var/list/atmos_overlay_types //gas IDs of current active gas overlays
 	var/significant_share_ticker = 0


### PR DESCRIPTION

## About The Pull Request
Sets all the turfs used to a static airmix, stopping atmos stuff from occurring (in any great amount)
Prob only worth a testmerge for now

## Why It's Good For The Game

Miasma problems and other stuffs