### PR TITLE
Makes Ordeal Fixers patrol (not you Pale)

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/ordeal/white.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/white.dm
@@ -21,6 +21,7 @@
 	projectiletype = /obj/projectile/black
 	attack_sound = 'sound/weapons/ego/hammer.ogg'
 	del_on_death = TRUE
+	can_patrol = TRUE
 
 	var/busy = FALSE
 	var/pulse_cooldown
@@ -150,6 +151,7 @@
 	simple_mob_flags = SILENCE_RANGED_MESSAGE
 	is_flying_animal = TRUE
 	del_on_death = TRUE
+	can_patrol = TRUE
 
 	var/can_act = TRUE
 	/// When this reaches 480 - begins reflecting damage

--- a/code/modules/mob/living/simple_animal/hostile/ordeal/white.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/white.dm
@@ -358,6 +358,7 @@
 	move_resist = MOVE_FORCE_OVERPOWERING
 	attack_sound = 'sound/effects/ordeals/white/red_attack.ogg'
 	del_on_death = TRUE
+	can_patrol = TRUE
 
 	var/busy = FALSE
 	var/multislash_cooldown


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Exactly what it says on the tin.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Red Fixer was famously the most underperforming fixer in Dusk, where all fixers should pose a challenge of their own, this should make him an unpredictable menace.
leaving White and Black out of it would be wrong though, let them be free too.

Pale already has too much fun, no patrolling for him.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Adds patrolling to Red Fixer
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
