### PR TITLE
Fixes broken laptops in Citymap; Adds new Laptop Preset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -235,4 +235,3 @@ tools/LinuxOneShot/TGS_Logs
 # Common build tooling
 !/tools/build
 code/modules/tgui/USE_BUILD_BAT_INSTEAD_OF_DREAM_MAKER.dm
-lobotomy-corp13.dme

--- a/.gitignore
+++ b/.gitignore
@@ -235,3 +235,4 @@ tools/LinuxOneShot/TGS_Logs
 # Common build tooling
 !/tools/build
 code/modules/tgui/USE_BUILD_BAT_INSTEAD_OF_DREAM_MAKER.dm
+lobotomy-corp13.dme

--- a/_maps/map_files/Event/city.dmm
+++ b/_maps/map_files/Event/city.dmm
@@ -863,25 +863,6 @@
 	},
 /turf/open/floor/wood,
 /area/city/backstreets_checkpoint)
-"hB" = (
-/obj/effect/turf_decal/tile/blue{
-	color = "#3234B9";
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#3234B9";
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#3234B9"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#3234B9";
-	dir = 8
-	},
-/obj/item/modular_computer/laptop/preset/fixer,
-/turf/open/floor/mineral/silver,
-/area/city/shop)
 "hC" = (
 /turf/open/floor/plating/dirt/jungle/dark,
 /area/city/backstreets_alley)
@@ -49087,7 +49068,7 @@ HA
 HA
 kJ
 OQ
-hB
+nl
 PL
 Gz
 OT

--- a/_maps/map_files/Event/city.dmm
+++ b/_maps/map_files/Event/city.dmm
@@ -749,6 +749,11 @@
 /obj/effect/landmark/cityloot,
 /turf/open/floor/facility/dark,
 /area/city)
+"gE" = (
+/obj/structure/table/reinforced,
+/obj/item/modular_computer/laptop/preset/fixer,
+/turf/open/indestructible/hoteltile,
+/area/city/house)
 "gF" = (
 /obj/structure/chair/wood,
 /obj/machinery/light{
@@ -1347,7 +1352,7 @@
 /area/facility_hallway/north)
 "mh" = (
 /obj/structure/table/wood,
-/obj/item/modular_computer/laptop/preset,
+/obj/item/modular_computer/laptop/preset/fixer,
 /turf/open/floor/plasteel/checker,
 /area/city/house)
 "mi" = (
@@ -3009,10 +3014,7 @@
 /area/city/house)
 "Bh" = (
 /obj/structure/table/wood,
-/obj/item/modular_computer/laptop{
-	desc = "Appears to be a fixers laptop.";
-	name = "Fixer Laptop"
-	},
+/obj/item/modular_computer/laptop/preset/civilian,
 /turf/open/floor/plasteel/grimy,
 /area/city/house)
 "Bl" = (
@@ -3597,9 +3599,7 @@
 	pixel_x = -9;
 	pixel_y = 3
 	},
-/obj/item/modular_computer/laptop/preset/civilian{
-	pixel_x = 7
-	},
+/obj/item/modular_computer/laptop/preset/fixer,
 /turf/open/floor/carpet/black,
 /area/city/house)
 "FC" = (
@@ -4263,6 +4263,7 @@
 /area/city)
 "Lk" = (
 /obj/structure/table/wood,
+/obj/item/modular_computer/laptop/preset/fixer,
 /turf/open/floor/vault,
 /area/city/house)
 "Ln" = (
@@ -4719,6 +4720,7 @@
 /area/city)
 "QY" = (
 /obj/structure/table/reinforced,
+/obj/item/modular_computer/laptop/preset/fixer,
 /turf/open/floor/oldshuttle,
 /area/city/house)
 "QZ" = (
@@ -4856,10 +4858,7 @@
 /area/city)
 "SZ" = (
 /obj/structure/table/wood,
-/obj/item/modular_computer/laptop{
-	desc = "Appears to be a fixers laptop.";
-	name = "Fixer Laptop"
-	},
+/obj/item/modular_computer/laptop/preset/fixer,
 /turf/open/floor/wood,
 /area/city/house)
 "Ta" = (
@@ -36717,7 +36716,7 @@ sT
 wK
 Ad
 EM
-SZ
+VM
 EK
 Hm
 Hm
@@ -44190,7 +44189,7 @@ Hm
 Hm
 Hm
 Dq
-Ab
+gE
 Ff
 Vb
 Vb
@@ -47793,7 +47792,7 @@ Dq
 TX
 Dq
 EM
-ll
+SZ
 mc
 YN
 YN

--- a/_maps/map_files/Event/city.dmm
+++ b/_maps/map_files/Event/city.dmm
@@ -749,11 +749,6 @@
 /obj/effect/landmark/cityloot,
 /turf/open/floor/facility/dark,
 /area/city)
