### PR TITLE
Fixes shield armor scaling

### DIFF
--- a/code/game/objects/items/ego_weapons/subtype/shield.dm
+++ b/code/game/objects/items/ego_weapons/subtype/shield.dm
@@ -86,7 +86,11 @@
 				return FALSE
 		block = TRUE
 		block_success = FALSE
-		shield_user.physiology.armor = shield_user.physiology.armor.modifyRating(red = reductions[1], white = reductions[2], black = reductions[3], pale = reductions[4], bomb = 1) //bomb defense must be over 0
+		shield_user.physiology.armor = shield_user.physiology.armor.modifyRating(bomb = 1) //bomb defense must be over 0
+		shield_user.physiology.red_mod *= (1 - ((reductions[1]) / 100))
+		shield_user.physiology.white_mod *= (1 - ((reductions[2]) / 100))
+		shield_user.physiology.black_mod *= (1 - ((reductions[3]) / 100))
+		shield_user.physiology.pale_mod *= (1 - ((reductions[4]) / 100))
 		RegisterSignal(user, COMSIG_MOB_APPLY_DAMGE, .proc/AnnounceBlock)
 		parry_timer = addtimer(CALLBACK(src, .proc/DisableBlock, shield_user), block_duration, TIMER_STOPPABLE)
 		to_chat(user,"<span class='userdanger'>[block_message]</span>")
@@ -94,7 +98,12 @@
 
 //Ends the block, causes you to take more damage for as long as debuff_duration if you did not block any damage
 /obj/item/ego_weapon/shield/proc/DisableBlock(mob/living/carbon/human/user)
-	user.physiology.armor = user.physiology.armor.modifyRating(red = -reductions[1], white = -reductions[2], black = -reductions[3], pale = -reductions[4], bomb = -1)
+	user.physiology.armor = user.physiology.armor.modifyRating(bomb = -1)
+	user.physiology.red_mod /= (1 - ((reductions[1]) / 100))
+	user.physiology.white_mod /= (1 - ((reductions[2]) / 100))
+	user.physiology.black_mod /= (1 - ((reductions[3]) / 100))
+	user.physiology.pale_mod /= (1 - ((reductions[4]) / 100))
+
 	UnregisterSignal(user, COMSIG_MOB_APPLY_DAMGE)
 	deltimer(parry_timer)
 	parry_timer = addtimer(CALLBACK(src, .proc/BlockCooldown, user), block_cooldown, TIMER_STOPPABLE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Converts shield armor from an addition to armor values to a physiology change. In layman's terms, this means that having a shield with 50 in an armor value while wearing an armor with 50 in that same value will no longer make you take zero damage. Instead, the armor values will stack multiplicatively, so you will end up taking the expected amount of damage instead.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
No more immortal shield users.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: shields can no longer make you invincible by wearing armor
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
