### PR TITLE
Revert Pillow to 9.3.0

### DIFF
--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,6 +1,6 @@
 pygit2==1.0.1
 bidict==0.13.1
-Pillow==10.0.1
+Pillow==9.3.0
 
 # changelogs
 PyYaml==5.4


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Reverts "Pillow" dependency to 9.3.0

## Why It's Good For The Game

The latest automatic dependabot broke certain tools, and /tg/station is still on 9.3.0
I do not have time to figure out if reverting it is a good idea, nor did anyone else find another solution, so we'll be doing that.
