### PR TITLE
Fix Aquarium Sprites

### DIFF
--- a/ModularTegustation/fishing/code/fish/freshwater_fish.dm
+++ b/ModularTegustation/fishing/code/fish/freshwater_fish.dm
@@ -45,8 +45,6 @@
 	name = "cory catfish"
 	desc = "A catfish has about 100,000 taste buds, and their bodies are covered with them to help detect chemicals present in the water and also to respond to touch."
 	icon_state = "catfish"
-	dedicated_in_aquarium_icon_state = "fish_greyscale"
-	aquarium_vc_color = "#907420"
 	average_size = 100
 	average_weight = 2000
 

--- a/ModularTegustation/fishing/code/fish/saltwater_fish.dm
+++ b/ModularTegustation/fishing/code/fish/saltwater_fish.dm
@@ -32,7 +32,6 @@
 	name = "cardinalfish"
 	desc = "Cardinalfish are often found near sea urchins, where the fish hide when threatened."
 	icon_state = "cardinalfish"
-	dedicated_in_aquarium_icon_state = "fish_greyscale"
 	average_size = 30
 	average_weight = 500
 	stable_population = 4
@@ -41,8 +40,6 @@
 	name = "green chromis"
 	desc = "The Chromis can vary in color from blue to green depending on the lighting and distance from the lights."
 	icon_state = "greenchromis"
-	dedicated_in_aquarium_icon_state = "fish_greyscale"
-	aquarium_vc_color = "#00ff00"
 	average_size = 30
 	average_weight = 500
 	stable_population = 5

--- a/code/datums/components/aquarium.dm
+++ b/code/datums/components/aquarium.dm
@@ -95,6 +95,7 @@
 	aquarium_vc_color = fish.aquarium_vc_color
 
 	if(fish.dedicated_in_aquarium_icon_state)
+		icon = 'icons/obj/aquarium.dmi'
 		icon_state = fish.dedicated_in_aquarium_icon_state
 		base_transform = matrix()
 	else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fix Aquarium Sprites by removing dedicated aquarium sprites from some fish and adding a icon override for aquarium component.

The issue came from someone adding dedicated fish icon sprites to fish that have a automated downsizing icon. They added 
dedicated_in_aquarium_icon_state = "fish_greyscale"
 to green chromis.

## Changelog
:cl:
Fix: fish sprites
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
