### PR TITLE
The great out of space rework of 2023

### DIFF
--- a/code/game/objects/items/ego_weapons/aleph.dm
+++ b/code/game/objects/items/ego_weapons/aleph.dm
@@ -539,7 +539,7 @@
 	desc = "It hails from realms whose mere existence stuns the brain and numbs us with the black extra-cosmic gulfs it throws open before our frenzied eyes."
 	special = "Use this weapon in hand to dash. Attack after a dash for an AOE."
 	icon_state = "space"
-	force = 70
+	force = 60//less dps for being able to do 2 damage types
 	damtype = WHITE_DAMAGE
 	armortype = WHITE_DAMAGE
 	attack_verb_continuous = list("cuts", "attacks", "slashes")
@@ -599,9 +599,6 @@
 	user.density = TRUE
 
 /obj/item/ego_weapon/space/attack(mob/living/target, mob/living/user)
-	..()
-	if(!CanUseEgo(user))
-		return
 	if(isanimal(target))
 		var/mob/living/simple_animal/M = target
 		if(M.damage_coeff[WHITE_DAMAGE] >= M.damage_coeff[BLACK_DAMAGE])
@@ -610,6 +607,7 @@
 		else
 			damtype = BLACK_DAMAGE
 			armortype = BLACK_DAMAGE
+
 	if(ishuman(target))
 		var/mob/living/carbon/human/H = target
 		if(H.run_armor_check(null, WHITE_DAMAGE) <= H.run_armor_check(null, BLACK_DAMAGE))
@@ -618,15 +616,21 @@
 		else
 			damtype = BLACK_DAMAGE
 			armortype = BLACK_DAMAGE
+
+	. = ..()
+	if(!CanUseEgo(user))
+		return
+
 	if(!canaoe)
 		return
+
 	if(do_after(user, 5, src, IGNORE_USER_LOC_CHANGE))
 		playsound(src, 'sound/weapons/rapierhit.ogg', 100, FALSE, 4)
 		for(var/turf/T in orange(1, user))
 			new /obj/effect/temp_visual/smash_effect(T)
 
 		for(var/mob/living/L in livinginrange(1, user))
-			var/aoe = force/2
+			var/aoe = force
 			var/userjust = (get_modified_attribute_level(user, JUSTICE_ATTRIBUTE))
 			var/justicemod = 1 + userjust/100
 			aoe*=justicemod

--- a/code/game/objects/items/ego_weapons/aleph.dm
+++ b/code/game/objects/items/ego_weapons/aleph.dm
@@ -539,7 +539,7 @@
 	desc = "It hails from realms whose mere existence stuns the brain and numbs us with the black extra-cosmic gulfs it throws open before our frenzied eyes."
 	special = "Use this weapon in hand to dash. Attack after a dash for an AOE."
 	icon_state = "space"
-	force = 60//less dps for being able to do 2 damage types
+	force = 64//less dps for being able to do 2 damage types
 	damtype = WHITE_DAMAGE
 	armortype = WHITE_DAMAGE
 	attack_verb_continuous = list("cuts", "attacks", "slashes")
@@ -607,23 +607,23 @@
 		else
 			damtype = BLACK_DAMAGE
 			armortype = BLACK_DAMAGE
-
 	if(ishuman(target))
 		var/mob/living/carbon/human/H = target
-		if(H.run_armor_check(null, WHITE_DAMAGE) <= H.run_armor_check(null, BLACK_DAMAGE))
+		if(H.sanity_lost)//makes it able to uninsane people easier
 			damtype = WHITE_DAMAGE
 			armortype = WHITE_DAMAGE
 		else
-			damtype = BLACK_DAMAGE
-			armortype = BLACK_DAMAGE
-
+			if(H.run_armor_check(null, WHITE_DAMAGE) <= H.run_armor_check(null, BLACK_DAMAGE))
+				damtype = WHITE_DAMAGE
+				armortype = WHITE_DAMAGE
+			else
+				damtype = BLACK_DAMAGE
+				armortype = BLACK_DAMAGE
 	. = ..()
 	if(!CanUseEgo(user))
 		return
-
 	if(!canaoe)
 		return
-
 	if(do_after(user, 5, src, IGNORE_USER_LOC_CHANGE))
 		playsound(src, 'sound/weapons/rapierhit.ogg', 100, FALSE, 4)
 		for(var/turf/T in orange(1, user))

--- a/code/game/objects/items/ego_weapons/aleph.dm
+++ b/code/game/objects/items/ego_weapons/aleph.dm
@@ -539,7 +539,7 @@
 	desc = "It hails from realms whose mere existence stuns the brain and numbs us with the black extra-cosmic gulfs it throws open before our frenzied eyes."
 	special = "Use this weapon in hand to dash. Attack after a dash for an AOE."
 	icon_state = "space"
-	force = 35	//Half white, half black.
+	force = 70
 	damtype = WHITE_DAMAGE
 	armortype = WHITE_DAMAGE
 	attack_verb_continuous = list("cuts", "attacks", "slashes")
@@ -582,8 +582,22 @@
 	..()
 	if(!CanUseEgo(user))
 		return
-	target.apply_damage(force, BLACK_DAMAGE, null, target.run_armor_check(null, BLACK_DAMAGE), spread_damage = FALSE)
-
+	if(isanimal(target))
+		var/mob/living/simple_animal/M = target
+		if(M.damage_coeff[WHITE_DAMAGE] > M.damage_coeff[BLACK_DAMAGE])
+			damtype = WHITE_DAMAGE
+			armortype = WHITE_DAMAGE
+		if(M.damage_coeff[BLACK_DAMAGE] > M.damage_coeff[WHITE_DAMAGE])
+			damtype = BLACK_DAMAGE
+			armortype = BLACK_DAMAGE
+	if(ishuman(target))
+		var/mob/living/carbon/human/H = target
+		if(H.physiology.white_mod> H.physiology.black_mod)
+			damtype = WHITE_DAMAGE
+			armortype = WHITE_DAMAGE
+		if(H.physiology.black_mod> H.physiology.white_mod)
+			damtype = BLACK_DAMAGE
+			armortype = BLACK_DAMAGE
 	if(!canaoe)
 		return
 	if(do_after(user, 5, src, IGNORE_USER_LOC_CHANGE))
@@ -604,7 +618,7 @@
 	canaoe = FALSE
 
 /obj/item/ego_weapon/space/EgoAttackInfo(mob/user)
-	return "<span class='notice'>It deals [force] of both white and black damage.</span>"
+	return "<span class='notice'>It deals [force] of either white or black damage depending on which would deal more damage.</span>"
 
 /obj/item/ego_weapon/seasons
 	name = "Seasons Greetings"

--- a/code/game/objects/items/ego_weapons/aleph.dm
+++ b/code/game/objects/items/ego_weapons/aleph.dm
@@ -552,7 +552,6 @@
 							JUSTICE_ATTRIBUTE = 80
 							)
 	var/canaoe
-	var/damagemode = 0
 
 /obj/item/ego_weapon/space/attack_self(mob/living/carbon/user)
 	if(!CanUseEgo(user))
@@ -621,12 +620,6 @@
 			armortype = BLACK_DAMAGE
 	if(!canaoe)
 		return
-	if(damagemode == 0)
-		damtype = WHITE_DAMAGE
-		armortype = WHITE_DAMAGE
-	if(damagemode == 1)
-		damtype = BLACK_DAMAGE
-		armortype = BLACK_DAMAGE
 	if(do_after(user, 5, src, IGNORE_USER_LOC_CHANGE))
 		playsound(src, 'sound/weapons/rapierhit.ogg', 100, FALSE, 4)
 		for(var/turf/T in orange(1, user))


### PR DESCRIPTION
## About The Pull Request

Heavily reworks out of space(loos' weapon)
Now it either does black or white(always does white to insane agents)
Dash looks cooler and no longer knocks you down when colliding with a player or wall(and new visual effects too)

## Why It's Good For The Game

Out of space was a neat idea just sucked in every way possible. doing both black and white isn't that useful due to most abnormalities that are weak to one usual resists or are immune/absorb the other. the dash is honestly horrid. Its easy to troll others by knocking them down with it and trying to use it normally is hard due to how easy it is to accidentally hit a wall or another player. these 2 changes are meant to address both of these problems making out of space a good aleph weapon by making it either black or white and making the dash suck less. Also nerfs the damage to 64 to compensate it being basically 2 weapons in one

## Changelog
:cl:
tweak: tweaked a out of space
balance: reworked out of space and nerfs the total damage to 64
code: changed some out of space code
/:cl: