### PR TITLE
Removes Toggle from Blind Rage AOE

### DIFF
--- a/code/game/objects/items/ego_weapons/waw.dm
+++ b/code/game/objects/items/ego_weapons/waw.dm
@@ -1031,7 +1031,7 @@
 	icon_state = "blind_rage"
 	force = 40
 	attack_speed = 1.2
-	special = "This weapon possesses a devastating Red AND Black damage AoE. Be careful! \nUse in hand to hold back the AoE!"
+	special = "This weapon possesses a devastating Red AND Black damage AoE. Be careful!"
 	damtype = RED_DAMAGE
 	armortype = RED_DAMAGE
 	attack_verb_continuous = list("smashes", "crushes", "flattens")
@@ -1046,17 +1046,9 @@
 	var/aoe_damage_type = BLACK_DAMAGE
 	var/aoe_range = 2
 	var/attacks = 0
-	var/toggled = FALSE
 
 /obj/item/ego_weapon/blind_rage/get_clamped_volume()
 	return 30
-
-/obj/item/ego_weapon/blind_rage/attack_self(mob/user)
-	toggled = !toggled
-	if(toggled)
-		to_chat(user, "<span class='warning'>You release the full power of [src].</span>")
-	else
-		to_chat(user, "<span class='notice'>You begin to hold back [src].</span>")
 
 /obj/item/ego_weapon/blind_rage/attack(mob/living/M, mob/living/user)
 	. = ..()
@@ -1072,10 +1064,6 @@
 			hitsound = 'sound/abnormalities/wrath_servant/big_smash2.ogg'
 		if(2)
 			hitsound = 'sound/abnormalities/wrath_servant/big_smash3.ogg'
-	if(!toggled)
-		if(prob(10))
-			new /obj/effect/gibspawner/generic/silent/wrath_acid(get_turf(M))
-		return
 	var/damage = aoe_damage * (1 + (get_modified_attribute_level(user, JUSTICE_ATTRIBUTE))/100)
 	if(attacks == 0)
 		damage *= 3

--- a/code/game/objects/items/ego_weapons/waw.dm
+++ b/code/game/objects/items/ego_weapons/waw.dm
@@ -1050,7 +1050,7 @@
 /obj/item/ego_weapon/blind_rage/get_clamped_volume()
 	return 30
 
-/obj/item/ego_weapon/blind_rage/attack(mob/living/M, mob/living/user)
+/obj/item/ego_weapon/blind_rage/attack(mob/living/M, mob/living/carbon/human/user)
 	. = ..()
 	if(!.)
 		return FALSE
@@ -1067,10 +1067,12 @@
 	var/damage = aoe_damage * (1 + (get_modified_attribute_level(user, JUSTICE_ATTRIBUTE))/100)
 	if(attacks == 0)
 		damage *= 3
+	if(user.sanity_lost)
+		damage *= 1.2
 	for(var/turf/open/T in range(aoe_range, M))
 		var/obj/effect/temp_visual/small_smoke/halfsecond/smonk = new(T)
 		smonk.color = COLOR_GREEN
-		user.HurtInTurf(T, list(), damage, damtype, hurt_mechs = TRUE, hurt_structure = TRUE, break_not_destroy = TRUE)
+		user.HurtInTurf(T, list(M), damage, damtype, hurt_mechs = TRUE, hurt_structure = TRUE, break_not_destroy = TRUE)
 		user.HurtInTurf(T, list(), damage, aoe_damage_type, hurt_mechs = TRUE, hurt_structure = TRUE, break_not_destroy = TRUE)
 		if(prob(5))
 			new /obj/effect/gibspawner/generic/silent/wrath_acid(T) // The non-damaging one


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
1. Removes the toggle effect from Blind Rage
2. Insane users deal 20% more damage with it.
3. Prevents the AoE from hitting the main target with the Red Damage twice (wasn't intended), they're still hit by the additional Black Damage.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Blind Rage has been consistently over performing, even if it's toggle damage IS lower than the standard for WAW weapons. With this it regains it's intended purpose as the Magic Bullet of Melee EGO.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: removed the non-AoE mode from Blind Rage
fix: prevents the AoE from hitting the main target twice
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
