### PR TITLE
Fixes Another Day's egoist

### DIFF
--- a/code/modules/mob/living/simple_animal/distortion/myth/another_day_work.dm
+++ b/code/modules/mob/living/simple_animal/distortion/myth/another_day_work.dm
@@ -38,6 +38,8 @@
 	gender = MALE
 	//The Egoist's outfit, which should usually be civilian unless you want them to be a fixer or something.
 	egoist_outfit = /datum/outfit/job/civilian
+	//The Egoist's starting stats, all across the board. MUST BE AT LEAST THE MINIMUM TO EQUIP THE EGO_GEAR IF ANY
+	egoist_attributes = 50
 	//Loot on death; distortions should be valuable targets in general.
 	loot = list(/obj/item/documents/ncorporation)
 

--- a/code/modules/mob/living/simple_animal/distortion/myth/another_day_work.dm
+++ b/code/modules/mob/living/simple_animal/distortion/myth/another_day_work.dm
@@ -39,7 +39,7 @@
 	//The Egoist's outfit, which should usually be civilian unless you want them to be a fixer or something.
 	egoist_outfit = /datum/outfit/job/civilian
 	//The Egoist's starting stats, all across the board. MUST BE AT LEAST THE MINIMUM TO EQUIP THE EGO_GEAR IF ANY
-	egoist_attributes = 50
+	egoist_attributes = 40
 	//Loot on death; distortions should be valuable targets in general.
 	loot = list(/obj/item/documents/ncorporation)
 


### PR DESCRIPTION
Adds Another Day's egoists' stats, considering his stats were 0 beforehand.

## About The Pull Request

Added one line of code that fixes Another Day's egoist having 0 stats.

## Why It's Good For The Game

Another Day's egoist gets fixed, since this was unintended.

## Changelog
:cl:
add: Added stats for Another Day's egoist.
/:cl: