### PR TITLE
add the ego venders to all maps

### DIFF
--- a/_maps/map_files/Alpha/alphacorp.dmm
+++ b/_maps/map_files/Alpha/alphacorp.dmm
@@ -144,11 +144,8 @@
 /turf/closed/indestructible/rock,
 /area/space)
 "be" = (
-/obj/effect/turf_decal/siding/red{
-	dir = 8
-	},
-/obj/machinery/vending/custom/unbreakable,
-/turf/open/floor/carpet/royalblack,
+/obj/machinery/smartfridge/extraction_storage/ego_weapon,
+/turf/closed/indestructible/reinforced,
 /area/department_main/control)
 "bj" = (
 /obj/effect/turf_decal/siding/yellow,
@@ -848,8 +845,7 @@
 /obj/machinery/camera/autoname{
 	dir = 1
 	},
-/obj/structure/rack,
-/obj/item/storage/belt/ego,
+/obj/machinery/vending/custom/unbreakable,
 /turf/open/floor/carpet/red,
 /area/department_main/control)
 "gR" = (
@@ -1622,6 +1618,7 @@
 /obj/machinery/light,
 /obj/structure/rack,
 /obj/item/storage/belt/ego,
+/obj/item/clothing/suit/armor/vest/alt,
 /turf/open/floor/carpet/red,
 /area/department_main/control)
 "mC" = (
@@ -3731,11 +3728,16 @@
 /turf/open/floor/plasteel/dark,
 /area/department_main/records)
 "Cn" = (
-/obj/machinery/camera/autoname{
-	dir = 1
+/obj/structure/filingcabinet{
+	pixel_x = -10
 	},
-/obj/structure/rack,
-/obj/item/clothing/suit/armor/vest/alt,
+/obj/structure/filingcabinet,
+/obj/structure/filingcabinet{
+	pixel_x = 10
+	},
+/obj/structure/sign/departments/extraction{
+	pixel_x = 32
+	},
 /turf/open/floor/carpet/red,
 /area/department_main/control)
 "Cp" = (
@@ -4353,6 +4355,9 @@
 /obj/machinery/newscaster{
 	pixel_x = 32
 	},
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/carpet/red,
 /area/department_main/control)
 "Ib" = (
@@ -4633,6 +4638,7 @@
 /obj/machinery/light,
 /obj/structure/rack,
 /obj/item/clothing/suit/armor/vest/alt,
+/obj/item/storage/belt/ego,
 /turf/open/floor/carpet/red,
 /area/department_main/control)
 "JP" = (
@@ -5403,10 +5409,8 @@
 /turf/open/floor/carpet/red,
 /area/department_main/control)
 "Qe" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/carpet/red,
+/obj/machinery/smartfridge/extraction_storage/ego_armor,
+/turf/closed/indestructible/reinforced,
 /area/department_main/control)
 "Qg" = (
 /obj/machinery/light{
@@ -5930,9 +5934,6 @@
 /area/facility_hallway/central)
 "TO" = (
 /obj/machinery/computer/ego_purchase,
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
 /turf/open/floor/carpet/royalblack,
 /area/department_main/control)
 "TX" = (
@@ -6518,10 +6519,11 @@
 /turf/open/floor/carpet/red,
 /area/department_main/control)
 "Yg" = (
-/obj/structure/sign/departments/extraction{
-	pixel_x = 32
+/obj/effect/turf_decal/siding/red{
+	dir = 8
 	},
-/turf/open/floor/carpet/red,
+/obj/structure/table/reinforced,
+/turf/open/floor/carpet/royalblack,
 /area/department_main/control)
 "Yj" = (
 /obj/structure/curtain,
@@ -38808,7 +38810,7 @@ Ol
 Ol
 TB
 Mi
-Cn
+gP
 rg
 vs
 yc
@@ -40854,12 +40856,12 @@ ZL
 ZL
 ZL
 rg
-ta
+Cn
 FV
 FV
 FV
-Yg
-Qe
+FV
+FV
 Ia
 FV
 xu
@@ -41115,8 +41117,8 @@ rg
 be
 tT
 tT
-rg
-rg
+Yg
+Qe
 rg
 FZ
 fo

--- a/_maps/map_files/Beta/betacorp.dmm
+++ b/_maps/map_files/Beta/betacorp.dmm
@@ -173,8 +173,10 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/department_main/information)
 "aJ" = (
-/obj/structure/reagent_dispensers/water_cooler,
-/turf/open/floor/carpet/red,
+/obj/machinery/computer/extraction_cargo{
+	dir = 8
+	},
+/turf/open/floor/carpet/royalblack,
 /area/department_main/discipline)
 "aK" = (
 /obj/structure/disposalpipe/segment{
@@ -1236,16 +1238,11 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/table/reinforced,
-/obj/item/encryptionkey/headset_discipline,
-/obj/item/encryptionkey/headset_discipline,
-/obj/item/encryptionkey/headset_discipline,
-/obj/item/encryptionkey/headset_discipline,
-/obj/item/encryptionkey/headset_discipline,
 /obj/effect/turf_decal/siding{
 	color = "#440000";
 	dir = 8
 	},
+/obj/machinery/vending/custom/unbreakable,
 /turf/open/floor/plasteel/dark,
 /area/department_main/discipline)
 "gA" = (
@@ -4497,6 +4494,11 @@
 	color = "#440000";
 	dir = 8
 	},
+/obj/item/encryptionkey/headset_discipline,
+/obj/item/encryptionkey/headset_discipline,
+/obj/item/encryptionkey/headset_discipline,
+/obj/item/encryptionkey/headset_discipline,
+/obj/item/encryptionkey/headset_discipline,
 /turf/open/floor/plasteel/dark,
 /area/department_main/discipline)
 "vt" = (
@@ -4826,10 +4828,6 @@
 	id = "extraction"
 	},
 /turf/open/floor/plating,
-/area/department_main/discipline)
-"xC" = (
-/obj/machinery/vending/snack,
-/turf/open/floor/carpet/red,
 /area/department_main/discipline)
 "xE" = (
 /obj/machinery/camera/autoname,
@@ -5199,8 +5197,8 @@
 /turf/open/floor/carpet/stellar,
 /area/department_main/command)
 "zB" = (
-/obj/machinery/vending/custom/unbreakable,
 /obj/structure/railing,
+/obj/structure/table/reinforced,
 /turf/open/floor/plasteel/dark,
 /area/department_main/discipline)
 "zC" = (
@@ -5439,9 +5437,8 @@
 /turf/open/floor/plasteel/dark,
 /area/department_main/control)
 "Ba" = (
-/obj/structure/table/reinforced,
-/obj/item/clipboard,
-/turf/open/floor/carpet/royalblack,
+/obj/machinery/smartfridge/extraction_storage/ego_armor,
+/turf/closed/indestructible/reinforced,
 /area/department_main/discipline)
 "Bb" = (
 /obj/structure/disposalpipe/segment{
@@ -5848,17 +5845,6 @@
 /obj/item/storage/belt/ego,
 /turf/open/floor/wood,
 /area/facility_hallway/north)
-"Dt" = (
-/obj/structure/table/reinforced,
-/obj/item/soap{
-	pixel_y = -10
-	},
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/turf/open/floor/facility/dark,
-/area/department_main/discipline)
 "Du" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
@@ -6667,13 +6653,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/department_main/information)
-"Hy" = (
-/obj/structure/sign/departments/extraction{
-	pixel_x = 32;
-	pixel_y = 32
-	},
-/turf/open/floor/carpet/red,
-/area/department_main/discipline)
 "Hz" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -7916,8 +7895,8 @@
 /turf/open/floor/plasteel/dark,
 /area/department_main/discipline)
 "NR" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/obj/machinery/smartfridge/extraction_storage/ego_weapon,
