### PR TITLE
Increases both roses armors stats by 1

### DIFF
--- a/code/modules/clothing/suits/ego_gear/aleph.dm
+++ b/code/modules/clothing/suits/ego_gear/aleph.dm
@@ -115,7 +115,7 @@ Any attempt to code risk class armor will result in a 10 day Github ban.*/
 	desc = "Just looking at this, you feel quite tacky."
 	icon_state = "blooming"
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT
-	armor = list(RED_DAMAGE = 80, WHITE_DAMAGE = 70, BLACK_DAMAGE = 0, PALE_DAMAGE = 80) // 230
+	armor = list(RED_DAMAGE = 80, WHITE_DAMAGE = 80, BLACK_DAMAGE = 0, PALE_DAMAGE = 80) // 240
 	attribute_requirements = list(
 							FORTITUDE_ATTRIBUTE = 80,
 							PRUDENCE_ATTRIBUTE = 80,
@@ -128,7 +128,7 @@ Any attempt to code risk class armor will result in a 10 day Github ban.*/
 	desc = "Ah, magicians are actually in greater need of mercy."
 	icon_state = "air"
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT
-	armor = list(RED_DAMAGE = 80, WHITE_DAMAGE = 80, BLACK_DAMAGE = 20, PALE_DAMAGE = 90) // 270
+	armor = list(RED_DAMAGE = 80, WHITE_DAMAGE = 80, BLACK_DAMAGE = 30, PALE_DAMAGE = 90) // 280
 	attribute_requirements = list(
 							FORTITUDE_ATTRIBUTE = 100,
 							PRUDENCE_ATTRIBUTE = 100,


### PR DESCRIPTION
## About The Pull Request

Changes blooming from 8/7/0/8 to 8/8/0/8 and flowering night from 8/8/2/9 to 8/8/3/9

## Why It's Good For The Game

Blooming having 1 less armor then all non paradise lost/9 aleph armors felt wrong and it having white 8 won't be that broken. Giving flowering night black 3 is due to it costing more than paradise lost while having 1 less armor think it would be fine to give it a slight increase to make the totals on par

## Changelog
balance: gave one white to blooming and one black to flowering night
code: modified aleph.dm
/:cl: