### PR TITLE
RBA buffs

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/teth/redblooded.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/redblooded.dm
@@ -1,13 +1,13 @@
 /mob/living/simple_animal/hostile/abnormality/redblooded
 	name = "Red Blooded American"
-	desc = "A bright red demon with oversized arms and long, sharp tusks. It is keeping its eyes focused on you."
+	desc = "A bright red demon with oversized arms and greasy black hair. It is keeping its eyes focused on you."
 	icon = 'ModularTegustation/Teguicons/32x48.dmi'
 	icon_state = "american_idle"
 	icon_living = "american_idle"
 	var/icon_furious = "american_idle_injured"
 	del_on_death = TRUE
-	maxHealth = 775
-	health = 775
+	maxHealth = 825
+	health = 825
 	rapid_melee = 1
 	melee_queue_distance = 2
 	move_to_delay = 4
@@ -20,14 +20,14 @@
 	ranged_cooldown_time = 4 SECONDS
 	casingtype = /obj/item/ammo_casing/caseless/true_patriot
 	projectilesound = 'sound/weapons/gun/shotgun/shot.ogg'
-	damage_coeff = list(BRUTE = 1, RED_DAMAGE = 0.8, WHITE_DAMAGE = 1.5, BLACK_DAMAGE = 1, PALE_DAMAGE = 2)
+	damage_coeff = list(BRUTE = 1, RED_DAMAGE = 0.7, WHITE_DAMAGE = 1.5, BLACK_DAMAGE = 1, PALE_DAMAGE = 2)
 	melee_damage_lower = 10
 	melee_damage_upper = 15
 	faction = list("hostile")
 	speak_emote = list("snarls")
 	can_breach = TRUE
 	threat_level = TETH_LEVEL
-	start_qliphoth = 3
+	start_qliphoth = 2
 	work_chances = list(
 						ABNORMALITY_WORK_INSTINCT = 45,
 						ABNORMALITY_WORK_INSIGHT = 30,
@@ -131,4 +131,4 @@
 	desc = "100% real, surplus military ammo."
 	damage_type = RED_DAMAGE
 
-	damage = 5
+	damage = 8


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The current version of RBA is way too easy to keep contained and even if it does breach, it's a bit of a non-issue. I'm staying a bit on the safer side since it is still a TETH but ideally, this makes it a bit more of a threat
-Bumped up its HP and its red resistance a tiny bit. It's meant to be more fragile than other abnos due to having a ranged attack but it feels too squishy right now.
-Lowered the Counter from 3 to 2. 3 is way too generous for an abno whos counter can be raised easily.
-Bumped its ranged damage. It's a slow abno with a ranged attack that has a lot of spread. It should hurt if you just take the full brunt of it.
-Edited the description. Just to fit better with the sprite.

## Why It's Good For The Game

In its current state, RBA feels like a pushover both when it comes to keeping it contained and while in a breach. This is to make it slightly more threatening. 

## Changelog
:cl:
balance: rebalances RBA.
/:cl:
