### PR TITLE
Nerfs gold dusk

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/waw/thunder_bird.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/thunder_bird.dm
@@ -357,6 +357,7 @@ GLOBAL_LIST_EMPTY(zombies)
 		C.icon_living = "human_thunderbolt"
 		C.desc = "What appears to be [H.real_name], only charred and screaming incoherently..."
 		C.gender = H.gender
+		C.faction = src.faction
 		H.gib()
 	can_act = TRUE
 

--- a/code/modules/mob/living/simple_animal/hostile/ordeal/gold.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/gold.dm
@@ -523,6 +523,8 @@
 	playsound(src, 'sound/effects/ordeals/gold/pridespin.ogg', 125, FALSE)
 
 /mob/living/simple_animal/hostile/ordeal/sin_pride/proc/Charge(move_dir, times_ran)
+	if(health <= 0)
+		return
 	var/stop_charge = FALSE
 	if(times_ran >= dash_num)
 		stop_charge = TRUE
@@ -577,8 +579,8 @@
 	icon_living = "thunder_warrior"
 	icon_dead = "thunder_warrior_dead"
 	faction = list("gold_ordeal")
-	maxHealth = 2200
-	health = 2200
+	maxHealth = 900
+	health = 900
 	melee_damage_type = BLACK_DAMAGE
 	armortype = BLACK_DAMAGE
 	melee_damage_lower = 26
@@ -590,7 +592,6 @@
 	damage_coeff = list(BRUTE = 1, RED_DAMAGE = 0.8, WHITE_DAMAGE = 0.5, BLACK_DAMAGE = 1, PALE_DAMAGE = 0.7)
 	butcher_results = list(/obj/item/food/meat/slab/chicken = 1, /obj/item/food/meat/slab/human = 1)
 	guaranteed_butcher_results = list(/obj/item/food/meat/slab/human = 1)
-	speed = 3
 	move_to_delay = 3
 	ranged = TRUE
 	projectiletype = /obj/projectile/thunder_tomahawk
@@ -655,8 +656,7 @@
 	damage_coeff = list(BRUTE = 1, RED_DAMAGE = 0.8, WHITE_DAMAGE = 0.5, BLACK_DAMAGE = 1, PALE_DAMAGE = 0.7)
 	butcher_results = list(/obj/item/food/meat/slab/robot = 1, /obj/item/food/meat/slab/human = 1)
 	guaranteed_butcher_results = list(/obj/item/food/meat/slab/human = 1)
-	speed = 3
-	move_to_delay = 3
+	move_to_delay = 4
 	var/pulse_cooldown
 	var/pulse_cooldown_time = 4 SECONDS
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Gold dusk is consistently destroying entire facilities that it really has no business destroying. This should make it a bit more fair.

- Roughly halves the HP of Thunder Warriors from 2200 to 900.
- Lowers the move speed of both of the main mobs.
- Fixes a bug where thunder zombies will attack one another due to inheriting factions inconsistently.
- Fixes a bug where the wheels can still finish a charge if you kill them while prepping.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It might be better
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: nerfed gold dusk
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
