### PR TITLE
Reverts Miasma From Rotting Gib

### DIFF
--- a/code/game/objects/effects/decals/cleanable/humans.dm
+++ b/code/game/objects/effects/decals/cleanable/humans.dm
@@ -121,7 +121,7 @@
 	. = ..()
 	if(!.)
 		return
-	AddComponent(/datum/component/rot, 0, 5 MINUTES, 0.7)
+	AddComponent(/datum/component/rot/gibs)
 
 /obj/effect/decal/cleanable/blood/gibs/ex_act(severity, target)
 	return FALSE


### PR DESCRIPTION
## About The Pull Request

Reverts the old code for gibs, making it generate 0 miasma again

## Why It's Good For The Game

Game unplayable without clerks

## Changelog
:cl:
fix: Removed miasma that was readded
/:cl: