### PR TITLE
Better living nest worms and some other realized ability changes

### DIFF
--- a/code/modules/clothing/suits/ego_gear/realized.dm
+++ b/code/modules/clothing/suits/ego_gear/realized.dm
@@ -375,7 +375,7 @@
 		return
 	addtimer(CALLBACK(src, .proc/Reset,user), 10 SECONDS)
 	playsound(get_turf(user), 'sound/misc/moist_impact.ogg', 30, 1)
-	var/mob/living/simple_animal/hostile/naked_nest_serpent_friend/W = new/mob/living/simple_animal/hostile/naked_nest_serpent_friend(get_turf(user))
+	var/mob/living/simple_animal/hostile/naked_nest_serpent_friend/W = new(get_turf(user))
 	W.origin_nest = user
 
 /* ALEPH Realizations */

--- a/code/modules/clothing/suits/ego_gear/realized.dm
+++ b/code/modules/clothing/suits/ego_gear/realized.dm
@@ -374,7 +374,9 @@
 	if(!CanSpawn)
 		return
 	addtimer(CALLBACK(src, .proc/Reset,user), 10 SECONDS)
-	new/mob/living/simple_animal/hostile/naked_nest_serpent_friend(get_turf(user))
+	playsound(get_turf(user), 'sound/misc/moist_impact.ogg', 30, 1)
+	var/mob/living/simple_animal/hostile/naked_nest_serpent_friend/W = new/mob/living/simple_animal/hostile/naked_nest_serpent_friend(get_turf(user))
+	W.origin_nest = user
 
 /* ALEPH Realizations */
 

--- a/code/modules/spells/ability_types/realized.dm
+++ b/code/modules/spells/ability_types/realized.dm
@@ -1162,8 +1162,8 @@
 	for(var/i = 1 to 9)
 		playsound(get_turf(user), 'sound/misc/moist_impact.ogg', 30, 1)
 		var/landing
-		pick(landing = locate(user.x, user.y + 2, user.z),landing = locate(user.x, user.y - 2, user.z),landing = locate(user.x + 2, user.y, user.z),landing = locate(user.x - 2, user.y, user.z),landing = locate(user.x + 1, user.y + 1, user.z),landing = locate(user.x + 1, user.y - 1, user.z),landing = locate(user.x - 1, user.y + 1, user.z),landing = locate(user.x - 1, user.y - 1, user.z))
-		var/mob/living/simple_animal/hostile/naked_nest_serpent_friend/W = new/mob/living/simple_animal/hostile/naked_nest_serpent_friend(get_turf(user))
+		landing = locate(user.x + pick(-2,-1,0,1,2), user.y + pick(-2,-1,0,1,2), user.z)
+		var/mob/living/simple_animal/hostile/naked_nest_serpent_friend/W = new(get_turf(user))
 		W.origin_nest = user
 		W.throw_at(landing, 0.5, 2, spin = FALSE)
 	return ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Made living nest's worm's damage stacking debuff actually work(totaling to 2x red damage taken with 20 worms/stacks) and reworked spawning and added sound. The counter from mouth of god now makes you red when triggered and changed repentance's ability's description to be more clear

## Why It's Good For The Game

Living nest worm debuff actually works now and some small tweaks are fine.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: tweaked mouth of god's and repentance's abilities
balance: Worms work now
fix: Worms work better
spellcheck: fixed a few typos
code: changed some code
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