+/turf/closed/indestructible/reinforced,
 /area/department_main/discipline)
 "NS" = (
 /obj/structure/railing{
@@ -9679,6 +9658,13 @@
 /obj/machinery/newscaster{
 	pixel_x = -32
 	},
+/obj/item/soap{
+	pixel_y = -10
+	},
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = 5;
+	pixel_y = 5
+	},
 /turf/open/floor/facility/dark,
 /area/department_main/discipline)
 "WI" = (
@@ -10178,12 +10164,6 @@
 	},
 /turf/open/floor/wood,
 /area/facility_hallway/south)
-"YH" = (
-/obj/machinery/computer/extraction_cargo{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/department_main/discipline)
 "YN" = (
 /obj/effect/turf_decal/siding{
 	color = "#440000";
@@ -10260,8 +10240,8 @@
 /turf/open/floor/plasteel,
 /area/department_main/welfare)
 "YX" = (
-/obj/structure/chair/office,
 /obj/structure/disposalpipe/segment,
+/obj/structure/chair/comfy/black,
 /obj/item/toy/plush/binah,
 /turf/open/floor/carpet/royalblack,
 /area/department_main/discipline)
@@ -36261,7 +36241,7 @@ JB
 rS
 pG
 nX
-YH
+PG
 oC
 WH
 pQ
@@ -37034,9 +37014,9 @@ XB
 zl
 ZB
 zl
-uk
-NR
-aJ
+vF
+Ba
+Px
 Ly
 xl
 xl
@@ -37291,7 +37271,7 @@ Ue
 zl
 uk
 zl
-vF
+zl
 zB
 Px
 Px
@@ -37805,7 +37785,7 @@ Bi
 zl
 uk
 zl
-Ba
+zl
 YS
 Px
 Px
@@ -38062,10 +38042,10 @@ XB
 zl
 uk
 zl
-uk
+aJ
 NR
-xC
-Hy
+Px
+Px
 xl
 xl
 Px
@@ -38579,7 +38559,7 @@ PG
 PG
 PG
 lb
-Px
+Ly
 Px
 Px
 Px
@@ -38831,7 +38811,7 @@ JB
 rS
 pG
 cx
-Dt
+KE
 jw
 Nj
 SE

--- a/_maps/map_files/Delta/deltacorp.dmm
+++ b/_maps/map_files/Delta/deltacorp.dmm
@@ -2207,6 +2207,16 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/department_main/discipline)
+"gu" = (
+/obj/effect/turf_decal/siding{
+	color = "#7D6521";
+	dir = 8
+	},
+/obj/machinery/light/cold/no_nightlight{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/department_main/extraction)
 "gv" = (
 /obj/structure/chair/stool/bar,
 /turf/open/floor/carpet/orange,
@@ -2676,6 +2686,10 @@
 /area/facility_hallway/information)
 "ie" = (
 /obj/machinery/computer/extraction_cargo{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding{
+	color = "#7D6521";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -3343,6 +3357,10 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/department_main/discipline)
+"ko" = (
+/obj/machinery/smartfridge/extraction_storage/ego_weapon,
+/turf/closed/indestructible/reinforced,
+/area/department_main/extraction)
 "kp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -3599,6 +3617,9 @@
 	dir = 1
 	},
 /obj/item/reagent_containers/food/drinks/mug/tea,
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "extraction"
+	},
 /turf/open/floor/facility/halls,
 /area/department_main/extraction)
 "kV" = (
@@ -4160,7 +4181,14 @@
 /area/facility_hallway/discipline)
 "mw" = (
 /obj/structure/table/reinforced,
-/obj/item/toy/crayon/spraycan/infinite,
+/obj/item/encryptionkey/headset_architecture,
+/obj/item/clothing/accessory/armband/lobotomy/extraction,
+/obj/item/clothing/accessory/armband/lobotomy/extraction,
+/obj/item/clothing/accessory/armband/lobotomy/extraction,
+/obj/effect/turf_decal/siding/white/corner{
+	color = "#7D6521";
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/department_main/extraction)
 "mx" = (
@@ -5032,6 +5060,16 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/department_main/records)
+"oK" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "windowblock"
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/department_main/extraction)
 "oL" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/plaque{
@@ -12245,6 +12283,9 @@
 /obj/structure/railing{
 	dir = 1
 	},
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "extraction"
+	},
 /turf/open/floor/facility/halls,
 /area/department_main/extraction)
 "Ky" = (
@@ -12599,14 +12640,16 @@
 	dir = 8
 	},
 /obj/item/toy/plush/binah,
