### PR TITLE
Fishing Boat that can Sail on Water Tiles & Water Tile Tweaks

### DIFF
--- a/ModularTegustation/fishing/code/fishing_items/fishing_boat.dm
+++ b/ModularTegustation/fishing/code/fishing_items/fishing_boat.dm
@@ -1,0 +1,62 @@
+/* Fishing Boats for traversing deep water turf without sinking.
+	Depends on the fishing deep water turfs code,
+	riding_vehicle.dm, and lavaboat.dm. */
+
+/datum/crafting_recipe/simple_boat
+	name = "One Person Boat"
+	result = /obj/vehicle/ridden/simple_boat
+	reqs = list(/obj/item/stack/sheet/mineral/wood = 250)
+	time = 50
+	category = CAT_MISC
+/* Honestly later on if we need boats for a larger amount of people we may have to go
+	the same method that final fantasy games did and just have several people be able
+	to sit in a 1 tile 48 or 64 pixel sized boat. -IP */
+/obj/vehicle/ridden/simple_boat
+	name = "dinghy"
+	desc = "A one person boat for traversing the waters. Can be renamed with a pen. May require an oar to be installed into it for sailing."
+	icon_state = "goliath_boat"
+	icon = 'icons/obj/lavaland/dragonboat.dmi'
+	//Set this and the component keytype to null to make it not require a key.
+	key_type = /obj/item/boat_oar
+	can_buckle = TRUE
+	//People can rename it with a pen when it has this.
+	obj_flags = UNIQUE_RENAME
+	/* This variable is apparently used for a typecache on what
+		types the boat can sail on. So all subtypes of water? -IP */
+	var/allowed_turf = /turf/open/water
+
+/obj/vehicle/ridden/simple_boat/Initialize()
+	. = ..()
+	AddElement(/datum/element/ridable, /datum/component/riding/vehicle/lavaboat/simple_boat)
+
+//Code Stolen from riding_vehicle.dm
+/datum/component/riding/vehicle/lavaboat/simple_boat
+	//Remove keytype from this and the simple boat to make it not require anything to move.
+	keytype = /obj/item/boat_oar
+	allowed_turf = /turf/open/water
+
+//Stolen from lavalandboat.dm
+/obj/item/boat_oar
+	name = "dinghy oar"
+	desc = "Used for sailing one person boats. Can be dissasembled back into wood using a knife."
+	icon = 'icons/obj/vehicles.dmi'
+	icon_state = "oar"
+	inhand_icon_state = "oar"
+	lefthand_file = 'icons/mob/inhands/misc/lavaland_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/misc/lavaland_righthand.dmi'
+	force = 12
+	w_class = WEIGHT_CLASS_NORMAL
+
+/obj/item/boat_oar/attackby(obj/item/attacking_item, mob/user, params)
+	var/sharpthing = attacking_item.get_sharpness()
+	if(sharpthing == SHARP_EDGED && attacking_item.force >= 5)
+		new /obj/item/stack/sheet/mineral/wood(get_turf(src))
+		return qdel(src)
+	return ..()
+
+/datum/crafting_recipe/boat_oar
+	name = "Boat Oar"
+	result = /obj/item/boat_oar
+	reqs = list(/obj/item/stack/sheet/mineral/wood = 2)
+	time = 15
+	category = CAT_MISC

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/wellcheers.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/wellcheers.dm
@@ -220,24 +220,39 @@
 
 //Shrimple boat stuff
 /turf/open/water/deep/saltwater/extradeep
+	static_target = TRUE
 
