### PR TITLE
Reworks manager shields, fixes welf reward & changes how info core works

### DIFF
--- a/ModularTegustation/tegu_items/gadgets/manager_bullets.dm
+++ b/ModularTegustation/tegu_items/gadgets/manager_bullets.dm
@@ -46,20 +46,6 @@
 /datum/status_effect/interventionshield/on_apply()
 	. = ..()
 	owner.add_overlay(statuseffectvisual)
-	var/mob/living/carbon/human/L = owner
-	switch(respectivedamage)
-		if(RED_DAMAGE)
-			inherentarmorcheck = L.physiology.red_mod
-			L.physiology.red_mod *= 0.0001
-		if(WHITE_DAMAGE)
-			inherentarmorcheck = L.physiology.white_mod
-			L.physiology.white_mod *= 0.0001
-		if(BLACK_DAMAGE)
-			inherentarmorcheck = L.physiology.black_mod
-			L.physiology.black_mod *= 0.0001
-		if(PALE_DAMAGE)
-			inherentarmorcheck = L.physiology.pale_mod
-			L.physiology.pale_mod *= 0.0001
 	owner.visible_message("<span class='notice'>[owner]s shield activates!</span>")
 	RegisterSignal(owner, COMSIG_MOB_APPLY_DAMGE, .proc/OnApplyDamage) //stolen from caluan
 	RegisterSignal(owner, COMSIG_WORK_STARTED, .proc/Destroy)
@@ -68,60 +54,38 @@
 	SIGNAL_HANDLER
 	if(damagetype != respectivedamage)
 		return
+
 	var/mob/living/carbon/human/H = owner
 	var/suitarmor = H.getarmor(null, respectivedamage) / 100
-	var/suit = owner.get_item_by_slot(ITEM_SLOT_OCLOTHING)
 	damagetaken = amount * (1 - suitarmor)
 	if(damagetaken <= 0)
 		return
-	if(!suit)
-		damagetaken = amount
+
 	if(damagetaken <= shieldhealth)
 		shieldhealth = shieldhealth - damagetaken
 		amount = 0
 		var/shielddiagnostics = shieldhealth / 100
 		if(shielddiagnostics < 0.95 && faltering != 1)
 			faltering = 1
-		return
+		return COMPONENT_MOB_DENY_DAMAGE // This return value completely negates the apply_damage proc
 	if(damagetaken >= shieldhealth && faltering != 1) //When you prep a shield before a big attack.
 		amount = 0
 		owner.visible_message("<span class='warning'>The shield around [owner] focuses all its energy on absorbing the damage.</span>")
 		duration = 1 SECONDS
-	else
-		qdel(src)
+		return COMPONENT_MOB_DENY_DAMAGE
+	qdel(src)
 	return
 
 /datum/status_effect/interventionshield/be_replaced()
-	var/mob/living/carbon/human/L = owner
-	if(!istype(L))
-		return ..()
-	switch(respectivedamage)
-		if(RED_DAMAGE)
-			L.physiology.red_mod /= 0.0001
-		if(WHITE_DAMAGE)
-			L.physiology.white_mod /= 0.0001
-		if(BLACK_DAMAGE)
-			L.physiology.black_mod /= 0.0001
-		if(PALE_DAMAGE)
-			L.physiology.pale_mod /= 0.0001
 	playsound(get_turf(owner), 'sound/effects/glassbr1.ogg', 50, 0, 10)
 	return ..()
 
 /datum/status_effect/interventionshield/on_remove()
-	var/mob/living/carbon/human/L = owner
-	switch(respectivedamage)
-		if(RED_DAMAGE)
-			L.physiology.red_mod /= 0.0001
-		if(WHITE_DAMAGE)
-			L.physiology.white_mod /= 0.0001
-		if(BLACK_DAMAGE)
-			L.physiology.black_mod /= 0.0001
-		if(PALE_DAMAGE)
-			L.physiology.pale_mod /= 0.0001
 	owner.cut_overlay(statuseffectvisual)
 	owner.visible_message("<span class='warning'>The shield around [owner] shatters!</span>")
 	playsound(get_turf(owner), 'sound/effects/glassbr1.ogg', 50, 0, 10)
 	UnregisterSignal(owner, COMSIG_MOB_APPLY_DAMGE)
+	UnregisterSignal(owner, COMSIG_WORK_STARTED)
 	return ..()
 
 /datum/status_effect/interventionshield/white

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -399,6 +399,8 @@
 
 ///from base of /mob/living/proc/apply_damage(): (damage, damagetype, def_zone)
 #define COMSIG_MOB_APPLY_DAMGE	"mob_apply_damage"
+/// Blocks the damage from being taken if this is returned in a signal handler
+#define COMPONENT_MOB_DENY_DAMAGE (1<<0)
 ///from base of /mob/throw_item(): (atom/target)
 #define COMSIG_MOB_THROW "mob_throw"
 ///from base of /mob/verb/examinate(): (atom/target)

--- a/code/__HELPERS/priority_announce.dm
+++ b/code/__HELPERS/priority_announce.dm
@@ -2,6 +2,11 @@
 	if(!text)
 		return
 
+	// All your text is gone. Enjoy.
+	if(istype(SSlobotomy_corp.core_suppression, /datum/suppression/information))
+		var/datum/suppression/information/I = SSlobotomy_corp.core_suppression
+		text = Gibberish(text, TRUE, I.gibberish_value)
+
 	var/announcement
 	if(!sound)
 		sound = SSstation.announcer.get_rand_alert_sound()

--- a/code/game/machinery/computer/abnormality_work.dm
+++ b/code/game/machinery/computer/abnormality_work.dm
@@ -86,7 +86,8 @@
 		if(scramble_list[wt] != null)
 			work_display += "?"
 		if(!tutorial && istype(SSlobotomy_corp.core_suppression, /datum/suppression/information))
-			work_display = Gibberish(work_display, TRUE, 60)
+			var/datum/suppression/information/I = SSlobotomy_corp.core_suppression
+			work_display = Gibberish(work_display, TRUE, I.gibberish_value)
 		if(HAS_TRAIT(user, TRAIT_WORK_KNOWLEDGE))
 			dat += "<A href='byond://?src=[REF(src)];do_work=[wt]'>[work_display] \[[datum_reference.get_work_chance(wt, user)]%\]</A> <br>"
 		else

--- a/code/modules/mob/living/carbon/damage_procs.dm
+++ b/code/modules/mob/living/carbon/damage_procs.dm
@@ -1,7 +1,10 @@
 
 
 /mob/living/carbon/apply_damage(damage, damagetype = BRUTE, def_zone = null, blocked = FALSE, forced = FALSE, spread_damage = FALSE, wound_bonus = 0, bare_wound_bonus = 0, sharpness = SHARP_NONE, white_healable = FALSE)
-	SEND_SIGNAL(src, COMSIG_MOB_APPLY_DAMGE, damage, damagetype, def_zone)
+	var/signal_return = SEND_SIGNAL(src, COMSIG_MOB_APPLY_DAMGE, damage, damagetype, def_zone)
+	if(signal_return & COMPONENT_MOB_DENY_DAMAGE)
+		return FALSE
+
 	var/hit_percent = (100-blocked)/100
 	if(!damage || (!forced && hit_percent <= 0))
 		return 0

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1576,7 +1576,10 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 	return TRUE
 
 /datum/species/proc/apply_damage(damage, damagetype = BRUTE, def_zone = null, blocked, mob/living/carbon/human/H, forced = FALSE, spread_damage = FALSE, wound_bonus = 0, bare_wound_bonus = 0, sharpness = SHARP_NONE, white_healable = FALSE)
-	SEND_SIGNAL(H, COMSIG_MOB_APPLY_DAMGE, damage, damagetype, def_zone, wound_bonus, bare_wound_bonus, sharpness) // make sure putting wound_bonus here doesn't screw up other signals or uses for this signal
+	var/signal_return = SEND_SIGNAL(H, COMSIG_MOB_APPLY_DAMGE, damage, damagetype, def_zone, wound_bonus, bare_wound_bonus, sharpness)
+	if(signal_return & COMPONENT_MOB_DENY_DAMAGE)
+		return FALSE
+
 	var/hit_percent = (100-(blocked+armor))/100
 	hit_percent = (hit_percent * (100-H.physiology.damage_resistance))/100
 	if(!damage || (!forced && hit_percent <= 0))

--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -15,7 +15,9 @@
  * Returns TRUE if damage applied
  */
 /mob/living/proc/apply_damage(damage = 0,damagetype = RED_DAMAGE, def_zone = null, blocked = FALSE, forced = FALSE, spread_damage = FALSE, wound_bonus = 0, bare_wound_bonus = 0, sharpness = SHARP_NONE, white_healable = FALSE)
-	SEND_SIGNAL(src, COMSIG_MOB_APPLY_DAMGE, damage, damagetype, def_zone)
+	var/signal_return = SEND_SIGNAL(src, COMSIG_MOB_APPLY_DAMGE, damage, damagetype, def_zone)
+	if(signal_return & COMPONENT_MOB_DENY_DAMAGE)
+		return FALSE
 	var/hit_percent = (100-blocked)/100
 	if(!damage || (!forced && hit_percent <= 0))
 		return FALSE

--- a/code/modules/suppressions/information.dm
+++ b/code/modules/suppressions/information.dm
@@ -2,17 +2,23 @@
 /datum/suppression/information
 	name = "Information Core Suppression"
 	desc = "Assignments on the abnormality work consoles will be in random positions.\n\
-			Telecommunications and suit sensors will be negatively impacted."
+			Announcement systems and suit sensors will be negatively impacted."
 	reward_text = "Unique PE gained by working on abnormalities is increased by 25%."
 	run_text = "The core suppression of Information department has begun. The information and sensors will be distorted for its duration."
+	/// Used in Gibberish() proc as third argument in relevant places.
+	var/gibberish_value = 30
 
 /datum/suppression/information/Run(run_white = FALSE)
 	. = ..()
-	for(var/obj/machinery/telecomms/processor/P in GLOB.telecomms_list)
-		P.process_mode = 0 // Makes all messages pure gibberish
+	RegisterSignal(SSdcs, COMSIG_GLOB_MELTDOWN_START, .proc/OnMeltdown)
 
 /datum/suppression/information/End()
-	for(var/obj/machinery/telecomms/processor/P in GLOB.telecomms_list)
-		P.process_mode = 1
+	UnregisterSignal(SSdcs, COMSIG_GLOB_MELTDOWN_START)
 	SSlobotomy_corp.box_work_multiplier *= 1.25
 	return ..()
+
+// Increase gibberish value every time an ordeal occurs
+/datum/suppression/information/proc/OnMeltdown(datum/source, ordeal = FALSE)
+	SIGNAL_HANDLER
+	if(ordeal)
+		gibberish_value = min(90, gibberish_value + 30)

--- a/code/modules/suppressions/information.dm
+++ b/code/modules/suppressions/information.dm
@@ -6,7 +6,7 @@
 	reward_text = "Unique PE gained by working on abnormalities is increased by 25%."
 	run_text = "The core suppression of Information department has begun. The information and sensors will be distorted for its duration."
 	/// Used in Gibberish() proc as third argument in relevant places.
-	var/gibberish_value = 30
+	var/gibberish_value = 20
 
 /datum/suppression/information/Run(run_white = FALSE)
 	. = ..()
@@ -21,4 +21,4 @@
 /datum/suppression/information/proc/OnMeltdown(datum/source, ordeal = FALSE)
 	SIGNAL_HANDLER
 	if(ordeal)
-		gibberish_value = min(90, gibberish_value + 30)
+		gibberish_value = min(80, gibberish_value + 30)

--- a/code/modules/suppressions/welfare.dm
+++ b/code/modules/suppressions/welfare.dm
@@ -163,9 +163,11 @@
 /datum/status_effect/welfare_reward/on_apply()
 	RegisterSignal(owner, COMSIG_MOB_APPLY_DAMGE, .proc/OnDamage)
 	to_chat(owner, "<span class='notice'>Welfare Department modification has been applied to you!</span>")
+	return ..()
 
-/datum/status_effect/welfare_reward/on_apply()
+/datum/status_effect/welfare_reward/on_remove()
 	UnregisterSignal(owner, COMSIG_MOB_APPLY_DAMGE)
+	return ..()
 
 // Called before damage applies, so we must check whereas situation WOULD kill the user
 // This comes with an issue, however, as damage will still be applied afterwards

--- a/code/modules/suppressions/welfare.dm
+++ b/code/modules/suppressions/welfare.dm
@@ -180,25 +180,33 @@
 	if(damage_taken <= 0)
 		return
 
+	var/block_damage = FALSE
 	switch(damagetype)
 		if(RED_DAMAGE)
 			if(H.health - damage_taken <= 0)
 				ActivateHealth()
+				block_damage = TRUE
 		if(WHITE_DAMAGE)
 			if(H.sanityhealth - damage_taken <= 0)
 				ActivateSanity()
+				block_damage = TRUE
 		if(BLACK_DAMAGE)
 			if(H.health - damage_taken <= 0)
 				ActivateHealth()
+				block_damage = TRUE
 			if(H.sanityhealth - damage_taken <= 0)
 				ActivateSanity()
+				block_damage = TRUE
 		if(PALE_DAMAGE)
 			damage_taken = H.maxHealth * (damage_taken / 100)
 			if(H.health - damage_taken <= 0)
 				ActivateHealth()
+				block_damage = TRUE
 
 	// ALWAYS blocks damage so you don't die
-	return COMPONENT_MOB_DENY_DAMAGE
+	if(block_damage)
+		return COMPONENT_MOB_DENY_DAMAGE
+	return
 
 /datum/status_effect/welfare_reward/proc/ActivateHealth()
 	var/mob/living/carbon/human/H = owner

--- a/code/modules/suppressions/welfare.dm
+++ b/code/modules/suppressions/welfare.dm
@@ -59,8 +59,8 @@
 	SIGNAL_HANDLER
 	var/current_damage_mod = damage_mod
 	if(ordeal)
-		current_damage_mod = 1.5 // Don't kill everyone too hard during ordeals(Pale Fixer with x4 damage be like...)
-		damage_mod = min(4, damage_mod + 1) // With each ordeal passing, normal meltdowns will be more difficult
+		current_damage_mod = 1.5 // Don't kill everyone too hard during ordeals(Pale Fixer with x3 damage be like...)
+		damage_mod = min(4, damage_mod + 0.5) // With each ordeal passing, normal meltdowns will be more difficult
 		mod_count = min(3, mod_count + 1) // More damage types get rolled
 	var/list/temp_list = current_resist.Copy()
 	for(var/R in current_resist) // Reset values
@@ -194,6 +194,9 @@
 			damage_taken = H.maxHealth * (damage_taken / 100)
 			if(H.health - damage_taken <= 0)
 				ActivateHealth()
+
+	// ALWAYS blocks damage so you don't die
+	return COMPONENT_MOB_DENY_DAMAGE
 
 /datum/status_effect/welfare_reward/proc/ActivateHealth()
 	var/mob/living/carbon/human/H = owner


### PR DESCRIPTION
## About The Pull Request

- Adds a return value to apply_damage() proc, which performs an early return (blocks damage).
- Manager shields and welfare reward now use said return value.
- Welfare Core Suppression nerfed. Instead of increasing damage modifiers by 1 each ordeal, it does so by 0.5
- Information Core Suppression changed. Instead of screwing with normal telecomms - it ruins all announcements. With each new ordeal - severity increases.

## Why It's Good For The Game

- A proper way to do it, I believe.
- Code improvement. Shouldn't affect players much.
- Less difficult, eh...
- More fun..! You can talk to people again.