### PR TITLE
Edits to Manager Holocommands and Glowing Commands

### DIFF
--- a/ModularTegustation/tegu_items/gadgets/unpowered.dm
+++ b/ModularTegustation/tegu_items/gadgets/unpowered.dm
@@ -62,14 +62,18 @@
 	var/commandtype = 1
 	var/commanddelay = 1.5 SECONDS
 	var/cooldown = 0
-	var/static/list/commandtypes = typecacheof(list(
-		/obj/effect/temp_visual/commandMove,
-		/obj/effect/temp_visual/commandWarn,
-		/obj/effect/temp_visual/commandGaurd,
-		/obj/effect/temp_visual/commandHeal,
-		/obj/effect/temp_visual/commandFightA,
-		/obj/effect/temp_visual/commandFightB
-		))
+	//Used for limiting the amount of commands that can exist.
+	var/current_commands = 0
+	var/max_commands = 5
+	//Command Types that can be deployed. Listed in order of commandtype.
+	var/list/commandtypes = list(
+		/obj/effect/temp_visual/HoloCommand/commandMove,
+		/obj/effect/temp_visual/HoloCommand/commandWarn,
+		/obj/effect/temp_visual/HoloCommand/commandGaurd,
+		/obj/effect/temp_visual/HoloCommand/commandHeal,
+		/obj/effect/temp_visual/HoloCommand/commandFightA,
+		/obj/effect/temp_visual/HoloCommand/commandFightB
+		)
 
 /obj/item/commandprojector/attack_self(mob/user)
 	..()
@@ -100,30 +104,25 @@
 /obj/item/commandprojector/afterattack(atom/target, mob/user, proximity_flag)
 	. = ..()
 	if(cooldown <= world.time)
-		for(var/obj/effect/temp_visual/V in range(get_turf(target), 0))
-			if(is_type_in_typecache(V, commandtypes))
-				qdel(V)
-				return
-		switch(commandtype)
-			if(1)
-				new /obj/effect/temp_visual/commandMove(get_turf(target))
-			if(2)
-				new /obj/effect/temp_visual/commandWarn(get_turf(target))
-			if(3)
-				new /obj/effect/temp_visual/commandGaurd(get_turf(target))
-			if(4)
-				new /obj/effect/temp_visual/commandHeal(get_turf(target))
-			if(5)
-				new /obj/effect/temp_visual/commandFightA(get_turf(target))
-			if(6)
-				new /obj/effect/temp_visual/commandFightB(get_turf(target))
-			else
-				to_chat(user, "<span class='warning'>CALIBRATION ERROR.</span>")
+		for(var/obj/effect/temp_visual/HoloCommand/V in get_turf(target))
+			qdel(V)
+			return
+		if(current_commands >= max_commands)
+			to_chat(user, "<span class='warning'>COMMAND CAPACITY REACHED.</span>")
+			return
+		if(commandtype > 0 && commandtype <= 6)
+			var/thing_to_spawn = commandtypes[commandtype]
+			var/thing_spawned = new thing_to_spawn(get_turf(target))
+			current_commands++
+			RegisterSignal(thing_spawned, COMSIG_PARENT_QDELETING, .proc/ReduceCommandAmount)
+		else
+			to_chat(user, "<span class='warning'>CALIBRATION ERROR.</span>")
 		cooldown = world.time + commanddelay
 	playsound(src, 'sound/machines/pda_button1.ogg', 20, TRUE)
 
-
-
+/obj/item/commandprojector/proc/ReduceCommandAmount()
+	SIGNAL_HANDLER
+	current_commands--
 
 //Deepscanner
 /obj/item/deepscanner //intended for ordeals

--- a/code/game/objects/effects/temporary_visuals/miscellaneous.dm
+++ b/code/game/objects/effects/temporary_visuals/miscellaneous.dm
@@ -1038,3 +1038,36 @@
 	name = "goodbye"
 	icon_state = "nobody_slash"
 	duration = 5
+
+/obj/effect/temp_visual/HoloCommand
+	icon = 'ModularTegustation/Teguicons/lc13icons.dmi'
+	light_range = 1.5
+	light_power = 0.2
+	light_system = MOVABLE_LIGHT
+	duration = 150 		//15 Seconds
+
+/obj/effect/temp_visual/HoloCommand/commandMove
+	icon_state = "Move_here_wagie"
+	light_range = 1
+	light_power = 1
+	light_color = COLOR_VERY_LIGHT_GRAY
+
+/obj/effect/temp_visual/HoloCommand/commandWarn
+	icon_state = "Watch_out_wagie"
+	light_color = COLOR_PALE_RED_GRAY
+
+/obj/effect/temp_visual/HoloCommand/commandGaurd
+	icon_state = "Guard_this_wagie"
+	light_color = COLOR_VERY_SOFT_YELLOW
+
+/obj/effect/temp_visual/HoloCommand/commandHeal
+	icon_state = "Heal_this_wagie"
+	light_color = COLOR_VERY_PALE_LIME_GREEN
+
+/obj/effect/temp_visual/HoloCommand/commandFightA
+	icon_state = "Fight_this_wagie1"
+	light_color = COLOR_PALE_BLUE_GRAY
+
+/obj/effect/temp_visual/HoloCommand/commandFightB
+	icon_state = "Fight_this_wagie2"
+	light_color = COLOR_PALE_BLUE_GRAY


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Requested by kirie to combat darkness.
Added a limit to the amount of commands you can have at once.
Made a check for holo commands to look for a root instead of a typecache.
Made manager holocommands a root of temp_effect/HoloCommand
Moved all manager temp effects to temporary_visuals/miscallanious.dm

My main concern about making the manager commands glow is that if we ever make a abnormality that lives in darkness the effects can be actually effective in suppressing it. Which i guess isnt a bad thing.
![Screenshot 2023-10-21 232911](https://github.com/vlggms/lobotomy-corp13/assets/109536843/49ef0d69-5471-4e13-9ba0-da83c9793bfd)
![Screenshot 2023-10-21 233059](https://github.com/vlggms/lobotomy-corp13/assets/109536843/a64f9fb1-9287-4d00-ba84-eb068f0cec89)

## Why It's Good For The Game
Combats darkness, allows manager to assist players in fighting watchman.

## Changelog
:cl:
tweak: edits holocommands and manager consoles handling of commands.
code: some edits to how commands are placed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