-/turf/open/water/deep/saltwater/extradeep/Entered(atom/movable/thing, atom/oldLoc) //Drowning code - you won't make it back to the station alive.
-	if(!target_turf || is_type_in_typecache(thing, forbidden_types) || (thing.throwing && !istype(thing, /obj/item/food/fish || /obj/item/aquarium_prop )) || (thing.movement_type & (FLOATING|FLYING))) //replace this with a varient of chasm component sometime.
-		return ..()
+/turf/open/water/deep/saltwater/extradeep/WarpSunkStuff(atom/movable/thing) //Drowning code - you won't make it back to the station alive.
+	if(!target_turf)
+		var/shrimpspot = locate(/obj/effect/landmark/shrimpship) in world.contents
+		if(shrimpspot)
+			target_turf = get_turf(shrimpspot)
+		else
+			qdel(thing)
+			return
 	if(isliving(thing))
 		var/mob/living/L = thing
 		if(L.movement_type & FLYING)
-			return ..()
+			return
 		if(!ishuman(L))
 			qdel(L)
 			return
-		var/shrimpspot = locate(/obj/effect/landmark/shrimpship) in world.contents
 		var/mob/living/carbon/human/H = L
-		for(var/obj/item/fishing_net/fishnet in H.GetAllContents())
-			fishnet.forceMove(get_turf(shrimpspot))
-		for(var/obj/item/fishing_rod/fishrod in H.GetAllContents())
-			fishrod.forceMove(get_turf(shrimpspot))
+		/* Im not entirely sure why this is here if the shrimp boat
+			is surrounded by indestructable railing. I guess if
+			other mappers want to use extradeep? -IP*/
+		if(target_turf)
+			for(var/obj/item/fishing_net/fishnet in H.GetAllContents())
+				fishnet.forceMove(target_turf)
+			for(var/obj/item/fishing_rod/fishrod in H.GetAllContents())
+				fishrod.forceMove(target_turf)
 		INVOKE_ASYNC(src, .proc/Drown, H)
+	else
+		//Fishing rods cant fit in bags or be worn so this may save any that fall into the water.
+		if((istype(thing, /obj/item/fishing_net) || istype(thing, /obj/item/fishing_rod)) && target_turf)
+			thing.forceMove(target_turf)
+			return
+		qdel(thing)
 
 /turf/open/water/deep/saltwater/extradeep/proc/Drown(mob/living/carbon/human/H)
 	H.Stun(30 SECONDS)

--- a/lobotomy-corp13.dme
+++ b/lobotomy-corp13.dme
@@ -3898,6 +3898,7 @@
 #include "ModularTegustation\fishing\code\fishing_items\fish_box.dm"
 #include "ModularTegustation\fishing\code\fishing_items\fish_points.dm"
 #include "ModularTegustation\fishing\code\fishing_items\fishing_bag.dm"
+#include "ModularTegustation\fishing\code\fishing_items\fishing_boat.dm"
 #include "ModularTegustation\fishing\code\fishing_items\fishing_cloak.dm"
 #include "ModularTegustation\fishing\code\fishing_items\fishing_hat.dm"
 #include "ModularTegustation\fishing\code\fishing_items\fishing_net.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Creates a fishing boat through repurposed lavaboat code
One Person Boat is in the misc crafting category and can be made with 250 wood. Yes i know that is a lot but you want this boat to be seaworthy. Currently the boat cannot be driven without a boat oar which is in the same catagory. 

Adds additional code tweak to water code to make it not run sink on certain objects.
cant_sink_types replaces the forbidden types typecache and now functions as a way to prevent certain atoms from running the sink stuff proc at all.
Added span_notice() macros to displayed text.
Added simple_boat to is_safe list which makes it so nothing can sink while a boat is on the tile. This of course has its own issue because items that are on the water will remain on the water after the boat leaves.

Edits wellcheers unique water extradeep to warp fishing rods to the correct area.
Requires https://github.com/vlggms/lobotomy-corp13/pull/1768 to be merged first so i can make the boat code around the new water rework.

## Why It's Good For The Game
Kirie said she may use these in the future in order to make extremely isolated island discovery maps. Sea of Thieves style.

## Changelog
:cl:
add: fishing_boat and boating oar
tweak: water turf
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