+/obj/effect/turf_decal/siding{
+	color = "#7D6521";
+	dir = 9
+	},
 /turf/open/floor/carpet/royalblack,
 /area/department_main/extraction)
 "Lz" = (
-/obj/machinery/button/door/indestructible{
-	id = "extraction";
-	name = "Extraction Access Shutters";
-	pixel_y = 32;
-	req_one_access_txt = "19"
+/obj/effect/turf_decal/siding{
+	color = "#7D6521";
+	dir = 1
 	},
 /turf/open/floor/carpet/royalblack,
 /area/department_main/extraction)
@@ -12954,17 +12997,17 @@
 /turf/open/floor/plasteel/dark,
 /area/department_main/extraction)
 "My" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/accessory/armband/lobotomy/extraction,
-/obj/item/clothing/accessory/armband/lobotomy/extraction,
-/obj/item/clothing/accessory/armband/lobotomy/extraction,
-/obj/item/encryptionkey/headset_architecture,
+/obj/structure/railing,
 /turf/open/floor/plasteel/dark,
 /area/department_main/extraction)
 "Mz" = (
 /obj/structure/closet/crate,
 /obj/machinery/light/cold/no_nightlight{
 	dir = 4
+	},
+/obj/effect/turf_decal/siding{
+	color = "#7D6521";
+	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
 /area/department_main/extraction)
@@ -13237,6 +13280,22 @@
 /area/department_main/extraction)
 "Nl" = (
 /obj/structure/rack,
+/obj/machinery/button/door/indestructible{
+	id = "extraction";
+	name = "Extraction Access Shutters";
+	pixel_y = -23;
+	req_one_access_txt = "19"
+	},
+/obj/effect/turf_decal/siding/white/corner{
+	color = "#7D6521";
+	dir = 4;
+	pixel_x = -27;
+	layer = 2.1
+	},
+/obj/effect/turf_decal/siding{
+	color = "#7D6521";
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/department_main/extraction)
 "Nm" = (
@@ -13340,6 +13399,21 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/facility_hallway/information)
+"Nw" = (
+/obj/structure/rack,
+/obj/item/toy/crayon/spraycan/infinite,
+/obj/machinery/button/door/indestructible{
+	id = "windowblock";
+	name = "Extraction Window Shutters";
+	pixel_y = -23;
+	req_one_access_txt = "19"
+	},
+/obj/effect/turf_decal/siding{
+	color = "#7D6521";
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/department_main/extraction)
 "Nx" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -13454,6 +13528,10 @@
 /obj/structure/rack,
 /obj/machinery/light/cold/no_nightlight{
 	dir = 4
+	},
+/obj/effect/turf_decal/siding{
+	color = "#7D6521";
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/department_main/extraction)
@@ -16142,6 +16220,10 @@
 /obj/item/flashlight/pen,
 /turf/open/floor/plasteel/white,
 /area/department_main/safety)
+"UL" = (
+/obj/machinery/smartfridge/extraction_storage/ego_armor,
+/turf/closed/indestructible/reinforced,
+/area/department_main/extraction)
 "UM" = (
 /obj/effect/turf_decal/stripes/full,
 /obj/machinery/door/poddoor{
@@ -16364,6 +16446,10 @@
 /obj/item/rawpe,
 /obj/item/rawpe,
 /obj/item/rawpe,
+/obj/effect/turf_decal/siding{
+	color = "#7D6521";
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/department_main/extraction)
 "Vt" = (
@@ -64538,7 +64624,7 @@ Gj
 Gj
 Gj
 IO
-Kn
+gu
 Kn
 Kn
 Kn
@@ -64796,9 +64882,9 @@ Gj
 Gj
 oh
 Cu
-IK
-IK
-IK
+oK
+oK
+UL
 Ni
 IK
 IK
@@ -65054,10 +65140,10 @@ Gj
 IQ
 Kx
 Lx
+Mw
 My
-MO
 Nk
-Nl
+MO
 hz
 Cu
 JB
@@ -65311,10 +65397,10 @@ Gj
 IV
 kU
 Ly
-Gj
-Gj
-Gj
-Gj
+YD
+YD
+YD
+YD
 Nl
 Cu
 JB
@@ -65566,13 +65652,13 @@ Gj
 Gj
 Gj
 IX
-Kx
+ko
+Lz
 Gj
 Gj
 Gj
 Gj
-Gj
-Nl
+Nw
 Cu
 JB
 JB

--- a/_maps/map_files/Epsilon/epsiloncorp.dmm
+++ b/_maps/map_files/Epsilon/epsiloncorp.dmm
@@ -11,6 +11,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/facility_hallway/control)
+"ar" = (
+/obj/structure/closet/crate,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/department_main/discipline)
 "au" = (
 /obj/machinery/regenerator,
 /obj/effect/turf_decal/siding/purple{
@@ -65,6 +72,10 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/dark,
 /area/facility_hallway/information)
+"bn" = (
+/obj/machinery/smartfridge/extraction_storage/ego_weapon,
+/turf/closed/indestructible/reinforced,
+/area/department_main/extraction)
 "bo" = (
 /obj/structure/bodycontainer/crematorium{
 	id = "incinerator1"
@@ -646,6 +657,10 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/plasteel/dark,
 /area/facility_hallway/information)
+"jO" = (
+/obj/machinery/vending/custom/unbreakable,
+/turf/open/floor/plasteel/dark,
+/area/department_main/discipline)
 "jZ" = (
 /obj/effect/turf_decal/siding/brown/corner{
 	dir = 4
@@ -1498,6 +1513,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/facility_hallway/discipline)
+"xl" = (
+/obj/machinery/smartfridge/extraction_storage/ego_armor,
+/turf/closed/indestructible/reinforced,
+/area/department_main/extraction)
 "xm" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/sign/departments/welfare{
@@ -2974,6 +2993,13 @@
 /obj/item/storage/belt/ego,
 /turf/open/floor/carpet/royalblack,
 /area/department_main/extraction)
+"SJ" = (
+/obj/structure/closet/crate,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/department_main/discipline)
 "SL" = (
 /obj/structure/table/glass,
 /obj/item/clothing/accessory/armband/lobotomy/info,
@@ -53255,7 +53281,7 @@ My
 My
 My
 My
-Oc
+ar
 XE
 GD
 pw
@@ -53512,7 +53538,7 @@ My
 My
 My
 My
-Oc
+jO
 XE
 XE
 XE
@@ -53769,7 +53795,7 @@ My
 My
 My
 My
-Oc
+SJ
 mh
 BY
 BY
@@ -54278,10 +54304,10 @@ QD
 QD
 XE
 KP
-KP
+xl
 Hz
 Hz
-KP
+bn
 TU
 KP
 mh

--- a/_maps/map_files/Eta/etacorp.dmm
+++ b/_maps/map_files/Eta/etacorp.dmm
@@ -5365,12 +5365,12 @@
 /turf/open/floor/carpet/purple,
 /area/department_main/information)
 "te" = (
-/obj/machinery/vending/custom/unbreakable,
 /obj/structure/window/reinforced/spawner/north{
 	max_integrity = 25;
 	pixel_y = 2
 	},
-/turf/open/floor/facility/dark,
+/obj/machinery/smartfridge/extraction_storage/ego_armor,
+/turf/closed/indestructible/reinforced,
 /area/department_main/extraction)
 "tg" = (
 /obj/effect/turf_decal/tile/green{
@@ -9242,6 +9242,18 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/department_main/command)
+"Ga" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/table/reinforced{
+	max_integrity = 25
+	},
+/obj/structure/window/reinforced/spawner{
+	max_integrity = 25
+	},
+/turf/open/floor/facility/dark,
+/area/department_main/extraction)
 "Gc" = (
 /obj/effect/turf_decal/siding/yellow,
 /obj/machinery/light/cold/no_nightlight,
@@ -9369,6 +9381,10 @@
 	},
 /obj/structure/table/reinforced{
 	max_integrity = 25
+	},
+/obj/structure/window/reinforced/spawner/north{
+	max_integrity = 25;
+	pixel_y = 2
 	},
 /turf/open/floor/facility/dark,
 /area/department_main/extraction)
@@ -9812,6 +9828,10 @@
 	},
 /turf/open/floor/carpet/stellar,
 /area/facility_hallway/east)
+"Ip" = (
+/obj/machinery/vending/custom/unbreakable,
+/turf/open/floor/facility/dark,
+/area/department_main/extraction)
 "Ir" = (
 /obj/structure/disposalpipe/junction/yjunction{
 	dir = 4
@@ -11317,11 +11337,11 @@
 /turf/open/floor/carpet/orange,
 /area/facility_hallway/training)
 "NG" = (
-/obj/machinery/vending/custom/unbreakable,
 /obj/structure/window/reinforced/spawner{
 	max_integrity = 25
 	},
-/turf/open/floor/facility/dark,
+/obj/machinery/smartfridge/extraction_storage/ego_weapon,
+/turf/closed/indestructible/reinforced,
 /area/department_main/extraction)
 "NH" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -49803,8 +49823,8 @@ Gh
 UU
 te
 gx
-Gz
-Gz
+Ga
+Ip
 Gz
 vx
 NG

--- a/_maps/map_files/Gamma/gammacorp.dmm
+++ b/_maps/map_files/Gamma/gammacorp.dmm
@@ -1521,9 +1521,6 @@
 	dir = 8
 	},
 /obj/machinery/light,
-/obj/structure/sink/kitchen{
-	dir = 1
-	},
 /turf/open/floor/plasteel,
 /area/department_main/training)
 "lG" = (
@@ -1762,6 +1759,7 @@
 "mU" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced/spawner/west,
+/obj/machinery/smartfridge/extraction_storage/ego_armor,
 /turf/open/floor/facility/halls,
 /area/department_main/extraction)
 "mV" = (
@@ -2105,13 +2103,13 @@
 /turf/open/floor/carpet/purple,
 /area/department_main/information)
 "oU" = (
-/obj/machinery/microwave{
-	pixel_y = 7
-	},
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/siding/brown{
 	dir = 9
 	},
+/obj/item/storage/box/papersack,
+/obj/item/storage/box/papersack,
+/obj/item/storage/box/papersack,
 /turf/open/floor/facility/white,
 /area/department_main/training)
 "oW" = (
@@ -3165,7 +3163,6 @@
 /area/department_main/information)
 "vO" = (
 /obj/structure/table/reinforced,
-/obj/item/toy/plush/pierre,
 /obj/effect/turf_decal/siding/brown{
 	dir = 10
 	},
@@ -3174,6 +3171,14 @@
 	pixel_x = 32;
 	pixel_y = -32
 	},
+/obj/structure/sink/kitchen{
+	dir = 8;
+	pixel_x = -15;
+	pixel_y = 3
+	},
+/obj/item/storage/box/papersack,
+/obj/item/storage/box/papersack,
+/obj/item/storage/box/papersack,
 /turf/open/floor/facility/white,
 /area/department_main/training)
 "vQ" = (
@@ -4631,6 +4636,10 @@
 	},
 /turf/open/floor/wood,
 /area/department_main/welfare)
