### PR TITLE
Updates W-Corp L2A Equipment

### DIFF
--- a/code/modules/jobs/job_types/wcorp/wcorprecon.dm
+++ b/code/modules/jobs/job_types/wcorp/wcorprecon.dm
@@ -33,25 +33,14 @@ GLOBAL_LIST_INIT(l2asquads, list("Axe", "Buckler", "Cleaver"))
 	ADD_TRAIT(H, TRAIT_COMBATFEAR_IMMUNE, JOB_TRAIT)
 	var/squad = pick_n_take(GLOB.l2asquads)
 	.=..()
-	var/ears = null
+
 	to_chat(M, "<span class='userdanger'>You have been assigned to the [squad] squad. </span>")
-	switch(squad)
-		if("Axe")
-			ears = /obj/item/radio/headset/wcorp/safety
-		if("Buckler")
-			ears = /obj/item/radio/headset/wcorp/discipline
-		if("Cleaver")
-			ears = /obj/item/radio/headset/wcorp/welfare
-	if(ears)
-		if(H.ears)
-			qdel(H.ears)
-		H.equip_to_slot_or_del(new ears(H),ITEM_SLOT_EARS)
 
 /datum/outfit/job/wcorpl2recon
 	name = "W-Corp L2 Type A Lieutenant"
 	jobtype = /datum/job/wcorpl2support
 
-	ears = /obj/item/radio/headset/headset_welfare
+	ears = /obj/item/radio/headset/agent_lieutenant
 	glasses = /obj/item/clothing/glasses/sunglasses
 	uniform = /obj/item/clothing/under/suit/lobotomy/wsenior
 	belt = /obj/item/ego_weapon/city/charge/wcorp


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes Wcorp L2A's to have a different set of comms to better command and control squads alongside the L3 Commanders
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Allows L2A's to better fill their role as a recon specialist and assistant to the L3 Commanders, rather than being treated as just another L2 Wcorper.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
Changes their headset to match that of the commanders to allow en-mass communication.
:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
