### PR TITLE
Adds Library area types and replaces library rooms with corresponding types

### DIFF
--- a/_maps/map_files/Library/floor_art.dmm
+++ b/_maps/map_files/Library/floor_art.dmm
@@ -1,21 +1,21 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /turf/open/floor/plating/dirt/jungle/wasteland,
-/area/city/backstreets_room)
+/area/library_floors/floor_art)
 "b" = (
 /turf/open/floor/fakepit{
 	density = 1
 	},
-/area/city/backstreets_room)
+/area/library_floors/floor_art)
 "d" = (
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/plating/dirt/jungle/wasteland,
-/area/city/backstreets_room)
+/area/library_floors/floor_art)
 "f" = (
 /obj/structure/alien/resin/wall/creature,
 /obj/item/wallframe/painting,
 /turf/closed/indestructible/rock,
-/area/city/backstreets_room)
+/area/library_floors/floor_art)
 "g" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/beer,
@@ -27,12 +27,12 @@
 	pixel_x = -9
 	},
 /turf/open/floor/plating/dirt/jungle/wasteland,
-/area/city/backstreets_room)
+/area/library_floors/floor_art)
 "h" = (
 /obj/item/broken_bottle,
 /obj/structure/table/wood,
 /turf/open/floor/plating/dirt/jungle/wasteland,
-/area/city/backstreets_room)
+/area/library_floors/floor_art)
 "i" = (
 /obj/item/book/random{
 	pixel_y = -11;
@@ -54,71 +54,71 @@
 	},
 /obj/structure/table/wood,
 /turf/open/floor/plating/dirt/jungle/wasteland,
-/area/city/backstreets_room)
+/area/library_floors/floor_art)
 "j" = (
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks/beer/fullupgrade{
 	dir = 1
 	},
 /turf/open/floor/plating/dirt/jungle/wasteland,
-/area/city/backstreets_room)
+/area/library_floors/floor_art)
 "k" = (
 /obj/structure/fluff/arc/angela,
 /turf/open/floor/plating/dirt/jungle/wasteland,
-/area/city/backstreets_room)
+/area/library_floors/floor_art)
 "l" = (
 /turf/open/space/basic,
 /area/space)
 "m" = (
 /obj/item/storage/crayons,
 /turf/open/floor/plating/dirt/jungle/wasteland,
-/area/city/backstreets_room)
+/area/library_floors/floor_art)
 "n" = (
 /obj/item/flashlight/spotlight,
 /turf/open/floor/fakepit{
 	density = 1
 	},
-/area/city/backstreets_room)
+/area/library_floors/floor_art)
 "o" = (
 /obj/item/paint/red,
 /obj/item/flashlight/spotlight,
 /turf/open/floor/plating/dirt/jungle/wasteland,
-/area/city/backstreets_room)
+/area/library_floors/floor_art)
 "p" = (
 /obj/structure/statue/plasma/scientist,
 /turf/open/floor/plating/dirt/jungle/wasteland,
-/area/city/backstreets_room)
+/area/library_floors/floor_art)
 "q" = (
 /obj/structure/statue/sandstone/venus{
 	anchored = 1
 	},
 /turf/open/floor/plating/dirt/jungle/wasteland,
-/area/city/backstreets_room)
+/area/library_floors/floor_art)
 "r" = (
 /obj/structure/bookcase/random/fiction,
 /turf/open/floor/plating/dirt/jungle/wasteland,
-/area/city/backstreets_room)
+/area/library_floors/floor_art)
 "s" = (
 /obj/item/paint/white,
 /turf/open/floor/plating/dirt/jungle/wasteland,
-/area/city/backstreets_room)
+/area/library_floors/floor_art)
 "t" = (
 /obj/structure/firetree,
 /turf/open/floor/plating/dirt/jungle/wasteland,
-/area/city/backstreets_room)
+/area/library_floors/floor_art)
 "u" = (
 /obj/structure/alien/resin/wall/creature,
 /obj/item/flashlight/spotlight,
 /turf/closed/indestructible/rock,
-/area/city/backstreets_room)
+/area/library_floors/floor_art)
 "v" = (
 /obj/item/paint,
 /turf/open/floor/plating/dirt/jungle/wasteland,
-/area/city/backstreets_room)
+/area/library_floors/floor_art)
 "w" = (
 /obj/item/toy/crayon/blue,
 /turf/open/floor/plating/dirt/jungle/wasteland,
-/area/city/backstreets_room)
+/area/library_floors/floor_art)
 "y" = (
 /obj/item/toy/plush/netzach,
 /obj/item/reagent_containers/food/drinks/beer{
@@ -131,16 +131,16 @@
 	},
 /obj/effect/decal/cleanable/vomit,
 /turf/open/floor/plating/dirt/jungle/wasteland,
-/area/city/backstreets_room)
+/area/library_floors/floor_art)
 "z" = (
 /obj/item/grown/log/tree,
 /turf/open/floor/plating/dirt/jungle/wasteland,
-/area/city/backstreets_room)
+/area/library_floors/floor_art)
 "D" = (
 /obj/structure/easel,
 /obj/item/canvas/nineteen_nineteen,
 /turf/open/floor/plating/dirt/jungle/wasteland,
-/area/city/backstreets_room)
+/area/library_floors/floor_art)
 "G" = (
 /obj/structure/fluff/drake_statue{
 	pixel_x = 0;
@@ -148,29 +148,29 @@
 	},
 /obj/item/flashlight/spotlight,
 /turf/open/floor/plating/dirt/jungle/wasteland,
-/area/city/backstreets_room)
+/area/library_floors/floor_art)
 "I" = (
 /turf/closed/indestructible/fakeglass,
-/area/city/backstreets_room)
+/area/library_floors/floor_art)
 "J" = (
 /obj/item/toy/crayon/rainbow,
 /turf/open/floor/plating/dirt/jungle/wasteland,
-/area/city/backstreets_room)
+/area/library_floors/floor_art)
 "K" = (
 /obj/structure/bookcase/random/fiction,
 /obj/item/flashlight/spotlight,
 /turf/open/floor/plating/dirt/jungle/wasteland,
-/area/city/backstreets_room)
+/area/library_floors/floor_art)
 "N" = (
 /obj/item/toy/crayon,
 /turf/open/floor/plating/dirt/jungle/wasteland,
-/area/city/backstreets_room)
+/area/library_floors/floor_art)
 "P" = (
 /obj/structure/easel,
 /obj/item/canvas/nineteen_nineteen,
 /obj/item/flashlight/spotlight,
 /turf/open/floor/plating/dirt/jungle/wasteland,
-/area/city/backstreets_room)
+/area/library_floors/floor_art)
 "R" = (
 /obj/item/book/random{
 	pixel_y = -11;
@@ -191,31 +191,31 @@
 	pixel_y = -8
 	},
 /turf/open/floor/plating/dirt/jungle/wasteland,
-/area/city/backstreets_room)
+/area/library_floors/floor_art)
 "S" = (
 /obj/item/broken_bottle,
 /turf/open/floor/plating/dirt/jungle/wasteland,
-/area/city/backstreets_room)
+/area/library_floors/floor_art)
 "U" = (
 /obj/structure/statue/sandstone/venus{
 	anchored = 1;
 	dir = 8
 	},
 /turf/open/floor/plating/dirt/jungle/wasteland,
-/area/city/backstreets_room)
+/area/library_floors/floor_art)
 "W" = (
 /obj/item/flashlight/spotlight,
 /turf/open/floor/plating/dirt/jungle/wasteland,
-/area/city/backstreets_room)
+/area/library_floors/floor_art)
 "X" = (
 /obj/structure/firetree,
 /obj/item/flashlight/spotlight,
 /turf/open/floor/plating/dirt/jungle/wasteland,
-/area/city/backstreets_room)
+/area/library_floors/floor_art)
 "Y" = (
 /obj/structure/alien/resin/wall/creature,
 /turf/closed/indestructible/rock,
-/area/city/backstreets_room)
+/area/library_floors/floor_art)
 
 (1,1,1) = {"
 l

--- a/_maps/map_files/Library/floor_history.dmm
+++ b/_maps/map_files/Library/floor_history.dmm
@@ -4,46 +4,46 @@
 /obj/item/ego_weapon/city/bladelineage,
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/wood,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "av" = (
 /obj/structure/easel,
 /obj/item/canvas,
 /turf/open/floor/plating/dirt/jungle/wasteland,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "aL" = (
 /obj/structure/bookcase/random/nonfiction,
 /obj/item/flashlight/spotlight,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "aN" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /obj/effect/decal/cleanable/blood/gibs/old,
 /turf/open/floor/wood,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "bf" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "bK" = (
 /obj/structure/alien/resin/wall/creature,
 /turf/open/space/basic,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "cf" = (
 /obj/machinery/door/airlock/wood,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "ct" = (
 /obj/item/canvas,
 /obj/item/flashlight/spotlight,
 /turf/open/floor/plating/dirt/jungle/wasteland,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "cH" = (
 /obj/item/flashlight/spotlight,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "cT" = (
 /obj/item/flashlight/spotlight,
 /obj/effect/turf_decal/siding/wood{
@@ -51,14 +51,14 @@
 	},
 /obj/effect/turf_decal/siding/wood,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "dG" = (
 /obj/structure/bookcase/random/fiction,
 /turf/closed/indestructible/wood,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "dI" = (
 /turf/closed/indestructible/wood,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "eB" = (
 /obj/structure/sink{
 	dir = 8;
@@ -66,34 +66,34 @@
 	pixel_y = 2
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "eH" = (
 /obj/structure/window/reinforced/fulltile/indestructable,
 /turf/open/floor/pod/dark,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "eV" = (
 /obj/item/flashlight/spotlight,
 /turf/open/floor/plating/dirt/jungle/wasteland,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "fP" = (
 /obj/structure/chair/wood{
 	dir = 4
 	},
 /obj/item/toy/plush/hod,
 /turf/open/floor/wood,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "gc" = (
 /obj/structure/table/wood/fancy/orange,
 /obj/item/book/random,
 /turf/open/floor/wood,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "gg" = (
 /obj/effect/turf_decal/siding/wood/corner,
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 8
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "hL" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -102,13 +102,13 @@
 	dir = 1
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "iK" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 10
 	},
 /turf/open/floor/pod/dark,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "jc" = (
 /obj/structure/table/wood,
 /obj/item/book/random{
@@ -118,11 +118,11 @@
 	dir = 2
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "jq" = (
 /obj/effect/decal/cleanable/vomit,
 /turf/open/floor/plating/dirt/jungle/wasteland,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "jI" = (
 /obj/item/book,
 /obj/item/book{
@@ -139,14 +139,14 @@
 	},
 /obj/effect/decal/cleanable/vomit,
 /turf/open/floor/plating/dirt/jungle/wasteland,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "jS" = (
 /obj/machinery/computer/camera_advanced/abductor,
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 9
 	},
 /turf/open/floor/pod/dark,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "ky" = (
 /obj/structure/table/wood,
 /obj/item/toy/plush/malkuth,
@@ -155,50 +155,50 @@
 	},
 /obj/item/flashlight/spotlight,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "kN" = (
 /obj/item/reagent_containers/food/drinks/beer{
 	pixel_x = 11;
 	pixel_y = -9
 	},
 /turf/open/floor/plating/dirt/jungle/wasteland,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "li" = (
 /obj/item/flashlight/spotlight,
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "mv" = (
 /obj/structure/table/wood/fancy/orange,
 /obj/item/book/random{
 	pixel_x = 7
 	},
 /turf/open/floor/wood,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "mP" = (
 /obj/structure/table/wood,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "nt" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
 	},
 /obj/structure/fireplace,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "nu" = (
 /obj/structure/table/optable/abductor,
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 5
 	},
 /turf/open/floor/pod/dark,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "nX" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner,
 /turf/open/floor/pod/dark,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "pJ" = (
 /obj/structure/table/wood,
 /obj/item/book/random{
@@ -206,21 +206,21 @@
 	pixel_x = 7
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "pL" = (
 /turf/open/floor/wood,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "pT" = (
 /obj/item/book/random,
 /obj/structure/displaycase/noalert,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "re" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "so" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -230,7 +230,7 @@
 	},
 /obj/structure/fireplace,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "sN" = (
 /obj/item/flashlight/spotlight,
 /obj/effect/turf_decal/siding/wood{
@@ -240,19 +240,19 @@
 	dir = 4
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "to" = (
 /obj/item/canvas,
 /obj/effect/decal/cleanable/vomit,
 /turf/open/floor/plating/dirt/jungle/wasteland,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "tK" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 6
 	},
 /obj/item/flashlight/spotlight,
 /turf/open/floor/pod/dark,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "tO" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 8
@@ -261,7 +261,7 @@
 	dir = 1
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "ui" = (
 /obj/item/reagent_containers/food/drinks/beer{
 	pixel_x = -10;
@@ -272,11 +272,11 @@
 	pixel_x = 23
 	},
 /turf/open/floor/plating/dirt/jungle/wasteland,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "uv" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/wood,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "uN" = (
 /obj/item/book/random,
 /obj/item/book/random{
@@ -295,7 +295,7 @@
 /obj/structure/table/wood,
 /obj/item/flashlight/spotlight,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "vm" = (
 /obj/structure/closet/abductor,
 /obj/item/slimepotion/speed,
@@ -303,7 +303,7 @@
 	dir = 1
 	},
 /turf/open/floor/pod/dark,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "vT" = (
 /obj/structure/table/wood/fancy/orange,
 /obj/item/book/codex_gigas{
@@ -311,17 +311,17 @@
 	pixel_x = -4
 	},
 /turf/open/floor/wood,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "wV" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "xg" = (
 /obj/structure/window/reinforced/fulltile/indestructable,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "xi" = (
 /turf/open/space/basic,
 /area/space)
@@ -331,7 +331,7 @@
 	},
 /obj/item/flashlight/spotlight,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "yk" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
@@ -340,7 +340,7 @@
 	dir = 2
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "yW" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
@@ -349,38 +349,38 @@
 	dir = 1
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "zK" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/effect/turf_decal/siding/wood,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "zT" = (
 /obj/machinery/abductor/pad,
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/pod/dark,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "Ai" = (
 /obj/structure/fireplace,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "AA" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
 /obj/structure/fireplace,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "AC" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 8
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "Cn" = (
 /obj/structure/falsewall/plastitanium,
 /turf/open/space/basic,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "Cs" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -389,19 +389,19 @@
 	dir = 1
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "Cx" = (
 /obj/item/canvas,
 /obj/item/reagent_containers/pill/maintenance,
 /turf/open/floor/plating/dirt/jungle/wasteland,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "CM" = (
 /obj/structure/chair/wood{
 	dir = 4
 	},
 /obj/effect/turf_decal/siding/wood,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "EY" = (
 /obj/item/mop,
 /obj/structure/mopbucket,
@@ -409,20 +409,20 @@
 	dir = 2
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "Fc" = (
 /obj/structure/chair/wood{
 	dir = 1
 	},
 /obj/item/toy/plush/bongbong,
 /turf/open/floor/wood,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "FS" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/pod/dark,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "FT" = (
 /obj/structure/closet/abductor,
 /obj/item/toy/plush/myo,
@@ -430,45 +430,45 @@
 	dir = 1
 	},
 /turf/open/floor/pod/dark,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "Ht" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "Hx" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
 /obj/effect/turf_decal/siding/wood,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "Il" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
 	},
 /obj/structure/fireplace,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "In" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "IM" = (
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks/beer,
 /turf/open/floor/plating/dirt/jungle/wasteland,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "IW" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "IZ" = (
 /obj/item/toy/plush/yesod,
 /obj/item/gun/ego_gun/pistol/solemnlament{
@@ -483,68 +483,68 @@
 	dir = 1
 	},
 /turf/open/floor/pod/dark,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "Jz" = (
 /obj/structure/chair/wood{
 	dir = 8
 	},
 /obj/item/toy/plush/yuri,
 /turf/open/floor/wood,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "JZ" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "KL" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
 /obj/item/flashlight/spotlight,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "Lk" = (
 /obj/item/reagent_containers/pill/maintenance,
 /turf/open/floor/plating/dirt/jungle/wasteland,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "Lx" = (
 /obj/item/flashlight/spotlight,
 /obj/structure/displaycase,
 /obj/item/flashlight/lantern,
 /turf/open/floor/wood,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "LU" = (
 /turf/open/floor/pod/dark,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "NZ" = (
 /obj/structure/chair/wood{
 	dir = 8
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "Oy" = (
 /obj/structure/window/reinforced/fulltile/indestructable,
 /turf/open/floor/plating/dirt/jungle/wasteland,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "OW" = (
 /obj/structure/bookcase/random/nonfiction,
 /turf/closed/indestructible/wood,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "OZ" = (
 /obj/item/flashlight/spotlight,
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "Pf" = (
 /obj/structure/table/wood,
 /obj/item/book/random{
 	pixel_x = -3
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "Qo" = (
 /obj/item/book/random,
 /obj/item/book/random{
@@ -563,20 +563,20 @@
 /obj/item/flashlight/spotlight,
 /obj/effect/turf_decal/siding/wood,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "Qs" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/item/flashlight/spotlight,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "RS" = (
 /obj/structure/table/wood,
 /obj/item/book/random,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "Su" = (
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "Sx" = (
 /obj/item/book/random,
 /obj/item/book/random{
@@ -594,7 +594,7 @@
 	},
 /obj/structure/table/wood,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "Sy" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -604,7 +604,7 @@
 	},
 /obj/structure/fireplace,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "SX" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -613,38 +613,38 @@
 	dir = 4
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "Tf" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 6
 	},
 /turf/open/floor/pod/dark,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "TX" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/wood,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "Uw" = (
 /obj/item/flashlight/spotlight,
 /obj/effect/turf_decal/siding/wood,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "Vp" = (
 /obj/structure/chair/wood{
 	dir = 4
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "WC" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 2
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "Xn" = (
 /obj/effect/turf_decal/siding/wood,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "XO" = (
 /obj/structure/table/wood,
 /obj/item/toy/plush/scorched,
@@ -652,14 +652,14 @@
 	dir = 8
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "Yn" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 10
 	},
 /obj/item/flashlight/spotlight,
 /turf/open/floor/pod/dark,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "YI" = (
 /obj/item/flashlight/spotlight,
 /obj/effect/turf_decal/siding/wood/corner{
@@ -667,15 +667,15 @@
 	},
 /obj/structure/fireplace,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "Zg" = (
 /obj/structure/bookcase/random/nonfiction,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "ZB" = (
 /obj/effect/decal/cleanable/blood/footprints,
 /turf/open/floor/wood,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 "ZW" = (
 /obj/structure/table/wood,
 /obj/item/gun/ego_gun/city/thumb/weak,
@@ -688,7 +688,7 @@
 	pixel_y = -9
 	},
 /turf/open/floor/plating/dirt/jungle/wasteland,
-/area/city/backstreets_room)
+/area/library_floors/floor_history)
 
 (1,1,1) = {"
 xi

--- a/_maps/map_files/Library/floor_language.dmm
+++ b/_maps/map_files/Library/floor_language.dmm
@@ -6,18 +6,18 @@
 	resistance_flags = 64
 	},
 /turf/open/lava,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "ao" = (
 /obj/item/flashlight/spotlight,
 /turf/open/floor/mineral/plastitanium,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "aY" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 10
 	},
 /obj/effect/decal/cleanable/ash,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "cw" = (
 /obj/structure/railing{
 	dir = 1;
@@ -25,30 +25,30 @@
 	resistance_flags = 64
 	},
 /turf/open/floor/plating/beach/sand,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "ei" = (
 /obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 8
 	},
 /turf/open/floor/stone,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "eI" = (
 /obj/item/target,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "gU" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/stone,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "hL" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "hT" = (
 /obj/structure/railing{
 	dir = 4;
@@ -56,194 +56,194 @@
 	max_integrity = 1e+007
 	},
 /turf/open/floor/plating/beach/sand,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "hY" = (
 /obj/item/target,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 5
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "ib" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 6
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "it" = (
 /obj/structure/chair/comfy,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "ja" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/plating/beach/sand,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "jN" = (
 /turf/open/floor/mineral/plastitanium,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "jZ" = (
 /obj/item/flashlight/spotlight,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "kV" = (
 /obj/structure/weightmachine/weightlifter,
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/plating/beach/sand,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "my" = (
 /obj/structure/table/reinforced,
 /obj/item/ego_weapon/city/shi_assassin,
 /turf/open/floor/mineral/plastitanium,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "nv" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /obj/item/flashlight/spotlight,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "ou" = (
 /obj/item/toy/plush/mosb,
 /turf/open/floor/stone,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "pz" = (
 /obj/structure/railing{
 	name = "invincible railing";
 	resistance_flags = 64
 	},
 /turf/open/floor/plating/beach/sand,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "qz" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "rn" = (
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "rr" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/stone,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "rv" = (
 /obj/structure/table/reinforced,
 /obj/item/ego_weapon/city/seven,
 /turf/open/floor/mineral/plastitanium,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "ry" = (
 /obj/structure/table/wood,
 /obj/item/lighter,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "rW" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/stone,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "ss" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/stone,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "sO" = (
 /obj/effect/decal/cleanable/ash,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 5
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "tK" = (
 /obj/structure/table/wood,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "uL" = (
 /obj/structure/window/reinforced/fulltile/indestructable,
 /obj/structure/grille,
 /turf/open/floor/stone,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "vb" = (
 /obj/structure/table/reinforced,
 /obj/item/ego_weapon/city/index,
 /turf/open/floor/mineral/plastitanium,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "vX" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/stone,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "we" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /turf/open/floor/stone,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "wu" = (
 /obj/machinery/computer/security/wooden_tv,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "ww" = (
 /obj/structure/bookcase/random/nonfiction,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "wP" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/cigarettes/cigpack_robust,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "xb" = (
 /obj/machinery/door/airlock/hatch,
 /turf/open/floor/stone,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "xB" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/cigarettes/cigpack_robustgold,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "yd" = (
 /turf/open/floor/holofloor/basalt,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "yq" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/plating/beach/sand,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "zF" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "AF" = (
 /obj/structure/table/reinforced,
 /obj/item/ego_weapon/city/dawn/zwei,
 /turf/open/floor/mineral/plastitanium,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "AW" = (
 /turf/open/lava{
 	density = 1
 	},
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "Br" = (
 /obj/structure/chair/comfy{
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "Di" = (
 /obj/item/toy/plush/melt,
 /turf/open/floor/stone,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "Dt" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 9
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "DP" = (
 /obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 4
 	},
 /turf/open/floor/stone,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "El" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -252,39 +252,39 @@
 	dir = 1
 	},
 /turf/open/lava,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "EB" = (
 /turf/open/floor/plating/beach/sand,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "ED" = (
 /obj/effect/decal/cleanable/ash,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "EU" = (
 /obj/item/chair/wood/wings,
 /obj/item/clothing/mask/cigarette,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "Fo" = (
 /obj/structure/bookcase/random/nonfiction,
 /turf/closed/indestructible/syndicate,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "FC" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /obj/item/flashlight/spotlight,
 /turf/open/floor/stone,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "Gb" = (
 /obj/structure/lattice/catwalk,
 /turf/open/lava,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "Gd" = (
 /obj/structure/table/wood,
 /obj/item/clothing/mask/cigarette,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "GM" = (
 /obj/item/toy/plush/gebura,
 /obj/item/ego_weapon/mimicry/kali{
@@ -296,21 +296,21 @@
 	pixel_y = 1
 	},
 /turf/open/floor/stone,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "GT" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/mob_spawn/human/corpse/assistant,
 /turf/open/floor/stone,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "HC" = (
 /obj/structure/weightmachine/weightlifter,
 /turf/open/floor/plating/beach/sand,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "HK" = (
 /obj/structure/chair/comfy,
 /obj/item/flashlight/spotlight,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "HM" = (
 /obj/structure/railing{
 	dir = 5;
@@ -319,33 +319,33 @@
 	},
 /obj/item/flashlight/spotlight,
 /turf/open/floor/plating/beach/sand,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "IM" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /obj/effect/mob_spawn/human/corpse/assistant,
 /turf/open/floor/stone,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "Jq" = (
 /obj/effect/decal/cleanable/blood/gibs/core,
 /turf/open/floor/stone,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "JF" = (
 /obj/structure/table/reinforced,
 /obj/item/ego_weapon/city/bladelineage,
 /turf/open/floor/mineral/plastitanium,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "LT" = (
 /obj/structure/table/reinforced,
 /obj/item/gun/ego_gun/city/thumb,
 /turf/open/floor/mineral/plastitanium,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "Mp" = (
 /obj/structure/bookcase/random,
 /turf/closed/indestructible/syndicate,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "MR" = (
 /turf/closed/indestructible/syndicate,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "Ov" = (
 /obj/structure/railing{
 	dir = 10;
@@ -354,7 +354,7 @@
 	},
 /obj/item/flashlight/spotlight,
 /turf/open/floor/plating/beach/sand,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "Ox" = (
 /obj/structure/railing{
 	dir = 8;
@@ -362,7 +362,7 @@
 	name = "invincible railing"
 	},
 /turf/open/floor/plating/beach/sand,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "ON" = (
 /obj/structure/railing{
 	dir = 9;
@@ -371,17 +371,17 @@
 	},
 /obj/item/flashlight/spotlight,
 /turf/open/floor/plating/beach/sand,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "PV" = (
 /obj/structure/chair/comfy{
 	dir = 1
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "Qd" = (
 /obj/structure/weightmachine/stacklifter,
 /turf/open/floor/plating/beach/sand,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "Rm" = (
 /obj/item/chair/wood/wings{
 	dir = 4
@@ -389,39 +389,39 @@
 /obj/item/clothing/mask/cigarette,
 /obj/item/flashlight/spotlight,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "Sf" = (
 /obj/item/chair/wood,
 /obj/effect/decal/cleanable/ash,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "Sw" = (
 /obj/structure/table/reinforced,
 /obj/item/ego_weapon/city/kurokumo,
 /turf/open/floor/mineral/plastitanium,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "SJ" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/item/flashlight/spotlight,
 /turf/open/floor/stone,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "TW" = (
 /obj/item/clothing/mask/cigarette,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "Ur" = (
 /obj/effect/decal/cleanable/ash,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "UV" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "VQ" = (
 /obj/structure/railing{
 	dir = 6;
@@ -430,13 +430,13 @@
 	},
 /obj/item/flashlight/spotlight,
 /turf/open/floor/plating/beach/sand,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "Xg" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 10
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "XD" = (
 /obj/structure/table/wood,
 /obj/item/lighter{
@@ -444,7 +444,7 @@
 	pixel_x = -8
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "XL" = (
 /turf/open/space/basic,
 /area/space)
@@ -452,15 +452,15 @@
 /obj/structure/table/reinforced,
 /obj/item/ego_weapon/city/liu/fist,
 /turf/open/floor/mineral/plastitanium,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "YX" = (
 /turf/open/floor/stone,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "ZO" = (
 /obj/structure/window/reinforced/fulltile/indestructable,
 /obj/structure/grille,
 /turf/open/floor/mineral/plastitanium,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 "ZQ" = (
 /obj/item/toy/plush/binah,
 /obj/item/reagent_containers/food/drinks/mug/tea{
@@ -468,7 +468,7 @@
 	pixel_x = 7
 	},
 /turf/open/floor/stone,
-/area/city/backstreets_room)
+/area/library_floors/floor_language)
 
 (1,1,1) = {"
 XL

--- a/_maps/map_files/Library/floor_literature.dmm
+++ b/_maps/map_files/Library/floor_literature.dmm
@@ -4,16 +4,16 @@
 	light_color = "#d8b66f"
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "bf" = (
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "cg" = (
 /obj/effect/turf_decal/siding/brown/corner{
 	dir = 8
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "ci" = (
 /obj/effect/turf_decal/siding/brown/corner{
 	dir = 1
@@ -22,7 +22,7 @@
 	dir = 8
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "cq" = (
 /obj/effect/turf_decal/siding/brown/corner{
 	dir = 1
@@ -34,7 +34,7 @@
 	dir = 8
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "cw" = (
 /obj/effect/turf_decal/siding/brown/corner{
 	dir = 8
@@ -46,7 +46,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "cJ" = (
 /obj/item/flashlight/spotlight{
 	light_color = "#d8b66f"
@@ -55,12 +55,12 @@
 	dir = 8
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "db" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/blood/footprints,
 /turf/open/indestructible/cult,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "du" = (
 /obj/item/flashlight/spotlight{
 	light_color = "#d8b66f"
@@ -69,17 +69,17 @@
 	dir = 4
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "ej" = (
 /obj/effect/turf_decal/siding/brown{
 	dir = 6
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "ga" = (
 /obj/structure/bookcase/random/fiction,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "gz" = (
 /obj/effect/turf_decal/siding/brown/corner{
 	dir = 8
@@ -88,20 +88,20 @@
 	dir = 8
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "gO" = (
 /obj/effect/turf_decal/siding/brown/corner,
 /obj/effect/turf_decal/siding/brown{
 	dir = 4
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "hq" = (
 /obj/effect/turf_decal/siding/brown/corner{
 	dir = 1
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "hW" = (
 /obj/structure/railing{
 	name = "invincible railing";
@@ -112,13 +112,13 @@
 	dir = 10
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "iD" = (
 /obj/effect/turf_decal/siding/brown/corner{
 	dir = 4
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "jS" = (
 /obj/machinery/door/airlock/cult/unruned/friendly,
 /obj/machinery/door/airlock/cult/unruned/friendly,
@@ -129,15 +129,15 @@
 /obj/structure/barricade/wooden,
 /obj/structure/barricade/wooden/crude,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "kL" = (
 /obj/machinery/light,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "lr" = (
 /obj/structure/sign/warning/biohazard,
 /turf/closed/indestructible/wood,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "lC" = (
 /obj/item/flashlight/spotlight{
 	light_color = "#d8b66f"
@@ -146,7 +146,7 @@
 	dir = 1
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "lR" = (
 /obj/effect/turf_decal/siding/brown/corner{
 	dir = 1
@@ -155,7 +155,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "nt" = (
 /obj/structure/railing{
 	name = "invincible railing";
@@ -166,7 +166,7 @@
 	dir = 9
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "nW" = (
 /obj/machinery/light{
 	dir = 4
@@ -180,47 +180,47 @@
 	dir = 5
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "oq" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "oy" = (
 /obj/effect/turf_decal/siding/brown{
 	dir = 10
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "oZ" = (
 /turf/open/floor/white{
 	density = 1
 	},
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "ru" = (
 /obj/structure/chair/wood,
 /obj/effect/turf_decal/siding/brown/corner{
 	dir = 8
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "rN" = (
 /obj/machinery/light{
 	dir = 8
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "ss" = (
 /obj/structure/window/reinforced/fulltile/indestructable,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "tu" = (
 /obj/effect/turf_decal/siding/brown{
 	dir = 8
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "tA" = (
 /obj/machinery/light{
 	dir = 4
@@ -229,27 +229,27 @@
 	dir = 4
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "tP" = (
 /obj/effect/turf_decal/siding/brown{
 	dir = 1
 	},
 /obj/effect/turf_decal/siding/brown,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "ua" = (
 /obj/effect/turf_decal/siding/brown{
 	dir = 9
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "uH" = (
 /obj/structure/chair/wood{
 	dir = 8
 	},
 /obj/effect/turf_decal/siding/brown/corner,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "uO" = (
 /obj/structure/railing{
 	name = "invincible railing";
@@ -257,10 +257,10 @@
 	},
 /obj/effect/turf_decal/siding/brown,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "vA" = (
 /turf/open/floor/white,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "vH" = (
 /turf/open/space/basic,
 /area/space)
@@ -271,11 +271,11 @@
 	},
 /obj/effect/turf_decal/trimline/red/filled/warning,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "xm" = (
 /obj/effect/decal/cleanable/blood/gibs/bubblegum,
 /turf/open/indestructible/cult,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "xw" = (
 /obj/effect/turf_decal/siding/brown{
 	dir = 4
@@ -284,20 +284,20 @@
 	dir = 8
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "yd" = (
 /obj/effect/turf_decal/siding/brown{
 	dir = 1
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "zq" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/blood/gibs/core,
 /obj/structure/kitchenspike,
 /obj/effect/mob_spawn/human/corpse/assistant,
 /turf/open/indestructible/cult,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "zt" = (
 /obj/structure/railing{
 	name = "invincible railing";
@@ -307,7 +307,7 @@
 	dir = 10
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "zW" = (
 /obj/machinery/light{
 	dir = 8
@@ -321,7 +321,7 @@
 	dir = 9
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "Ak" = (
 /obj/item/flashlight/spotlight{
 	light_color = "#d8b66f"
@@ -330,14 +330,14 @@
 	dir = 8
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "An" = (
 /obj/effect/turf_decal/siding/brown,
 /obj/effect/turf_decal/siding/brown{
 	dir = 1
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "Aw" = (
 /obj/effect/turf_decal/siding/brown/corner{
 	dir = 8
@@ -346,12 +346,12 @@
 	dir = 1
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "AD" = (
 /obj/structure/displaycase,
 /obj/item/book/random,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "AI" = (
 /obj/machinery/door/airlock/cult/unruned/friendly,
 /obj/structure/barricade/wooden/crude,
@@ -361,16 +361,16 @@
 /obj/structure/barricade/wooden,
 /obj/structure/barricade/wooden/crude,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "BM" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/blood/gibs/core,
 /turf/open/indestructible/cult,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "Ce" = (
 /obj/effect/decal/cleanable/blood/gibs/core,
 /turf/open/indestructible/cult,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "Ch" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/siding/brown{
@@ -378,7 +378,7 @@
 	},
 /obj/item/book/random,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "CI" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/siding/brown{
@@ -386,25 +386,25 @@
 	},
 /obj/item/book/random,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "En" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/indestructible/cult,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "EW" = (
 /obj/effect/decal/cleanable/blood/footprints,
 /obj/effect/decal/cleanable/blood/gibs/up,
 /turf/open/indestructible/cult,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "FE" = (
 /obj/structure/sign/warning,
 /turf/closed/indestructible/wood,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "FU" = (
 /obj/structure/bookcase/random/fiction,
 /turf/closed/indestructible/wood,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "Gt" = (
 /obj/effect/turf_decal/siding/brown{
 	dir = 1
@@ -413,13 +413,13 @@
 	dir = 4
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "Gy" = (
 /obj/effect/turf_decal/siding/brown{
 	dir = 4
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "Hx" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/item/toy/plush/hod,
@@ -428,7 +428,7 @@
 	pixel_x = -7
 	},
 /turf/open/indestructible/cult,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "HK" = (
 /obj/effect/turf_decal/siding/brown{
 	dir = 8
@@ -437,12 +437,12 @@
 	dir = 4
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "Ic" = (
 /obj/structure/chair/wood,
 /obj/effect/turf_decal/siding/brown/corner,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "IC" = (
 /obj/structure/railing{
 	name = "invincible railing";
@@ -452,22 +452,22 @@
 	dir = 6
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "IF" = (
 /obj/structure/stairs{
 	dir = 2
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "IH" = (
 /obj/structure/table/wood,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "Jc" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/blood/gibs/body,
 /turf/open/indestructible/cult,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "JV" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -476,7 +476,7 @@
 	dir = 1
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "Ku" = (
 /obj/effect/turf_decal/siding/brown,
 /obj/effect/turf_decal/siding/brown/corner{
@@ -484,12 +484,12 @@
 	},
 /obj/effect/turf_decal/trimline/red/filled/warning,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "Kx" = (
 /obj/effect/decal/cleanable/blood/footprints,
 /obj/item/flashlight/spotlight,
 /turf/open/indestructible/cult,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "KY" = (
 /obj/structure/railing{
 	name = "invincible railing";
@@ -500,29 +500,29 @@
 	dir = 1
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "Lq" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/structure/kitchenspike,
 /obj/effect/mob_spawn/human/corpse/assistant,
 /turf/open/indestructible/cult,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "Lu" = (
 /obj/effect/turf_decal/siding/brown/end{
 	dir = 4
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "LD" = (
 /obj/structure/table/wood,
 /obj/item/book/random,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "Mf" = (
 /turf/open/floor/plasteel/stairs{
 	dir = 4
 	},
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "MI" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -531,7 +531,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "Nc" = (
 /obj/effect/turf_decal/siding/brown/corner{
 	dir = 8
@@ -540,11 +540,11 @@
 	dir = 2
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "Ng" = (
 /obj/machinery/door/airlock/wood/glass,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "Oh" = (
 /obj/effect/turf_decal/siding/brown,
 /obj/effect/turf_decal/siding/brown{
@@ -554,7 +554,7 @@
 	dir = 8
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "Oi" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/siding/brown{
@@ -562,20 +562,20 @@
 	},
 /obj/item/reagent_containers/blood/a_minus,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "Pw" = (
 /obj/item/flashlight/spotlight{
 	light_color = "#d8b66f"
 	},
 /turf/open/floor/white,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "PJ" = (
 /obj/effect/turf_decal/siding/brown,
 /obj/effect/turf_decal/siding/brown/corner{
 	dir = 4
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "Qv" = (
 /obj/machinery/light{
 	dir = 8
@@ -584,7 +584,7 @@
 	dir = 8
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "ST" = (
 /obj/machinery/light{
 	dir = 4
@@ -597,14 +597,14 @@
 	dir = 6
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "Tk" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/siding/brown{
 	dir = 4
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "Tm" = (
 /obj/item/flashlight/spotlight{
 	light_color = "#d8b66f"
@@ -612,13 +612,13 @@
 /turf/open/floor/white{
 	density = 1
 	},
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "Ty" = (
 /obj/effect/turf_decal/siding/brown{
 	dir = 5
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "TK" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -627,7 +627,7 @@
 	light_color = "#d8b66f"
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "Ug" = (
 /obj/effect/turf_decal/siding/brown/corner{
 	dir = 8
@@ -636,24 +636,24 @@
 	dir = 1
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "UB" = (
 /obj/effect/turf_decal/siding/brown/corner,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "VJ" = (
 /obj/machinery/light{
 	dir = 4
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "VT" = (
 /obj/effect/turf_decal/siding/brown/corner,
 /obj/effect/turf_decal/siding/brown{
 	dir = 1
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "WR" = (
 /obj/machinery/light{
 	dir = 8
@@ -666,7 +666,7 @@
 	dir = 10
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "WW" = (
 /obj/structure/railing{
 	name = "invincible railing";
@@ -677,17 +677,17 @@
 	dir = 5
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "Xa" = (
 /turf/open/floor/plasteel/stairs{
 	dir = 8
 	},
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "XF" = (
 /obj/effect/decal/cleanable/blood/gibs/core,
 /obj/effect/decal/cleanable/blood,
 /turf/open/indestructible/cult,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "XM" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -696,14 +696,14 @@
 	dir = 4
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "Ze" = (
 /obj/effect/turf_decal/siding/brown,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 "Zj" = (
 /turf/closed/indestructible/wood,
-/area/city/backstreets_room)
+/area/library_floors/floor_literature)
 
 (1,1,1) = {"
 vH

--- a/_maps/map_files/Library/floor_naturalsci.dmm
+++ b/_maps/map_files/Library/floor_naturalsci.dmm
@@ -3,16 +3,16 @@
 /turf/open/floor/white{
 	density = 1
 	},
-/area/city/backstreets_room)
+/area/library_floors/floor_naturalsci)
 "as" = (
 /obj/item/flashlight/spotlight,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_naturalsci)
 "cg" = (
 /obj/structure/table/wood,
 /obj/item/book/random,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_naturalsci)
 "cJ" = (
 /obj/structure/railing{
 	dir = 5;
@@ -20,7 +20,7 @@
 	name = "invincible railing"
 	},
 /turf/open/floor/carpet/lone,
-/area/city/backstreets_room)
+/area/library_floors/floor_naturalsci)
 "dl" = (
 /obj/structure/railing{
 	dir = 9;
@@ -28,13 +28,13 @@
 	name = "invincible railing"
 	},
 /turf/open/floor/carpet/lone,
-/area/city/backstreets_room)
+/area/library_floors/floor_naturalsci)
 "eb" = (
 /obj/structure/ladder/unbreakable{
 	pixel_y = 8
 	},
 /turf/open/floor/carpet/red,
-/area/city/backstreets_room)
+/area/library_floors/floor_naturalsci)
 "ec" = (
 /turf/open/floor/white{
 	density = 1
@@ -44,7 +44,7 @@
 /obj/structure/lattice,
 /obj/structure/window/reinforced/fulltile/indestructable,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_naturalsci)
 "fe" = (
 /obj/item/toy/plush/kod,
 /obj/item/ego_weapon/despair{
@@ -52,19 +52,19 @@
 	pixel_y = 4
 	},
 /turf/open/floor/facility/dark,
-/area/city/backstreets_room)
+/area/library_floors/floor_naturalsci)
 "fw" = (
 /obj/structure/railing/corner{
 	dir = 1
 	},
 /turf/open/floor/carpet/lone,
-/area/city/backstreets_room)
+/area/library_floors/floor_naturalsci)
 "gn" = (
 /obj/structure/flora/icestalactite/small{
 	pixel_y = -13
 	},
 /turf/open/chasm,
-/area/city/backstreets_room)
+/area/library_floors/floor_naturalsci)
 "gL" = (
 /obj/item/flashlight/spotlight,
 /obj/structure/railing{
@@ -73,42 +73,43 @@
 	name = "invincible railing"
 	},
 /turf/open/floor/mineral/gold,
-/area/city/backstreets_room)
+/area/library_floors/floor_naturalsci)
 "hD" = (
 /obj/item/flashlight/spotlight,
 /turf/open/floor/carpet/red,
-/area/city/backstreets_room)
+/area/library_floors/floor_naturalsci)
 "id" = (
 /obj/structure/chair/wood{
 	dir = 8
 	},
 /turf/open/floor/carpet/lone,
-/area/city/backstreets_room)
+/area/library_floors/floor_naturalsci)
 "iE" = (
 /obj/structure/railing/corner,
 /turf/open/floor/mineral/gold,
-/area/city/backstreets_room)
+/area/library_floors/floor_naturalsci)
 "iK" = (
 /obj/structure/altar_of_gods,
 /turf/open/floor/carpet/red,
-/area/city/backstreets_room)
+/area/library_floors/floor_naturalsci)
 "lf" = (
 /obj/item/toy/plush/nihil,
+/obj/item/flashlight/spotlight,
 /turf/open/floor/facility/dark,
-/area/city/backstreets_room)
+/area/library_floors/floor_naturalsci)
 "lp" = (
 /obj/structure/bookcase/random/nonfiction,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_naturalsci)
 "lG" = (
 /obj/structure/table/wood,
 /obj/structure/table/wood,
 /turf/open/floor/carpet/lone,
-/area/city/backstreets_room)
+/area/library_floors/floor_naturalsci)
 "nt" = (
 /obj/item/flashlight/spotlight,
 /turf/open/floor/mineral/gold,
-/area/city/backstreets_room)
+/area/library_floors/floor_naturalsci)
 "nP" = (
 /obj/structure/railing/corner{
 	dir = 8;
@@ -116,23 +117,23 @@
 	pixel_y = 2
 	},
 /turf/open/floor/mineral/gold,
-/area/city/backstreets_room)
+/area/library_floors/floor_naturalsci)
 "oe" = (
 /obj/structure/flora/icestalactite{
 	pixel_y = -16
 	},
 /turf/open/chasm,
-/area/city/backstreets_room)
+/area/library_floors/floor_naturalsci)
 "px" = (
 /turf/open/chasm,
-/area/city/backstreets_room)
+/area/library_floors/floor_naturalsci)
 "pL" = (
 /obj/item/flashlight/spotlight,
 /obj/structure/chair/wood{
 	dir = 8
 	},
 /turf/open/floor/carpet/lone,
-/area/city/backstreets_room)
+/area/library_floors/floor_naturalsci)
 "qj" = (
 /obj/item/toy/plush/kog,
 /obj/item/ego_weapon/goldrush{
@@ -140,17 +141,17 @@
 	pixel_x = 13
 	},
 /turf/open/floor/facility/dark,
-/area/city/backstreets_room)
+/area/library_floors/floor_naturalsci)
 "qk" = (
 /obj/structure/railing/corner{
 	dir = 4
 	},
 /turf/open/floor/carpet/lone,
-/area/city/backstreets_room)
+/area/library_floors/floor_naturalsci)
 "qt" = (
 /obj/item/flashlight/spotlight,
 /turf/open/floor/carpet/lone,
-/area/city/backstreets_room)
+/area/library_floors/floor_naturalsci)
 "qC" = (
 /obj/item/flashlight/spotlight,
 /obj/structure/railing{
@@ -158,7 +159,7 @@
 	resistance_flags = 64
 	},
 /turf/open/floor/mineral/gold,
-/area/city/backstreets_room)
+/area/library_floors/floor_naturalsci)
 "un" = (
 /obj/item/toy/plush/sow,
 /obj/item/ego_weapon/blind_rage{
@@ -166,17 +167,17 @@
 	pixel_y = -7
 	},
 /turf/open/floor/facility/dark,
-/area/city/backstreets_room)
+/area/library_floors/floor_naturalsci)
 "uH" = (
 /turf/open/space/basic,
 /area/space)
 "vA" = (
 /obj/structure/bookcase/random/nonfiction,
 /turf/open/floor/carpet/red,
-/area/city/backstreets_room)
+/area/library_floors/floor_naturalsci)
 "wa" = (
 /turf/open/floor/carpet/lone,
-/area/city/backstreets_room)
+/area/library_floors/floor_naturalsci)
 "wn" = (
 /obj/structure/railing{
 	dir = 10;
@@ -184,15 +185,15 @@
 	name = "invincible railing"
 	},
 /turf/open/floor/mineral/gold,
-/area/city/backstreets_room)
+/area/library_floors/floor_naturalsci)
 "wp" = (
 /obj/item/flashlight/spotlight,
 /turf/open/chasm,
-/area/city/backstreets_room)
+/area/library_floors/floor_naturalsci)
 "wz" = (
 /obj/structure/railing,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_naturalsci)
 "wD" = (
 /obj/item/flashlight/spotlight,
 /turf/open/floor/white{
@@ -205,11 +206,11 @@
 /turf/open/floor/white{
 	density = 1
 	},
-/area/city/backstreets_room)
+/area/library_floors/floor_naturalsci)
 "wO" = (
 /obj/item/candle/infinite,
 /turf/closed/wall/mineral/gold,
-/area/city/backstreets_room)
+/area/library_floors/floor_naturalsci)
 "xx" = (
 /obj/structure/railing{
 	dir = 6;
@@ -217,34 +218,34 @@
 	max_integrity = 1e+007
 	},
 /turf/open/floor/mineral/gold,
-/area/city/backstreets_room)
+/area/library_floors/floor_naturalsci)
 "yJ" = (
 /obj/structure/chair/wood/wings{
 	pixel_y = 0;
 	dir = 1
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_naturalsci)
 "zj" = (
 /obj/structure/displaycase/noalert,
 /turf/open/floor/carpet/red,
-/area/city/backstreets_room)
+/area/library_floors/floor_naturalsci)
 "zq" = (
 /obj/structure/railing/corner{
 	dir = 4
 	},
 /turf/open/floor/mineral/gold,
-/area/city/backstreets_room)
+/area/library_floors/floor_naturalsci)
 "zP" = (
 /obj/structure/table/wood/fancy,
 /turf/open/floor/mineral/gold,
-/area/city/backstreets_room)
+/area/library_floors/floor_naturalsci)
 "Aq" = (
 /obj/item/flashlight/spotlight,
 /turf/open/floor/plating/ice{
 	density = 1
 	},
-/area/city/backstreets_room)
+/area/library_floors/floor_naturalsci)
 "BB" = (
 /obj/structure/railing{
 	name = "invincible railing";
@@ -252,12 +253,16 @@
 	dir = 1
 	},
 /turf/open/floor/mineral/gold,
-/area/city/backstreets_room)
+/area/library_floors/floor_naturalsci)
 "BX" = (
 /turf/open/floor/plating/ice{
 	density = 1
 	},
-/area/city/backstreets_room)
+/area/library_floors/floor_naturalsci)
+"BY" = (
+/obj/item/flashlight/spotlight,
+/turf/open/floor/facility/dark,
+/area/library_floors/floor_naturalsci)
 "Ch" = (
 /obj/item/toy/plush/qoh,
 /obj/item/gun/ego_gun/hatred{
@@ -265,28 +270,33 @@
 	pixel_y = 5
 	},
 /turf/open/floor/facility/dark,
-/area/city/backstreets_room)
+/area/library_floors/floor_naturalsci)
 "CA" = (
 /obj/item/toy/plush/lisa,
 /obj/structure/railing,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_naturalsci)
 "EG" = (
 /turf/open/floor/carpet/red,
-/area/city/backstreets_room)
+/area/library_floors/floor_naturalsci)
 "Gp" = (
 /obj/structure/table/wood,
 /turf/open/floor/carpet/lone,
-/area/city/backstreets_room)
+/area/library_floors/floor_naturalsci)
 "Jz" = (
 /turf/open/floor/facility/dark,
-/area/city/backstreets_room)
+/area/library_floors/floor_naturalsci)
 "JX" = (
 /obj/structure/chair/wood{
 	dir = 4
 	},
 /turf/open/floor/carpet/lone,
-/area/city/backstreets_room)
+/area/library_floors/floor_naturalsci)
+"Kb" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/spotlight,
+/turf/open/floor/carpet/lone,
+/area/library_floors/floor_naturalsci)
 "KI" = (
 /obj/item/flashlight/spotlight{
 	light_color = "#d8b66f"
@@ -294,12 +304,12 @@
 /turf/open/floor/white{
 	density = 1
 	},
-/area/city/backstreets_room)
+/area/library_floors/floor_naturalsci)
 "KV" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/spotlight,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_naturalsci)
 "Ms" = (
 /obj/item/flashlight/spotlight{
 	light_color = "#d8b66f"
@@ -314,13 +324,13 @@
 	resistance_flags = 64
 	},
 /turf/open/floor/mineral/gold,
-/area/city/backstreets_room)
+/area/library_floors/floor_naturalsci)
 "Pq" = (
 /obj/item/flashlight/spotlight{
 	light_color = "#d8b66f"
 	},
 /turf/open/floor/mineral/gold,
-/area/city/backstreets_room)
+/area/library_floors/floor_naturalsci)
 "PZ" = (
 /obj/structure/railing{
 	dir = 8;
@@ -328,12 +338,12 @@
 	name = "invincible railing"
 	},
 /turf/open/floor/carpet/lone,
-/area/city/backstreets_room)
+/area/library_floors/floor_naturalsci)
 "Qe" = (
 /turf/open/lava{
 	density = 1
 	},
-/area/city/backstreets_room)
+/area/library_floors/floor_naturalsci)
 "Qo" = (
 /obj/item/flashlight/spotlight,
 /obj/structure/railing{
@@ -342,34 +352,34 @@
 	max_integrity = 1e+007
 	},
 /turf/open/floor/mineral/gold,
-/area/city/backstreets_room)
+/area/library_floors/floor_naturalsci)
 "QB" = (
 /turf/closed/wall/mineral/gold,
-/area/city/backstreets_room)
+/area/library_floors/floor_naturalsci)
 "QK" = (
 /obj/structure/table/wood,
 /obj/item/book/random,
 /turf/open/floor/carpet/lone,
-/area/city/backstreets_room)
+/area/library_floors/floor_naturalsci)
 "Sq" = (
 /obj/structure/railing/corner,
 /obj/structure/railing/corner{
 	dir = 8
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_naturalsci)
 "SI" = (
 /obj/structure/altar_of_gods,
 /obj/structure/flora/iceslab/alt{
 	pixel_y = 14
 	},
 /turf/open/floor/mineral/gold,
-/area/city/backstreets_room)
+/area/library_floors/floor_naturalsci)
 "Tc" = (
 /obj/structure/altar_of_gods,
 /obj/structure/flora/tree/dead,
 /turf/open/floor/mineral/gold,
-/area/city/backstreets_room)
+/area/library_floors/floor_naturalsci)
 "TL" = (
 /obj/structure/table/wood/fancy,
 /obj/item/candle/infinite{
@@ -377,10 +387,16 @@
 	pixel_x = 16
 	},
 /turf/open/floor/mineral/gold,
-/area/city/backstreets_room)
+/area/library_floors/floor_naturalsci)
 "UJ" = (
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_naturalsci)
+"Vj" = (
+/obj/structure/table/wood,
+/obj/item/book/random,
+/obj/item/flashlight/spotlight,
+/turf/open/floor/carpet/lone,
+/area/library_floors/floor_naturalsci)
 "WW" = (
 /obj/structure/railing{
 	dir = 4;
@@ -388,7 +404,7 @@
 	max_integrity = 1e+007
 	},
 /turf/open/floor/carpet/lone,
-/area/city/backstreets_room)
+/area/library_floors/floor_naturalsci)
 "Xk" = (
 /obj/structure/railing{
 	dir = 1;
@@ -396,30 +412,30 @@
 	resistance_flags = 64
 	},
 /turf/open/floor/carpet/lone,
-/area/city/backstreets_room)
+/area/library_floors/floor_naturalsci)
 "Yy" = (
 /obj/structure/table/wood,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_naturalsci)
 "Zb" = (
 /obj/structure/railing/corner{
 	dir = 1
 	},
 /turf/open/floor/mineral/gold,
-/area/city/backstreets_room)
+/area/library_floors/floor_naturalsci)
 "Zm" = (
 /obj/machinery/door/airlock/wood/glass,
 /turf/open/floor/carpet/red,
-/area/city/backstreets_room)
+/area/library_floors/floor_naturalsci)
 "Zw" = (
 /turf/open/floor/mineral/gold,
-/area/city/backstreets_room)
+/area/library_floors/floor_naturalsci)
 "ZA" = (
 /obj/structure/table/wood,
 /obj/item/book/random,
 /obj/item/flashlight/spotlight,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_naturalsci)
 
 (1,1,1) = {"
 uH
@@ -479,8 +495,8 @@ uH
 uH
 ec
 ec
-KI
-ac
+Ms
+ec
 QB
 cg
 UJ
@@ -520,7 +536,7 @@ UJ
 lp
 QB
 un
-Jz
+BY
 Ch
 QB
 uH
@@ -609,8 +625,8 @@ uH
 uH
 ec
 ec
-ec
-ec
+ac
+ac
 QB
 Yy
 UJ
@@ -1793,7 +1809,7 @@ wa
 wa
 wa
 wa
-Gp
+Kb
 QK
 wN
 ec
@@ -1871,7 +1887,7 @@ wa
 wa
 wa
 wa
-QK
+Vj
 Gp
 wN
 ec

--- a/_maps/map_files/Library/floor_philosophy.dmm
+++ b/_maps/map_files/Library/floor_philosophy.dmm
@@ -9,24 +9,24 @@
 	resistance_flags = 64
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "aA" = (
 /obj/structure/bookcase/random/reference,
 /turf/closed/indestructible/wood,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "aI" = (
 /obj/machinery/door/airlock/wood,
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "aV" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "bk" = (
 /obj/structure/flora/grass/green,
 /turf/open/water,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "bs" = (
 /obj/effect/turf_decal/siding{
 	color = "#7D6521";
@@ -37,7 +37,7 @@
 	dir = 1
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "cq" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
@@ -47,21 +47,21 @@
 	dir = 8
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "cs" = (
 /obj/item/flashlight/lantern{
 	anchored = 1;
 	pixel_y = 17
 	},
 /turf/closed/indestructible/wood,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "cG" = (
 /obj/structure/chair/wood/wings{
 	dir = 4
 	},
 /obj/item/flashlight/spotlight,
 /turf/open/floor/carpet/royalblack,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "cX" = (
 /obj/effect/turf_decal/siding{
 	color = "#7D6521";
@@ -72,14 +72,14 @@
 	dir = 8
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "dy" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 8
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "dz" = (
 /obj/effect/turf_decal/siding/white/corner{
 	color = "#7D6521"
@@ -89,39 +89,39 @@
 	dir = 9
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "dG" = (
 /obj/item/flashlight/spotlight,
 /turf/open/water,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "gd" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light{
 	dir = 8
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "gY" = (
 /obj/effect/turf_decal/siding{
 	color = "#7D6521";
 	dir = 8
 	},
 /turf/open/floor/carpet/royalblack,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "hi" = (
 /obj/structure/window/reinforced/fulltile/indestructable,
 /obj/structure/barricade/wooden,
 /obj/structure/barricade/wooden/crude,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "hI" = (
 /obj/effect/decal/cleanable/blood/footprints,
 /turf/open/floor/plating/dirt,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "iA" = (
 /obj/structure/flora/junglebush,
 /turf/open/water,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "jm" = (
 /obj/structure/sink/kitchen{
 	pixel_y = 19
@@ -131,7 +131,7 @@
 	dir = 1
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "ki" = (
 /obj/effect/turf_decal/siding{
 	color = "#7D6521";
@@ -142,7 +142,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "kG" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
@@ -152,7 +152,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "kS" = (
 /obj/effect/turf_decal/siding/white/corner{
 	color = "#7D6521";
@@ -163,36 +163,36 @@
 	dir = 5
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "kZ" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating/dirt,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "mj" = (
 /obj/structure/chair/wood/wings{
 	dir = 8
 	},
 /turf/open/floor/carpet/royalblack,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "mm" = (
 /obj/structure/flora/tree/dead,
 /turf/open/floor/plating/dirt,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "ms" = (
 /obj/structure/table_frame/wood,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "mI" = (
 /obj/effect/turf_decal/siding{
 	color = "#7D6521";
 	dir = 8
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "ne" = (
 /obj/item/flashlight/lantern,
 /turf/open/floor/plating/dirt,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "nj" = (
 /obj/effect/turf_decal/siding/white/corner{
 	color = "#7D6521";
@@ -203,21 +203,21 @@
 	dir = 1
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "nP" = (
 /obj/effect/turf_decal/siding{
 	color = "#7D6521";
 	dir = 5
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "nZ" = (
 /obj/effect/turf_decal/siding{
 	color = "#7D6521";
 	dir = 4
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "ok" = (
 /obj/structure/table/wood/fancy/black,
 /obj/item/reagent_containers/food/drinks/mug/tea{
@@ -229,10 +229,10 @@
 	pixel_x = 9
 	},
 /turf/open/floor/carpet/royalblack,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "ow" = (
 /turf/open/floor/facility/dark,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "pC" = (
 /obj/structure/railing{
 	dir = 1;
@@ -241,32 +241,32 @@
 	},
 /obj/machinery/light,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "pV" = (
 /obj/item/ego_weapon/mimicry/kali,
 /obj/item/flashlight/spotlight,
 /obj/structure/displaycase/noalert,
 /turf/open/floor/facility/dark,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "qv" = (
 /obj/effect/turf_decal/siding{
 	color = "#7D6521";
 	dir = 6
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "qw" = (
 /obj/structure/window/reinforced/fulltile/indestructable,
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "rg" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/siding{
 	color = "#7D6521"
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "rm" = (
 /obj/structure/chair/wood/wings{
 	pixel_y = 0;
@@ -274,7 +274,7 @@
 	},
 /obj/item/flashlight/spotlight,
 /turf/open/floor/carpet/royalblack,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "rB" = (
 /obj/effect/turf_decal/siding/white/corner{
 	color = "#7D6521"
@@ -284,7 +284,7 @@
 	dir = 1
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "rC" = (
 /obj/effect/turf_decal/siding{
 	color = "#7D6521"
@@ -294,24 +294,24 @@
 	dir = 4
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "rE" = (
 /obj/item/chair/wood,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "rL" = (
 /turf/open/water,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "rT" = (
 /obj/machinery/vending/dinnerware,
 /turf/closed/indestructible/wood,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "sb" = (
 /obj/machinery/light/floor,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "sl" = (
 /turf/open/space/basic,
 /area/space)
@@ -327,7 +327,7 @@
 	pixel_x = -7
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "sw" = (
 /obj/effect/turf_decal/siding{
 	color = "#7D6521"
@@ -337,21 +337,21 @@
 	dir = 1
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "sC" = (
 /obj/structure/flora/tree/dead,
 /turf/open/water,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "tm" = (
 /obj/effect/turf_decal/siding{
 	color = "#7D6521"
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "ur" = (
 /obj/structure/pbird_perch,
 /turf/open/floor/plating/dirt,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "uH" = (
 /obj/item/toy/plush/chesed,
 /obj/item/clothing/accessory/maidapron{
@@ -362,16 +362,16 @@
 	dir = 8
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "uZ" = (
 /obj/item/flashlight/spotlight,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "vK" = (
 /obj/machinery/light/floor,
 /obj/item/flashlight/spotlight,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "wa" = (
 /obj/effect/turf_decal/siding{
 	color = "#7D6521";
@@ -379,7 +379,7 @@
 	},
 /obj/item/flashlight/spotlight,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "wl" = (
 /obj/effect/turf_decal/siding{
 	color = "#7D6521";
@@ -387,17 +387,17 @@
 	},
 /obj/item/flashlight/spotlight,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "wo" = (
 /obj/effect/turf_decal/siding/white/corner{
 	color = "#7D6521"
 	},
 /turf/open/floor/carpet/royalblack,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "xh" = (
 /obj/structure/flora/grass/brown,
 /turf/open/water,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "xq" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/mug/tea{
@@ -408,55 +408,55 @@
 	dir = 6
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "xv" = (
 /obj/structure/chair/wood/wings{
 	dir = 4
 	},
 /turf/open/floor/carpet/royalblack,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "yI" = (
 /obj/structure/table/wood/fancy/black,
 /obj/item/book/random,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "At" = (
 /turf/open/floor/fakespace{
 	density = 1
 	},
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "Be" = (
 /obj/effect/turf_decal/siding/white/corner{
 	color = "#7D6521";
 	dir = 8
 	},
 /turf/open/floor/carpet/royalblack,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "Bj" = (
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "Bk" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/water,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "BR" = (
 /obj/structure/flora/bush,
 /turf/open/water,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "Cq" = (
 /turf/open/floor/carpet/royalblack,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "Da" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/condiment/sugar,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "De" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 8
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "DJ" = (
 /obj/item/gavelhammer,
 /obj/item/gavelblock{
@@ -464,35 +464,35 @@
 	pixel_x = -9
 	},
 /turf/open/floor/plating/dirt,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "DO" = (
 /obj/effect/turf_decal/siding/white/corner{
 	color = "#7D6521"
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "DZ" = (
 /obj/structure/chair/wood/wings,
 /turf/open/floor/carpet/royalblack,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "Es" = (
 /obj/machinery/light/broken{
 	dir = 4
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "ED" = (
 /obj/structure/chair/wood/wings{
 	dir = 8
 	},
 /obj/item/flashlight/spotlight,
 /turf/open/floor/carpet/royalblack,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "Fk" = (
 /obj/structure/table/wood/fancy/black,
 /obj/item/food/cake/bbird,
 /turf/open/floor/carpet/royalblack,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "FD" = (
 /obj/effect/turf_decal/siding{
 	color = "#7D6521";
@@ -503,7 +503,7 @@
 	dir = 8
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "FW" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
@@ -518,14 +518,14 @@
 	dir = 1
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "Gc" = (
 /obj/effect/turf_decal/siding{
 	color = "#7D6521";
 	dir = 10
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "Gp" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 9
@@ -540,7 +540,7 @@
 	name = "invincible railing"
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "Gr" = (
 /obj/effect/turf_decal/siding{
 	color = "#7D6521";
@@ -548,21 +548,21 @@
 	},
 /obj/item/flashlight/spotlight,
 /turf/open/floor/carpet/royalblack,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "Gu" = (
 /obj/structure/flora/rock/pile,
 /turf/open/water,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "GD" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/mug,
 /obj/item/flashlight/spotlight,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "HQ" = (
 /obj/structure/grille/broken,
 /turf/open/floor/plating/rust,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "Im" = (
 /obj/effect/turf_decal/siding{
 	color = "#7D6521";
@@ -574,12 +574,12 @@
 	},
 /obj/item/flashlight/spotlight,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "IK" = (
 /obj/structure/table/wood,
 /obj/item/food/cake/apple,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "Jl" = (
 /obj/effect/turf_decal/siding/white/corner{
 	color = "#7D6521";
@@ -590,14 +590,14 @@
 	dir = 6
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "JA" = (
 /obj/effect/turf_decal/siding{
 	color = "#7D6521";
 	dir = 1
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "JB" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 6
@@ -612,7 +612,7 @@
 	max_integrity = 1e+007
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "JD" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 5
@@ -627,20 +627,20 @@
 	name = "invincible railing"
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "JT" = (
 /obj/machinery/chem_dispenser/drinks,
 /turf/closed/indestructible/wood,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "KT" = (
 /obj/machinery/light{
 	dir = 8
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "KU" = (
 /turf/open/floor/plating/rust,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "Lm" = (
 /obj/structure/railing{
 	dir = 5;
@@ -649,13 +649,13 @@
 	},
 /obj/machinery/light,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "Lx" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 10
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "Ly" = (
 /obj/structure/table/wood/fancy/black,
 /obj/item/book/random{
@@ -663,7 +663,7 @@
 	pixel_x = 7
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "LB" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 10
@@ -678,57 +678,57 @@
 	name = "invincible railing"
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "LP" = (
 /obj/structure/flora/grass/both,
 /turf/open/water,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "LS" = (
 /obj/structure/chair/wood/wings{
 	pixel_y = 0;
 	dir = 1
 	},
 /turf/open/floor/carpet/royalblack,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "Me" = (
 /turf/closed/indestructible/fakeglass,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "Ml" = (
 /turf/open/floor/plating,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "Mz" = (
 /obj/item/reagent_containers/food/drinks/mug/tea{
 	pixel_y = -7
 	},
 /obj/structure/displaycase/noalert,
 /turf/open/floor/carpet/royalblack,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "Ne" = (
 /obj/structure/window/reinforced/fulltile/indestructable,
 /obj/structure/barricade/wooden/crude,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "NJ" = (
 /obj/effect/turf_decal/siding/white/corner{
 	color = "#7D6521";
 	dir = 8
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "NU" = (
 /obj/effect/turf_decal/siding{
 	color = "#7D6521";
 	dir = 9
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "Oh" = (
 /obj/effect/turf_decal/siding{
 	color = "#7D6521";
 	dir = 4
 	},
 /turf/open/floor/carpet/royalblack,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "PW" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/mug/tea{
@@ -736,17 +736,17 @@
 	pixel_x = -7
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "Qp" = (
 /turf/closed/indestructible/wood,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "Rc" = (
 /turf/open/floor/plating/dirt,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "Rg" = (
 /obj/structure/barricade/wooden/crude,
 /turf/closed/indestructible/fakeglass,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "Ri" = (
 /obj/structure/table/wood/fancy/black,
 /obj/item/reagent_containers/food/drinks/mug/tea{
@@ -754,7 +754,7 @@
 	pixel_x = -4
 	},
 /turf/open/floor/carpet/royalblack,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "Rl" = (
 /obj/effect/turf_decal/siding/white/corner{
 	color = "#7D6521";
@@ -764,26 +764,26 @@
 	color = "#7D6521"
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "Ru" = (
 /obj/structure/window/reinforced/fulltile/indestructable,
 /obj/structure/grille,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "RS" = (
 /obj/structure/table/wood/fancy/black,
 /turf/open/floor/carpet/royalblack,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "Sx" = (
 /obj/machinery/bookbinder,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "SF" = (
 /obj/item/bodypart/l_arm,
 /obj/item/flashlight/spotlight,
 /obj/structure/displaycase/noalert,
 /turf/open/floor/facility/dark,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "SV" = (
 /obj/item/flashlight/spotlight{
 	light_color = "#d8b66f"
@@ -791,7 +791,7 @@
 /turf/open/floor/fakespace{
 	density = 1
 	},
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "TR" = (
 /obj/structure/table/wood/fancy/black,
 /obj/item/reagent_containers/food/drinks/mug/tea{
@@ -799,28 +799,28 @@
 	pixel_x = -7
 	},
 /turf/open/floor/carpet/royalblack,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "TZ" = (
 /obj/effect/decal/cleanable/blood/footprints,
 /obj/item/flashlight/spotlight,
 /turf/open/floor/plating/dirt,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "Uf" = (
 /obj/item/flashlight/spotlight,
 /turf/open/floor/carpet/royalblack,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "Uu" = (
 /obj/structure/table/wood/fancy/black,
 /obj/item/reagent_containers/food/drinks/mug/tea{
 	pixel_y = 0
 	},
 /turf/open/floor/carpet/royalblack,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "Uv" = (
 /obj/item/reagent_containers/honeycomb,
 /obj/structure/displaycase/noalert,
 /turf/open/floor/carpet/royalblack,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "UC" = (
 /obj/structure/railing{
 	dir = 1;
@@ -828,7 +828,7 @@
 	resistance_flags = 64
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "UL" = (
 /obj/structure/railing{
 	dir = 1;
@@ -841,14 +841,14 @@
 	},
 /obj/item/toy/plush/binah,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "UU" = (
 /obj/item/flashlight/lantern{
 	anchored = 1;
 	pixel_y = 16
 	},
 /turf/closed/indestructible/wood,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "VE" = (
 /obj/effect/turf_decal/siding/white/corner{
 	color = "#7D6521";
@@ -859,7 +859,7 @@
 	dir = 10
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "WR" = (
 /obj/structure/table/wood/fancy/black,
 /obj/item/reagent_containers/food/drinks/mug/tea{
@@ -867,7 +867,7 @@
 	pixel_x = 7
 	},
 /turf/open/floor/carpet/royalblack,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "XC" = (
 /obj/structure/table/wood/fancy/black,
 /obj/item/reagent_containers/food/drinks/mug/tea{
@@ -875,10 +875,10 @@
 	pixel_x = -1
 	},
 /turf/open/floor/carpet/royalblack,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "XJ" = (
 /turf/closed/wall,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "YE" = (
 /obj/effect/turf_decal/siding{
 	color = "#7D6521";
@@ -888,7 +888,7 @@
 	color = "#7D6521"
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "YO" = (
 /obj/effect/turf_decal/siding/white/corner{
 	color = "#7D6521";
@@ -899,10 +899,10 @@
 	},
 /obj/item/flashlight/spotlight,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "Zn" = (
 /turf/closed/wall/rust,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 "Zv" = (
 /obj/effect/turf_decal/siding{
 	color = "#7D6521";
@@ -912,7 +912,7 @@
 	color = "#7D6521"
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_philosophy)
 
 (1,1,1) = {"
 sl

--- a/_maps/map_files/Library/floor_religion.dmm
+++ b/_maps/map_files/Library/floor_religion.dmm
@@ -3,28 +3,28 @@
 /obj/structure/table/wood,
 /obj/item/clipboard,
 /turf/open/floor/stone,
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "aR" = (
 /obj/structure/window/reinforced/fulltile/indestructable,
 /turf/open/floor/stone,
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "cm" = (
 /turf/open/floor/plasteel/stairs{
 	dir = 4
 	},
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "cr" = (
 /obj/structure/altar_of_gods,
 /turf/open/floor/plasteel/chapel{
 	dir = 2
 	},
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "cS" = (
 /obj/structure/table/wood,
 /obj/item/pen,
 /obj/item/paper,
 /turf/open/floor/stone,
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "dd" = (
 /turf/open/space/basic,
 /area/space)
@@ -38,7 +38,7 @@
 	dir = 1
 	},
 /turf/open/floor/stone,
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "fA" = (
 /obj/structure/table/wood/fancy/black,
 /obj/item/storage/book/bible{
@@ -47,7 +47,7 @@
 /obj/item/candle/infinite,
 /obj/item/flashlight/spotlight,
 /turf/open/floor/white,
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "fO" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 8
@@ -61,7 +61,7 @@
 	name = "invincible railing"
 	},
 /turf/open/floor/stone,
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "gu" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 9
@@ -69,7 +69,7 @@
 /obj/effect/turf_decal/siding/thinplating/corner,
 /obj/structure/railing/corner,
 /turf/open/floor/stone,
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "gU" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 1
@@ -77,7 +77,7 @@
 /obj/effect/turf_decal/siding/white,
 /obj/structure/railing/corner,
 /turf/open/floor/stone,
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "gW" = (
 /obj/effect/turf_decal/siding/white/end{
 	dir = 8
@@ -88,24 +88,24 @@
 	resistance_flags = 64
 	},
 /turf/open/floor/stone,
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "hs" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 9
 	},
 /obj/structure/railing/corner,
 /turf/open/floor/stone,
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "hO" = (
 /obj/item/flashlight/spotlight,
 /turf/open/floor/white,
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "hP" = (
 /turf/open/floor/plasteel/dark/corner,
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "hW" = (
 /turf/open/floor/plasteel/dark,
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "kB" = (
 /obj/effect/turf_decal/siding/white/end{
 	dir = 4
@@ -116,26 +116,26 @@
 	max_integrity = 1e+007
 	},
 /turf/open/floor/stone,
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "lm" = (
 /obj/machinery/bookbinder,
 /turf/open/floor/stone,
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "mE" = (
 /obj/structure/chair/comfy{
 	dir = 4
 	},
 /turf/open/floor/stone,
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "nh" = (
 /turf/open/floor/plasteel/chapel{
 	dir = 4
 	},
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "nk" = (
 /obj/structure/table/wood/fancy/black,
 /turf/open/floor/plasteel/dark,
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "nx" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 1
@@ -147,26 +147,26 @@
 	dir = 1
 	},
 /turf/open/floor/stone,
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "nz" = (
 /obj/item/toy/plush/ayin,
 /obj/item/flashlight/spotlight,
 /obj/structure/displaycase/noalert,
 /turf/open/floor/stone,
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "oy" = (
 /turf/open/floor/plasteel/chapel{
 	dir = 2
 	},
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "oV" = (
 /obj/item/flashlight/spotlight,
 /turf/open/floor/stone,
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "pn" = (
 /obj/item/flashlight/spotlight,
 /turf/open/floor/plasteel/dark,
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "ps" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 5
@@ -180,25 +180,25 @@
 	pixel_y = 2
 	},
 /turf/open/floor/stone,
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "pu" = (
 /turf/open/floor/white{
 	density = 1
 	},
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "pM" = (
 /obj/effect/decal/fakelattice,
 /obj/item/flashlight/spotlight,
 /turf/open/floor/white{
 	density = 1
 	},
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "rk" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "rs" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 1
@@ -210,10 +210,10 @@
 	max_integrity = 1e+007
 	},
 /turf/open/floor/stone,
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "rA" = (
 /turf/open/floor/plasteel/dark/side,
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "rY" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 6
@@ -225,19 +225,19 @@
 	dir = 1
 	},
 /turf/open/floor/stone,
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "vn" = (
 /obj/structure/chair/wood/wings{
 	dir = 8
 	},
 /obj/item/flashlight/spotlight,
 /turf/open/floor/stone,
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "vq" = (
 /obj/structure/table/wood/fancy/black,
 /obj/item/candle/infinite,
 /turf/open/floor/white,
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "wr" = (
 /obj/effect/turf_decal/siding/white,
 /obj/effect/turf_decal/siding/white{
@@ -249,41 +249,41 @@
 	resistance_flags = 64
 	},
 /turf/open/floor/stone,
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "wy" = (
 /obj/structure/table/wood,
 /obj/item/storage/book/bible,
 /turf/open/floor/stone,
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "wC" = (
 /turf/open/floor/white,
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "xv" = (
 /obj/item/flashlight/spotlight,
 /obj/structure/altar_of_gods,
 /turf/open/floor/stone,
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "xy" = (
 /obj/structure/lattice/catwalk,
 /turf/open/floor/white{
 	density = 1
 	},
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "xE" = (
 /obj/structure/table/greyscale,
 /obj/item/shield/riot/buckler,
 /turf/open/floor/stone,
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "ym" = (
 /obj/structure/table/wood/fancy/black,
 /obj/item/storage/fancy/candle_box,
 /turf/open/floor/plasteel/dark,
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "yE" = (
 /obj/structure/bookcase/random/religion,
 /obj/item/flashlight/spotlight,
 /turf/open/floor/stone,
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "zi" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 1
@@ -295,24 +295,24 @@
 	resistance_flags = 64
 	},
 /turf/open/floor/stone,
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "zD" = (
 /obj/structure/table/wood,
 /turf/open/floor/stone,
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "zJ" = (
 /obj/structure/chair/wood/wings{
 	dir = 4
 	},
 /obj/item/flashlight/spotlight,
 /turf/open/floor/stone,
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "zV" = (
 /obj/item/flashlight/spotlight,
 /turf/open/floor/plasteel/stairs{
 	dir = 8
 	},
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "Ak" = (
 /obj/effect/turf_decal/siding/white,
 /obj/effect/turf_decal/siding/white{
@@ -322,29 +322,29 @@
 	dir = 1
 	},
 /turf/open/floor/stone,
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "Bi" = (
 /obj/structure/table/wood,
 /obj/item/pen,
 /turf/open/floor/stone,
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "Bo" = (
 /turf/open/floor/plasteel/chapel{
 	dir = 1
 	},
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "Ca" = (
 /turf/open/floor/plasteel/chapel{
 	dir = 8
 	},
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "Cg" = (
 /obj/effect/turf_decal/siding/white,
 /obj/effect/turf_decal/siding/white{
 	dir = 1
 	},
 /turf/open/floor/stone,
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "Cl" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 10
@@ -353,18 +353,18 @@
 	dir = 4
 	},
 /turf/open/floor/stone,
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "Cn" = (
 /obj/item/flashlight/spotlight,
 /turf/open/floor/white{
 	density = 1
 	},
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "DK" = (
 /turf/open/floor/plasteel/dark/corner{
 	dir = 4
 	},
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "GH" = (
 /obj/effect/turf_decal/siding/white/end{
 	dir = 4
@@ -375,7 +375,7 @@
 	resistance_flags = 64
 	},
 /turf/open/floor/stone,
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "Hh" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 4
@@ -389,7 +389,7 @@
 	name = "invincible railing"
 	},
 /turf/open/floor/stone,
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "HV" = (
 /obj/effect/turf_decal/siding/white,
 /obj/effect/turf_decal/siding/white{
@@ -399,7 +399,7 @@
 	dir = 4
 	},
 /turf/open/floor/stone,
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "Io" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 4
@@ -413,42 +413,42 @@
 	max_integrity = 1e+007
 	},
 /turf/open/floor/stone,
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "Jj" = (
 /obj/structure/table/greyscale,
 /obj/item/shield/riot,
 /obj/item/flashlight/spotlight,
 /turf/open/floor/stone,
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "JS" = (
 /turf/open/floor/stone,
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "Kx" = (
 /obj/structure/bookcase/random/religion,
 /turf/open/floor/stone,
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "Lt" = (
 /obj/structure/table/greyscale,
 /obj/structure/table/greyscale,
 /obj/item/shield/riot/roman,
 /turf/open/floor/stone,
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "Lv" = (
 /turf/open/floor/plasteel/dark/side{
 	dir = 8
 	},
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "LJ" = (
 /turf/open/floor/plasteel/dark/corner{
 	dir = 8
 	},
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "Ms" = (
 /obj/structure/bookcase/random/religion,
 /turf/open/floor/white{
 	density = 1
 	},
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "MF" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 8
@@ -462,7 +462,7 @@
 	max_integrity = 1e+007
 	},
 /turf/open/floor/stone,
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "Nk" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 1
@@ -476,69 +476,69 @@
 	max_integrity = 1e+007
 	},
 /turf/open/floor/stone,
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "Nz" = (
 /obj/structure/table/wood/fancy/black,
 /obj/item/storage/book/bible,
 /turf/open/floor/plasteel/dark,
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "NA" = (
 /turf/open/floor/plasteel/dark/side{
 	dir = 1
 	},
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "Oo" = (
 /obj/structure/chair/wood/wings{
 	dir = 1
 	},
 /obj/item/toy/plush/benjamin,
 /turf/open/floor/stone,
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "Oy" = (
 /obj/structure/altar_of_gods,
 /turf/open/floor/stone,
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "Oz" = (
 /obj/structure/chair/wood/wings{
 	dir = 4
 	},
 /turf/open/floor/stone,
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "OO" = (
 /obj/structure/altar_of_gods,
 /turf/open/floor/plasteel/chapel{
 	dir = 8
 	},
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "OR" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 4
 	},
 /obj/item/flashlight/spotlight,
 /turf/open/floor/plasteel/dark,
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "QF" = (
 /obj/effect/decal/fakelattice,
 /turf/open/floor/white{
 	density = 1
 	},
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "Sd" = (
 /obj/structure/chair/comfy{
 	dir = 8
 	},
 /turf/open/floor/stone,
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "Si" = (
 /turf/open/floor/plasteel/dark/side{
 	dir = 4
 	},
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "Ub" = (
 /turf/open/floor/plasteel/dark/corner{
 	dir = 1
 	},
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "Up" = (
 /obj/effect/turf_decal/siding/white/end{
 	dir = 8
@@ -549,7 +549,7 @@
 	max_integrity = 1e+007
 	},
 /turf/open/floor/stone,
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "UD" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 10
@@ -561,7 +561,7 @@
 	dir = 4
 	},
 /turf/open/floor/stone,
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "UI" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 1
@@ -573,34 +573,34 @@
 	pixel_y = 2
 	},
 /turf/open/floor/stone,
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "VH" = (
 /turf/closed/indestructible/syndicate,
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "Wr" = (
 /obj/item/toy/plush/hokma,
 /obj/structure/chair/wood/wings{
 	dir = 1
 	},
 /turf/open/floor/stone,
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "WC" = (
 /obj/structure/table/greyscale,
 /obj/item/shield/mirror,
 /turf/open/floor/stone,
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "Xc" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
 /turf/open/floor/stone,
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "Yi" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 1
 	},
 /obj/effect/turf_decal/siding/white,
 /turf/open/floor/stone,
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "ZH" = (
 /obj/effect/turf_decal/siding/white,
 /obj/effect/turf_decal/siding/white{
@@ -612,13 +612,13 @@
 	max_integrity = 1e+007
 	},
 /turf/open/floor/stone,
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 "ZU" = (
 /obj/structure/chair/wood/wings{
 	dir = 8
 	},
 /turf/open/floor/stone,
-/area/city/backstreets_room)
+/area/library_floors/floor_religion)
 
 (1,1,1) = {"
 dd

--- a/_maps/map_files/Library/floor_socialsci.dmm
+++ b/_maps/map_files/Library/floor_socialsci.dmm
@@ -2,17 +2,17 @@
 "aa" = (
 /obj/item/flashlight/spotlight,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "by" = (
 /turf/open/floor/wood{
 	icon_state = "wood-broken"
 	},
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "bM" = (
 /obj/structure/table/wood/fancy/blue,
 /obj/item/reagent_containers/food/condiment/sugar,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "dm" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -21,7 +21,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "dn" = (
 /obj/structure/railing{
 	name = "invincible railing";
@@ -29,38 +29,38 @@
 	dir = 1
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "dT" = (
 /obj/structure/flora/rock/jungle,
 /turf/open/water/deep/saltwater,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "ef" = (
 /obj/structure/bookcase/random/nonfiction,
 /obj/structure/bookcase/random/nonfiction,
 /turf/closed/indestructible/wood,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "en" = (
 /obj/machinery/chem_dispenser/drinks/fullupgrade{
 	pixel_y = 6;
 	dir = 1
 	},
 /turf/closed/indestructible/wood,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "eB" = (
 /turf/open/floor/wood{
 	icon_state = "wood-broken2"
 	},
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "ft" = (
 /obj/structure/bookcase/random/nonfiction,
 /turf/closed/indestructible/wood,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "fN" = (
 /obj/machinery/light{
 	dir = 8
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "fV" = (
 /obj/structure/fermenting_barrel,
 /obj/effect/turf_decal/siding/wood{
@@ -70,13 +70,13 @@
 	dir = 4
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "gm" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "gJ" = (
 /obj/structure/railing{
 	dir = 10;
@@ -84,25 +84,25 @@
 	name = "invincible railing"
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "hP" = (
 /obj/structure/closet/crate/wooden,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "hU" = (
 /obj/structure/chair/stool/bar,
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "hW" = (
 /obj/structure/chair/stool/bar,
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "ie" = (
 /obj/machinery/light{
 	dir = 4
@@ -110,54 +110,54 @@
 /turf/open/floor/wood{
 	icon_state = "wood-broken5"
 	},
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "iJ" = (
 /obj/effect/turf_decal/siding/wood,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "je" = (
 /obj/machinery/chem_dispenser/drinks,
 /turf/closed/indestructible/wood,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "jI" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
 	},
 /turf/open/floor/carpet/royalblue,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "ky" = (
 /turf/closed/indestructible/wood,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "kJ" = (
 /obj/structure/railing{
 	name = "invincible railing";
 	resistance_flags = 64
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "lG" = (
 /turf/open/floor/wood{
 	icon_state = "wood-broken3"
 	},
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "lK" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
 /turf/open/floor/carpet/royalblue,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "mA" = (
 /obj/effect/decal/fakelattice,
 /obj/item/flashlight/spotlight,
 /turf/open/water/deep/saltwater,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "mR" = (
 /obj/structure/chair/comfy{
 	dir = 1;
 	pixel_y = 11
 	},
 /turf/open/floor/carpet/royalblue,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "nB" = (
 /obj/structure/railing{
 	name = "invincible railing";
@@ -166,12 +166,12 @@
 /turf/open/floor/wood{
 	icon_state = "wood-broken7"
 	},
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "pa" = (
 /obj/structure/table/wood/fancy/blue,
 /obj/item/reagent_containers/food/drinks/coffee,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "pL" = (
 /obj/structure/fermenting_barrel,
 /obj/effect/turf_decal/siding/wood{
@@ -185,13 +185,13 @@
 	},
 /obj/item/flashlight/spotlight,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "qb" = (
 /obj/structure/railing/corner{
 	dir = 4
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "qn" = (
 /obj/structure/chair/wood/wings{
 	dir = 8
@@ -200,45 +200,45 @@
 	dir = 4
 	},
 /turf/open/floor/carpet/royalblue,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "rj" = (
 /turf/open/floor/wood{
 	icon_state = "wood-broken7"
 	},
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "rT" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 8
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "sf" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
 	},
 /turf/open/floor/carpet/royalblue,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "sl" = (
 /obj/structure/closet/crate/wooden,
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "sL" = (
 /obj/structure/flora/rock/pile/largejungle,
 /turf/open/water/deep/saltwater,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "tw" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
 /turf/open/floor/carpet/royalblue,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "uI" = (
 /obj/structure/chair/comfy,
 /turf/open/floor/carpet/royalblue,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "uN" = (
 /turf/open/water/deep/saltwater,
 /area/space)
@@ -249,13 +249,13 @@
 	max_integrity = 1e+007
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "wM" = (
 /obj/machinery/light{
 	dir = 4
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "wW" = (
 /obj/structure/railing{
 	dir = 1;
@@ -263,11 +263,11 @@
 	resistance_flags = 64
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "xJ" = (
 /obj/structure/flora/rock/pile,
 /turf/open/water/deep/saltwater,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "xY" = (
 /obj/structure/railing{
 	name = "invincible railing";
@@ -280,20 +280,20 @@
 	dir = 8
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "yc" = (
 /obj/structure/table/wood/fancy/blue,
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
 	},
 /turf/open/floor/carpet/royalblue,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "yA" = (
 /obj/structure/chair/wood/wings{
 	dir = 8
 	},
 /turf/open/floor/carpet/royalblue,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "yN" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -303,19 +303,19 @@
 	},
 /obj/item/flashlight/spotlight,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "zb" = (
 /obj/item/reagent_containers/food/drinks/coffee,
 /obj/structure/table/wood/fancy/blue,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "zv" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
 /obj/item/flashlight/spotlight,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "BA" = (
 /obj/structure/table/wood/fancy/blue,
 /obj/item/reagent_containers/food/condiment/saltshaker{
@@ -323,11 +323,11 @@
 	pixel_x = -6
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "BK" = (
 /obj/structure/window/reinforced/fulltile/indestructable,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "BM" = (
 /obj/structure/flora/rock/jungle,
 /turf/open/water/deep/saltwater,
@@ -337,7 +337,7 @@
 	dir = 1
 	},
 /turf/open/floor/carpet/royalblue,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "Dg" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -346,7 +346,7 @@
 	dir = 8
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "DW" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -354,7 +354,7 @@
 /turf/open/floor/wood{
 	icon_state = "wood-broken7"
 	},
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "Fa" = (
 /obj/structure/chair/wood/wings{
 	dir = 4
@@ -363,7 +363,7 @@
 	dir = 8
 	},
 /turf/open/floor/carpet/royalblue,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "FK" = (
 /obj/structure/railing{
 	name = "invincible railing";
@@ -373,51 +373,51 @@
 /turf/open/floor/wood{
 	icon_state = "wood-broken3"
 	},
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "Gh" = (
 /turf/open/floor/carpet/royalblue,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "GG" = (
 /obj/item/flashlight/spotlight,
 /turf/open/water/deep/saltwater,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "Hg" = (
 /obj/structure/table/wood/fancy/blue,
 /obj/item/flashlight/spotlight,
 /turf/open/floor/carpet/royalblue,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "Hx" = (
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/carpet/royalblue,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "HJ" = (
 /obj/machinery/vending/dinnerware,
 /turf/closed/indestructible/wood,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "IE" = (
 /obj/structure/fermenting_barrel,
 /obj/item/flashlight/lantern{
 	pixel_y = 18
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "IR" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
 	},
 /turf/open/floor/carpet/royalblue,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "JJ" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
 	},
 /turf/open/floor/carpet/royalblue,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "JW" = (
 /turf/open/floor/plasteel/stairs{
 	dir = 4
 	},
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "JX" = (
 /obj/structure/railing{
 	dir = 5;
@@ -425,10 +425,10 @@
 	name = "invincible railing"
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "Ky" = (
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "KT" = (
 /obj/structure/chair/wood/wings{
 	dir = 8
@@ -438,36 +438,36 @@
 	},
 /obj/item/flashlight/spotlight,
 /turf/open/floor/carpet/royalblue,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "MI" = (
 /obj/structure/railing/corner{
 	dir = 8
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "Nj" = (
 /obj/structure/chair/comfy,
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
 /turf/open/floor/carpet/royalblue,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "NI" = (
 /obj/structure/table/wood/fancy/blue,
 /obj/item/reagent_containers/food/drinks/mug,
 /obj/item/flashlight/spotlight,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "NM" = (
 /turf/open/water/deep/saltwater,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "Op" = (
 /turf/open/floor/plasteel/stairs,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "ON" = (
 /obj/effect/decal/fakelattice,
 /turf/open/water/deep/saltwater,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "OR" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -475,23 +475,23 @@
 /turf/open/floor/wood{
 	icon_state = "wood-broken5"
 	},
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "OX" = (
 /obj/structure/railing/corner{
 	dir = 1
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "Py" = (
 /obj/structure/railing/corner,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "PP" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "Qn" = (
 /obj/structure/railing{
 	name = "invincible railing";
@@ -499,11 +499,11 @@
 	},
 /obj/item/flashlight/spotlight,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "Rq" = (
 /obj/structure/bookcase/random/nonfiction,
 /turf/open/floor/carpet/royalblue,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "Rs" = (
 /obj/structure/railing{
 	name = "invincible railing";
@@ -517,19 +517,19 @@
 	dir = 8
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "Ru" = (
 /turf/open/floor/plasteel/stairs{
 	dir = 1
 	},
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "Sp" = (
 /obj/structure/table/wood/fancy/blue,
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
 /turf/open/floor/carpet/royalblue,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "SC" = (
 /obj/structure/railing{
 	name = "invincible railing";
@@ -543,7 +543,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "SR" = (
 /obj/structure/flora/rock/pile/largejungle,
 /turf/open/water/deep/saltwater,
@@ -553,17 +553,17 @@
 	dir = 8
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "SZ" = (
 /obj/structure/table/wood/fancy/blue,
 /turf/open/floor/carpet/royalblue,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "Tv" = (
 /obj/structure/chair/comfy{
 	dir = 8
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "TE" = (
 /obj/structure/table/wood/fancy/blue,
 /obj/effect/turf_decal/siding/wood{
@@ -575,30 +575,30 @@
 	pixel_x = 12
 	},
 /turf/open/floor/carpet/royalblue,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "Ue" = (
 /turf/open/floor/wood{
 	icon_state = "wood-broken5"
 	},
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "UB" = (
 /obj/structure/bookcase/random/nonfiction,
 /obj/item/flashlight/spotlight,
 /turf/open/floor/carpet/royalblue,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "Vc" = (
 /obj/structure/chair/wood/wings{
 	dir = 4
 	},
 /turf/open/floor/carpet/royalblue,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "VT" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
 /obj/machinery/light,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "WH" = (
 /obj/structure/railing{
 	name = "invincible railing";
@@ -611,11 +611,11 @@
 	dir = 4
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "WR" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/water/deep/saltwater,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "WS" = (
 /obj/structure/railing{
 	dir = 9;
@@ -623,7 +623,7 @@
 	name = "invincible railing"
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "Xa" = (
 /obj/structure/chair/comfy{
 	dir = 1;
@@ -633,11 +633,11 @@
 	pixel_y = 0
 	},
 /turf/open/floor/carpet/royalblue,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "Xx" = (
 /obj/structure/fermenting_barrel,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "XL" = (
 /obj/structure/railing{
 	dir = 1;
@@ -646,17 +646,17 @@
 	},
 /obj/item/flashlight/spotlight,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "XV" = (
 /obj/structure/flora/rock,
 /turf/open/water/deep/saltwater,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "XW" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
 	},
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 "YL" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/water/deep/saltwater,
@@ -670,7 +670,7 @@
 	},
 /obj/item/flashlight/spotlight,
 /turf/open/indestructible/hotelwood,
-/area/city/backstreets_room)
+/area/library_floors/floor_socialsci)
 
 (1,1,1) = {"
 uN

--- a/_maps/map_files/Library/floor_techsci.dmm
+++ b/_maps/map_files/Library/floor_techsci.dmm
@@ -12,24 +12,24 @@
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/item/flashlight/spotlight,
 /turf/open/floor/pod/dark,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "aH" = (
 /obj/structure/window/reinforced/fulltile/indestructable,
 /turf/open/floor/pod/dark,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "bi" = (
 /turf/open/floor/plating/ashplanet,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "bF" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
 	},
 /turf/open/floor/pod/dark,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "cU" = (
 /obj/effect/decal/cleanable/robot_debris/old,
 /turf/open/floor/plating/ashplanet,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "dI" = (
 /obj/structure/railing{
 	name = "invincible railing";
@@ -38,30 +38,37 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/pod/light,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
+"eJ" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
+/obj/structure/bookcase/random/nonfiction,
+/turf/open/floor/pod/dark,
+/area/library_floors/floor_techsci)
 "eN" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/pod/dark,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "fW" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plating/ashplanet,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "gG" = (
 /obj/structure/mecha_wreckage/durand,
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 9
 	},
 /turf/open/floor/pod/dark,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "gN" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
 /turf/open/floor/pod/dark,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "iz" = (
 /obj/structure/chair/greyscale{
 	dir = 4
@@ -70,28 +77,35 @@
 	dir = 4
 	},
 /turf/open/floor/pod/dark,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
+"iE" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
+/obj/item/flashlight/spotlight,
+/turf/open/floor/pod/dark,
+/area/library_floors/floor_techsci)
 "iM" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/drinks/coffee,
 /turf/open/floor/pod/dark,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "js" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 5
 	},
 /turf/open/floor/pod/dark,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "kk" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 6
 	},
 /turf/open/floor/pod/dark,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "lg" = (
 /obj/effect/decal/cleanable/robot_debris/general_scrap,
 /turf/open/floor/plating/ashplanet,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "mH" = (
 /obj/structure/railing{
 	name = "invincible railing";
@@ -101,7 +115,7 @@
 	dir = 10
 	},
 /turf/open/floor/pod/light,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "mN" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
@@ -110,11 +124,11 @@
 	dir = 8
 	},
 /turf/open/floor/pod/dark,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "ng" = (
 /obj/item/flashlight/spotlight,
 /turf/open/floor/plating/ashplanet,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "nJ" = (
 /obj/structure/railing{
 	name = "invincible railing";
@@ -124,26 +138,26 @@
 	dir = 6
 	},
 /turf/open/floor/pod/light,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "or" = (
 /obj/machinery/door/airlock/hatch,
 /turf/open/floor/pod/dark,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "qa" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/pod/dark,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "rK" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating/ashplanet,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "rN" = (
 /obj/structure/falsewall/plastitanium,
 /turf/open/floor/pod/dark,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "rY" = (
 /obj/structure/railing{
 	name = "invincible railing";
@@ -151,37 +165,38 @@
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/pod/light,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "sm" = (
 /obj/item/light/bulb/broken,
 /turf/open/floor/plating/ashplanet,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "sF" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/fancy/donut_box,
 /turf/open/floor/pod/dark,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "tx" = (
 /obj/structure/table/reinforced,
 /obj/item/flashlight/spotlight,
 /turf/open/floor/pod/dark,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "ty" = (
 /obj/structure/table/reinforced,
 /obj/item/book/random,
 /turf/open/floor/pod/dark,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "vI" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 5
 	},
 /obj/item/flashlight/spotlight,
 /turf/open/floor/pod/dark,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "wj" = (
 /obj/structure/fluff/divine/nexus,
+/obj/item/flashlight/spotlight,
 /turf/open/floor/pod/dark,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "wX" = (
 /obj/machinery/shuttle_manipulator{
 	desc = "A holographic display of the cruise shuttle we're on right now.";
@@ -190,27 +205,28 @@
 	name = "shuttle holographic display"
 	},
 /turf/open/floor/pod/dark,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "xo" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
 /obj/structure/bookcase/random/nonfiction,
 /turf/open/floor/pod/dark,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "yr" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
 /obj/structure/bookcase/random/nonfiction,
+/obj/item/flashlight/spotlight,
 /turf/open/floor/pod/dark,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "yO" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/pod/dark,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "zb" = (
 /obj/structure/railing{
 	name = "invincible railing";
@@ -221,51 +237,46 @@
 	pixel_y = 12
 	},
 /turf/open/floor/pod/light,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "Am" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
 /obj/structure/mecha_wreckage,
 /turf/open/floor/plating/ashplanet,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "AE" = (
 /obj/effect/decal/cleanable/glass,
 /obj/item/flashlight/spotlight,
 /turf/open/floor/plating/ashplanet,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "AN" = (
 /obj/item/flashlight/spotlight,
 /turf/open/floor/pod/dark,
-/area/city/backstreets_room)
-"Bp" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 9
-	},
-/turf/open/floor/pod/dark,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "BF" = (
 /obj/structure/falsewall/plastitanium,
 /turf/open/space/basic,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "BN" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner,
 /turf/open/floor/pod/dark,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "BR" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 6
 	},
 /obj/structure/bookcase/random/nonfiction,
+/obj/item/flashlight/spotlight,
 /turf/open/floor/pod/dark,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "Ck" = (
 /obj/structure/bookcase/random/nonfiction,
 /turf/open/floor/pod/dark,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "Cl" = (
 /obj/structure/railing{
 	name = "invincible railing";
@@ -277,17 +288,17 @@
 	dir = 1
 	},
 /turf/open/floor/pod/light,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "Cq" = (
 /obj/effect/turf_decal/trimline/white/filled/line{
 	pixel_y = 10
 	},
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating/ashplanet,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "Cu" = (
 /turf/open/floor/pod/dark,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "Db" = (
 /obj/structure/chair/greyscale{
 	dir = 8
@@ -296,27 +307,27 @@
 	dir = 8
 	},
 /turf/open/floor/pod/dark,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "Ep" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
 /turf/open/floor/pod/dark,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "EZ" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 9
 	},
 /obj/structure/bookcase/random/nonfiction,
 /turf/open/floor/pod/dark,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "Fg" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 9
 	},
 /obj/item/flashlight/spotlight,
 /turf/open/floor/pod/dark,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "FY" = (
 /obj/structure/railing{
 	name = "invincible railing";
@@ -327,19 +338,19 @@
 	dir = 5
 	},
 /turf/open/floor/pod/light,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "Gu" = (
 /obj/structure/falsewall/plastitanium,
 /obj/item/wallframe/newscaster,
 /turf/open/space/basic,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "Hg" = (
 /obj/item/toy/plush/myo,
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 10
 	},
 /turf/open/floor/pod/dark,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "Hk" = (
 /turf/open/space/basic,
 /area/space)
@@ -348,34 +359,35 @@
 	dir = 4
 	},
 /turf/open/floor/pod/dark,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "Ix" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
 	},
 /obj/structure/bookcase/random/nonfiction,
+/obj/item/flashlight/spotlight,
 /turf/open/floor/pod/dark,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "Iy" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner,
 /turf/open/floor/pod/dark,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "JL" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/effect/decal/cleanable/robot_debris/limb,
 /obj/effect/decal/cleanable/robot_debris/old,
 /turf/open/floor/plating/ashplanet,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "Kd" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 5
 	},
 /obj/structure/bookcase/random/nonfiction,
 /turf/open/floor/pod/dark,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "Ki" = (
 /obj/structure/railing{
 	name = "invincible railing";
@@ -386,55 +398,55 @@
 	pixel_y = 11
 	},
 /turf/open/floor/pod/light,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "Kr" = (
 /obj/item/light/bulb/broken,
 /obj/item/flashlight/spotlight,
 /turf/open/floor/plating/ashplanet,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "Kt" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/plating/ashplanet,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "KG" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner,
 /turf/open/floor/pod/dark,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "KL" = (
 /obj/structure/flora/rock/pile,
 /turf/open/floor/plating/ashplanet,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "KX" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/effect/decal/cleanable/shreds,
 /turf/open/floor/plating/ashplanet,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "Lf" = (
 /obj/effect/turf_decal/trimline/purple/filled/end,
 /turf/open/floor/pod/dark,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "Me" = (
 /obj/structure/flora/rock/jungle,
 /turf/open/floor/plating/ashplanet,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "MV" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/structure/bookcase/random/nonfiction,
 /turf/open/floor/pod/dark,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "Os" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
 /obj/structure/chair/greyscale,
 /turf/open/floor/pod/dark,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "PB" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/pod/dark,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "PY" = (
 /obj/structure/chair/greyscale{
 	dir = 1
@@ -443,18 +455,19 @@
 	dir = 1
 	},
 /turf/open/floor/pod/dark,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "Qs" = (
 /obj/effect/decal/cleanable/robot_debris/limb,
 /obj/item/flashlight/spotlight,
 /turf/open/floor/plating/ashplanet,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "Rk" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 10
 	},
+/obj/item/flashlight/spotlight,
 /turf/open/floor/pod/dark,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "RW" = (
 /obj/structure/railing{
 	name = "invincible railing";
@@ -465,29 +478,36 @@
 	dir = 9
 	},
 /turf/open/floor/pod/light,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "SW" = (
 /obj/structure/table/reinforced,
 /obj/item/book/random,
 /obj/item/flashlight/spotlight,
 /turf/open/floor/pod/dark,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "Uk" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/pod/dark,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "Us" = (
 /obj/item/toy/plush/rabbit,
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
 /turf/open/floor/pod/dark,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "Uz" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/item/flashlight/spotlight,
 /turf/open/floor/pod/dark,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
+"UQ" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
+/obj/structure/bookcase/random/nonfiction,
+/turf/open/floor/pod/dark,
+/area/library_floors/floor_techsci)
 "VC" = (
 /obj/structure/railing{
 	name = "invincible railing";
@@ -498,7 +518,17 @@
 	dir = 1
 	},
 /turf/open/floor/pod/light,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
+"WM" = (
+/obj/structure/fluff/divine/nexus,
+/turf/open/floor/pod/dark,
+/area/library_floors/floor_techsci)
+"WS" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 10
+	},
+/turf/open/floor/pod/dark,
+/area/library_floors/floor_techsci)
 "WT" = (
 /obj/structure/railing{
 	name = "invincible railing";
@@ -512,35 +542,35 @@
 	pixel_y = 12
 	},
 /turf/open/floor/pod/light,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "Xk" = (
 /obj/machinery/modular_computer/console{
 	dir = 1
 	},
 /turf/open/floor/pod/dark,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "Xt" = (
 /turf/open/floor/fakepit{
 	density = 1
 	},
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "Yz" = (
 /obj/effect/turf_decal/trimline/white/filled/line{
 	pixel_y = 10
 	},
 /turf/open/floor/plating/ashplanet,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "YE" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 10
 	},
 /obj/structure/bookcase/random/nonfiction,
 /turf/open/floor/pod/dark,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "YF" = (
 /obj/structure/flora/rock,
 /turf/open/floor/plating/ashplanet,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "Za" = (
 /obj/structure/railing{
 	name = "invincible railing";
@@ -555,7 +585,7 @@
 	pixel_y = 12
 	},
 /turf/open/floor/pod/light,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "Zz" = (
 /obj/structure/railing{
 	name = "invincible railing";
@@ -570,12 +600,12 @@
 	pixel_y = 12
 	},
 /turf/open/floor/pod/light,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 "ZK" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/structure/mecha_wreckage,
 /turf/open/floor/plating/ashplanet,
-/area/city/backstreets_room)
+/area/library_floors/floor_techsci)
 
 (1,1,1) = {"
 Hk
@@ -614,10 +644,10 @@ Hk
 BF
 EZ
 bF
-Ix
-bF
-Ix
-Ix
+eJ
+iE
+eJ
+eJ
 bF
 Ix
 bF
@@ -714,7 +744,7 @@ Hk
 Hk
 Hk
 BF
-wj
+WM
 aH
 Os
 Cu
@@ -1860,9 +1890,9 @@ Hk
 Hk
 Hk
 BF
-Bp
+Fg
 bF
-Rk
+WS
 SW
 eN
 eN
@@ -2025,7 +2055,7 @@ Cu
 Cu
 AN
 PB
-Rk
+WS
 aH
 gN
 aq
@@ -2098,8 +2128,8 @@ Kd
 Ep
 yr
 Ep
-yr
-yr
+UQ
+UQ
 Ep
 yr
 Ep

--- a/code/game/area/areas/lobotomy_corp.dm
+++ b/code/game/area/areas/lobotomy_corp.dm
@@ -295,6 +295,43 @@
 	name = "Backstreets Room"
 	icon_state = "hallA"
 
+/area/library_floors
+	name = "Library"
+	icon_state = "library"
+	requires_power = FALSE
+	has_gravity = STANDARD_GRAVITY
+	sound_enviroment = SOUND_AREA_STANDARD_STATION
+	dynamic_lighting = DYNAMIC_LIGHTING_FORCED
+
+//Areas for Library
+
+/area/library_floors/floor_history
+	name = "Floor of History"
+
+/area/library_floors/floor_techsci
+	name = "Floor of Technological Science"
+
+/area/library_floors/floor_art
+	name = "Floor of Art"
+
+/area/library_floors/floor_literature
+	name = "Floor of Literature"
+
+/area/library_floors/floor_naturalsci
+	name = "Floor of Natural Science"
+
+/area/library_floors/floor_language
+	name = "Floor of Language"
+
+/area/library_floors/floor_socialsci
+	name = "Floor of Social Science"
+
+/area/library_floors/floor_religion
+	name = "Floor of Religion"
+
+/area/library_floors/floor_philosophy
+	name = "Floor of Philosophy"
+
 //Miscellaneous Areas
 /area/shelter
 	name = "Shelter"
@@ -327,3 +364,4 @@
 	has_gravity = STANDARD_GRAVITY
 	sound_environment = SOUND_ENVIRONMENT_CAVE
 	dynamic_lighting = DYNAMIC_LIGHTING_FORCED
+

--- a/code/game/area/areas/lobotomy_corp.dm
+++ b/code/game/area/areas/lobotomy_corp.dm
@@ -300,7 +300,7 @@
 	icon_state = "library"
 	requires_power = FALSE
 	has_gravity = STANDARD_GRAVITY
-	sound_enviroment = SOUND_AREA_STANDARD_STATION
+	sound_environment = SOUND_AREA_STANDARD_STATION
 	dynamic_lighting = DYNAMIC_LIGHTING_FORCED
 
 //Areas for Library


### PR DESCRIPTION
Adds the new area types and replaces each corresponding floor with their corresponding area

## About The Pull Request

Created new area types, gave them gravity, power, etc, applied them to the corresponding floors

## Why It's Good For The Game

At the moment spawning the library is a step by step process, which is already an ordeal in of itself, then theres the ordeal of "finding" the library, which before this PR has "backstreets room" as its default room type, this causes, many, many issues and greatly limits an admins ability to do some more wacky and creative events

Now, we can just teleport to the room which is uniquely labelled for each individual floor, saving time and frustration.

