### PR TITLE
Regenerating borg shakers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -235,4 +235,3 @@ tools/LinuxOneShot/TGS_Logs
 # Common build tooling
 !/tools/build
 code/modules/tgui/USE_BUILD_BAT_INSTEAD_OF_DREAM_MAKER.dm
-lobotomy-corp13.dme

--- a/.gitignore
+++ b/.gitignore
@@ -235,3 +235,4 @@ tools/LinuxOneShot/TGS_Logs
 # Common build tooling
 !/tools/build
 code/modules/tgui/USE_BUILD_BAT_INSTEAD_OF_DREAM_MAKER.dm
+lobotomy-corp13.dme

--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -227,15 +227,11 @@ Borg Shaker
 	return //Can't inject stuff with a shaker, can we? //not with that attitude
 
 /obj/item/reagent_containers/borghypo/borgshaker/regenerate_reagents()
-	if(iscyborg(src.loc))
-		var/mob/living/silicon/robot/R = src.loc
-		if(R?.cell)
-			for(var/i in modes) //Lots of reagents in this one, so it's best to regenrate them all at once to keep it from being tedious.
-				var/valueofi = modes[i]
-				var/datum/reagents/RG = reagent_list[valueofi]
-				if(RG.total_volume < RG.maximum_volume)
-					R.cell.use(charge_cost)
-					RG.add_reagent(reagent_ids[valueofi], 5)
+	for(var/i in modes) //Lots of reagents in this one, so it's best to regenrate them all at once to keep it from being tedious.
+		var/valueofi = modes[i]
+		var/datum/reagents/RG = reagent_list[valueofi]
+		if(RG.total_volume < RG.maximum_volume)
+			RG.add_reagent(reagent_ids[valueofi], 5)
 
 /obj/item/reagent_containers/borghypo/borgshaker/afterattack(obj/target, mob/user, proximity)
 	. = ..()

--- a/code/modules/vending/boozeomat.dm
+++ b/code/modules/vending/boozeomat.dm
@@ -6,6 +6,7 @@
 	products = list(/obj/item/reagent_containers/food/drinks/drinkingglass = 30,
 					/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass = 12,
 					/obj/item/reagent_containers/food/drinks/flask = 3,
+					/obj/item/reagent_containers/food/drinks/shaker = 1,
 					/obj/item/reagent_containers/food/drinks/ice = 10,
 					/obj/item/reagent_containers/food/drinks/bottle/orangejuice = 4,
 					/obj/item/reagent_containers/food/drinks/bottle/tomatojuice = 4,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Borg shakers now regenerate. (Borg shakers can be found on the LoR13 map, in both bars.)
Also, puts 1 normal Shaker in the Booze-O-Mat.

## Why It's Good For The Game
Allows players to mix drinks anywhere.
Adds normal shakers to a map that normally lacks them.

## Changelog
:cl:
add: Borg shakers now regenerate
add: Normal shakers now sold in Booze-O-Mat.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