-"gE" = (
-/obj/structure/table/reinforced,
-/obj/item/modular_computer/laptop/preset/fixer,
-/turf/open/indestructible/hoteltile,
-/area/city/house)
 "gF" = (
 /obj/structure/chair/wood,
 /obj/machinery/light{
@@ -868,6 +863,25 @@
 	},
 /turf/open/floor/wood,
 /area/city/backstreets_checkpoint)
+"hB" = (
+/obj/effect/turf_decal/tile/blue{
+	color = "#3234B9";
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#3234B9";
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#3234B9"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#3234B9";
+	dir = 8
+	},
+/obj/item/modular_computer/laptop/preset/fixer,
+/turf/open/floor/mineral/silver,
+/area/city/shop)
 "hC" = (
 /turf/open/floor/plating/dirt/jungle/dark,
 /area/city/backstreets_alley)
@@ -1855,6 +1869,11 @@
 /obj/machinery/telecomms/receiver/preset_left,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/facility_hallway/north)
+"so" = (
+/obj/structure/table/reinforced,
+/obj/item/modular_computer/laptop/preset/fixer,
+/turf/open/indestructible/hoteltile,
+/area/city/house)
 "sp" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 10
@@ -44189,7 +44208,7 @@ Hm
 Hm
 Hm
 Dq
-gE
+so
 Ff
 Vb
 Vb
@@ -49068,7 +49087,7 @@ HA
 HA
 kJ
 OQ
-nl
+hB
 PL
 Gz
 OT

--- a/_maps/map_files/Event/city.dmm
+++ b/_maps/map_files/Event/city.dmm
@@ -3033,7 +3033,7 @@
 /area/city/house)
 "Bh" = (
 /obj/structure/table/wood,
-/obj/item/modular_computer/laptop/preset/civilian,
+/obj/item/modular_computer/laptop/preset/fixer,
 /turf/open/floor/plasteel/grimy,
 /area/city/house)
 "Bl" = (

--- a/code/modules/modular_computers/computers/item/laptop_presets.dm
+++ b/code/modules/modular_computers/computers/item/laptop_presets.dm
@@ -10,7 +10,15 @@
 /obj/item/modular_computer/laptop/preset/proc/install_programs()
 	return
 
+/obj/item/modular_computer/laptop/preset/fixer
+	name = "Fixer Laptop"
+	desc = "A portable laptop computer often used by Fixers to view the Bounty Board Service (BBS)."
 
+
+/obj/item/modular_computer/laptop/preset/fixer/install_programs()
+	var/obj/item/computer_hardware/hard_drive/hard_drive = all_components[MC_HDD]
+	hard_drive.store_file(new/datum/computer_file/program/chatclient())
+	hard_drive.store_file(new/datum/computer_file/program/bounty_board())
 
 
 /obj/item/modular_computer/laptop/preset/civilian


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a new Laptop preset, "Fixer Laptop," that comes pre-installed with the Bulletin Board System and the Chat Client.
Also adds a bunch more laptops to the LoR13 map - every house should have one laptop, except for the one that has a full computer.
In addition, reorganizes the laptop type found inside the houses for ludonarrative purposes. If the house has a special item inside (i.e. a Hydroponics tray or Aquarium), the house will contain a normal civilian laptop. No real mechanical difference - you can manually install the Bulletin Board System.

## Why It's Good For The Game
Fixes a broken Laptop type.
Makes the BBS easier to access.

## Changelog
:cl:
add: New laptop preset!
add: More laptops on Citymap.
fix: Fixed broken laptops on Citymap
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
