### PR TITLE
Weighted Abnormality Choices

### DIFF
--- a/code/datums/abnormality/datum/abnormality.dm
+++ b/code/datums/abnormality/datum/abnormality.dm
@@ -72,6 +72,7 @@
 	desc = initial(abno_path.desc)
 	RespawnAbno()
 	FillEgoList()
+	ModifyOdds()
 
 /datum/abnormality/Destroy()
 	SSlobotomy_corp.all_abnormality_datums -= src
@@ -143,6 +144,14 @@
 		GLOB.ego_datums["[ED.name][ED.item_category]"] = ED
 	return TRUE
 
+/datum/abnormality/proc/ModifyOdds()
+	var/turf/spawn_turf = locate(1, 1, 1)
+	var/mob/living/simple_animal/hostile/abnormality/abno = new abno_path(spawn_turf)
+	for(var/path in abno.grouped_abnos)
+		var/mob/living/simple_animal/hostile/abnormality/abno_friend = path
+		if(abno_friend in SSabnormality_queue.possible_abnormalities[initial(abno_friend.threat_level)])
+			SSabnormality_queue.possible_abnormalities[initial(abno_friend.threat_level)][abno_friend] = SSabnormality_queue.possible_abnormalities[initial(abno_friend.threat_level)][abno_friend] * abno.grouped_abnos[abno_friend]
+	QDEL_NULL(abno)
 
 /datum/abnormality/proc/work_complete(mob/living/carbon/human/user, work_type, pe, work_time, was_melting, canceled)
 	current.WorkComplete(user, work_type, pe, work_time, canceled) // Cross-referencing gone wrong

--- a/code/modules/mob/living/simple_animal/abnormality/_abnormality.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_abnormality.dm
@@ -79,6 +79,9 @@
 	var/harvest_phrase_third = "%PERSON harvests... something... into %VESSEL."
 	// Dummy chemicals - called if chem_type is null.
 	var/list/dummy_chems = list(/datum/reagent/abnormality/nutrition, /datum/reagent/abnormality/cleanliness, /datum/reagent/abnormality/consensus, /datum/reagent/abnormality/amusement, /datum/reagent/abnormality/violence)
+	// Increased Abno appearance chance
+	/// Assoc list, you do [path] = [probability_multiplier] for each entry
+	var/list/grouped_abnos = list()
 
 /mob/living/simple_animal/hostile/abnormality/Initialize(mapload)
 	SHOULD_CALL_PARENT(TRUE)

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/army_in_black.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/army_in_black.dm
@@ -45,6 +45,12 @@ GLOBAL_LIST_EMPTY(army)
 		)
 	gift_type =  /datum/ego_gifts/pink
 
+	grouped_abnos = list(
+		/mob/living/simple_animal/hostile/abnormality/quiet_day = 1.5,
+		/mob/living/simple_animal/hostile/abnormality/khz = 1.5,
+		/mob/living/simple_animal/hostile/abnormality/mhz = 1.5
+	)
+
 	//Unique variables
 	var/death_counter = 0
 	var/protection_duration = 120 SECONDS

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/nihil.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/nihil.dm
@@ -41,6 +41,13 @@
 		)
 	gift_type = /datum/ego_gifts/nihil
 
+	grouped_abnos = list(
+		/mob/living/simple_animal/hostile/abnormality/hatred_queen = 5,
+		/mob/living/simple_animal/hostile/abnormality/despair_knight = 5,
+		/mob/living/simple_animal/hostile/abnormality/greed_king = 5,
+		/mob/living/simple_animal/hostile/abnormality/wrath_servant = 5
+	)
+
 	// Range ofthe debuff
 	var/debuff_range = 40
 	var/list/quotes = list("Everybody's agony becomes one.",

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/nobody_is.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/nobody_is.dm
@@ -38,6 +38,11 @@
 	gift_type =  /datum/ego_gifts/mockery
 	abnormality_origin = ABNORMALITY_ORIGIN_WONDERLAB
 
+	grouped_abnos = list(
+		/mob/living/simple_animal/hostile/abnormality/nothing_there = 1.5,
+		/mob/living/simple_animal/hostile/abnormality/kqe = 1.5
+	)
+
 	//Contained Variables
 	var/reflect_timer
 	var/mob/living/disguise = null

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/nothing_there.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/nothing_there.dm
@@ -39,6 +39,12 @@
 		)
 	gift_type =  /datum/ego_gifts/mimicry
 	abnormality_origin = ABNORMALITY_ORIGIN_LOBOTOMY
+
+	grouped_abnos = list(
+		/mob/living/simple_animal/hostile/abnormality/kqe = 1.5,
+		/mob/living/simple_animal/hostile/abnormality/nobody_is = 1.5
+	)
+
 	var/mob/living/disguise = null
 	var/saved_appearance
 	var/can_act = TRUE

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/white_night.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/white_night.dm
@@ -47,6 +47,10 @@ GLOBAL_LIST_EMPTY(apostles)
 	gift_type =  /datum/ego_gifts/paradise
 	abnormality_origin = ABNORMALITY_ORIGIN_LOBOTOMY
 
+	grouped_abnos = list(
+		/mob/living/simple_animal/hostile/abnormality/onesin = 5
+	)
+
 	var/holy_revival_cooldown
 	var/holy_revival_cooldown_base = 75 SECONDS
 	var/holy_revival_damage = 80 // Pale damage, scales with distance

--- a/code/modules/mob/living/simple_animal/abnormality/he/KHz.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/KHz.dm
@@ -24,6 +24,12 @@
 	)
 	gift_type = /datum/ego_gifts/transmission
 
+	grouped_abnos = list(
+		/mob/living/simple_animal/hostile/abnormality/quiet_day = 1.5,
+		/mob/living/simple_animal/hostile/abnormality/mhz = 1.5,
+		/mob/living/simple_animal/hostile/abnormality/army = 1.5
+	)
+
 	var/input
 	var/bitposition = 4	//You write in bits. You need to successfully write a string of 5 to sucessfully work
 	var/bitcalculator = 0

--- a/code/modules/mob/living/simple_animal/abnormality/he/KQE.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/KQE.dm
@@ -41,6 +41,12 @@
 	gift_type =  /datum/ego_gifts/replica
 	gift_message = "The abnormality hands you a pendant made from circuits and sinews."
 	abnormality_origin = ABNORMALITY_ORIGIN_LIMBUS
+
+	grouped_abnos = list(
+		/mob/living/simple_animal/hostile/abnormality/nothing_there = 1.5,
+		/mob/living/simple_animal/hostile/abnormality/nobody_is = 1.5
+	)
+
 	var/can_act = TRUE
 	var/grab_cooldown
 	var/grab_cooldown_time = 15 SECONDS

--- a/code/modules/mob/living/simple_animal/abnormality/he/blue_shepherd.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/blue_shepherd.dm
@@ -47,6 +47,10 @@
 	gift_type = /datum/ego_gifts/oppression
 	abnormality_origin = ABNORMALITY_ORIGIN_WONDERLAB
 
+	grouped_abnos = list(
+		/mob/living/simple_animal/hostile/abnormality/red_buddy = 5
+	)
+
 	var/death_counter //He won't go off a timer, he'll go off deaths. Takes 8 for him.
 	var/slash_current = 4
 	var/slash_cooldown = 4

--- a/code/modules/mob/living/simple_animal/abnormality/he/golden_false_apple.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/golden_false_apple.dm
@@ -59,6 +59,11 @@
 	gift_message = "You feel a sense of kinship with the apple. Because you're both pests."
 	abnormality_origin = ABNORMALITY_ORIGIN_LIMBUS
 
+	grouped_abnos = list(
+		/mob/living/simple_animal/hostile/abnormality/snow_whites_apple = 1.5,
+		/mob/living/simple_animal/hostile/abnormality/ebony_queen = 1.5
+	)
+
 	attack_action_types = list(
 		/datum/action/cooldown/gapple_pulse
 		)

--- a/code/modules/mob/living/simple_animal/abnormality/he/helper.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/helper.dm
@@ -37,6 +37,12 @@
 	gift_type =  /datum/ego_gifts/grinder
 	gift_message = "Contamination scan complete. Initiating cleaning protocol."
 	abnormality_origin = ABNORMALITY_ORIGIN_LOBOTOMY
+
+	grouped_abnos = list(
+		/mob/living/simple_animal/hostile/abnormality/we_can_change_anything = 1.5,
+		/mob/living/simple_animal/hostile/abnormality/cleaner = 1.5
+	)
+
 	var/charging = FALSE
 	var/dash_num = 50
 	var/dash_cooldown = 0

--- a/code/modules/mob/living/simple_animal/abnormality/he/red_buddy.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/red_buddy.dm
@@ -44,6 +44,10 @@
 	gift_type = /datum/ego_gifts/totalitarianism
 	abnormality_origin = ABNORMALITY_ORIGIN_WONDERLAB
 
+	grouped_abnos = list(
+		/mob/living/simple_animal/hostile/abnormality/blue_shepherd = 5
+	)
+
 	///The blue smocked shepherd linked to red buddy
 	var/datum/abnormality/master
 	//the living shepherd it is currently fighting with

--- a/code/modules/mob/living/simple_animal/abnormality/he/road_home.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/road_home.dm
@@ -34,6 +34,14 @@
 	gift_type = /datum/ego_gifts/homing_instinct
 	abnormality_origin = ABNORMALITY_ORIGIN_WONDERLAB
 
+	grouped_abnos = list(
+		/mob/living/simple_animal/hostile/abnormality/scarecrow = 2,
+		/mob/living/simple_animal/hostile/abnormality/woodsman = 2,
+		/mob/living/simple_animal/hostile/abnormality/scaredy_cat = 2,
+		// Ozma = 2,
+		// Lies = 1.5
+	)
+
 	///Stuff related to the house and its path
 	var/obj/road_house/house
 	var/list/house_path

--- a/code/modules/mob/living/simple_animal/abnormality/he/scarecrow.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/scarecrow.dm
@@ -38,6 +38,15 @@
 		)
 	gift_type =  /datum/ego_gifts/harvest
 	abnormality_origin = ABNORMALITY_ORIGIN_LOBOTOMY
+
+	grouped_abnos = list(
+		/mob/living/simple_animal/hostile/abnormality/road_home = 2,
+		/mob/living/simple_animal/hostile/abnormality/woodsman = 2,
+		/mob/living/simple_animal/hostile/abnormality/scaredy_cat = 2,
+		// Ozma = 2,
+		// Lies = 1.5
+	)
+
 	/// Can't move/attack when it's TRUE
 	var/finishing = FALSE
 

--- a/code/modules/mob/living/simple_animal/abnormality/he/scaredy_cat.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/scaredy_cat.dm
@@ -40,6 +40,15 @@
 		)
 	gift_type =  /datum/ego_gifts/courage_cat //the sprites for the EGO are shitty codersprites placeholders and are only here so that there's EGO to use
 	abnormality_origin = ABNORMALITY_ORIGIN_WONDERLAB
+
+	grouped_abnos = list(
+		/mob/living/simple_animal/hostile/abnormality/scarecrow = 2,
+		/mob/living/simple_animal/hostile/abnormality/woodsman = 2,
+		/mob/living/simple_animal/hostile/abnormality/road_home = 2,
+		// Ozma = 2,
+		// Lies = 1.5
+	)
+
 	/// The list of abnormality scaredy cat will automatically join when they breach, add any "Oz" abno to this list if possible
 	var/list/prefered_abno_list = list(
 									/mob/living/simple_animal/hostile/abnormality/woodsman,

--- a/code/modules/mob/living/simple_animal/abnormality/he/woodsman.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/woodsman.dm
@@ -39,6 +39,15 @@
 		)
 	gift_type =  /datum/ego_gifts/loggging
 	abnormality_origin = ABNORMALITY_ORIGIN_LOBOTOMY
+
+	grouped_abnos = list(
+		/mob/living/simple_animal/hostile/abnormality/scarecrow = 2,
+		/mob/living/simple_animal/hostile/abnormality/road_home = 2,
+		/mob/living/simple_animal/hostile/abnormality/scaredy_cat = 2,
+		// Ozma = 2,
+		// Lies = 1.5
+	)
+
 	var/flurry_cooldown = 0
 	var/flurry_cooldown_time = 15 SECONDS
 	var/flurry_count = 7

--- a/code/modules/mob/living/simple_animal/abnormality/teth/MHz.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/MHz.dm
@@ -28,6 +28,12 @@
 	gift_type =  /datum/ego_gifts/noise
 	abnormality_origin = ABNORMALITY_ORIGIN_LOBOTOMY
 
+	grouped_abnos = list(
+		/mob/living/simple_animal/hostile/abnormality/quiet_day = 1.5,
+		/mob/living/simple_animal/hostile/abnormality/khz = 1.5,
+		/mob/living/simple_animal/hostile/abnormality/army = 1.5
+	)
+
 	var/reset_time = 4 MINUTES //Qliphoth resets after this time. To prevent bugs
 
 /mob/living/simple_animal/hostile/abnormality/mhz/WorkChance(mob/living/carbon/human/user, chance)

--- a/code/modules/mob/living/simple_animal/abnormality/teth/cleaner.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/cleaner.dm
@@ -38,6 +38,12 @@
 	gift_type =  /datum/ego_gifts/sanitizer
 	gift_message = "Contamination scan complete. Initiating cleaning protocol."
 	abnormality_origin = ABNORMALITY_ORIGIN_LIMBUS
+
+	grouped_abnos = list(
+		/mob/living/simple_animal/hostile/abnormality/helper = 1.5,
+		/mob/living/simple_animal/hostile/abnormality/we_can_change_anything = 1.5
+	)
+
 	var/bumpdamage = 10
 
 /mob/living/simple_animal/hostile/abnormality/cleaner/Move()

--- a/code/modules/mob/living/simple_animal/abnormality/teth/fairy_gentleman.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/fairy_gentleman.dm
@@ -38,6 +38,13 @@
 	gift_type = /datum/ego_gifts/sloshing
 	gift_message = "This wine tastes quite good..."
 	abnormality_origin = ABNORMALITY_ORIGIN_LIMBUS
+
+	grouped_abnos = list(
+		/mob/living/simple_animal/hostile/abnormality/fairy_festival = 1.5,
+		/mob/living/simple_animal/hostile/abnormality/fairy_longlegs = 1.5,
+		// Fae Lantern = 1.5
+	)
+
 	var/can_act = TRUE
 	var/jump_cooldown = 0
 	var/jump_cooldown_time = 8 SECONDS

--- a/code/modules/mob/living/simple_animal/abnormality/teth/fairy_long_legs.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/fairy_long_legs.dm
@@ -35,6 +35,13 @@
 	deathmessage = "coalesces into a primordial egg."
 	deathsound = 'sound/abnormalities/fairy_longlegs/death.ogg'
 	abnormality_origin = ABNORMALITY_ORIGIN_LIMBUS
+
+	grouped_abnos = list(
+		/mob/living/simple_animal/hostile/abnormality/fairy_gentleman = 1.5,
+		/mob/living/simple_animal/hostile/abnormality/fairy_festival = 1.5,
+		// Fae Lantern = 1.5
+	)
+
 	var/finishing = FALSE //cant move/attack when it's TRUE
 	var/work_count = 0
 	var/raining = FALSE

--- a/code/modules/mob/living/simple_animal/abnormality/teth/punishing_bird.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/punishing_bird.dm
@@ -51,6 +51,12 @@
 		)
 	gift_type =  /datum/ego_gifts/beak
 	abnormality_origin = ABNORMALITY_ORIGIN_LOBOTOMY
+
+	grouped_abnos = list(
+		/mob/living/simple_animal/hostile/abnormality/big_bird = 3,
+		/mob/living/simple_animal/hostile/abnormality/judgement_bird = 3
+	)
+
 	var/list/enemies = list()
 	var/list/pecking_targets = list()
 	var/list/already_punished = list()

--- a/code/modules/mob/living/simple_animal/abnormality/waw/big_bird.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/big_bird.dm
@@ -49,6 +49,11 @@
 	gift_type =  /datum/ego_gifts/lamp
 	abnormality_origin = ABNORMALITY_ORIGIN_LOBOTOMY
 
+	grouped_abnos = list(
+		/mob/living/simple_animal/hostile/abnormality/judgement_bird = 3,
+		/mob/living/simple_animal/hostile/abnormality/punishing_bird = 3
+	)
+
 	var/bite_cooldown
 	var/bite_cooldown_time = 8 SECONDS
 	var/hypnosis_cooldown

--- a/code/modules/mob/living/simple_animal/abnormality/waw/despair_knight.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/despair_knight.dm
@@ -37,6 +37,14 @@
 		)
 	gift_type =  /datum/ego_gifts/tears
 	abnormality_origin = ABNORMALITY_ORIGIN_LOBOTOMY
+
+	grouped_abnos = list(
+		/mob/living/simple_animal/hostile/abnormality/wrath_servant = 2,
+		/mob/living/simple_animal/hostile/abnormality/hatred_queen = 2,
+		/mob/living/simple_animal/hostile/abnormality/greed_king = 2,
+		/mob/living/simple_animal/hostile/abnormality/nihil = 1.5
+	)
+
 	var/mob/living/carbon/human/blessed_human = null
 	var/teleport_cooldown
 	var/teleport_cooldown_time = 20 SECONDS

--- a/code/modules/mob/living/simple_animal/abnormality/waw/ebony_queen.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/ebony_queen.dm
@@ -57,6 +57,11 @@
 	gift_type =  /datum/ego_gifts/ebony_stem
 	abnormality_origin = ABNORMALITY_ORIGIN_LIMBUS
 
+	grouped_abnos = list(
+		/mob/living/simple_animal/hostile/abnormality/golden_apple = 1.5,
+		/mob/living/simple_animal/hostile/abnormality/snow_whites_apple = 1.5
+	)
+
 	//PLAYABLES ATTACKS
 	attack_action_types = list(
 	/datum/action/innate/abnormality_attack/ebony_root,

--- a/code/modules/mob/living/simple_animal/abnormality/waw/generalb.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/generalb.dm
@@ -32,6 +32,10 @@
 	melee_damage_upper = 52
 	melee_damage_type = RED_DAMAGE
 	stat_attack = HARD_CRIT
+
+	grouped_abnos = list(
+		/mob/living/simple_animal/hostile/abnormality/queen_bee = 5
+	)
 	//She has a Quad Artillery Cannon
 
 	var/fire_cooldown_time = 3 SECONDS	//She has 4 cannons, fires 4 times faster than the artillery bees

--- a/code/modules/mob/living/simple_animal/abnormality/waw/greed_king.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/greed_king.dm
@@ -45,6 +45,13 @@
 	gift_type =  /datum/ego_gifts/goldrush
 	abnormality_origin = ABNORMALITY_ORIGIN_LOBOTOMY
 
+	grouped_abnos = list(
+		/mob/living/simple_animal/hostile/abnormality/despair_knight = 2,
+		/mob/living/simple_animal/hostile/abnormality/hatred_queen = 2,
+		/mob/living/simple_animal/hostile/abnormality/wrath_servant = 2,
+		/mob/living/simple_animal/hostile/abnormality/nihil = 1.5
+	)
+
 	//PLAYABLES ATTACKS
 	attack_action_types = list(
 	/datum/action/innate/abnormality_attack/kog_dash,

--- a/code/modules/mob/living/simple_animal/abnormality/waw/hatred_queen.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/hatred_queen.dm
@@ -51,6 +51,13 @@
 	gift_type = /datum/ego_gifts/love_and_hate
 	gift_message = "In fact, \"peace\" is not what she desires."
 
+	grouped_abnos = list(
+		/mob/living/simple_animal/hostile/abnormality/despair_knight = 2,
+		/mob/living/simple_animal/hostile/abnormality/wrath_servant = 2,
+		/mob/living/simple_animal/hostile/abnormality/greed_king = 2,
+		/mob/living/simple_animal/hostile/abnormality/nihil = 1.5
+	)
+
 	var/chance_modifier = 1
 	var/death_counter = 0
 	/// Reduce qliphoth if not enough people have died for too long

--- a/code/modules/mob/living/simple_animal/abnormality/waw/judgement_bird.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/judgement_bird.dm
@@ -40,6 +40,12 @@
 		)
 	gift_type =  /datum/ego_gifts/justitia
 	abnormality_origin = ABNORMALITY_ORIGIN_LOBOTOMY
+
+	grouped_abnos = list(
+		/mob/living/simple_animal/hostile/abnormality/big_bird = 3,
+		/mob/living/simple_animal/hostile/abnormality/punishing_bird = 3
+	)
+
 	var/judgement_cooldown = 10 SECONDS
 	var/judgement_cooldown_base = 10 SECONDS
 	var/judgement_damage = 45

--- a/code/modules/mob/living/simple_animal/abnormality/waw/queen_bee.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/queen_bee.dm
@@ -28,6 +28,11 @@
 		)
 	gift_type =  /datum/ego_gifts/hornet
 	abnormality_origin = ABNORMALITY_ORIGIN_LOBOTOMY
+
+	grouped_abnos = list(
+		/mob/living/simple_animal/hostile/abnormality/general_b = 5
+	)
+
 	var/datum/looping_sound/queenbee/soundloop
 	var/breached_others = FALSE
 

--- a/code/modules/mob/living/simple_animal/abnormality/waw/shrimp.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/shrimp.dm
@@ -24,6 +24,9 @@
 		)
 	gift_type =  /datum/ego_gifts/executive
 
+	grouped_abnos = list(
+		/mob/living/simple_animal/hostile/abnormality/wellcheers = 1.5 // I... if you ever get a zayin this far in, good luck.
+	)
 
 	var/liked
 	var/happy = TRUE

--- a/code/modules/mob/living/simple_animal/abnormality/waw/snow_whites_apple.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/snow_whites_apple.dm
@@ -49,6 +49,11 @@ GLOBAL_LIST_EMPTY(vine_list)
 	gift_type =  /datum/ego_gifts/stem
 	abnormality_origin = ABNORMALITY_ORIGIN_LOBOTOMY
 
+	grouped_abnos = list(
+		/mob/living/simple_animal/hostile/abnormality/golden_apple = 1.5,
+		/mob/living/simple_animal/hostile/abnormality/ebony_queen = 1.5
+	)
+
 /mob/living/simple_animal/hostile/abnormality/snow_whites_apple/NeutralEffect(mob/living/carbon/human/user, work_type, pe)
 	if(prob(50))
 		datum_reference.qliphoth_change(-1)

--- a/code/modules/mob/living/simple_animal/abnormality/waw/wrath_servant.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/wrath_servant.dm
@@ -1,7 +1,7 @@
 #define STATUS_EFFECT_ACIDIC_GOO  /datum/status_effect/wrath_burning
 #define SERVANT_SMASH_COOLDOWN (30 SECONDS)
 #define SERVANT_DASH_COOLDOWN (15 SECONDS)
-/mob/living/simple_animal/hostile/abnormality/servant_wrath
+/mob/living/simple_animal/hostile/abnormality/wrath_servant
 	name = "\proper Servant of Wrath"
 	desc = "A small girl in a puffy green magical girl outfit. \
 		She seems lonely."
@@ -50,6 +50,13 @@
 	gift_type = /datum/ego_gifts/blind_rage
 	abnormality_origin = ABNORMALITY_ORIGIN_WONDERLAB
 
+	grouped_abnos = list(
+		/mob/living/simple_animal/hostile/abnormality/despair_knight = 2,
+		/mob/living/simple_animal/hostile/abnormality/hatred_queen = 2,
+		/mob/living/simple_animal/hostile/abnormality/greed_king = 2,
+		/mob/living/simple_animal/hostile/abnormality/nihil = 1.5
+	)
+
 	var/friendly = TRUE
 	var/list/friend_ship = list()
 	var/instability = 0
@@ -86,9 +93,9 @@
 /datum/action/cooldown/wrath_smash/Trigger()
 	if(!..())
 		return FALSE
-	if(!istype(owner, /mob/living/simple_animal/hostile/abnormality/servant_wrath))
+	if(!istype(owner, /mob/living/simple_animal/hostile/abnormality/wrath_servant))
 		return FALSE
-	var/mob/living/simple_animal/hostile/abnormality/servant_wrath/servant = owner
+	var/mob/living/simple_animal/hostile/abnormality/wrath_servant/servant = owner
 	if(servant.IsContained()) // No more using cooldowns while contained
 		return FALSE
 	servant.Smash()
@@ -106,25 +113,25 @@
 /datum/action/cooldown/wrath_dash/Trigger()
 	if(!..())
 		return FALSE
-	if(!istype(owner, /mob/living/simple_animal/hostile/abnormality/servant_wrath))
+	if(!istype(owner, /mob/living/simple_animal/hostile/abnormality/wrath_servant))
 		return FALSE
-	var/mob/living/simple_animal/hostile/abnormality/servant_wrath/servant = owner
+	var/mob/living/simple_animal/hostile/abnormality/wrath_servant/servant = owner
 	if(servant.IsContained()) // No more using cooldowns while contained
 		return FALSE
 	servant.Dash()
 	StartCooldown()
 	return TRUE
 
-/mob/living/simple_animal/hostile/abnormality/servant_wrath/Initialize(mapload)
+/mob/living/simple_animal/hostile/abnormality/wrath_servant/Initialize(mapload)
 	. = ..()
 	RegisterSignal(SSdcs, COMSIG_GLOB_MOB_DEATH, .proc/OnMobDeath)
 
-/mob/living/simple_animal/hostile/abnormality/servant_wrath/IsContained()
+/mob/living/simple_animal/hostile/abnormality/wrath_servant/IsContained()
 	if((status_flags & GODMODE) && !stunned)
 		return TRUE
 	return FALSE
 
-/mob/living/simple_animal/hostile/abnormality/servant_wrath/OpenFire(atom/A)
+/mob/living/simple_animal/hostile/abnormality/wrath_servant/OpenFire(atom/A)
 	if(!can_act || stunned)
 		return
 	if(client)
@@ -137,7 +144,7 @@
 		Smash()
 		return
 
-/mob/living/simple_animal/hostile/abnormality/servant_wrath/Life()
+/mob/living/simple_animal/hostile/abnormality/wrath_servant/Life()
 	. = ..()
 	if(IsContained() || !can_act)
 		return
@@ -171,7 +178,7 @@
 			Teleport(T)
 			break
 
-/mob/living/simple_animal/hostile/abnormality/servant_wrath/attack_hand(mob/living/carbon/human/M)
+/mob/living/simple_animal/hostile/abnormality/wrath_servant/attack_hand(mob/living/carbon/human/M)
 	if(!stunned)
 		return ..()
 	to_chat(M, span_warning("You start pulling the staff from the [src]!"))
@@ -182,7 +189,7 @@
 	Unstun()
 	return
 
-/mob/living/simple_animal/hostile/abnormality/servant_wrath/proc/AdjustInstability(amount = 0)
+/mob/living/simple_animal/hostile/abnormality/wrath_servant/proc/AdjustInstability(amount = 0)
 	instability = clamp(instability + amount, (4*length(friend_ship)), 100)
 	if(!IsContained())
 		return TRUE
@@ -201,7 +208,7 @@
 			icon_state = "wrath_2"
 	return TRUE
 
-/mob/living/simple_animal/hostile/abnormality/servant_wrath/proc/Unstun()
+/mob/living/simple_animal/hostile/abnormality/wrath_servant/proc/Unstun()
 	if(!stunned)
 		return
 	status_flags &= ~GODMODE
@@ -211,24 +218,24 @@
 	desc = "A large red monster with white bandages hanging from it. Its flesh oozes a bubble acid."
 	manual_emote("begins to move once more!")
 
-/mob/living/simple_animal/hostile/abnormality/servant_wrath/Move()
+/mob/living/simple_animal/hostile/abnormality/wrath_servant/Move()
 	if(!can_act || stunned)
 		return FALSE
 	..()
 
-/mob/living/simple_animal/hostile/abnormality/servant_wrath/Found(atom/A)
+/mob/living/simple_animal/hostile/abnormality/wrath_servant/Found(atom/A)
 	if(istype(A, /mob/living/simple_animal/hostile/azure_stave)) // 1st Priority
 		return TRUE
 	if(istype(A, /mob/living/simple_animal/hostile/azure_hermit)) // 2nd Priority
 		return TRUE
 	return FALSE // Everything Else
 
-/mob/living/simple_animal/hostile/abnormality/servant_wrath/PickTarget(list/Targets)
+/mob/living/simple_animal/hostile/abnormality/wrath_servant/PickTarget(list/Targets)
 	if(!isnull(hunted_target))
 		return hunted_target
 	return ..()
 
-/mob/living/simple_animal/hostile/abnormality/servant_wrath/AttackingTarget(atom/attacked_target)
+/mob/living/simple_animal/hostile/abnormality/wrath_servant/AttackingTarget(atom/attacked_target)
 	if(!can_act || stunned)
 		return
 	if(COOLDOWN_FINISHED(src, smash) && prob(30) && !client)
@@ -252,7 +259,7 @@
 		return
 	PerformEnding(AZ)
 
-/mob/living/simple_animal/hostile/abnormality/servant_wrath/PostWorkEffect(mob/living/carbon/human/user, work_type, pe, work_time, canceled)
+/mob/living/simple_animal/hostile/abnormality/wrath_servant/PostWorkEffect(mob/living/carbon/human/user, work_type, pe, work_time, canceled)
 	. = ..()
 	if(prob(instability))
 		datum_reference.qliphoth_change(-1)
@@ -282,7 +289,7 @@
 		AdjustInstability(3) // Was 1
 	return
 
-/mob/living/simple_animal/hostile/abnormality/servant_wrath/AttemptWork(mob/living/carbon/human/user, work_type)
+/mob/living/simple_animal/hostile/abnormality/wrath_servant/AttemptWork(mob/living/carbon/human/user, work_type)
 	if(work_type != "Request")
 		return ..()
 	if(datum_reference.console.meltdown)
@@ -307,12 +314,12 @@
 	BreachEffect(user)
 	return FALSE
 
-/mob/living/simple_animal/hostile/abnormality/servant_wrath/ZeroQliphoth(mob/living/carbon/human/user)
+/mob/living/simple_animal/hostile/abnormality/wrath_servant/ZeroQliphoth(mob/living/carbon/human/user)
 	friendly = FALSE
 	BreachEffect()
 	return
 
-/mob/living/simple_animal/hostile/abnormality/servant_wrath/BreachEffect(mob/living/carbon/human/user)
+/mob/living/simple_animal/hostile/abnormality/wrath_servant/BreachEffect(mob/living/carbon/human/user)
 	if(!datum_reference)
 		friendly = FALSE
 	if(friendly)
@@ -387,7 +394,7 @@
 		playsound(dep, 'sound/abnormalities/wrath_servant/hermit_magic.ogg', 60, FALSE, 10)
 		break
 
-/mob/living/simple_animal/hostile/abnormality/servant_wrath/proc/Dash()
+/mob/living/simple_animal/hostile/abnormality/wrath_servant/proc/Dash()
 	visible_message(span_warning("[src] sprints toward [target]!"), span_notice("You quickly dash!"), span_notice("You hear heavy footsteps speed up."))
 	var/duration = 1 SECONDS
 	if(client)
@@ -395,7 +402,7 @@
 	TemporarySpeedChange(-4, duration)
 	COOLDOWN_START(src, dash, dash_cooldown)
 
-/mob/living/simple_animal/hostile/abnormality/servant_wrath/proc/Smash()
+/mob/living/simple_animal/hostile/abnormality/wrath_servant/proc/Smash()
 	if(!can_act || stunned)
 		return FALSE
 	can_act = FALSE
@@ -439,7 +446,7 @@
 	icon_state = icon_living
 	can_act = TRUE
 
-/mob/living/simple_animal/hostile/abnormality/servant_wrath/proc/Teleport(turf/location)
+/mob/living/simple_animal/hostile/abnormality/wrath_servant/proc/Teleport(turf/location)
 	can_act = FALSE
 	animate(src, alpha = 0, time = 5)
 	new /obj/effect/temp_visual/guardian/phase(get_turf(src))
@@ -449,12 +456,12 @@
 	new /obj/effect/temp_visual/guardian/phase/out(location)
 	can_act = TRUE
 
-/mob/living/simple_animal/hostile/abnormality/servant_wrath/proc/OnMobDeath(datum/source, mob/living/died, gibbed)
+/mob/living/simple_animal/hostile/abnormality/wrath_servant/proc/OnMobDeath(datum/source, mob/living/died, gibbed)
 	if(died != hunted_target)
 		return
 	ReturnHome()
 
-/mob/living/simple_animal/hostile/abnormality/servant_wrath/proc/ReturnHome()
+/mob/living/simple_animal/hostile/abnormality/wrath_servant/proc/ReturnHome()
 	can_act = FALSE
 	hunted_target = null
 	say("For our friendship...")
@@ -471,7 +478,7 @@
 	friendly = FALSE
 	AdjustInstability()
 
-/mob/living/simple_animal/hostile/abnormality/servant_wrath/proc/PerformEnding(mob/living/simple_animal/hostile/azure_hermit/target = null)
+/mob/living/simple_animal/hostile/abnormality/wrath_servant/proc/PerformEnding(mob/living/simple_animal/hostile/azure_hermit/target = null)
 	ending = TRUE
 	can_act = FALSE
 	target.gib(TRUE)
@@ -511,7 +518,7 @@
 	dir = EAST
 	ending = FALSE
 
-/mob/living/simple_animal/hostile/abnormality/servant_wrath/proc/Downed()
+/mob/living/simple_animal/hostile/abnormality/wrath_servant/proc/Downed()
 	can_act = FALSE
 	status_flags |= GODMODE
 	if(friendly)
@@ -533,7 +540,7 @@
 	visible_message(span_warning("[src] gets back up!"))
 	can_act = TRUE
 
-/mob/living/simple_animal/hostile/abnormality/servant_wrath/death(gibbed)
+/mob/living/simple_animal/hostile/abnormality/wrath_servant/death(gibbed)
 	if(!datum_reference)
 		return ..()
 	if(ending)
@@ -541,7 +548,7 @@
 	INVOKE_ASYNC(src, .proc/Downed)
 	return FALSE
 
-/mob/living/simple_animal/hostile/abnormality/servant_wrath/gib()
+/mob/living/simple_animal/hostile/abnormality/wrath_servant/gib()
 	if(ending)
 		return FALSE
 	death()
@@ -589,9 +596,9 @@
 	COOLDOWN_START(src, conjure, conjure_cooldown)
 
 /mob/living/simple_animal/hostile/azure_hermit/Found(atom/A)
-	if(!istype(A, /mob/living/simple_animal/hostile/abnormality/servant_wrath))
+	if(!istype(A, /mob/living/simple_animal/hostile/abnormality/wrath_servant))
 		return FALSE
-	var/mob/living/simple_animal/hostile/abnormality/servant_wrath/SW = A
+	var/mob/living/simple_animal/hostile/abnormality/wrath_servant/SW = A
 	if(SW.stunned) // OUR WORK HERE IS DONE.
 		return FALSE
 	return TRUE
@@ -614,8 +621,8 @@
 /mob/living/simple_animal/hostile/azure_hermit/AttackingTarget(atom/attacked_target)
 	if(!can_act || (status_flags & GODMODE))
 		return
-	if(istype(target, /mob/living/simple_animal/hostile/abnormality/servant_wrath))
-		var/mob/living/simple_animal/hostile/abnormality/servant_wrath/SW = target
+	if(istype(target, /mob/living/simple_animal/hostile/abnormality/wrath_servant))
+		var/mob/living/simple_animal/hostile/abnormality/wrath_servant/SW = target
 		if(SW.stunned)
 			return
 		if(SW.health > 400)
@@ -639,7 +646,7 @@
 			playsound(SW, 'sound/abnormalities/wrath_servant/enrage.ogg', 100, FALSE, 40, falloff_distance = 20)
 			visible_message(span_userdanger("[src] plunges their staff into [SW]'s chest!"))
 			SW.stunned = TRUE
-			addtimer(CALLBACK(SW, /mob/living/simple_animal/hostile/abnormality/servant_wrath/proc/Unstun), 3 MINUTES)
+			addtimer(CALLBACK(SW, /mob/living/simple_animal/hostile/abnormality/wrath_servant/proc/Unstun), 3 MINUTES)
 			SW.status_flags |= GODMODE
 			SW.icon_state = "wrath_staff_stun"
 			SW.desc = "A large red monster with white bandages hanging from it. Its flesh oozes a bubble acid. A wooden staff is impaled in its chest, it can't seem to move!"
@@ -798,7 +805,7 @@
 		return FALSE
 	if(!isliving(AM))
 		return FALSE
-	if(istype(AM, /mob/living/simple_animal/hostile/abnormality/servant_wrath))
+	if(istype(AM, /mob/living/simple_animal/hostile/abnormality/wrath_servant))
 		return
 	var/mob/living/L = AM
 	L.apply_status_effect(STATUS_EFFECT_ACIDIC_GOO)

--- a/code/modules/mob/living/simple_animal/abnormality/waw/yang.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/yang.dm
@@ -40,6 +40,10 @@
 	gift_type = /datum/ego_gifts/assonance
 	abnormality_origin = ABNORMALITY_ORIGIN_ALTERED
 
+	grouped_abnos = list(
+		/mob/living/simple_animal/hostile/abnormality/yin = 5 // TAKE THE FISH. DO IT NOW.
+	)
+
 	//Melee
 	damage_coeff = list(BRUTE = 1, RED_DAMAGE = 1, WHITE_DAMAGE = 0.2, BLACK_DAMAGE = 1.7, PALE_DAMAGE = 2)
 	melee_damage_lower = 30

--- a/code/modules/mob/living/simple_animal/abnormality/waw/yin.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/yin.dm
@@ -39,6 +39,10 @@
 	gift_type = /datum/ego_gifts/discord
 	abnormality_origin = ABNORMALITY_ORIGIN_LOBOTOMY
 
