### PR TITLE
Fix Out of Stock wording on vendors

### DIFF
--- a/tgui/packages/tgui/interfaces/Vending.js
+++ b/tgui/packages/tgui/interfaces/Vending.js
@@ -60,7 +60,8 @@ const VendingRow = (props, context) => {
             || productStock <= (product.max_amount / 2) && 'average'
             || 'good'
           )}>
-          {custom ? product.amount : productStock.amount} in stock
+          {custom ? product.amount : productStock.amount}
+          {productStock <= 0 ? 'sold out' : 'in stock'}
         </Box>
       </Table.Cell>
       <Table.Cell collapsing textAlign="center">


### PR DESCRIPTION
## About The Pull Request
Before the color of the letters "in stock" would indicate if it was in stock or not. Now there is words. If the first vendor creator had a reason for this choice i will reap the unforseen consequences. The color is still there but now it will say "sold out" or "in stock".

## Changelog
:cl:
tweak: vendor tgui
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
