### PR TITLE
Dying No Longer Resets Timer While Insane

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -228,10 +228,14 @@
 	msg += "</span>"
 	to_chat(user, msg)
 
-/datum/mind/proc/set_death_time()
+/datum/mind/proc/set_death_time(mob/living/L, gibbed)
 	SIGNAL_HANDLER
 
 	last_death = world.time
+	if(ishuman(L))
+		var/mob/living/carbon/human/H = L
+		if(H.sanity_lost)
+			return
 	respawn_cooldown = world.time + CONFIG_GET(number/respawn_delay)
 
 /datum/mind/proc/store_memory(new_text)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Dying while insane no longer resets your death timer
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Nice.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: double respawn timer gone
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