+	grouped_abnos = list(
+		/mob/living/simple_animal/hostile/abnormality/yang = 5 // TAKE THE FISH. DO IT
+	)
+
 	faction = list("neutral", "hostile") // Not fought by anything, typically. But...
 	var/faction_override = list("hostile") // The effects hit non-hostiles.
 

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/fairy_festival.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/fairy_festival.dm
@@ -31,6 +31,13 @@
 	var/heal_cooldown_base = 2 SECONDS
 	var/list/mob/living/carbon/human/protected_people = list()
 	abnormality_origin = ABNORMALITY_ORIGIN_LOBOTOMY
+
+	grouped_abnos = list(
+		/mob/living/simple_animal/hostile/abnormality/fairy_gentleman = 1.5,
+		/mob/living/simple_animal/hostile/abnormality/fairy_longlegs = 1.5,
+		// Fae Lantern = 1.5
+	)
+
 	chem_type = /datum/reagent/abnormality/fairy_festival
 	harvest_phrase = span_notice("A fairy presents you a small flower, then pours its contents into %VESSEL.")
 	harvest_phrase_third = "A fairy presents %PERSON with a small flower, then pours it into %VESSEL."

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/one_sin.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/one_sin.dm
@@ -26,6 +26,11 @@
 	gift_type =  /datum/ego_gifts/penitence
 	gift_message = "From this day forth, you shall never forget his words."
 	abnormality_origin = ABNORMALITY_ORIGIN_LOBOTOMY
+
+	grouped_abnos = list(
+		/mob/living/simple_animal/hostile/abnormality/white_night = 5
+	)
+
 	chem_type = /datum/reagent/abnormality/onesin
 	harvest_phrase = span_notice("As you hold it up before %ABNO, holy light fills %VESSEL.")
 	harvest_phrase_third = "%PERSON holds up %VESSEL, letting it be filled with holy light."

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/quiet_day.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/quiet_day.dm
@@ -25,6 +25,13 @@
 		/datum/ego_datum/weapon/nostalgia,
 		/datum/ego_datum/armor/nostalgia
 	)
+
+	grouped_abnos = list(
+		/mob/living/simple_animal/hostile/abnormality/mhz = 1.5,
+		/mob/living/simple_animal/hostile/abnormality/khz = 1.5,
+		/mob/living/simple_animal/hostile/abnormality/army = 1.5
+	)
+
 	chem_type = /datum/reagent/abnormality/quiet_day
 	harvest_phrase = span_notice("%ABNO looks curiously at %VESSEL for a moment. You blink, and suddenly, it seems to contain a shadowy substance.")
 	harvest_phrase_third = "%ABNO glances at %PERSON. Suddenly, %VESSEL seems to be more full."

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/we_can_change_anything.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/we_can_change_anything.dm
@@ -29,6 +29,11 @@
 	gift_message = "Your heart beats with new vigor."
 	abnormality_origin = ABNORMALITY_ORIGIN_ALTERED
 
+	grouped_abnos = list(
+		/mob/living/simple_animal/hostile/abnormality/helper = 1.5,
+		/mob/living/simple_animal/hostile/abnormality/cleaner = 1.5
+	)
+
 	chem_type = /datum/reagent/abnormality/we_can_change_anything
 	harvest_phrase = span_notice("You scoop up some goo from the inner lip of %ABNO using %VESSEL.")
 	harvest_phrase_third = "%PERSON scoops up some goo from the inner lip of %ABNO with %VESSEL."

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/wellcheers.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/wellcheers.dm
@@ -24,6 +24,11 @@
 	gift_type = /datum/ego_gifts/soda
 	gift_message = "You feel like you've been doing this your whole life."
 	abnormality_origin = ABNORMALITY_ORIGIN_LOBOTOMY
+
+	grouped_abnos = list(
+		/mob/living/simple_animal/hostile/abnormality/shrimp_exec = 1.5
+	)
+
 	chem_type = /datum/reagent/abnormality/wellcheers_zero
 	harvest_phrase = span_notice("The machine dispenses some clear-ish soda into %VESSEL.")
 	harvest_phrase_third = "%PERSON holds up %VESSEL and lets %ABNO dispense some clear-ish soda into it."

--- a/code/modules/paperwork/records/info/waw.dm
+++ b/code/modules/paperwork/records/info/waw.dm
@@ -346,7 +346,7 @@
 
 //Servant of Wrath
 /obj/item/paper/fluff/info/waw/wrath
-	abno_type = /mob/living/simple_animal/hostile/abnormality/servant_wrath
+	abno_type = /mob/living/simple_animal/hostile/abnormality/wrath_servant
 	abno_code = "O-01-139"
 	abno_info = list(
 		"Whenever the work result was Good, the Servant of Wrath grew more unstable.",


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes all abnormalities weighted by pickweight, primarily making more frequently picked abnormalities appearing less often. 
Abnormalities in relevant groups (Yin and Yang) gain a varying weight increase whenever one member of this group is chosen to make others of that group appear more often.
Some groups have been included cosmetically, most (if not all) of these have a 1.5x multiplier to the weight per member picked. Fairies make fairies more likely, etc. 

Also refactors Servant of Wrath's code to be wrath_servant as opposed to servant_wrath, so that it's in line with EVERY OTHER magical girl.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Encourages diversity without permanently excluding any ONE abnormality. No abnormality will ever have a 0% pick chance. Also allows for easier acquisition of sets.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: List weighting to abnormality queue
add: Persistence to abnormality picking.
add: abnormality group modifiers to many abnormalities
refactor: initial "possible abnormality" list filling has been moved to Persistence subsystem
server: changed initialization order for abnormality queue to always be behind Persistence
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
