### PR TITLE
Minor insanity tweaks

### DIFF
--- a/code/datums/ai/sanity/_sanityloss_controller.dm
+++ b/code/datums/ai/sanity/_sanityloss_controller.dm
@@ -174,6 +174,12 @@
 			blackboard[BB_INSANE_CURRENT_ATTACK_TARGET] = L
 			return
 
+/datum/ai_controller/insane/murder/PerformIdleBehavior(delta_time)
+	var/mob/living/living_pawn = pawn
+	if((living_pawn.mobility_flags & MOBILITY_MOVE) && isturf(living_pawn.loc) && !living_pawn.pulledby)
+		var/move_dir = pick(GLOB.alldirs)
+		living_pawn.Move(get_step(living_pawn, move_dir), move_dir)
+
 /datum/ai_controller/insane/murder/ResistCheck()
 	var/mob/living/living_pawn = pawn
 	if(living_pawn.pulledby && living_pawn.pulledby?.grab_state < GRAB_AGGRESSIVE)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -346,9 +346,14 @@
 					msg += "[t_He] [t_has] a stupid expression on [t_his] face.\n"
 		if(getorgan(/obj/item/organ/brain))
 			if(ai_controller?.ai_status == AI_STATUS_ON)
-				msg += "<span class='deadsay'>[t_He] do[t_es]n't appear to be [t_him]self.</span>\n"
+				if(istype(ai_controller, /datum/ai_controller/insane))
+					msg += span_danger("[t_He] [t_is] completely out of [t_his] mind!")
+				else
+					msg += "<span class='deadsay'>[t_He] do[t_es]n't appear to be [t_him]self.</span>\n"
 			if(!key)
-				msg += "<span class='deadsay'>[t_He] [t_is] totally catatonic. The stresses of life in deep-space must have been too much for [t_him]. Any recovery is unlikely.</span>\n"
+				var/mob/dead/observer/ghost = get_ghost()
+				if(!ghost || !ghost.client)
+					msg += "<span class='deadsay'>[t_He] [t_is] totally catatonic. The stresses of life in deep-space must have been too much for [t_him]. Any recovery is unlikely.</span>\n"
 			else if(!client)
 				msg += "[t_He] [t_has] a blank, absent-minded stare and appears completely unresponsive to anything. [t_He] may snap out of it soon.\n"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Insane mobs now display a different examine message.
- Catatonic mobs that have client ghosts (i.e. from insane mobs) will not display the catatonic examine message.
- Murder insane will now idly walk around when they have nothing to do.

## Why It's Good For The Game

- Helps new players to understand what is going on.
- Similar to the above. Now you can know for sure if the mob has a player attached or not.
- They now don't stand in place like dummies.
