### PR TITLE
Manager Camera now has Following!

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/_abnormality.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_abnormality.dm
@@ -173,6 +173,11 @@
 	HarvestChem(my_container, user)
 	return
 
+/mob/living/simple_animal/hostile/abnormality/can_track(mob/living/user)
+	if((status_flags & GODMODE))
+		return FALSE
+	return ..()
+
 /mob/living/simple_animal/hostile/abnormality/proc/HarvestChem(obj/item/reagent_containers/C, mob/user)
 	visible_message(HarvestMessageProcess(harvest_phrase_third, user, C), HarvestMessageProcess(harvest_phrase, user, C))
 	if(chem_type)

--- a/code/modules/mob/living/simple_animal/abnormality/teth/meat_lantern.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/meat_lantern.dm
@@ -46,6 +46,10 @@
 	med_hud_set_health() //show medhud while in containment
 	med_hud_set_status()
 
+//Cameras cant auto track it now.
+/mob/living/simple_animal/hostile/abnormality/meat_lantern/can_track(mob/living/user)
+	return FALSE
+
 /mob/living/simple_animal/hostile/abnormality/meat_lantern/PickTarget(list/Targets)
 	return FALSE
 

--- a/code/modules/mob/living/simple_animal/abnormality/waw/dimension_refraction.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/dimension_refraction.dm
@@ -55,6 +55,10 @@
 /mob/living/simple_animal/hostile/abnormality/dimensional_refraction/PickTarget(list/Targets)
 	return
 
+//Cannot be automatically followed by manager camera follow command.
+/mob/living/simple_animal/hostile/abnormality/dimensional_refraction/can_track(mob/living/user)
+	return FALSE
+
 /* Qliphoth/Breach effects */
 /mob/living/simple_animal/hostile/abnormality/dimensional_refraction/BreachEffect(mob/living/carbon/human/user)
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I butchered AI code to make it a feature for the manager camera. Testing shows that it essentially works but we should test it first due to the tracking datum being shared by sephirah and managers. 
DRV and meat lantern have a false on their track so they wont be able to be followed by the managers ability.
Two creatures with the same name will show up the same on the managers follow choices. It is randomized who you end up following. Dead agents will need to be either disfigured or cleaned up to prevent the system from getting confused.

Doubleclicking to follow code is hardcoded into AI mobs so unless we are allowed to make a signal for double click, which may be weird since we already have a signal for clicking, we may have to use more roundabout solutions.

## Why It's Good For The Game
Ive been requested to code this by a few manager players. Quality of life even if it is very rough in its development.

## Changelog
:cl:
add: follow ability for manager console
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
