### PR TITLE
Eris Hotfixes

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/he/eris.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/eris.dm
@@ -94,7 +94,7 @@
 	var/mob/living/H = the_target
 	if(H.stat >= SOFT_CRIT)
 		return TRUE
-	return ..()
+	return FALSE
 
 /mob/living/simple_animal/hostile/abnormality/eris/AttackingTarget(atom/attacked_target)
 	if(ishuman(target))
@@ -167,14 +167,14 @@
 	if(!ishuman(Proj.firer))
 		return
 	var/mob/living/carbon/human/H = Proj.firer
-	H.apply_damage(girlboss_level +3, WHITE_DAMAGE, null, H.run_armor_check(null, WHITE_DAMAGE), spread_damage = TRUE)
+	H.apply_damage(40*(0.15*girlboss_level +3/(0.15*girlboss_level + 3)), WHITE_DAMAGE, null, H.run_armor_check(null, WHITE_DAMAGE), spread_damage = TRUE)
 
 
 /mob/living/simple_animal/hostile/abnormality/eris/attacked_by(obj/item/I, mob/living/user)
 	..()
 	if(!user)
 		return
-	user.apply_damage(girlboss_level*3 +3, WHITE_DAMAGE, null, user.run_armor_check(null, WHITE_DAMAGE), spread_damage = TRUE)
+	user.apply_damage(40*(0.15*girlboss_level +3/(0.15*girlboss_level + 3)), WHITE_DAMAGE, null, user.run_armor_check(null, WHITE_DAMAGE), spread_damage = TRUE)
 
 
 //Okay, but here's the work effects

--- a/code/modules/mob/living/simple_animal/abnormality/he/eris.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/eris.dm
@@ -156,7 +156,7 @@
 	for(var/mob/living/H in view(10, get_turf(src)))
 		if(H.stat >= SOFT_CRIT)
 			continue
-		//Shamelessly fucking stolen from risk of rain's teddy bear.
+		//Shamelessly fucking stolen from risk of rain's teddy bear. Maxes out at 20.
 		var/healamount = 20 * ((0.15*girlboss_level)/(0.15*girlboss_level + 1))
 		H.adjustBruteLoss(-healamount)	//Healing for those around.
 		new /obj/effect/temp_visual/heal(get_turf(H), "#FF4444")
@@ -167,14 +167,14 @@
 	if(!ishuman(Proj.firer))
 		return
 	var/mob/living/carbon/human/H = Proj.firer
-	H.apply_damage(40*(0.15*girlboss_level +3/(0.15*girlboss_level + 3)), WHITE_DAMAGE, null, H.run_armor_check(null, WHITE_DAMAGE), spread_damage = TRUE)
+	H.apply_damage(40*(0.15*girlboss_level/(0.15*girlboss_level + 1)), WHITE_DAMAGE, null, H.run_armor_check(null, WHITE_DAMAGE), spread_damage = TRUE)
 
 
 /mob/living/simple_animal/hostile/abnormality/eris/attacked_by(obj/item/I, mob/living/user)
 	..()
 	if(!user)
 		return
-	user.apply_damage(40*(0.15*girlboss_level +3/(0.15*girlboss_level + 3)), WHITE_DAMAGE, null, user.run_armor_check(null, WHITE_DAMAGE), spread_damage = TRUE)
+	user.apply_damage(40*(0.15*girlboss_level/(0.15*girlboss_level + 1)), WHITE_DAMAGE, null, user.run_armor_check(null, WHITE_DAMAGE), spread_damage = TRUE)
 
 
 //Okay, but here's the work effects


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Eris now has been fixed to only attack dying agents (and instantly killing them)
Eris now scales her damage to the same as the healing.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Eris was always intended to remain neutral, and only kill dying agents.
Her counter damage would get absurd extremely quickly. I want to curb this by making it scale roughly at damage healed x2.
She'll still be annoying to take down but it's not that difficult if a team of players wants to.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Stopped Eris from dealing scaling damage on her counter.
fix: fixed Eris attacking all agents.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
