### PR TITLE
Fixes Homing Instinct not correctly going back to a minimum

### DIFF
--- a/code/game/objects/items/ego_weapons/he.dm
+++ b/code/game/objects/items/ego_weapons/he.dm
@@ -582,7 +582,7 @@
 
 /obj/item/ego_weapon/homing_instinct/attack(mob/living/M, mob/living/carbon/human/user)
 	..()
-	force = min(initial(force), round(force/2)) //It doesn't lose all its force in one go after each hit.
+	force = max(initial(force), round(force/2)) //It doesn't lose all its force in one go after each hit.
 
 
 /obj/item/ego_weapon/homing_instinct/proc/UserMoved()

--- a/code/game/objects/items/ego_weapons/he.dm
+++ b/code/game/objects/items/ego_weapons/he.dm
@@ -582,7 +582,8 @@
 
 /obj/item/ego_weapon/homing_instinct/attack(mob/living/M, mob/living/carbon/human/user)
 	..()
-	force = round(force/2) //It doesn't lose all its force in one go after each hit.
+	force = min(initial(force), round(force/2)) //It doesn't lose all its force in one go after each hit.
+
 
 /obj/item/ego_weapon/homing_instinct/proc/UserMoved()
 	SIGNAL_HANDLER


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Homing instinct now has a minimum as initially intended by god.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Changelog
:cl:
fix: fixed homing instinct not going back to a minimum
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
