### PR TITLE
Vitals Projector and Enkephalin Injector Buff

### DIFF
--- a/ModularTegustation/tegu_items/gadgets/powered.dm
+++ b/ModularTegustation/tegu_items/gadgets/powered.dm
@@ -330,7 +330,7 @@
 
 /obj/item/powered_gadget/vitals_projector/attack_self(mob/user)
 	var/mod1_ask = alert("modify tool?", "Choose a target type.", "Human", "Ordeal", "Abnormality", "cancel")
-	if(do_after(user, 3 SECONDS, target = user, IGNORE_USER_LOC_CHANGE | IGNORE_TARGET_LOC_CHANGE))
+	if(do_after(user, 3 SECONDS, user, IGNORE_USER_LOC_CHANGE | IGNORE_TARGET_LOC_CHANGE))
 		switch(mod1_ask)
 			if("cancel")
 				return

--- a/ModularTegustation/tegu_items/gadgets/powered.dm
+++ b/ModularTegustation/tegu_items/gadgets/powered.dm
@@ -324,25 +324,27 @@
 	 //roundabout way of making update item easily changed. Used in updateicon proc.
 	default_icon = "gadgetmod"
 
-/obj/item/powered_gadget/vitals_projector/attackby(obj/item/W, mob/user)
-	if(W.tool_behaviour == TOOL_WRENCH)
-		var/mod1_ask = alert("modify tool?", "Choose a target type.", "Human", "Ordeal", "Abnormality", "cancel")
-		batterycost = initial(batterycost)
-		if(do_after(user, 5 SECONDS, target = user))
-			switch(mod1_ask)
-				if("cancel")
-					return
-				if("Human")
-					chosen_target_type = 1
-				if("Ordeal")
-					chosen_target_type = 2
-					batterycost += round(cell.maxcharge * 0.15)
-				if("Abnormality")
-					chosen_target_type = 3
-					batterycost += round(cell.maxcharge * 0.25)
-			update_icon()
-			return
-	return ..()
+/obj/item/powered_gadget/vitals_projector/Initialize()
+	. = ..()
+	batterycost = round(cell.maxcharge * 0.10)
+
+/obj/item/powered_gadget/vitals_projector/attack_self(mob/user)
+	var/mod1_ask = alert("modify tool?", "Choose a target type.", "Human", "Ordeal", "Abnormality", "cancel")
+	if(do_after(user, 3 SECONDS, target = user, IGNORE_USER_LOC_CHANGE | IGNORE_TARGET_LOC_CHANGE))
+		switch(mod1_ask)
+			if("cancel")
+				return
+			if("Human")
+				chosen_target_type = 1
+				batterycost = round(cell.maxcharge * 0.10)
+			if("Ordeal")
+				chosen_target_type = 2
+				batterycost = round(cell.maxcharge * 0.15)
+			if("Abnormality")
+				chosen_target_type = 3
+				batterycost = round(cell.maxcharge * 0.20)
+		update_icon()
+	return
 
 /obj/item/powered_gadget/vitals_projector/update_overlays()
 	. = ..()
@@ -357,7 +359,7 @@
 /obj/item/powered_gadget/vitals_projector/afterattack(atom/target, mob/user, proximity_flag)
 	. = ..()
 	if(!chosen_target_type)
-		to_chat(user, "<span class='warning'>A wrench is needed to set the target type!</span>")
+		to_chat(user, "<span class='warning'>Use in-hand to set the target type!</span>")
 	if(cell && cell.charge >= batterycost && target_check(target))
 		cell.charge -= batterycost
 		var/mob/living/L = target
@@ -431,7 +433,9 @@
 //Injector
 /obj/item/powered_gadget/enkephalin_injector
 	name = "Prototype Enkephalin Injector"
-	desc = "A tool designed to inject raw enkephalin from our batteries to pacify hostile lifeforms. However, the development was discontinued after the safety department abused it for... other purposes. This version only makes the entities even more hostile towards you. Only for clerks"
+	desc = "A tool designed to inject raw enkephalin from our batteries to pacify hostile lifeforms. \
+			However, the development was discontinued after the safety department abused it for... other purposes. \
+			This version only makes the entities even more hostile towards you. Only for clerks"
 	icon_state = "e_injector"
 	default_icon = "e_injector"
 	batterycost = 5000
@@ -445,7 +449,7 @@
 		var/mob/living/simple_animal/hostile/H = T
 		if(H.target != user)
 			hit_message = "<span class='warning'>[user] injected some enkephalin into [T].</span>"
-			H.target = user
+			H.GiveTarget(user)
 			user.visible_message(hit_message)
 			cell.charge -= batterycost
 			update_icon()

--- a/ModularTegustation/tegu_items/gadgets/powered.dm
+++ b/ModularTegustation/tegu_items/gadgets/powered.dm
@@ -445,11 +445,17 @@
 	if(!istype(user) || !(user?.mind?.assigned_role in GLOB.service_positions))
 		to_chat(user, "<span class='notice'>The Gadget's light flashes red. You aren't a clerk. Check the label before use.</span>")
 		return
+	if(T.status_flags & GODMODE)
+		to_chat(user, "<span class='notice'>[T] simply ignores you.</span>")
+		return
 	if(cell.charge >= batterycost && ishostile(T) && T.stat != DEAD && !(T.status_flags & GODMODE) && !T.client)
 		var/mob/living/simple_animal/hostile/H = T
 		if(H.target != user)
 			hit_message = "<span class='warning'>[user] injected some enkephalin into [T].</span>"
 			H.GiveTarget(user)
+			if(isabnormalitymob(H)) // RISK. REWARD.
+				var/mob/living/simple_animal/hostile/abnormality/abno = H
+				abno.GiftUser(user, 1, 100)
 			user.visible_message(hit_message)
 			cell.charge -= batterycost
 			update_icon()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Vital Projects no longer needs a WRENCH to change it's mode (??????????) Vital Projector no longer sucks most of the battery out every use (why was it more or less 20% + 15% to 25% of the battery????) It can also be changed while moving.

Enkephalin Injector now uses GiveTarget instead of just... changing the target. This is the proper way to do this.
Enkephalin Injector now gives you the gift of the abnormality you use it on. Yes, it's still locked to Clerks.
Enkephalin Injector no longer works on mobs in Godmode.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes these gadgets more useful.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Removed Wrench requirement for Vital Projector
balance: reduced battery usage of Vital Projector
balance: Enkephalin Injector now gives the user the Abno's gift.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