+"FY" = (
+/obj/machinery/vending/dinnerware,
+/turf/open/floor/facility/white,
+/area/department_main/training)
 "Ga" = (
 /obj/effect/spawner/abnormality_room,
 /turf/closed/indestructible/reinforced,
@@ -5269,19 +5278,10 @@
 /area/department_main/information)
 "Kn" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/box/papersack,
-/obj/item/storage/box/papersack,
-/obj/item/storage/box/papersack,
-/obj/item/storage/box/papersack,
-/obj/item/storage/box/papersack,
-/obj/item/storage/box/papersack,
-/obj/item/storage/box/papersack,
-/obj/item/storage/box/papersack,
-/obj/item/storage/box/papersack,
-/obj/item/storage/box/papersack,
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/item/toy/plush/pierre,
 /turf/open/floor/facility/white,
 /area/department_main/training)
 "Ko" = (
@@ -5651,7 +5651,6 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
-/obj/machinery/vending/custom/unbreakable,
 /obj/structure/sign/poster/lobotomycorp/random{
 	pixel_x = 32
 	},
@@ -5862,6 +5861,7 @@
 "NM" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced/spawner/east,
+/obj/machinery/smartfridge/extraction_storage/ego_weapon,
 /turf/open/floor/facility/halls,
 /area/department_main/extraction)
 "NN" = (
@@ -6063,7 +6063,7 @@
 /turf/open/floor/plasteel,
 /area/facility_hallway/welfare)
 "Pm" = (
-/obj/machinery/vending/dinnerware,
+/obj/machinery/vending/custom/unbreakable,
 /turf/open/floor/plasteel,
 /area/department_main/training)
 "Pp" = (
@@ -34084,7 +34084,7 @@ dG
 dG
 ae
 dz
-pQ
+FY
 pQ
 TL
 SB

--- a/_maps/map_files/Lambda/lambdacorp.dmm
+++ b/_maps/map_files/Lambda/lambdacorp.dmm
@@ -1469,14 +1469,8 @@
 /turf/open/floor/plasteel/dark,
 /area/department_main/discipline)
 "eT" = (
-/obj/structure/table/wood,
 /obj/machinery/light/floor,
-/obj/machinery/recharger{
-	pixel_x = 6
-	},
-/obj/machinery/recharger{
-	pixel_x = -6
-	},
+/obj/machinery/vending/custom/unbreakable,
 /turf/open/floor/carpet/purple,
 /area/department_main/information)
 "eU" = (
@@ -5479,10 +5473,11 @@
 /turf/open/floor/carpet/stellar,
 /area/department_main/command)
 "ua" = (
-/obj/structure/railing{
-	dir = 4
+/obj/structure/window/reinforced/spawner/north,
+/obj/machinery/smartfridge/extraction_storage/ego_armor,
+/turf/closed/indestructible/iron{
+	opacity = 1
 	},
-/turf/open/floor/plasteel/sepia,
 /area/department_main/information)
 "uc" = (
 /obj/effect/turf_decal/siding/purple{
@@ -9983,17 +9978,11 @@
 /turf/open/floor/plasteel/dark,
 /area/facility_hallway/central)
 "KE" = (
-/obj/machinery/vending/custom/unbreakable,
 /obj/structure/window/reinforced/spawner/north,
-/obj/effect/turf_decal/siding{
-	color = "#7D6521";
-	dir = 4
+/obj/machinery/smartfridge/extraction_storage/ego_weapon,
+/turf/closed/indestructible/iron{
+	opacity = 1
 	},
-/obj/effect/turf_decal/siding{
-	color = "#7D6521";
-	dir = 8
-	},
-/turf/open/floor/carpet/royalblack,
 /area/department_main/information)
 "KF" = (
 /obj/effect/turf_decal/siding/brown{
@@ -48404,13 +48393,13 @@ aX
 cs
 Eb
 ox
-fw
+ox
 Df
 fw
 fw
 fw
 bJ
-ua
+tb
 dJ
 nT
 ny
@@ -48661,7 +48650,7 @@ jZ
 sG
 nT
 yH
-KE
+ua
 Ix
 qs
 qs

--- a/_maps/map_files/Psi/psicorp.dmm
+++ b/_maps/map_files/Psi/psicorp.dmm
@@ -1578,13 +1578,8 @@
 /turf/open/floor/holofloor/white,
 /area/facility_hallway/discipline)
 "je" = (
-/obj/machinery/vending/custom/unbreakable{
-	pixel_x = -3
-	},
-/obj/structure/window/reinforced/spawner/east{
-	max_integrity = 25
-	},
-/turf/open/floor/facility/dark,
+/obj/machinery/smartfridge/extraction_storage/ego_armor,
+/turf/closed/indestructible/reinforced,
 /area/department_main/extraction)
 "jf" = (
 /obj/effect/turf_decal/tile/blue{
@@ -5473,6 +5468,9 @@
 /obj/machinery/light/cold/no_nightlight{
 	dir = 8
 	},
+/obj/machinery/vending/custom/unbreakable{
+	pixel_x = -3
+	},
 /turf/open/floor/plasteel/dark,
 /area/department_main/extraction)
 "Dn" = (
@@ -6825,6 +6823,9 @@
 /obj/machinery/light/cold/no_nightlight{
 	dir = 8
 	},
+/obj/machinery/vending/custom/unbreakable{
+	pixel_x = -3
+	},
 /turf/open/floor/plasteel/dark,
 /area/department_main/extraction)
 "Kx" = (
@@ -7049,13 +7050,8 @@
 /turf/open/floor/carpet/royalblack,
 /area/department_main/extraction)
 "Ma" = (
-/obj/machinery/vending/custom/unbreakable{
-	pixel_x = 3
-	},
-/obj/structure/window/reinforced/spawner/west{
-	max_integrity = 25
-	},
-/turf/open/floor/facility/dark,
+/obj/machinery/smartfridge/extraction_storage/ego_weapon,
+/turf/closed/indestructible/reinforced,
 /area/department_main/extraction)
 "Mc" = (
 /obj/effect/turf_decal/plaque{

--- a/_maps/map_files/Theta/thetacorp.dmm
+++ b/_maps/map_files/Theta/thetacorp.dmm
@@ -3613,12 +3613,13 @@
 /turf/open/floor/plasteel/sepia,
 /area/department_main/training)
 "iu" = (
-/obj/machinery/vending/custom/unbreakable{
-	pixel_x = 3
-	},
 /obj/structure/window/reinforced/spawner/west{
 	max_integrity = 25
 	},
+/obj/structure/table/reinforced{
+	max_integrity = 25
+	},
+/obj/machinery/smartfridge/extraction_storage/ego_armor,
 /turf/open/floor/facility/dark,
 /area/department_main/extraction)
 "iw" = (
@@ -8336,15 +8337,12 @@
 /turf/open/floor/carpet,
 /area/department_main/control)
 "tc" = (
-/obj/effect/turf_decal/siding{
-	color = "#7D6521";
-	dir = 10
-	},
 /obj/machinery/light/cold/no_nightlight{
 	dir = 8
 	},
 /obj/machinery/light/cold/no_nightlight,
-/turf/open/floor/carpet/royalblack,
+/obj/machinery/vending/custom/unbreakable,
+/turf/open/floor/facility/dark,
 /area/department_main/extraction)
 "td" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -8690,17 +8688,14 @@
 /turf/open/floor/plasteel/sepia,
 /area/facility_hallway/welfare)
 "tG" = (
-/obj/effect/turf_decal/siding{
-	color = "#7D6521";
-	dir = 9
-	},
 /obj/machinery/light/cold/no_nightlight{
 	dir = 1
 	},
 /obj/machinery/light/cold/no_nightlight{
 	dir = 8
 	},
-/turf/open/floor/carpet/royalblack,
+/obj/machinery/vending/custom/unbreakable,
+/turf/open/floor/facility/dark,
 /area/department_main/extraction)
 "tH" = (
 /obj/effect/turf_decal/tile/brown{
@@ -10578,12 +10573,13 @@
 /turf/open/floor/plasteel/dark,
 /area/facility_hallway/control)
 "xZ" = (
-/obj/machinery/vending/custom/unbreakable{
-	pixel_x = -3
-	},
 /obj/structure/window/reinforced/spawner/east{
 	max_integrity = 25
 	},
+/obj/structure/table/reinforced{
+	max_integrity = 25
+	},
+/obj/machinery/smartfridge/extraction_storage/ego_weapon,
 /turf/open/floor/facility/dark,
 /area/department_main/extraction)
 "ya" = (
@@ -14294,6 +14290,13 @@
 	desc = "An anomalous field of inky blackness caused by a wing's singularity, not even the bravest dares to delve into."
 	},
 /area/facility_hallway/central)
+"FR" = (
+/obj/effect/turf_decal/siding/white/corner{
+	color = "#7D6521";
+	dir = 1
+	},
+/turf/open/floor/carpet/royalblack,
+/area/department_main/extraction)
 "FS" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Records Office"
@@ -14822,6 +14825,13 @@
 	},
 /turf/open/floor/plasteel/sepia,
 /area/department_main/information)
+"GU" = (
+/obj/effect/turf_decal/siding/white/corner{
+	color = "#7D6521";
+	dir = 8
+	},
+/turf/open/floor/carpet/royalblack,
+/area/department_main/extraction)
 "GV" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -66623,7 +66633,7 @@ zk
 Kh
 hV
 tG
-Gb
+yV
 Gb
 pC
 bF
@@ -66633,7 +66643,7 @@ Qq
 yV
 tA
 Gb
-Gb
+bF
 tc
 hV
 QG
@@ -66879,8 +66889,8 @@ zk
 zk
 zk
 hV
-uO
-PX
+yV
+FR
 PX
 PX
 dq
@@ -66890,8 +66900,8 @@ Qq
 uO
 PX
 PX
-PX
-dq
+GU
+bF
 hV
 Jr
 zk

--- a/_maps/map_files/Xi/xicorp.dmm
+++ b/_maps/map_files/Xi/xicorp.dmm
@@ -1812,6 +1812,14 @@
 /obj/structure/fluff/broken_flooring,
 /turf/open/floor/plating,
 /area/facility_hallway/central)
+"mM" = (
+/obj/structure/window/reinforced/spawner/north{
+	max_integrity = 25;
+	pixel_y = 2
+	},
+/obj/machinery/smartfridge/extraction_storage/ego_weapon,
+/turf/closed/indestructible/reinforced,
+/area/department_main/information)
 "mN" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
@@ -4295,6 +4303,12 @@
 	color = "a1a1a1"
 	},
 /area/facility_hallway/information)
