### PR TITLE
Gives clerks a random item on spawn.

### DIFF
--- a/code/modules/jobs/job_types/assistant.dm
+++ b/code/modules/jobs/job_types/assistant.dm
@@ -1,6 +1,8 @@
 /*
 Assistant
 */
+GLOBAL_LIST_EMPTY(spawned_clerks)
+
 /datum/job/assistant
 	title = "Clerk"
 	faction = "Station"
@@ -35,8 +37,27 @@ Assistant
 	jobtype = /datum/job/assistant
 	uniform = /obj/item/clothing/under/suit/black
 	l_pocket = /obj/item/sensor_device
-	r_pocket = /obj/item/modular_computer/tablet/preset/advanced/medical
 	backpack_contents = list(
 		/obj/item/healthanalyzer = 1,
 		/obj/item/gun/ego_gun/clerk = 1)
 	implants = list(/obj/item/organ/cyberimp/eyes/hud/medical)
+
+/datum/outfit/job/assistant/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	..()
+	if(H.ckey in GLOB.spawned_clerks)
+		return
+	var/item = pick(
+	/obj/item/forcefield_projector,
+	/obj/item/deepscanner,
+	/obj/item/powered_gadget/slowingtrapmk1,
+	/obj/item/safety_kit,
+	/obj/item/powered_gadget/detector_gadget/abnormality,
+	/obj/item/powered_gadget/detector_gadget/ordeal,
+	/obj/item/powered_gadget/enkephalin_injector,
+	/obj/item/powered_gadget/clerkbot_gadget,
+	/obj/item/powered_gadget/handheld_taser,
+	/obj/item/powered_gadget/vitals_projector,
+	/obj/item/reagent_containers/hypospray/emais,
+	)
+	GLOB.spawned_clerks += H.ckey
+	H.equip_to_slot_or_del(new item(H),ITEM_SLOT_HANDS, TRUE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Clerks now spawn with a random gadget on spawn.
You can only spawn with one, any respawns as clerks do not have gadgets.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Clerks are supposed to be the goofy gadget guys, but no one uses them.
Let's see if giving them gadgets on spawn makes them more popular.
I have a theory that the reason gadgets aren't widespread is because players don't know what they do, let's see if it's correct.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Clerks now spawn with a gadget
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
