### PR TITLE
Fixes DamageEffect

### DIFF
--- a/code/modules/mob/living/simple_animal/animal_defense.dm
+++ b/code/modules/mob/living/simple_animal/animal_defense.dm
@@ -128,7 +128,11 @@
 /mob/living/simple_animal/proc/attack_threshold_check(damage, damagetype = BRUTE, actuallydamage = TRUE)
 	var/temp_damage = damage
 
-	temp_damage *= damage_coeff.getCoeff(damagetype)
+	if(islist(damage_coeff))
+		temp_damage *= damage_coeff[damagetype]
+		stack_trace("[src] has a damage_coeff list and was hurt!")
+	else
+		temp_damage *= damage_coeff.getCoeff(damagetype)
 
 	if(temp_damage >= 0 && temp_damage <= force_threshold)
 		visible_message("<span class='warning'>[src] looks unharmed!</span>")

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -193,8 +193,8 @@
 /mob/living/simple_animal/hostile/proc/DamageEffect(amount, damtype)
 	//Code stolen from attack_threshold_check() in animal_defense.dm
 	var/temp_damage = amount
-	if(!damage_coeff.getCoeff(damtype))
-		temp_damage = 0
+	if(islist(damage_coeff))
+		temp_damage *= damage_coeff[damtype]
 	else
 		temp_damage *= damage_coeff.getCoeff(damtype)
 

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -193,10 +193,10 @@
 /mob/living/simple_animal/hostile/proc/DamageEffect(amount, damtype)
 	//Code stolen from attack_threshold_check() in animal_defense.dm
 	var/temp_damage = amount
-	if(!damage_coeff[damtype])
+	if(!damage_coeff.getCoeff(damtype))
 		temp_damage = 0
 	else
-		temp_damage *= damage_coeff[damtype]
+		temp_damage *= damage_coeff.getCoeff(damtype)
 
 	if(temp_damage > 0)
 		return FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Used Old Implementation of DamageCoeff, this updates it to no longer do that. It also includes a check for damage_coeff being a list when it shouldn't be and adds a log for it.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes the indicators work once more.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: damage_coeff being treated as a list when it isn't
add: logging for attack_threshold (which should cover DamageEffect)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
