### PR TITLE
we do a lil bit of code cleaning on LC13 computers

### DIFF
--- a/code/game/machinery/computer/abnormality_archive.dm
+++ b/code/game/machinery/computer/abnormality_archive.dm
@@ -10,8 +10,10 @@
 	var/notehtml
 	var/note
 	var/linecount
-	var/paper = 1 //You get one paper
-	var/papermax = 10 //Recycle more paper
+	/// How much paper do we currently have inside us?
+	var/paper = 1
+	/// How much paper can we have at maximum capacity?
+	var/papermax = 10
 	var/list/note_list
 	var/list/abno_data = list()
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
@@ -56,6 +58,8 @@
 	switch(action)
 		if("print_file")
 			if(paper <= 0)
+				playsound(src, 'sound/machines/buzz-sigh.ogg', 75, TRUE)
+				say("Warning: paper reserves too low! Please insert paper in order to continue.")
 				return
 			printfile = params["ref"]
 			print_file(printfile)
@@ -68,7 +72,7 @@
 
 /obj/machinery/computer/abnormality_archive/proc/print_file(file)
 	paper = paper - 1
-	visible_message("<span class='notice'>[src] begins to print a file.</span>")
+	visible_message(span_notice("[src] begins to print a file."))
 	playsound(src, 'sound/machines/terminal_prompt_confirm.ogg', 30, TRUE)
 	new file(get_turf(src))
 

--- a/code/game/machinery/computer/abnormality_auxilary.dm
+++ b/code/game/machinery/computer/abnormality_auxilary.dm
@@ -47,7 +47,7 @@
 			if(!ispath(core_type) || !(core_type in SSlobotomy_corp.available_core_suppressions))
 				return FALSE
 			selected_core_type = core_type
-			to_chat(usr, "<span class='notice'>[initial(selected_core_type.name)] has been selected!</span>")
+			to_chat(usr, span_notice("[initial(selected_core_type.name)] has been selected!"))
 			playsound(get_turf(src), 'sound/machines/terminal_prompt_confirm.ogg', 50, TRUE)
 			updateUsrDialog()
 			return TRUE
@@ -55,12 +55,12 @@
 			if(!ispath(selected_core_type) || !(selected_core_type in SSlobotomy_corp.available_core_suppressions))
 				return FALSE
 			if(istype(SSlobotomy_corp.core_suppression))
-				to_chat(usr, "<span class='warning'>A core suppression is already in the progress!</span>")
+				to_chat(usr, span_warning("A core suppression is already in the progress!"))
 				selected_core_type = null
 				return FALSE
 			SSlobotomy_corp.core_suppression = new selected_core_type
 			SSlobotomy_corp.available_core_suppressions = list()
-			to_chat(usr, "<span class='userdanger'>Good luck, Manager.</span>")
+			to_chat(usr, span_userdanger("Good luck, Manager."))
 			playsound(get_turf(src), 'sound/machines/terminal_prompt_confirm.ogg', 50, TRUE)
 			updateUsrDialog()
 			addtimer(CALLBACK(SSlobotomy_corp.core_suppression, /datum/suppression/proc/Run), 2 SECONDS)

--- a/code/game/machinery/computer/abnormality_ego.dm
+++ b/code/game/machinery/computer/abnormality_ego.dm
@@ -53,13 +53,13 @@
 			if(!E || !A)
 				return FALSE
 			if(A.stored_boxes < E.cost)
-				to_chat(usr, "<span class='warning'>Not enough PE boxes stored for this operation.</span>")
+				to_chat(usr, span_warning("Not enough PE boxes stored for this operation."))
 				playsound(get_turf(src), 'sound/machines/terminal_prompt_deny.ogg', 50, TRUE)
 				return FALSE
 			var/obj/item/I = new E.item_path(get_turf(src))
 			A.stored_boxes -= E.cost
 			A.current_ego += I
-			to_chat(usr, "<span class='notice'>[I] has been dispensed!</span>")
+			to_chat(usr, span_notice("[I] has been dispensed!"))
 			playsound(get_turf(src), 'sound/machines/terminal_prompt_confirm.ogg', 50, TRUE)
 			updateUsrDialog()
 			return TRUE

--- a/code/game/machinery/computer/abnormality_logs.dm
+++ b/code/game/machinery/computer/abnormality_logs.dm
@@ -52,9 +52,9 @@
 			popup.open()
 			return TRUE
 
-		///////////////////
-		// Agent work stats
-		///////////////////
+		/**
+		 *	Agent work stats
+		 */
 		if(href_list["work_stats_menu"])
 			var/abno_num = text2num(href_list["work_stats_menu"])
 			var/datum/abnormality/A = SSlobotomy_corp.all_abnormality_datums[abno_num]
@@ -79,9 +79,9 @@
 			popup.open()
 			return TRUE
 
-		//////////////////////////////////////////////////////////////////////
-		// The individual window of an agent's work stats for that abnormality
-		//////////////////////////////////////////////////////////////////////
+		/**
+		 *	The individual window of an agent's work stats for that abnormality
+		 */
 		if(href_list["agent_stats"])
 			var/worker = href_list["agent_stats"]
 			var/abno_num = text2num(href_list["abno_number"])
@@ -112,9 +112,9 @@
 			popup.open()
 			return TRUE
 
-		////////////////////
-		// Same, but GLOBAL!
-		////////////////////
+		/**
+		 *	Same, but GLOBAL!
+		 */
 		if(href_list["global_agent_stats"])
 			var/worker = href_list["global_agent_stats"]
 			var/dat

--- a/code/game/machinery/computer/abnormality_queue.dm
+++ b/code/game/machinery/computer/abnormality_queue.dm
@@ -52,7 +52,7 @@
 	if(.)
 		return
 	if(locked)
-		to_chat(usr, "<span class='boldwarning'>The selected Abnormality cannot be changed.</span>")
+		to_chat(usr, span_boldwarning("The selected Abnormality cannot be changed."))
 		playsound(get_turf(src), 'sound/machines/terminal_prompt_deny.ogg', 50, TRUE)
 		return
 
@@ -62,12 +62,12 @@
 			var/mob/living/simple_animal/hostile/abnormality/target_type = text2path(param)
 
 			if(!ispath(target_type)) // Should never happen
-				to_chat(usr, "<span class='warning'>Extraction request has been denied.</span>")
+				to_chat(usr, span_warning("Extraction request has been denied."))
 				playsound(get_turf(src), 'sound/machines/terminal_prompt_deny.ogg', 50, TRUE)
 				return FALSE
 
 			if(!(target_type in SSabnormality_queue.picking_abnormalities))
-				to_chat(usr, "<span class='warning'>Your Extraction request has timed out. Retry.</span>")
+				to_chat(usr, span_warning("Your Extraction request has timed out. Retry."))
 				playsound(get_turf(src), 'sound/machines/terminal_prompt_deny.ogg', 50, TRUE)
 				updateUsrDialog() // Forcibly update it, in case someone doesn't understand why it won't work
 				return FALSE
@@ -90,7 +90,7 @@
 
 /obj/machinery/computer/abnormality_queue/proc/UpdateAnomaly(mob/living/simple_animal/hostile/abnormality/target_type, logstring, lock_after)
 	SSabnormality_queue.queued_abnormality = target_type
-	to_chat(usr, "<span class='boldnotice'>[initial(target_type.name)] has been selected.</span>")
+	to_chat(usr, span_boldnotice("[initial(target_type.name)] has been selected."))
 	playsound(get_turf(src), 'sound/machines/terminal_prompt_confirm.ogg', 50, TRUE)
 	log_game("[usr] has [logstring] the anomaly to [initial(target_type.name)].")
 	if(lock_after)
@@ -98,7 +98,7 @@
 		locked = TRUE
 		// PE awarded for yellow roll - just as kirie had wanted.
 		SSlobotomy_corp.available_box += 250
-		to_chat(usr, "<span class='boldnotice'>A random Abnormality has been selected. L Corp HQ has reimbursed you for the costs of extracting a specific Abnormality.</span>")
+		to_chat(usr, span_boldnotice("A random Abnormality has been selected. L Corp HQ has reimbursed you for the costs of extracting a specific Abnormality."))
 		SSabnormality_queue.AnnounceLock()
 		SSabnormality_queue.ClearChoices()
 		SStgui.close_uis(src) // Hacky solution but I don't care

--- a/code/game/machinery/computer/abnormality_work.dm
+++ b/code/game/machinery/computer/abnormality_work.dm
@@ -40,13 +40,13 @@
 	. = ..()
 	if(!datum_reference)
 		return
-	. += "<span class='info'>This console is connected to [datum_reference.GetName()]'s containment unit.</span>"
+	. += span_info("This console is connected to [datum_reference.GetName()]'s containment unit.")
 	var/threat_level = "<span style='color: [THREAT_TO_COLOR[datum_reference.GetRiskLevel()]]'>[THREAT_TO_NAME[datum_reference.GetRiskLevel()]]</span>"
-	. += "<span class='info'>Risk Level:</span> [threat_level]<span class='info'>.</span>" // Professionals have standards
+	. += span_info("Risk Level: ") + "[threat_level]" // Professionals have standards
 	if(datum_reference.qliphoth_meter_max > 0)
-		. += "<span class='info'>Current Qliphoth Counter: [datum_reference.qliphoth_meter].</span>"
+		. += span_info("Current Qliphoth Counter: [datum_reference.qliphoth_meter].")
 	if(datum_reference.overload_chance[user.ckey])
-		. += "<span class='warning'>Current Personal Qliphoth Overload: [datum_reference.overload_chance[user.ckey]]%.</span>"
+		. += span_warning("Current Personal Qliphoth Overload: [datum_reference.overload_chance[user.ckey]]%.")
 	if(meltdown)
 		var/melt_text = ""
 		switch(meltdown)
@@ -60,14 +60,14 @@
 				melt_text = " of Pillars. Success rates reduced by 20%. Failing to clear it will cause Arbiter to perform their deadly attack"
 			if(MELTDOWN_BLACK)
 				melt_text = " of Lunacy. Failure to clear the meltdown will cause another abnormality to breach"
-		. += "<span class='warning'>The containment unit is currently affected by a Qliphoth Meltdown[melt_text]. Time left: [meltdown_time].</span>"
+		. += span_warning("The containment unit is currently affected by a Qliphoth Meltdown[melt_text]. Time left: [meltdown_time].")
 
 /obj/machinery/computer/abnormality/ui_interact(mob/user)
 	. = ..()
 	if(isliving(user))
 		playsound(src, 'sound/machines/terminal_prompt_confirm.ogg', 50, FALSE)
 	if(!istype(datum_reference))
-		to_chat(user, "<span class='boldannounce'>The console has no information stored!</span>")
+		to_chat(user, span_boldannounce("The console has no information stored!"))
 		return
 	var/dat
 	dat += "<b><span style='color: [THREAT_TO_COLOR[datum_reference.GetRiskLevel()]]'>\[[THREAT_TO_NAME[datum_reference.GetRiskLevel()]]\]</span> [datum_reference.GetName()]</b><br>"
@@ -105,21 +105,21 @@
 		usr.set_machine(src)
 		if(href_list["do_work"] in datum_reference.available_work)
 			if(HAS_TRAIT(usr, TRAIT_WORK_FORBIDDEN) && recorded) //let clerks work training rabbit
-				to_chat(usr, "<span class='warning'>The console cannot be operated by [prob(0.1) ? "a filthy clerk" : "you"]!</span>")
+				to_chat(usr, span_warning("The console cannot be operated by [prob(0.1) ? "a filthy clerk" : "you"]!"))
 				return
 			if(datum_reference.working)
-				to_chat(usr, "<span class='warning'>The console is currently being operated!</span>")
+				to_chat(usr, span_warning("The console is currently being operated!"))
 				return
 			if(!istype(datum_reference.current) || (datum_reference.current.stat == DEAD))
-				to_chat(usr, "<span class='warning'>The Abnormality is currently in the process of revival!</span>")
+				to_chat(usr, span_warning("The Abnormality is currently in the process of revival!"))
 				return
 			if(!(datum_reference.current.status_flags & GODMODE))
-				to_chat(usr, "<span class='warning'>The Abnormality has breached containment!</span>")
+				to_chat(usr, span_warning("The Abnormality has breached containment!"))
 				return
 			var/work_attempt = datum_reference.current.AttemptWork(usr, href_list["do_work"])
 			if(!work_attempt)
 				if(work_attempt == FALSE)
-					to_chat(usr, "<span class='warning'>This operation is currently unavailable.</span>")
+					to_chat(usr, span_warning("This operation is currently unavailable."))
 				return
 			start_work(usr, href_list["do_work"])
 
@@ -153,15 +153,15 @@
 		return
 	switch(sanity_result)
 		if(-INFINITY to -1)
-			to_chat(user, "<span class='nicegreen'>This assignment is too easy!</span>")
+			to_chat(user, span_nicegreen("This assignment is too easy!"))
 		if(0)
-			to_chat(user, "<span class='notice'>I'll handle it as I always do.</span>")
+			to_chat(user, span_notice("I'll handle it as I always do."))
 		if(1)
-			to_chat(user, "<span class='warning'>Just follow standard procedures...</span>")
+			to_chat(user, span_warning("Just follow standard procedures..."))
 		if(2)
-			to_chat(user, "<span class='danger'>Calm down... Calm down...</span>")
+			to_chat(user, span_danger("Calm down... Calm down..."))
 		if(3 to INFINITY)
-			to_chat(user, "<span class='userdanger'>I'm not ready for this!</span>")
+			to_chat(user, span_userdanger("I'm not ready for this!"))
 	var/was_melting = meltdown //to remember if it was melting down before the work started
 	meltdown = FALSE // Reset meltdown
 	if(was_melting)
@@ -210,7 +210,7 @@
 			for(var/i = 0 to round((work_time - total_boxes)*(1-((work_chance*0.5)/100)), 1)) // Take double of what you'd fail on average as NE box damage.
 				datum_reference.current.WorktickFailure(user)
 			playsound(src, 'sound/machines/synth_no.ogg', 75, FALSE, -4)
-			to_chat(user, "<span class='warning'>The Abnormality grows frustrated as you cut your work short!")
+			to_chat(user, span_warning("The Abnormality grows frustrated as you cut your work short!"))
 			success_boxes = 0
 			canceled = TRUE
 			break
@@ -246,17 +246,17 @@
 	if(!work_type)
 		work_type = pick(datum_reference.available_work)
 	if(datum_reference.max_boxes != 0) // All these messages should be visible (on the console) and audible (announced by machine)
-		audible_message("<span class='notice'>[work_type] work finished. [pe]/[datum_reference.max_boxes] PE acquired.</span>",\
-				"<span class='notice'>[work_type] work finished. [pe]/[datum_reference.max_boxes] PE acquired.</span>")
+		audible_message(span_notice("[work_type] work finished. [pe]/[datum_reference.max_boxes] PE acquired."),\
+				span_notice("[work_type] work finished. [pe]/[datum_reference.max_boxes] PE acquired."))
 		if(pe >= datum_reference.success_boxes)
-			audible_message("<span class='notice'>Work Result: Good</span>",\
-				"<span class='notice'>Work Result: Good</span>")
+			audible_message(span_notice("Work Result: Good"),\
+				span_notice("Work Result: Good"))
 		else if(pe >= datum_reference.neutral_boxes)
-			audible_message("<span class='notice'>Work Result: Normal</span>",\
-				"<span class='notice'>Work Result: Normal</span>")
+			audible_message(span_notice("Work Result: Normal"),\
+				span_notice("Work Result: Normal"))
 		else
-			audible_message("<span class='notice'>Work Result: Bad</span>",\
-				"<span class='notice'>Work Result: Bad</span>")
+			audible_message(span_notice("Work Result: Bad"),\
+				span_notice("Work Result: Bad"))
 	if(istype(user))
 		datum_reference.work_complete(user, work_type, pe, work_speed*datum_reference.max_boxes, was_melting, canceled)
 		if(recorded) //neither rabbit nor tutorial calls this


### PR DESCRIPTION
## About The Pull Request

- Changed all \<span class= 'whatever'> into proper span_classes on LC13 computers

- Instead of using giant boxes of 
//////////
// This //
//////////
the logging computer now uses
/**
 *This
 */
Since it helps with visibility, and hell TG has it in its contributor guidelines

- Also added an error message to the archive console instead of it just refusing to print papers... for less player confusion

- And finally changed // comments in the archive console near the variables into /// ones that describe what the variables actually do

## Why It's Good For The Game

Moar clarity and code readibility = gud

## Changelog
:cl:
add: If you fail to print a record in the archive computer, it will now inform you
code: LC13 unique computers now use proper span classes where possible
code: abnormality logging consoles now use /** / comments instead of giant boxes of //////
/:cl:
