### PR TITLE
Adding Type C weapons as well as fixing Quantum pad and L2 Research.

### DIFF
--- a/ModularTegustation/tegu_items/representative/research/wcorp.dm
+++ b/ModularTegustation/tegu_items/representative/research/wcorp.dm
@@ -17,6 +17,19 @@
 	ItemUnlock(caller.order_list, "W Corp Type A Hatchet ",	/obj/item/ego_weapon/city/charge/wcorp/hatchet, 1000)
 	..()
 
+/datum/data/lc13research/w_corp_typec
+	research_name = "W Corp Type C Weapons"
+	research_desc = "W Corp will let you purchase their Type-C Support weapons, for a price."
+	cost = AVERAGE_RESEARCH_PRICE
+	corp = W_CORP_REP
+
+/datum/data/lc13research/w_corp_typec/ResearchEffect(obj/structure/representative_console/caller)
+	ItemUnlock(caller.order_list, "W Corp Type C ShieldBlade ",	/obj/item/ego_weapon/city/charge/wcorp/shield, 850)
+	ItemUnlock(caller.order_list, "W Corp Type C ShieldGlaive ",		/obj/item/ego_weapon/city/charge/wcorp/shield/spear, 1000)
+	ItemUnlock(caller.order_list, "W Corp Type C ShieldClub ",	/obj/item/ego_weapon/city/charge/wcorp/shield/club, 850)
+	ItemUnlock(caller.order_list, "W Corp Type C ShieldAxe ",	/obj/item/ego_weapon/city/charge/wcorp/shield/axe, 850)
+	..()
+
 /datum/data/lc13research/mobspawner/wcorp
 	research_name = "W-Corp L1 Cleanup Team"
 	research_desc = "The nearby intern staff are looking for easy training. <br>We can ship them to you but they won't be that effective."
@@ -29,8 +42,8 @@
 	research_desc = "The nearby L2 staff are looking for their monthly bonus. <br>They're at the ready should you need them."
 	cost = AVERAGE_RESEARCH_PRICE
 	corp = W_CORP_REP
-	mobspawner_type = /obj/effect/mob_spawn/human/supplypod/r_corp/wcorp_call
-	required_research = /obj/effect/mob_spawn/human/supplypod/r_corp/wcorp_call/level2
+	mobspawner_type = /obj/effect/mob_spawn/human/supplypod/r_corp/wcorp_call/level2
+	required_research = /datum/data/lc13research/mobspawner/wcorp
 
 //Teleporters
 /datum/data/lc13research/teleporter
@@ -40,7 +53,7 @@
 	corp = W_CORP_REP
 
 /datum/data/lc13research/teleporter/ResearchEffect(obj/structure/representative_console/caller)
-	var/place_to_place = get_turf(src)
+	var/place_to_place = get_turf(caller)
 	//two keycards for both quantum pads.
 	new /obj/item/quantum_keycard(place_to_place)
 	new /obj/item/quantum_keycard(place_to_place)


### PR DESCRIPTION


## About The Pull Request

Added Type C shield weapons that were added in W-corp Cleanup to the Reps arsenal, Also fixed the broken L2 call in and Quantum pad research.

This is my first PR so if I did something wrong please do let me know.

## Why It's Good For The Game

Broken researches don't feel great, and with the lack of offerings compared to other reps W-corp rep has always felt a bit.. meh? to actually play.

## Changelog
:cl:
add: W-corp Cleanup Type C support weapons unlock research added to W-reps arsenal.
fix: L2 research now calls L2 spawner instead of another L1 Spawner.
fix: Quantum pad researches now know where to actually place items purchased.
/:cl:
