### PR TITLE
Buffs the shit out of lantern

### DIFF
--- a/code/game/objects/items/ego_weapons/teth.dm
+++ b/code/game/objects/items/ego_weapons/teth.dm
@@ -272,98 +272,30 @@
 	icon_state = "smash1"
 	duration = 3
 
-#define LANTERN_MODE_REMOTE 1
-#define LANTERN_MODE_AUTO 2
-
 /obj/item/ego_weapon/lantern //meat lantern
 	name = "lantern"
 	desc = "Teeth sticking out of some spots of the equipment is a rather frightening sight."
-	special = "Attack nearby turfs to create traps. Remote mode can trigger traps from a distance. \
-	Automatic mode places traps that trigger when enemies walk over them. Use in hand to switch between modes."
+	special = "This weapon attacks all non-humans in an AOE. \
+		This weapon deals double damage on direct attack."
 	icon_state = "lantern"
-	force = 8 //less than the baton, don't hit things with it
+	force = 14
+	attack_speed = 1.6
 	damtype = BLACK_DAMAGE
 	hitsound = 'sound/weapons/fixer/generic/gen1.ogg'
-	var/mode = LANTERN_MODE_REMOTE
-	var/traplimit = 6
-	var/list/traps = list()
 
-/obj/item/ego_weapon/lantern/attack_self(mob/user)
-	if(mode == LANTERN_MODE_REMOTE)
-		to_chat(user, "<span class='info'>You adjust any newly-placed traps to be set off by motion.</span>")
-		mode = LANTERN_MODE_AUTO
-	else
-		to_chat(user, "<span class='info'>You can now remotely trigger any placed traps.</span>")
-		mode = LANTERN_MODE_REMOTE
-
-/obj/item/ego_weapon/lantern/proc/CreateTrap(target, mob/user, proximity_flag)
-	var/turf/T = get_turf(target)
-	if((get_dist(user, T) > 20))
-		return
-	var/obj/effect/temp_visual/lanterntrap/R = locate(/obj/effect/temp_visual/lanterntrap) in T
-	if(R)
-		if(!proximity_flag && mode != LANTERN_MODE_REMOTE)
-			return
-		R.burst()
-		return
-	if(proximity_flag && (LAZYLEN(traps) < traplimit))
-		new /obj/effect/temp_visual/lanterntrap(T, user, src, mode)
-		user.changeNext_move(CLICK_CD_MELEE)
-
-/obj/item/ego_weapon/lantern/afterattack(atom/target, mob/living/user, proximity_flag, params)
-	if(check_allowed_items(target, 1))
-		CreateTrap(target, user, proximity_flag)
+/obj/item/ego_weapon/lantern/attack(mob/living/M, mob/living/user)
 	. = ..()
-
-/obj/effect/temp_visual/lanterntrap
-	name = "lantern trap"
-	icon_state = "shield1" //temp visual
-	layer = ABOVE_ALL_MOB_LAYER
-	duration = 30 SECONDS
-	var/resonance_damage = 35
-	var/damage_multiplier = 1
-	var/mob/creator
-	var/obj/item/ego_weapon/lantern/res
-	var/rupturing = FALSE //So it won't recurse
-
-/obj/effect/temp_visual/lanterntrap/Initialize(mapload, set_creator, set_resonator, mode)
-	if(mode == LANTERN_MODE_AUTO)
-		icon_state = "shield2" //temp visual
-		resonance_damage = 25
-		RegisterSignal(src, list(COMSIG_MOVABLE_CROSSED, COMSIG_ATOM_ENTERED), .proc/burst)
-	. = ..()
-	creator = set_creator
-	res = set_resonator
-	if(res)
-		res.traps += src
-	playsound(src,'sound/weapons/resonator_fire.ogg',50,TRUE)
-	deltimer(timerid)
-	timerid = addtimer(CALLBACK(src, .proc/burst), duration, TIMER_STOPPABLE)
-
-/obj/effect/temp_visual/lanterntrap/Destroy()
-	if(res)
-		res.traps -= src
-		res = null
-	creator = null
-	. = ..()
-
-/obj/effect/temp_visual/lanterntrap/proc/burst()
-	rupturing = TRUE
-	var/turf/T = get_turf(src)
-	new /obj/effect/temp_visual/resonance_crush(T) //temp visual
-	playsound(T,'sound/weapons/resonator_blast.ogg',50,TRUE)
-
-	for(var/mob/living/L in creator.HurtInTurf(T, list(), resonance_damage, BLACK_DAMAGE, check_faction = TRUE, hurt_mechs = TRUE))
-		to_chat(L, "<span class='userdanger'>[src] bites you!</span>")
-		if(creator)
-			creator.visible_message("<span class='danger'>[creator] activates [src] on [L]!</span>","<span class='danger'>You activate [src] on [L]!</span>", null, COMBAT_MESSAGE_RANGE, L)
-	for(var/obj/effect/temp_visual/lanterntrap/field in range(1, src))
-		if(field != src && !field.rupturing)
-			field.burst()
-	qdel(src)
-
-#undef LANTERN_MODE_REMOTE
-#undef LANTERN_MODE_AUTO
+	if(!.)
+		return FALSE
+	for(var/mob/living/L in view(1, M))
+		var/aoe = 14
+		var/userjust = (get_modified_attribute_level(user, JUSTICE_ATTRIBUTE))
+		var/justicemod = 1 + userjust/100
+		aoe*=justicemod
+		if(L == user || ishuman(L))
+			continue
+		L.apply_damage(aoe, BLACK_DAMAGE, null, L.run_armor_check(null, BLACK_DAMAGE), spread_damage = TRUE)
+		new /obj/effect/temp_visual/small_smoke/halfsecond(get_turf(L))
 
 /obj/item/ego_weapon/sloshing
 	name = "sloshing"

