### PR TITLE
Changes to duality of harmony

### DIFF
--- a/code/modules/clothing/suits/ego_gear/realized.dm
+++ b/code/modules/clothing/suits/ego_gear/realized.dm
@@ -330,7 +330,7 @@
 	name = "duality of harmony"
 	desc = "When good and evil meet discord and assonance will be quelled."
 	icon_state = "duality_yang"
-	armor = list(RED_DAMAGE = 40, WHITE_DAMAGE = 100, BLACK_DAMAGE = 40, PALE_DAMAGE = 80)
+	armor = list(RED_DAMAGE = 40, WHITE_DAMAGE = 90, BLACK_DAMAGE = 40, PALE_DAMAGE = 90)
 	realized_ability = /obj/effect/proc_holder/ability/tranquility
 
 /obj/item/clothing/suit/armor/ego_gear/realization/duality_yin

--- a/code/modules/spells/ability_types/realized.dm
+++ b/code/modules/spells/ability_types/realized.dm
@@ -864,7 +864,7 @@
 	H.adjust_attribute_buff(FORTITUDE_ATTRIBUTE, -10)
 	H.adjust_attribute_buff(PRUDENCE_ATTRIBUTE, -10)
 	H.adjust_attribute_buff(TEMPERANCE_ATTRIBUTE, -10)
-	H.adjust_attribute_buff(JUSTICE_ATTRIBUTE, 10)
+	H.adjust_attribute_buff(JUSTICE_ATTRIBUTE, -10)
 
 /*Child of the Galaxy - Our Galaxy */
 /obj/effect/proc_holder/ability/galaxy_gift
@@ -1063,7 +1063,6 @@
 		var/mob/living/L = target
 		if(L.health < 0 || L.stat == DEAD)
 			L.gib() //Punch them so hard they explode
-
 /* Flesh Idol - Repentance */
 /obj/effect/proc_holder/ability/prayer
 	name = "Prayer"


### PR DESCRIPTION
## About The Pull Request

Made its stats 4/9/4/9 and fixed its ability's synergy with yin's armor giving the yin armor +10 justice when the ability times out

## Why It's Good For The Game

now with kod being shit I think its fair for it to have pale 9 now and to make it a full on inverse of harmony of duality. also fixes a silly bug

## Changelog
:cl:
balance: Changes duality of harmony's armor values from 4/10/4/8 to 4/9/4/9
fix: no more infinite justice stacking from getting hit by yangs blast
code: changed 2 lines of code
/:cl:
