### PR TITLE
Central Command core suppression

### DIFF
--- a/code/controllers/subsystem/lobotomy_corp.dm
+++ b/code/controllers/subsystem/lobotomy_corp.dm
@@ -77,6 +77,10 @@ SUBSYSTEM_DEF(lobotomy_corp)
 	var/goal_reached = FALSE
 	/// Multiplier to PE earned from working on abnormalities
 	var/box_work_multiplier = 1
+	/// Multiplier towards attribute points earned for working on melting abnormalities
+	var/melt_work_multiplier = 1
+	/// The area of effect of manager's bullets; -1 is for direct target only
+	var/manager_bullet_area = -1
 	/// When TRUE - abnormalities can be possessed by ghosts
 	var/enable_possession = FALSE
 	/// Amount of abnormalities that agents achieved full understanding on
@@ -254,6 +258,14 @@ SUBSYSTEM_DEF(lobotomy_corp)
 	qliphoth_meltdown_amount = max(1, round(abno_amount * CONFIG_GET(number/qliphoth_meltdown_percent)))
 
 /datum/controller/subsystem/lobotomy_corp/proc/InitiateMeltdown(meltdown_amount = 1, forced = TRUE, type = MELTDOWN_NORMAL, min_time = 60, max_time = 90, alert_text = "Qliphoth meltdown occured in containment zones of the following abnormalities:", alert_sound = 'sound/effects/meltdownAlert.ogg')
+	// Honestly, I wish I could do it another way, but oh well
+	if(istype(core_suppression, /datum/suppression/command))
+		// All abno levels melt
+		forced = TRUE
+		var/datum/suppression/command/C = core_suppression
+		meltdown_amount += C.meltdown_count_increase
+		min_time = round(min_time * C.meltdown_time_multiplier)
+		max_time = round(max_time * C.meltdown_time_multiplier)
 	var/list/computer_list = list()
 	var/list/meltdown_occured = list()
 	for(var/obj/machinery/computer/abnormality/cmp in shuffle(GLOB.abnormality_consoles))

--- a/code/datums/abnormality/datum/abnormality.dm
+++ b/code/datums/abnormality/datum/abnormality.dm
@@ -160,7 +160,7 @@
 				attribute_given = max(0, maximum_attribute_level - user_attribute_level)
 			if(attribute_given == 0)
 				if(was_melting)
-					attribute_given = threat_level //pity stats on meltdowns
+					attribute_given = threat_level * SSlobotomy_corp.melt_work_multiplier
 				else
 					to_chat(user, "<span class='warning'>You don't feel like you've learned anything from this!</span>")
 			user.adjust_attribute_level(attribute_type, attribute_given)

--- a/code/game/machinery/computer/manager_camera.dm
+++ b/code/game/machinery/computer/manager_camera.dm
@@ -109,51 +109,67 @@
 
 /obj/machinery/computer/camera_advanced/manager/proc/on_hotkey_click(datum/source, atom/clicked_atom) //system control for hotkeys
 	SIGNAL_HANDLER
+
+	// No target :(
 	if(!isliving(clicked_atom))
 		return
+
+	// No bullets :(
+	if(!ammo)
+		playsound(get_turf(src), 'sound/weapons/empty.ogg', 10, 0, 3)
+		to_chat(source, "<span class='warning'>AMMO RESERVE EMPTY.</span>")
+		return
+
+	// AOE bullets
+	if(SSlobotomy_corp.manager_bullet_area > -1)
+		var/success = FALSE
+		for(var/mob/living/L in range(SSlobotomy_corp.manager_bullet_area, clicked_atom))
+			if(ishuman(clicked_atom))
+				clickedemployee(source, clicked_atom)
+				success = TRUE
+			if(ishostile(clicked_atom))
+				clickedabno(source, clicked_atom)
+				success = TRUE
+		if(success)
+			ammo--
+		return
+
+	// Non-AOE
 	if(ishuman(clicked_atom))
 		clickedemployee(source, clicked_atom)
+		ammo--
 		return
 	if(ishostile(clicked_atom))
 		clickedabno(source, clicked_atom)
+		ammo--
 		return
 
 /obj/machinery/computer/camera_advanced/manager/proc/clickedemployee(mob/living/owner, mob/living/carbon/employee) //contains carbon copy code of fire action
-	if(ammo >= 1)
-		var/mob/living/carbon/human/H = employee
-		switch(bullettype)
-			if(HP_BULLET)
-				H.adjustBruteLoss(-0.15*H.maxHealth)
-			if(SP_BULLET)
-				H.adjustSanityLoss(-0.15*H.maxSanity)
-			if(RED_BULLET)
-				H.apply_status_effect(/datum/status_effect/interventionshield)
-			if(WHITE_BULLET)
-				H.apply_status_effect(/datum/status_effect/interventionshield/white)
-			if(BLACK_BULLET)
-				H.apply_status_effect(/datum/status_effect/interventionshield/black)
-			if(PALE_BULLET)
-				H.apply_status_effect(/datum/status_effect/interventionshield/pale)
-			if(YELLOW_BULLET)
-				if(!owner.faction_check_mob(H))
-					H.apply_status_effect(/datum/status_effect/qliphothoverload)
-				else
-					to_chat(owner, "<span class='warning'>WELFARE SAFETY SYSTEM ERROR: TARGET SHARES CORPORATE FACTION.</span>")
-					return
+	var/mob/living/carbon/human/H = employee
+	switch(bullettype)
+		if(HP_BULLET)
+			H.adjustBruteLoss(-0.15*H.maxHealth)
+		if(SP_BULLET)
+			H.adjustSanityLoss(-0.15*H.maxSanity)
+		if(RED_BULLET)
+			H.apply_status_effect(/datum/status_effect/interventionshield)
+		if(WHITE_BULLET)
+			H.apply_status_effect(/datum/status_effect/interventionshield/white)
+		if(BLACK_BULLET)
+			H.apply_status_effect(/datum/status_effect/interventionshield/black)
+		if(PALE_BULLET)
+			H.apply_status_effect(/datum/status_effect/interventionshield/pale)
+		if(YELLOW_BULLET)
+			if(!owner.faction_check_mob(H))
+				H.apply_status_effect(/datum/status_effect/qliphothoverload)
 			else
-				to_chat(owner, "<span class='warning'>ERROR: BULLET INITIALIZATION FAILURE.</span>")
+				to_chat(owner, "<span class='warning'>WELFARE SAFETY SYSTEM ERROR: TARGET SHARES CORPORATE FACTION.</span>")
 				return
-		ammo--
-		playsound(get_turf(src), 'ModularTegustation/Tegusounds/weapons/guns/manager_bullet_fire.ogg', 10, 0, 3)
-		playsound(get_turf(H), 'ModularTegustation/Tegusounds/weapons/guns/manager_bullet_fire.ogg', 10, 0, 3)
-		to_chat(owner, "<span class='warning'>Loading [ammo] Bullets.</span>")
-		return
-	if(ammo <= 0)
-		playsound(get_turf(src), 'sound/weapons/empty.ogg', 10, 0, 3)
-		to_chat(owner, "<span class='warning'>AMMO RESERVE EMPTY.</span>")
-	else
-		to_chat(owner, "<span class='warning'>NO TARGET.</span>")
-		return
+		else
+			to_chat(owner, "<span class='warning'>ERROR: BULLET INITIALIZATION FAILURE.</span>")
+			return
+	playsound(get_turf(src), 'ModularTegustation/Tegusounds/weapons/guns/manager_bullet_fire.ogg', 10, 0, 3)
+	playsound(get_turf(H), 'ModularTegustation/Tegusounds/weapons/guns/manager_bullet_fire.ogg', 10, 0, 3)
 
 /obj/machinery/computer/camera_advanced/manager/proc/clickedabno(mob/living/owner, mob/living/simple_animal/hostile/critter)
 	if(ammo >= 1)

--- a/code/modules/suppressions/command.dm
+++ b/code/modules/suppressions/command.dm
@@ -1,0 +1,59 @@
+/datum/suppression/command
+	name = "Central Command Core Suppression"
+	desc = "Meltdowns immunities of certain abnormality levels will be forfeit for the duration of the suppression \
+			and more meltdowns will occur with lower timer on each. Missed or failed meltdowns will trigger a \
+			meltdown on another abnormality within the facility."
+	reward_text = "Managerial bullets will activate in a small area around original target. \
+			Works performed on a melting cell will net more attributes."
+	run_text = "The core suppression of Central Command department has begun. \n\
+			Meltdown immunities are forfeit and qliphoth meltdowns will have lesser timer. \n\
+			Failed meltdowns will trigger a meltdown in another cell."
+
+	/// Amount of additional abnormalities melting each qliphoth event
+	var/meltdown_count_increase = 2
+	/// Multiplier to the duration of abnormality meltdowns
+	var/meltdown_time_multiplier = 0.9
+
+/datum/suppression/command/Run(run_white = FALSE)
+	. = ..()
+	RegisterSignal(SSdcs, COMSIG_GLOB_MELTDOWN_START, .proc/OnQlipMeltdown)
+	RegisterSignal(SSdcs, COMSIG_GLOB_MELTDOWN_FINISHED, .proc/OnAbnoMeltdown)
+
+/datum/suppression/command/End()
+	UnregisterSignal(SSdcs, COMSIG_GLOB_MELTDOWN_START)
+	UnregisterSignal(SSdcs, COMSIG_GLOB_MELTDOWN_FINISHED)
+	SSlobotomy_corp.melt_work_multiplier += 1
+	SSlobotomy_corp.manager_bullet_area = 1 // Bullets will activate in a 3x3 AOE
+	return ..()
+
+/datum/suppression/command/proc/OnQlipMeltdown(datum/source, ordeal = FALSE)
+	SIGNAL_HANDLER
+	if(ordeal)
+		meltdown_count_increase += 1
+		meltdown_time_multiplier -= 0.2
+
+/datum/suppression/command/proc/OnAbnoMeltdown(obj/machinery/computer/abnormality/source, melt_removed = TRUE)
+	SIGNAL_HANDLER
+	if(!istype(source))
+		return
+	if(melt_removed)
+		return
+	var/list/potential_consoles = list()
+	for(var/obj/machinery/computer/abnormality/A in GLOB.abnormality_consoles)
+		if(!A.can_meltdown)
+			continue
+		if(!A.datum_reference || !A.datum_reference.current)
+			continue
+		if(A.meltdown || A.datum_reference.working)
+			continue
+		if(!A.datum_reference.current.IsContained()) // Does what the old check did, but allows it to be redefined by abnormalities that do so.
+			continue
+		potential_consoles |= A
+
+	if(!LAZYLEN(potential_consoles))
+		return
+	var/obj/machinery/computer/abnormality/A = pick(potential_consoles)
+	source.Beam(A, icon_state = "volt_ray", time = 5 SECONDS)
+	playsound(source, 'sound/weapons/zapbang.ogg', 50, TRUE)
+	playsound(A, 'sound/weapons/zapbang.ogg', 50, TRUE)
+	A.start_meltdown(MELTDOWN_NORMAL, round(40 * meltdown_time_multiplier), round(60 * meltdown_time_multiplier))

--- a/code/modules/suppressions/command.dm
+++ b/code/modules/suppressions/command.dm
@@ -30,7 +30,7 @@
 	SIGNAL_HANDLER
 	if(ordeal)
 		meltdown_count_increase += 1
-		meltdown_time_multiplier -= 0.2
+		meltdown_time_multiplier = max(0.1, meltdown_time_multiplier - 0.2)
 
 /datum/suppression/command/proc/OnAbnoMeltdown(obj/machinery/computer/abnormality/source, melt_removed = TRUE)
 	SIGNAL_HANDLER

--- a/code/modules/suppressions/control.dm
+++ b/code/modules/suppressions/control.dm
@@ -24,6 +24,7 @@
 
 // On lobotomy_corp meltdown event
 /datum/suppression/control/proc/OnMeltdown(datum/source, ordeal = FALSE)
+	SIGNAL_HANDLER
 	var/list/normal_works = shuffle(list(ABNORMALITY_WORK_INSTINCT, ABNORMALITY_WORK_INSIGHT, ABNORMALITY_WORK_ATTACHMENT, ABNORMALITY_WORK_REPRESSION))
 	var/list/application_scramble_list = list()
 	var/list/choose_from = normal_works.Copy()

--- a/lobotomy-corp13.dme
+++ b/lobotomy-corp13.dme
@@ -3613,6 +3613,7 @@
 #include "code\modules\station_goals\shield.dm"
 #include "code\modules\station_goals\station_goal.dm"
 #include "code\modules\suppressions\_core_suppression.dm"
+#include "code\modules\suppressions\command.dm"
 #include "code\modules\suppressions\control.dm"
 #include "code\modules\suppressions\extraction.dm"
 #include "code\modules\suppressions\information.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds the CC core suppression!

Challenge:
- More meltdowns in general. Ignores threat level "immunities" (ZAYINs and TETHs can melt even late into the game).
- Lower meltdown timer (faster meltdowns).
- Abnormalities that have melted down cause another, random abnormality to start melting (a beam will "shoot" from melted console to another to indicate it).

Rewards:
- Meltdown works grant more attributes.
- Manager bullets will act in a 3x3 AOE: Healing/Shield bullets will trigger on all agents in that range, and slowdown bullets will similarly trigger on all enemies.

## Why It's Good For The Game

Another fascinating and F.U.N. core suppression that was missing. This time - completely reworked from how it was in base game for more F.U.N. experience.
