### PR TITLE
Random egoist stats

### DIFF
--- a/code/modules/mob/living/simple_animal/distortion/myth/another_day_work.dm
+++ b/code/modules/mob/living/simple_animal/distortion/myth/another_day_work.dm
@@ -38,6 +38,8 @@
 	gender = MALE
 	//The Egoist's outfit, which should usually be civilian unless you want them to be a fixer or something.
 	egoist_outfit = /datum/outfit/job/civilian
+	//The Egoist's starting stats, all across the board. MUST BE AT LEAST THE MINIMUM TO EQUIP THE EGO_GEAR IF ANY
+	egoist_attributes = 50
 	//Loot on death; distortions should be valuable targets in general.
 	loot = list(/obj/item/documents/ncorporation)
 

--- a/code/modules/mob/living/simple_animal/distortion/myth/another_day_work.dm
+++ b/code/modules/mob/living/simple_animal/distortion/myth/another_day_work.dm
@@ -39,7 +39,7 @@
 	//The Egoist's outfit, which should usually be civilian unless you want them to be a fixer or something.
 	egoist_outfit = /datum/outfit/job/civilian
 	//The Egoist's starting stats, all across the board. MUST BE AT LEAST THE MINIMUM TO EQUIP THE EGO_GEAR IF ANY
-	egoist_attributes = 50
+	egoist_attributes = 40
 	//Loot on death; distortions should be valuable targets in general.
 	loot = list(/obj/item/documents/ncorporation)
 

--- a/code/modules/mob/living/simple_animal/distortion/myth/another_day_work.dm
+++ b/code/modules/mob/living/simple_animal/distortion/myth/another_day_work.dm
@@ -43,6 +43,12 @@
 	//Loot on death; distortions should be valuable targets in general.
 	loot = list(/obj/item/documents/ncorporation)
 
+//Set random stats for the egoist
+/mob/living/simple_animal/hostile/distortion/another_day_work/Initialize()
+    . = ..()
+    egoist_attributes = min(rand(0, 130), rand(0, 130))
+    return
+
 	var/can_act = TRUE
 
 //Proc that can be used for additional effects on unmanifest

--- a/code/modules/mob/living/simple_animal/distortion/myth/another_day_work.dm
+++ b/code/modules/mob/living/simple_animal/distortion/myth/another_day_work.dm
@@ -46,7 +46,7 @@
 //Set random stats for the egoist
 /mob/living/simple_animal/hostile/distortion/another_day_work/Initialize()
     . = ..()
-    egoist_attributes = min(rand(0, 130), rand(0, 130))
+    egoist_attributes = min(rand(egoist_attributes, 130), rand(egoist_attributes, 130))
     return
 
 	var/can_act = TRUE

--- a/code/modules/mob/living/simple_animal/distortion/plague/bunnyman.dm
+++ b/code/modules/mob/living/simple_animal/distortion/plague/bunnyman.dm
@@ -45,6 +45,12 @@
 	var/can_act = TRUE
 	var/transformed = FALSE
 
+//Set random stats for the egoist
+/mob/living/simple_animal/hostile/distortion/bunnyman/Initialize()
+    . = ..()
+    egoist_attributes = min(rand(80, 130), rand(80, 130))
+    return
+
 //Proc that can be used for additional effects on unmanifest
 /mob/living/simple_animal/hostile/distortion/bunnyman/PostUnmanifest(mob/living/carbon/human/egoist)
 	playsound(src, 'sound/effects/blobattack.ogg', 150, FALSE, 4)

--- a/code/modules/mob/living/simple_animal/distortion/plague/bunnyman.dm
+++ b/code/modules/mob/living/simple_animal/distortion/plague/bunnyman.dm
@@ -48,7 +48,7 @@
 //Set random stats for the egoist
 /mob/living/simple_animal/hostile/distortion/bunnyman/Initialize()
     . = ..()
-    egoist_attributes = min(rand(80, 130), rand(80, 130))
+    egoist_attributes = min(rand(egoist_attributes, 130), rand(egoist_attributes, 130))
     return
 
 //Proc that can be used for additional effects on unmanifest


### PR DESCRIPTION
## About The Pull Request

Adds random stats for the current egoists. Higher grade distortions have a better chance to spawn with better stats than weaker distortions.

## Why It's Good For The Game

It adds randomization of egoist stats, meaning they don't always spawn with the same stats.

## Changelog
:cl:
add: Added randomization of egoist stats.
/:cl: