### PR TITLE
Damage Coeff Instancing

### DIFF
--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -207,6 +207,8 @@
 	if(!unsuitable_heat_damage)
 		unsuitable_heat_damage = unsuitable_atmos_damage
 
+	damage_coeff = damage_coeff.Copy()
+
 /mob/living/simple_animal/Life()
 	. = ..()
 	if(staminaloss > 0)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Lists defined in a type's definition, see:
```cjs
/mob/living/simple_animal/hostile/abnormality
	...
	var/list/work_chances = list(
		ABNORMALITY_WORK_INSTINCT = list(50, 55, 60, 65, 70),
		ABNORMALITY_WORK_INSIGHT = list(50, 55, 60, 65, 70),
		ABNORMALITY_WORK_ATTACHMENT = list(50, 55, 60, 65, 70),
		ABNORMALITY_WORK_REPRESSION = list(50, 55, 60, 65, 70)
		)
	...
```
Are kept and shared between all instances of the type, including ones actually created into the world and ones yet to be made. This means if you, for example, change a Sweeper's damage resistance to White Damage, it would change ALL Sweeper's White Resist. Simultaneously. The way to prevent this is to simply "make a new list" by setting all lists that are created to a `Copy()` of what they start as in `Initialize()`. 

This PR does SPECIFICALLY THAT for damage_coeff on all `simple_animal`s 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Prevents the Overmind.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: simple_animal mobs sharing resistances
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
