### PR TITLE
Updates some abnormalities

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -5858,9 +5858,8 @@
 /obj/item/reagent_containers/food/drinks/waterbottle/large,
 /obj/item/reagent_containers/food/drinks/waterbottle/large,
 /obj/item/reagent_containers/food/drinks/waterbottle/large,
-/obj/item/reagent_containers/food/drinks/waterbottle/large,
-/obj/structure/closet/crate/pcorp,
 /obj/effect/shelter_forcefield,
+/obj/structure/closet/crate/pcorp/shelter,
 /turf/open/floor/shelter,
 /area/shelter)
 "wu" = (
@@ -11431,12 +11430,12 @@
 /turf/open/floor/plasteel,
 /area/centcom/supplypod/loading/two)
 "Sf" = (
-/obj/structure/closet/crate/pcorp,
 /obj/item/storage/box/pcorp,
 /obj/item/storage/box/pcorp,
 /obj/item/storage/box/pcorp,
 /obj/item/storage/box/pcorp,
 /obj/effect/shelter_forcefield,
+/obj/structure/closet/crate/pcorp/shelter,
 /turf/open/floor/shelter,
 /area/shelter)
 "Sg" = (
@@ -12493,12 +12492,12 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/structure/closet/crate/pcorp,
 /obj/item/storage/box/pcorp,
 /obj/item/storage/box/pcorp,
 /obj/item/storage/box/pcorp,
 /obj/item/storage/box/pcorp,
 /obj/effect/shelter_forcefield,
+/obj/structure/closet/crate/pcorp/shelter,
 /turf/open/floor/shelter,
 /area/shelter)
 "WQ" = (
@@ -12950,7 +12949,6 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/centcom/holding)
 "Yw" = (
-/obj/structure/closet/crate/pcorp,
 /obj/machinery/light/small{
 	dir = 4
 	},
@@ -12959,6 +12957,7 @@
 /obj/item/storage/box/pcorp,
 /obj/item/storage/box/pcorp,
 /obj/effect/shelter_forcefield,
+/obj/structure/closet/crate/pcorp/shelter,
 /turf/open/floor/shelter,
 /area/shelter)
 "YA" = (

--- a/code/modules/mob/living/simple_animal/abnormality/_tools/he/shelter.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_tools/he/shelter.dm
@@ -12,7 +12,15 @@
 	var/atom/movable/AM
 	if(user.pulling)
 		AM = user.pulling
-		AM.forceMove(T)
+		if(ishuman(AM)) //We don't want players dragging the supplies in and out
+			var/mob/living/carbon/human/Person = AM
+			for(var/obj/item/storage/box/pcorp/foodbox in Person.GetAllContents())
+				Person.dropItemToGround(foodbox, TRUE)
+			for(var/obj/item/food/canned/pcorp/foodcan in Person.GetAllContents())
+				Person.dropItemToGround(foodcan, TRUE)
+			AM.forceMove(T)
+		else
+			user.stop_pulling()
 	user.forceMove(T)
 	if(AM)
 		user.start_pulling(AM)
@@ -76,11 +84,10 @@
 
 // Shelter contents
 // Crate
-/obj/structure/closet/crate/pcorp
-	name = "p-corp crate"
+/obj/structure/closet/crate/pcorp/shelter //Lots of storage but not normally accessible
+	name = "P-Corp crate"
 	desc = "A dark steel crate emblazoned with the symbol of P corp."
-	icon = 'icons/obj/crates.dmi'
-	icon_state = "pcorp_crate"
+	storage_capacity = 10
 
 // Food Box
 /obj/item/storage/box/pcorp

--- a/code/modules/mob/living/simple_animal/abnormality/teth/book.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/book.dm
@@ -5,6 +5,7 @@
 	icon_state = "book_0"
 	maxHealth = 600
 	health = 600
+	start_qliphoth = 2
 	threat_level = TETH_LEVEL
 	work_chances = list(
 		ABNORMALITY_WORK_INSTINCT = list(50, 45, 40, 40, 40),
@@ -22,6 +23,15 @@
 	abnormality_origin = ABNORMALITY_ORIGIN_ARTBOOK
 
 	var/wordcount = 0
+	var/list/oddities = list( //List gets populated with friendly animals
+		)
+	var/list/nasties = list( //Todo: Eventually make a list of custom threats possibly
+		/mob/living/simple_animal/hostile/ordeal/green_bot,
+		/mob/living/simple_animal/hostile/ordeal/indigo_dawn,
+		/mob/living/simple_animal/hostile/ordeal/violet_fruit
+		)
+	var/meltdown_cooldown //no spamming the meltdown effect
+	var/meltdown_cooldown_time = 30 SECONDS
 
 /mob/living/simple_animal/hostile/abnormality/book/PostWorkEffect(mob/living/carbon/human/user, work_type, pe, work_time)
 	if(work_type == ABNORMALITY_WORK_REPRESSION)
@@ -29,6 +39,7 @@
 			if(Approach(user))
 				visible_message(span_warning("[user] starts ripping pages out of [src]!"))
 				playsound(get_turf(src), 'sound/items/poster_ripped.ogg', 50, 1, FALSE)
+				RipPages()
 				wordcount = 0
 				icon_state = "book_[wordcount]"
 	else
@@ -60,3 +71,70 @@
 	step_towards(user, src)
 	sleep(0.5 SECONDS)
 	return TRUE
+
+//Special breach-related stuff, pretty much copied off a contract signed
+/mob/living/simple_animal/hostile/abnormality/book/Initialize()
+	. = ..()
+	//We'll use the global_friendly_animal_types list. It's empty by default, so we need to populate it.
+	if(!GLOB.friendly_animal_types.len)
+		for(var/T in typesof(/mob/living/simple_animal))
+			var/mob/living/simple_animal/SA = T
+			if(initial(SA.gold_core_spawnable) == FRIENDLY_SPAWN)
+				GLOB.friendly_animal_types += SA
+	oddities += GLOB.friendly_animal_types
+
+	//We need a list of all abnormalities that are TETH and can breach
+	var/list/queue = subtypesof(/mob/living/simple_animal/hostile/abnormality)
+	for(var/i in queue)
+		var/mob/living/simple_animal/hostile/abnormality/abno = i
+		if(!(initial(abno.can_spawn)) || !(initial(abno.can_breach)))
+			continue
+		if((initial(abno.threat_level)) <= TETH_LEVEL)
+			nasties += abno
+
+/mob/living/simple_animal/hostile/abnormality/book/proc/RipPages()
+	var/mob/living/simple_animal/newspawn
+	if(wordcount >= 3)
+		newspawn = pick(oddities)
+		SpawnMob(newspawn)
+		return
+	else
+		datum_reference.qliphoth_change(-wordcount)
+
+/mob/living/simple_animal/hostile/abnormality/book/proc/SpawnMob(mob/living/simple_animal/newspawn)
+	var/mob/living/simple_animal/spawnedmob = new newspawn(get_turf(src))
+	if(isabnormalitymob(spawnedmob))
+		var/mob/living/simple_animal/hostile/abnormality/abno = spawnedmob
+		abno.BreachEffect()
+	if(spawnedmob.butcher_results)
+		spawnedmob.butcher_results = list(/obj/item/paper = 1)
+	spawnedmob.loot = list(/obj/item/paper = 1)
+	var/inverted_icon
+	var/icon/papericon = icon("[spawnedmob.icon]", spawnedmob.icon_state) //create inverted colors icon
+	papericon.MapColors(0.8,0.8,0.8, 0.2,0.2,0.2, 0.8,0.8,0.8, 0,0,0)
+	inverted_icon = papericon
+	spawnedmob.icon = inverted_icon
+	spawnedmob.desc = "It looks like a [spawnedmob.name] but made of paper."
+	spawnedmob.name = "Paper [initial(spawnedmob.name)]"
+	spawnedmob.faction = list("hostile")
+	spawnedmob.health = (spawnedmob.maxHealth / 10)
+	spawnedmob.deathmessage = "collapses into a bunch of writing material."
+	spawnedmob.filters += filter(type="drop_shadow", x=0, y=0, size=1, offset=0, color=rgb(0, 0, 0))
+	src.visible_message(span_warning("Pages of [src] fold into [spawnedmob]!"))
+	playsound(get_turf(src), 'sound/items/handling/paper_pickup.ogg', 90, 1, FALSE)
+
+/mob/living/simple_animal/hostile/abnormality/book/ZeroQliphoth(mob/living/carbon/human/user)
+	datum_reference.qliphoth_change(start_qliphoth) //no need for qliphoth to be stuck at 0
+	if(meltdown_cooldown > world.time)
+		return
+	meltdown_cooldown = world.time + meltdown_cooldown_time
+	MeltdownEffect()
+	return
+
+/mob/living/simple_animal/hostile/abnormality/book/proc/MeltdownEffect(mob/living/carbon/human/user)
+	var/mob/living/simple_animal/newspawn
+	var/spawn_num = rand(3,5)
+	for(var/i=1, i<=spawn_num, i++)
+		sleep(0.5 SECONDS)
+		newspawn = pick(nasties)
+		SpawnMob(newspawn)

--- a/code/modules/mob/living/simple_animal/abnormality/teth/pale_horse.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/pale_horse.dm
@@ -40,7 +40,7 @@
 	var/teleport_cooldown_time = 30 SECONDS
 	//attack
 	var/mob/living/set_target
-	var/pulse_range = 7 //same range as scorched girl
+	var/pulse_range = 11 //fairly large area - enough to breach several abnormalities
 	var/fog_damage = 3
 	var/ash_damage = 20
 
@@ -113,13 +113,15 @@
 			H.apply_damage(fog_damage, PALE_DAMAGE, null, H.run_armor_check(null, PALE_DAMAGE), spread_damage = TRUE)
 
 
-/mob/living/simple_animal/hostile/abnormality/pale_horse/Move() //more damaging fog when moving
+/mob/living/simple_animal/hostile/abnormality/pale_horse/Moved() //more damaging fog when moving
+	. = ..()
+	if(!.)
+		return
 	var/turf/target_turf = get_turf(src)
 	for(var/turf/T in view(1, target_turf))
 		new /obj/effect/temp_visual/palefog(T)
-	..()
 
-/mob/living/simple_animal/hostile/abnormality/pale_horse/AttackingTarget() //works but abnormality does not do it on its own todo: FIX!
+/mob/living/simple_animal/hostile/abnormality/pale_horse/AttackingTarget()
 	. = ..()
 	if(!ishuman(target))
 		return FALSE
@@ -258,19 +260,25 @@
 	duration = 5
 
 //status effects
-//MORTIS - Raises pale vulnurability briefly
+//MORTIS - Raises pale vulnurability briefly and deals pale damage over time
 /datum/status_effect/mortis
 	id = "mortis"
 	duration = 15 SECONDS
 	status_type = STATUS_EFFECT_UNIQUE
 	alert_type = /atom/movable/screen/alert/status_effect/mortis
 	var/datum/abnormality/datum_reference = null
+	var/damage = 2
 
 /atom/movable/screen/alert/status_effect/mortis
 	name = "Fated to die"
 	desc = "The pale horse saw your end and wept."
 	icon = 'ModularTegustation/Teguicons/status_sprites.dmi'
 	icon_state = "mortis"
+
+/datum/status_effect/mortis/tick()
+	owner.apply_damage(damage, PALE_DAMAGE, null, owner.run_armor_check(null, PALE_DAMAGE), spread_damage = TRUE)
+	if(owner.health < 0 && ishuman(owner))
+		owner.dust()
 
 /datum/status_effect/mortis/on_apply()
 	. = ..()

--- a/code/modules/paperwork/records/info/teth.dm
+++ b/code/modules/paperwork/records/info/teth.dm
@@ -236,6 +236,8 @@
 		"When work was performed, the employee felt compelled to write in the book regardless of result.",
 		"Employees suffered from higher amounts of damage during work when the book was closer to completion.",
 		"Upon finishing repression work, employee Noah felt compelled to rip pages out of the abnormality.",
+		"When the abnormality was not full of words when pages were torn out, the torn pages twisted into hostile forms and attacked nearby employees.",
+		"When the abnormality was full of words when pages were torn out, the torn pages became friendly creatures instead.",
 		"Attempted repression work when the book was already empty nearly always ended in failure. In constrast, repression work performed when the book was full was usually successful.")
 
 //Someone's Portrait


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adjusts a couple abnormalities, may add more soon.

Makes pale horse slightly more dangerous.

- Status effect now deals a small amount of pale damage over time.
- Increased the range of most attacks.

Fixes an issue with shelter from the 27th of march
- Players can no longer drag objects in and out of the shelter, only players.

Book without pictures or dialogue has been mostly reworked

- Performing repression work early now lowers qlipthoth in addition to previous effects.
- A breach effect has been added, spawning between 3 and 5 "paper" mobs. They have 1/10th of the usual health.
- Performing repression work when the book is full as intended spawns a friendly animal in paper form.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Stuff is less bad.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Pale horse now has a larger area of attack
tweak: Book without pictures or dialogue has been entirely reworked
fix: crates can no longer be dragged out of the shelter
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
