### PR TITLE
replaces ". = ..()" parent calls with "return ..()" where applicable without changing surrounding code. Forces some abnormality procs to be called by children

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/_abnormality.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_abnormality.dm
@@ -81,6 +81,7 @@
 	var/list/dummy_chems = list(/datum/reagent/abnormality/nutrition, /datum/reagent/abnormality/cleanliness, /datum/reagent/abnormality/consensus, /datum/reagent/abnormality/amusement, /datum/reagent/abnormality/violence)
 
 /mob/living/simple_animal/hostile/abnormality/Initialize(mapload)
+	SHOULD_CALL_PARENT(TRUE)
 	. = ..()
 	if(!(type in GLOB.cached_abno_work_rates))
 		GLOB.cached_abno_work_rates[type] = work_chances.Copy()
@@ -114,6 +115,7 @@
 		gift_message += "\nYou are granted a gift by [src]!"
 
 /mob/living/simple_animal/hostile/abnormality/Destroy()
+	SHOULD_CALL_PARENT(TRUE)
 	if(istype(datum_reference)) // Respawn the mob on death
 		datum_reference.current = null
 		addtimer(CALLBACK (datum_reference, .datum/abnormality/proc/RespawnAbno), 30 SECONDS)
@@ -142,6 +144,7 @@
 	..()
 
 /mob/living/simple_animal/hostile/abnormality/Life()
+	SHOULD_CALL_PARENT(TRUE)
 	. = ..()
 	if(!.) // Dead
 		return FALSE
@@ -274,6 +277,7 @@
 
 // Called by datum_reference when work is done
 /mob/living/simple_animal/hostile/abnormality/proc/WorkComplete(mob/living/carbon/human/user, work_type, pe, work_time, canceled)
+	SHOULD_CALL_PARENT(TRUE)
 	if(pe >= datum_reference.success_boxes)
 		SuccessEffect(user, work_type, pe, work_time, canceled)
 	else if(pe >= datum_reference.neutral_boxes)
@@ -302,6 +306,7 @@
 
 // Giving an EGO gift to the user after work is complete
 /mob/living/simple_animal/hostile/abnormality/proc/GiftUser(mob/living/carbon/human/user, pe, chance = gift_chance)
+	SHOULD_CALL_PARENT(TRUE)
 	if(!istype(user) || isnull(gift_type))
 		return FALSE
 	if(istype(user.ego_gift_list[initial(gift_type.slot)], gift_type)) // If we already have same gift - don't run the checks

