### PR TITLE
Dingle-Dangle Rework.

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/teth/dingle_dangle.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/dingle_dangle.dm
@@ -1,7 +1,7 @@
 #define STATUS_EFFECT_DANGLE /datum/status_effect/dangle
 /mob/living/simple_animal/hostile/abnormality/dingledangle
 	name = "Dingle-Dangle"
-	desc = "A code with bodies strung up in the ceiling."
+	desc = "A cone that goes up to the ceiling with a ribbon tied around it. Bodies are strung up around it, seeming to be tied to the ceiling."
 	icon = 'ModularTegustation/Teguicons/64x96.dmi'
 	icon_state = "dangle"
 	maxHealth = 600

--- a/code/modules/mob/living/simple_animal/abnormality/teth/dingle_dangle.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/dingle_dangle.dm
@@ -1,6 +1,7 @@
+#define STATUS_EFFECT_DANGLE /datum/status_effect/dangle
 /mob/living/simple_animal/hostile/abnormality/dingledangle
 	name = "Dingle-Dangle"
-	desc = "A giant, disgusting creature."
+	desc = "A code with bodies strung up in the ceiling."
 	icon = 'ModularTegustation/Teguicons/64x96.dmi'
 	icon_state = "dangle"
 	maxHealth = 600
@@ -12,6 +13,7 @@
 		ABNORMALITY_WORK_ATTACHMENT = 40,
 		ABNORMALITY_WORK_REPRESSION = 40
 			)
+	start_qliphoth = 3
 	pixel_x = -16
 	base_pixel_x = -16
 	work_damage_amount = 8
@@ -24,19 +26,56 @@
 	gift_type = /datum/ego_gifts/lutemis
 	abnormality_origin = ABNORMALITY_ORIGIN_WONDERLAB
 
+//Introduction to our hallucinations. This is a global hallucination, but it's all it really does.
+/mob/living/simple_animal/hostile/abnormality/dingledangle/ZeroQliphoth(mob/living/carbon/human/user)
+	for(var/mob/living/carbon/human/H in GLOB.player_list)
+		H.hallucination += 10
+	datum_reference.qliphoth_change(3)
 
 /mob/living/simple_animal/hostile/abnormality/dingledangle/PostWorkEffect(mob/living/carbon/human/user, work_type, pe)
-	if(get_attribute_level(user, PRUDENCE_ATTRIBUTE) >= 60)
-		//I mean it does this in wonderlabs
-		user.dust()
+	//if your prudence is low, give a short hallucination, apply the buff, and lower counter.
+	if(get_attribute_level(user, PRUDENCE_ATTRIBUTE) > 60)
+		user.hallucination += 20
+		user.apply_status_effect(STATUS_EFFECT_DANGLE)
+		datum_reference.qliphoth_change(-1)
+		return ..()
 
-		//But here's the twist: You get a better ego.
-		var/location = get_turf(user)
-		new /obj/item/clothing/suit/armor/ego_gear/he/lutemis(location)
+	if(get_attribute_level(user, FORTITUDE_ATTRIBUTE) <= 80)
+		return ..()
+
+	//I mean it does this in wonderlabs
+	user.dust()
+
+	//But here's the twist: You get a better ego.
+	var/location = get_turf(user)
+	new /obj/item/clothing/suit/armor/ego_gear/he/lutemis(location)
 
 /mob/living/simple_animal/hostile/abnormality/dingledangle/FailureEffect(mob/living/carbon/human/user, work_type, pe)
 	if(prob(50))
 		//Yeah dust them too. No ego this time tho
 		user.dust()
 
+/atom/movable/screen/alert/status_effect/dangle
+	name = "That Woozy Feeling"
+	desc = "+15 to Combat bonus."
+	icon = 'ModularTegustation/Teguicons/status_sprites.dmi'
+	icon_state = "rest"
 
+//A simple 5 minute stat bonus increase
+/datum/status_effect/dangle
+	id = "dangle"
+	status_type = STATUS_EFFECT_UNIQUE
+	duration = 3000		//Lasts 5 minutes
+	alert_type = /atom/movable/screen/alert/status_effect/dangle
+
+/datum/status_effect/dangle/on_apply()
+	. = ..()
+	if(ishuman(owner))
+		var/mob/living/carbon/human/L = owner
+		L.adjust_attribute_bonus(JUSTICE_ATTRIBUTE, 15)
+
+/datum/status_effect/dangle/on_remove()
+	. = ..()
+	if(ishuman(owner))
+		var/mob/living/carbon/human/L = owner
+		L.adjust_attribute_bonus(JUSTICE_ATTRIBUTE, -15)

--- a/code/modules/paperwork/records/info/teth.dm
+++ b/code/modules/paperwork/records/info/teth.dm
@@ -49,7 +49,9 @@
 	abno_type = /mob/living/simple_animal/hostile/abnormality/dingledangle
 	abno_code = "T-04-111"
 	abno_info = list(
-		"When employees with Prudence Level 3 or higher completed their work, they were immediately consumed by Dingle-Dangle.",
+		"When employees with Prudence Level 3 or higher completed their work, they were immediately consumed by Dingle-Dangle, unless their Fortitude was Level 4 or above.",
+		"When employees with Prudence Level 2 or lower completed work with Dingle-Dangle, the Qliphoth counter lowered.",
+		"When employees with Prudence Level 2 or lower completed work with Dingle-Dangle, they reported heightend combat abilities.",
 		"When the work result was Bad, the employee was consumed by Dingle-Dangle with a normal probability.")
 
 //Beauty and the Beast


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Dingle-Dangle has been reworked to the following:
Fortitude L4 or above now no longer kills you.
If your prudence is below level 3, you do a couple of things.
- Issue a justice buff
- Lower Counter
- Apply Hallucination

If the counter reaches 0, then everyone is given a shorter hallucination.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Dingle-Dangle has been one of our first abnormalities, and now acts as an introduction to hallucinations, which is something that we should use more.
It also now lets people work on it late game without dying.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Reworked Dingle-Dangle.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
