### PR TITLE
Red shoes no longer raises your prudence permanently

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/he/red_shoes.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/red_shoes.dm
@@ -254,7 +254,7 @@
 	if(!ishuman(owner))
 		return
 	var/mob/living/carbon/human/H = owner
-	H.adjust_attribute_buff(PRUDENCE_ATTRIBUTE, 50)
+	H.adjust_attribute_bonus(PRUDENCE_ATTRIBUTE, 50)//Return prudence back to normal
 	if(H.sanity_lost)
 		QDEL_NULL(owner.ai_controller)
 		H.ai_controller = /datum/ai_controller/insane/red_possess


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

What it says on the tin

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Bugs are generally not good for the game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: red shoes' possession no longer raises prudence when removed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