--- a/code/game/objects/items/ego_weapons/teth.dm
+++ b/code/game/objects/items/ego_weapons/teth.dm
@@ -272,30 +272,102 @@
 	icon_state = "smash1"
 	duration = 3
 
+#define LANTERN_MODE_REMOTE 1
+#define LANTERN_MODE_AUTO 2
+
 /obj/item/ego_weapon/lantern //meat lantern
 	name = "lantern"
 	desc = "Teeth sticking out of some spots of the equipment is a rather frightening sight."
-	special = "This weapon attacks all non-humans in an AOE. \
-		This weapon deals double damage on direct attack."
+	special = "Attack nearby turfs to create traps. Remote mode can trigger traps from a distance. \
+	Automatic mode places traps that trigger when enemies walk over them. Use in hand to switch between modes."
 	icon_state = "lantern"
-	force = 12
-	attack_speed = 1.3
+	force = 28
+	attack_speed = 2
 	damtype = BLACK_DAMAGE
 	hitsound = 'sound/weapons/fixer/generic/gen1.ogg'
+	var/mode = LANTERN_MODE_REMOTE
+	var/traplimit = 6
+	var/list/traps = list()
 
-/obj/item/ego_weapon/lantern/attack(mob/living/M, mob/living/user)
-	. = ..()
-	if(!.)
-		return FALSE
-	for(var/mob/living/L in view(1, M))
-		var/aoe = 12
+/obj/item/ego_weapon/lantern/attack_self(mob/user)
+	if(mode == LANTERN_MODE_REMOTE)
+		to_chat(user, "<span class='info'>You adjust any newly-placed traps to be set off by motion.</span>")
+		mode = LANTERN_MODE_AUTO
+	else
+		to_chat(user, "<span class='info'>You can now remotely trigger any placed traps.</span>")
+		mode = LANTERN_MODE_REMOTE
+
+/obj/item/ego_weapon/lantern/proc/CreateTrap(target, mob/user, proximity_flag)
+	var/turf/T = get_turf(target)
+	if((get_dist(user, T) > 20))
+		return
+	var/obj/effect/temp_visual/lanterntrap/R = locate(/obj/effect/temp_visual/lanterntrap) in T
+	if(R)
+		if(!proximity_flag && mode != LANTERN_MODE_REMOTE)
+			return
+		R.burst()
+		return
+	if(proximity_flag && (LAZYLEN(traps) < traplimit))
+		var /obj/effect/temp_visual/lanterntrap/trap = new(T, user, src, mode)
 		var/userjust = (get_modified_attribute_level(user, JUSTICE_ATTRIBUTE))
 		var/justicemod = 1 + userjust/100