+"FP" = (
+/obj/machinery/vending/cigarette,
+/turf/open/floor/facility/white{
+	color = "a1a1a1"
+	},
+/area/facility_hallway/command)
 "FU" = (
 /turf/open/floor/mineral/titanium/white,
 /area/department_main/safety)
@@ -4612,8 +4626,15 @@
 /obj/effect/turf_decal/siding/purple{
 	dir = 6
 	},
-/obj/machinery/vending/cigarette,
+/obj/machinery/vending/custom/unbreakable,
 /turf/open/floor/carpet/purple,
+/area/department_main/information)
+"It" = (
+/obj/structure/window/reinforced/spawner/east{
+	max_integrity = 25
+	},
+/obj/machinery/smartfridge/extraction_storage/ego_armor,
+/turf/closed/indestructible/reinforced,
 /area/department_main/information)
 "Ix" = (
 /obj/structure/window/reinforced/spawner/north,
@@ -40473,7 +40494,7 @@ xx
 xx
 xx
 oa
-jP
+It
 rp
 II
 MO
@@ -40725,7 +40746,7 @@ il
 OL
 Du
 Du
-Du
+FP
 xx
 if
 if
@@ -41247,7 +41268,7 @@ oa
 MR
 aP
 lc
-pz
+mM
 hj
 hj
 hj

--- a/_maps/map_files/Zeta/zetacorp.dmm
+++ b/_maps/map_files/Zeta/zetacorp.dmm
@@ -632,6 +632,9 @@
 /obj/structure/railing{
 	dir = 4
 	},
+/obj/item/storage/belt/ego,
+/obj/item/storage/belt/ego,
+/obj/item/storage/belt/ego,
 /turf/open/floor/facility/dark,
 /area/department_main/command)
 "ep" = (
@@ -2130,10 +2133,10 @@
 /turf/open/floor/carpet/black,
 /area/department_main/command)
 "ns" = (
+/obj/structure/railing/corner,
 /obj/structure/table/reinforced{
 	max_integrity = 25
 	},
-/obj/structure/railing/corner,
 /turf/open/floor/facility/dark,
 /area/department_main/command)
 "nu" = (
@@ -4103,18 +4106,11 @@
 /turf/open/floor/carpet,
 /area/department_main/control)
 "zA" = (
-/obj/structure/rack{
-	pixel_x = -1
-	},
 /obj/effect/turf_decal/siding{
 	color = "#7D6521";
 	dir = 1
 	},
-/obj/item/storage/belt/ego,
-/obj/item/storage/belt/ego,
-/obj/item/storage/belt/ego,
-/obj/item/storage/belt/ego,
-/obj/item/price_tagger,
+/obj/machinery/vending/custom/unbreakable,
 /turf/open/floor/facility/dark,
 /area/department_main/command)
 "zD" = (
@@ -4291,8 +4287,6 @@
 /obj/structure/table/wood,
 /obj/item/fish_feed,
 /obj/item/fish_feed,
-/obj/item/simple_fishing_rod,
-/obj/item/simple_fishing_rod,
 /obj/item/storage/fish_case,
 /obj/item/storage/fish_case,
 /turf/open/floor/carpet/stellar,
@@ -4379,6 +4373,7 @@
 	max_integrity = 25
 	},
 /obj/structure/railing,
