### PR TITLE
Prevents Multiple Actions from Justice Panic Controller

### DIFF
--- a/code/datums/ai/sanity/_sanityloss_controller.dm
+++ b/code/datums/ai/sanity/_sanityloss_controller.dm
@@ -363,7 +363,7 @@
 
 /datum/ai_controller/insane/release/SelectBehaviors(delta_time)
 	..()
-	if(blackboard[BB_INSANE_CURRENT_ATTACK_TARGET] != null || GET_AI_BEHAVIOR(/datum/ai_behavior/insanity_smash_console) in current_behaviors)
+	if(blackboard[BB_INSANE_CURRENT_ATTACK_TARGET] != null || (GET_AI_BEHAVIOR(/datum/ai_behavior/insanity_smash_console) in current_behaviors))
 		return
 
 	if(DT_PROB(5, delta_time))

--- a/code/datums/ai/sanity/_sanityloss_controller.dm
+++ b/code/datums/ai/sanity/_sanityloss_controller.dm
@@ -363,7 +363,7 @@
 
 /datum/ai_controller/insane/release/SelectBehaviors(delta_time)
 	..()
-	if(blackboard[BB_INSANE_CURRENT_ATTACK_TARGET] != null)
+	if(blackboard[BB_INSANE_CURRENT_ATTACK_TARGET] != null || GET_AI_BEHAVIOR(/datum/ai_behavior/insanity_smash_console) in current_behaviors)
 		return
 
 	if(DT_PROB(5, delta_time))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a check to see if the insane mob is already doing the breach action to prevent it stacking MoveTo calls and having the mob move multitudes faster than it should.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fix
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixed justice panic moving multiple spaces at once and instant breaching things
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