-		aoe*=justicemod
-		if(L == user || ishuman(L))
-			continue
-		L.apply_damage(aoe, BLACK_DAMAGE, null, L.run_armor_check(null, BLACK_DAMAGE), spread_damage = TRUE)
-		new /obj/effect/temp_visual/small_smoke/halfsecond(get_turf(L))
+		trap.damage_multiplier = 1 * justicemod
+		user.changeNext_move(CLICK_CD_MELEE)
+
+/obj/item/ego_weapon/lantern/afterattack(atom/target, mob/living/user, proximity_flag, params)
+	if(check_allowed_items(target, 1))
+		CreateTrap(target, user, proximity_flag)
+	. = ..()
+
+/obj/effect/temp_visual/lanterntrap
+	name = "lantern trap"
+	icon_state = "shield1" //temp visual
+	layer = ABOVE_ALL_MOB_LAYER
+	duration = 30 SECONDS
+	var/resonance_damage = 35
+	var/damage_multiplier = 1
+	var/mob/creator
+	var/obj/item/ego_weapon/lantern/res
+	var/rupturing = FALSE //So it won't recurse
+
+/obj/effect/temp_visual/lanterntrap/Initialize(mapload, set_creator, set_resonator, mode)
+	if(mode == LANTERN_MODE_AUTO)
+		icon_state = "shield2" //temp visual
+		resonance_damage = 25
+		RegisterSignal(src, list(COMSIG_MOVABLE_CROSSED, COMSIG_ATOM_ENTERED), .proc/burst)
+	. = ..()
+	creator = set_creator
+	res = set_resonator
+	if(res)
+		res.traps += src
+	playsound(src,'sound/weapons/resonator_fire.ogg',50,TRUE)
+	deltimer(timerid)
+	timerid = addtimer(CALLBACK(src, .proc/burst), duration, TIMER_STOPPABLE)
+
+/obj/effect/temp_visual/lanterntrap/Destroy()
+	if(res)
+		res.traps -= src
+		res = null
+	creator = null
+	. = ..()
+
+/obj/effect/temp_visual/lanterntrap/proc/burst()
+	rupturing = TRUE
+	var/turf/T = get_turf(src)
+	new /obj/effect/temp_visual/resonance_crush(T) //temp visual
+	playsound(T,'sound/weapons/resonator_blast.ogg',50,TRUE)
+	for(var/turf/open/T2 in range(1, src))
+		for(var/mob/living/L in creator.HurtInTurf(T2, list(), resonance_damage * damage_multiplier, BLACK_DAMAGE, check_faction = TRUE, hurt_mechs = TRUE))
+			to_chat(L, "<span class='userdanger'>[src] bites you!</span>")
+			if(creator)
+				creator.visible_message("<span class='danger'>[creator] activates [src] on [L]!</span>","<span class='danger'>You activate [src] on [L]!</span>", null, COMBAT_MESSAGE_RANGE, L)
+	for(var/obj/effect/temp_visual/lanterntrap/field in range(1, src))
+		if(field != src && !field.rupturing)
+			field.burst()
+	qdel(src)
+
+#undef LANTERN_MODE_REMOTE
+#undef LANTERN_MODE_AUTO
 
 /obj/item/ego_weapon/sloshing
 	name = "sloshing"

--- a/code/game/objects/items/ego_weapons/teth.dm
+++ b/code/game/objects/items/ego_weapons/teth.dm
@@ -278,8 +278,8 @@
 	special = "This weapon attacks all non-humans in an AOE. \
 		This weapon deals double damage on direct attack."
 	icon_state = "lantern"
-	force = 14
-	attack_speed = 1.6
+	force = 12
+	attack_speed = 1.3
 	damtype = BLACK_DAMAGE
 	hitsound = 'sound/weapons/fixer/generic/gen1.ogg'
 
@@ -288,7 +288,7 @@
 	if(!.)
 		return FALSE
 	for(var/mob/living/L in view(1, M))
-		var/aoe = 14
+		var/aoe = 12
 		var/userjust = (get_modified_attribute_level(user, JUSTICE_ATTRIBUTE))
 		var/justicemod = 1 + userjust/100
 		aoe*=justicemod

--- a/code/game/objects/items/ego_weapons/teth.dm
+++ b/code/game/objects/items/ego_weapons/teth.dm
@@ -281,8 +281,8 @@
 	special = "Attack nearby turfs to create traps. Remote mode can trigger traps from a distance. \
 	Automatic mode places traps that trigger when enemies walk over them. Use in hand to switch between modes."
 	icon_state = "lantern"
-	force = 28
-	attack_speed = 2
+	force = 33
+	attack_speed = 1.5
 	damtype = BLACK_DAMAGE
 	hitsound = 'sound/weapons/fixer/generic/gen1.ogg'
 	var/mode = LANTERN_MODE_REMOTE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes lantern into a 35 black damage with 1.5 attack speed. mines scale with justice and damages in a 3x3 area.

## Why It's Good For The Game

It was a really bad weapon for a teth like meat lantern so making it not overly weak(8 black) in one on one combat while making the mines strong should help it be more on par with other teth weapons

## Changelog
:cl:
balance: rebalanced lantern to not be a shit post
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