+/obj/machinery/smartfridge/extraction_storage/ego_weapon,
 /turf/open/floor/facility/dark,
 /area/department_main/command)
 "AT" = (
@@ -6204,6 +6199,7 @@
 	dir = 4
 	},
 /obj/machinery/camera/autoname,
+/obj/machinery/smartfridge/extraction_storage/ego_armor,
 /turf/open/floor/facility/dark,
 /area/department_main/command)
 "Mc" = (
@@ -7303,6 +7299,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/machinery/vending/custom/unbreakable,
+/obj/machinery/vending/custom/unbreakable,
 /turf/open/floor/wood,
 /area/department_main/command)
 "Sl" = (
@@ -7469,10 +7467,6 @@
 	},
 /turf/open/floor/wood,
 /area/facility_hallway/training)
-"TH" = (
-/obj/machinery/vending/custom/unbreakable,
-/turf/open/floor/facility/dark,
-/area/department_main/command)
 "TJ" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
@@ -8177,6 +8171,7 @@
 	max_integrity = 25
 	},
 /obj/structure/railing,
+/obj/item/price_tagger,
 /turf/open/floor/facility/dark,
 /area/department_main/command)
 "XO" = (
@@ -39457,7 +39452,7 @@ zA
 kB
 SO
 Jt
-TH
+NL
 xN
 Dj
 Ot
@@ -39714,7 +39709,7 @@ sX
 aY
 rY
 vv
-TH
+NL
 xN
 Dj
 Ot


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

adds the ego weapon, ego armor, and regular item venders on every map in extraction

## Why It's Good For The Game

requested by kirie