### PR TITLE
Sunset Traveller buff

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/zayin/sunset_traveller.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/sunset_traveller.dm
@@ -34,7 +34,6 @@
 	light_power = 7
 
 
-
 /mob/living/simple_animal/hostile/abnormality/sunset_traveller/PostWorkEffect(mob/living/carbon/human/user, work_type, pe, work_time)
 	if(pe == 0)
 		return
@@ -44,12 +43,13 @@
 	SLEEP_CHECK_DEATH(15)
 	say("Why don't you stop for a moment and take a breather here?")
 	while (PlayerCheck(user))
-		//Heal 5% for every 3 seconds you're here
-		user.adjustBruteLoss(-(maxHealth*0.05))
-		user.adjustSanityLoss(-(maxHealth*0.05))
-		if(prob(5))
-			say(pick(saylines))
-		SLEEP_CHECK_DEATH(30)
+		for(var/mob/living/carbon/human/H in view(3, src))
+			//Heal 5% for every 3 seconds you're here
+			user.adjustBruteLoss(-(maxHealth*0.05))
+			user.adjustSanityLoss(-(maxHealth*0.05))
+			if(prob(5))
+				say(pick(saylines))
+			SLEEP_CHECK_DEATH(30)
 
 
 /mob/living/simple_animal/hostile/abnormality/sunset_traveller/proc/PlayerCheck(mob/living/carbon/human/user)

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/sunset_traveller.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/sunset_traveller.dm
@@ -47,9 +47,9 @@
 			//Heal 5% for every 3 seconds you're here
 			user.adjustBruteLoss(-(maxHealth*0.05))
 			user.adjustSanityLoss(-(maxHealth*0.05))
-			if(prob(5))
-				say(pick(saylines))
-			SLEEP_CHECK_DEATH(30)
+		if(prob(5))
+			say(pick(saylines))
+		SLEEP_CHECK_DEATH(30)
 
 
 /mob/living/simple_animal/hostile/abnormality/sunset_traveller/proc/PlayerCheck(mob/living/carbon/human/user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Sunset traveller will now set up a heal zone that heals everyone in range, instead of just healing the person that made it.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This converts Sunset traveller from a single use "Heal me fast" abnormality, to one that lets you set up a healing zone, as long as the person who last worked on it is inside the room.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Sunset Traveller now heals everyone in the room instead of just the person who last worked on it.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