--- a/code/modules/mob/living/simple_animal/abnormality/_tools/tool_abnormality.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_tools/tool_abnormality.dm
@@ -34,6 +34,7 @@ GLOBAL_LIST_INIT(unspawned_tools, list(
 	icon_state = "x4"
 
 /obj/effect/landmark/toolspawn/Initialize()
+	SHOULD_CALL_PARENT(TRUE)
 	..()
 	if(!LAZYLEN(GLOB.unspawned_tools)) // You shouldn't ever need this but I mean go on I guess
 		return INITIALIZE_HINT_QDEL

--- a/code/modules/mob/living/simple_animal/abnormality/he/blue_shepherd.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/blue_shepherd.dm
@@ -252,7 +252,7 @@
 		return FALSE
 	if(awakened_buddy)
 		awakened_buddy.LoseTarget()
-	. = ..()
+	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/blue_shepherd/stop_pulling()
 	if(pulling == awakened_buddy) //it's tempting to make player controlled shepherd pull you forever but I'll hold off on it

--- a/code/modules/mob/living/simple_animal/abnormality/he/galaxy_child.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/galaxy_child.dm
@@ -76,7 +76,7 @@
 		chance = 100
 		chance_modifier = 1
 		depressed = FALSE
-	. = ..(user, pe, chance)
+	return ..(user, pe, chance)
 
 /mob/living/simple_animal/hostile/abnormality/galaxy_child/proc/TurfTransform(turf/turf_type)
 	for(var/turf/T in range(1,src))

--- a/code/modules/mob/living/simple_animal/abnormality/he/laetitia.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/laetitia.dm
@@ -93,7 +93,7 @@
 
 /datum/status_effect/pranked/on_creation(mob/living/new_owner, ...)
 	duration = rand(1800,2400)
-	. = ..()
+	return ..()
 
 /datum/status_effect/pranked/on_apply()
 	if(get_attribute_level(owner, PRUDENCE_ATTRIBUTE) >= 80)

--- a/code/modules/mob/living/simple_animal/abnormality/he/pisc_mermaid.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/pisc_mermaid.dm
@@ -297,7 +297,7 @@
 
 /obj/effect/mermaid_water/unbuckle_mob(mob/living/carbon/human/buckled_mob, force)
 	if(buckled_mob.stat == DEAD || buckled_mob.losebreath <= 0) //you can only unbuckle yourself if you somehow survive the oxyloss long enough, or you're dead
-		. = ..()
+		return ..()
 
 ///the loved's movespeed is nerfed by a LOT while she's out, meaning if you're in the process of being chased by big bird, I have bad news for you.
 /datum/movespeed_modifier/unrequited_slowdown

--- a/code/modules/mob/living/simple_animal/abnormality/he/porccubus.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/porccubus.dm
@@ -133,7 +133,7 @@
 	return FALSE
 
 /mob/living/simple_animal/hostile/abnormality/porccubus/Life()
-	. =..()
+	. = ..()
 	if(status_flags & GODMODE)
 		return
 	if(teleport_cooldown < world.time) //if porccubus hasn't taken damage for 5 minutes we make him move so he doesn't stay stuck in whatever cell he got thrown in.

--- a/code/modules/mob/living/simple_animal/abnormality/he/red_buddy.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/red_buddy.dm
@@ -176,11 +176,11 @@
 ///we're doing a bunch of checks for diagonal movement because it acts real weird with forced dragging
 /mob/living/simple_animal/hostile/abnormality/red_buddy/Move(atom/newloc)
 	if(!awakened_master || (moving_diagonally && !target))
-		return . = ..()
+		return ..()
 
 	if(!awakened_master.Adjacent(newloc) && !awakened_master.moving_diagonally)
 		return FALSE
-	. = ..()
+	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/red_buddy/BreachEffect()
 	..()

--- a/code/modules/mob/living/simple_animal/abnormality/he/you_strong.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/you_strong.dm
@@ -241,17 +241,15 @@
 /mob/living/simple_animal/hostile/grown_strong/Move(atom/newloc, dir, step_x, step_y)
 	if(status_flags & GODMODE)
 		return FALSE
-	. = ..()
-	return
+	return ..()
 
 /mob/living/simple_animal/hostile/grown_strong/AttackingTarget(atom/attacked_target)
 	if(status_flags & GODMODE)
 		return FALSE
-	. = ..()
-	return
+	return ..()
 
 /mob/living/simple_animal/hostile/grown_strong/Initialize()
-	. = ..()
+	return ..() // replace with . = ..() once the icon state code gets un-commented
 	//icon_state = pick("1", "2", "3")
 
 /mob/living/simple_animal/hostile/grown_strong/proc/UpdateGear()

--- a/code/modules/mob/living/simple_animal/abnormality/waw/judgement_bird.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/judgement_bird.dm
@@ -57,7 +57,7 @@
 /mob/living/simple_animal/hostile/abnormality/judgement_bird/Move()
 	if(judging)
 		return FALSE
-	. = ..()
+	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/judgement_bird/AttackingTarget(atom/attacked_target)
 	return OpenFire()

--- a/code/modules/mob/living/simple_animal/abnormality/waw/naked_nest.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/naked_nest.dm
@@ -187,7 +187,7 @@
 	if(istype(target, /mob/living/simple_animal/hostile/abnormality/naked_nest))
 		var/mob/living/simple_animal/hostile/abnormality/naked_nest/nest = target
 		nest.RecoverSerpent(src)
-	. = ..()
+	return ..()
 
 /mob/living/simple_animal/hostile/naked_nest_serpent/CanAttack(atom/the_target)
 	if(panic_timer > world.time)

--- a/code/modules/mob/living/simple_animal/abnormality/waw/parasite_tree.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/parasite_tree.dm
@@ -289,7 +289,7 @@
 				connected_abno.datum_reference.qliphoth_change(1)
 		H.adjust_attribute_buff(TEMPERANCE_ATTRIBUTE, -10)
 		H.adjust_attribute_buff(PRUDENCE_ATTRIBUTE, -10)
-	. = ..()
+	return ..()
 
 /datum/status_effect/display/parasite_tree_blessing/proc/facadeFalls()
 	owner.apply_status_effect(THE_TREE_CURSE)
@@ -335,7 +335,7 @@
 		nested_items(N, host.get_item_by_slot(ITEM_SLOT_BACK))
 		nested_items(N, host.get_item_by_slot(ITEM_SLOT_OCLOTHING))
 		QDEL_IN(owner, 5) //rabbit sanity implant explodes at 5
-	. = ..()
+	return ..()
 
 /datum/status_effect/display/parasite_tree_curse/TweakDisplayIcon()
 	..()


### PR DESCRIPTION

## About The Pull Request

changes ". = ..()" calls for "return ..()" where it can be changed without affecting surrounding code
forces initialize(), destroy(), life(), WorkComplete() and GiftUser() to be called by an abnormality if they implement custom code
i would have also forced people to call FearEffect() but meat lantern requires to not call parent to be stealthy

## Why It's Good For The ~Game~ Codebase

juuuuuuuust in case contributors forget to call . = ..() on some procs and have to spend time diagonising the issue, this makes it a lil bit faster to show up

## Changelog
:cl:
code: . = ..() calls were replaced with return ..()
/:cl:
