### PR TITLE
Removes dark color restriction for spraying but removes spraying in LoR

### DIFF
--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -754,10 +754,16 @@
 			var/list/rgb = hex2rgb(paint_color)
 			var/list/hsl = rgb2hsl(rgb[1], rgb[2], rgb[3])
 			var/color_is_dark = hsl[3] < DARK_COLOR_LIGHTNESS_THRESHOLD
+			
+			if(SSmaptype.maptype == "city")
+				to_chat(user, "<span class='warning'>Vandalizing the head's property is punishable by death...</span>")
+				return FALSE
 
+			/*
 			if (color_is_dark && !(target.flags_1 & ALLOW_DARK_PAINTS_1))
 				to_chat(user, "<span class='warning'>A color that dark on an object like this? Surely not...</span>")
 				return FALSE
+			*/
 
 			target.add_atom_colour(paint_color, WASHABLE_COLOUR_PRIORITY)
 			SEND_SIGNAL(target, COMSIG_OBJ_PAINTED, color_is_dark)


### PR DESCRIPTION
## About The Pull Request

- Removes spray can restriction from being able to give dark colors to items
- Removes the ability to change item colors with spray can in LoR

## Why It's Good For The Game

More freedom for fashion13, you can always just clean it with the chem spray anyways
The latter is just to remove shenanigans in LoR mode, apparently

## Changelog
:cl:
tweak: made dark restriction into a comment and adds a map check for LoR to prevent spraying
/:cl: