### PR TITLE
Changes some ego gift stats

### DIFF
--- a/code/modules/mob/living/carbon/human/ego_gifts.dm
+++ b/code/modules/mob/living/carbon/human/ego_gifts.dm
@@ -1044,25 +1044,10 @@
 /datum/ego_gifts/discord
 	name = "Discord"
 	icon_state = "discord"
-	desc = "Provides the user with 4% resistance to all damage sources."//meant to be its 8% chance reflect to damage in base Lc but cut in half. since it doesnt give any stats but rather shuffles them think it give 4% damage reduction might be fine.
-	fortitude_bonus = -10
-	prudence_bonus = -10
+	fortitude_bonus = -7
+	prudence_bonus = -7
 	justice_bonus = 20
 	slot = HELMET
-
-/datum/ego_gifts/discord/Initialize(mob/living/carbon/human/user)
-	.=..()
-	user.physiology.red_mod *= 0.96
-	user.physiology.white_mod *= 0.96
-	user.physiology.black_mod *= 0.96
-	user.physiology.pale_mod *= 0.96
-
-/datum/ego_gifts/discord/Remove(mob/living/carbon/human/user)
-	user.physiology.red_mod /= 0.96
-	user.physiology.white_mod /= 0.96
-	user.physiology.black_mod /= 0.96
-	user.physiology.pale_mod /= 0.96
-	.=..()
 
 /datum/ego_gifts/diffraction
 	name = "Diffraction"

--- a/code/modules/mob/living/carbon/human/ego_gifts.dm
+++ b/code/modules/mob/living/carbon/human/ego_gifts.dm
@@ -1179,8 +1179,8 @@
 /datum/ego_gifts/swan
 	name = "Black Swan"
 	icon_state = "swan"
-	fortitude_bonus = -2
-	prudence_bonus = -2
+	fortitude_bonus = -3
+	prudence_bonus = -3
 	temperance_bonus = 10
 	slot = HAT
 

--- a/code/modules/mob/living/carbon/human/ego_gifts.dm
+++ b/code/modules/mob/living/carbon/human/ego_gifts.dm
@@ -543,8 +543,8 @@
 /datum/ego_gifts/magicbullet
 	name = "Magic Bullet"
 	icon_state = "magicbullet"
-	fortitude_bonus = -5
-	prudence_bonus = -5
+	fortitude_bonus = -3
+	prudence_bonus = -3
 	justice_bonus = 10
 	slot = MOUTH_2
 
@@ -1044,10 +1044,25 @@
 /datum/ego_gifts/discord
 	name = "Discord"
 	icon_state = "discord"
+	desc = "Provides the user with 4% resistance to all damage sources."//meant to be its 8% chance reflect to damage in base Lc but cut in half. since it doesnt give any stats but rather shuffles them think it give 4% damage reduction might be fine.
 	fortitude_bonus = -10
 	prudence_bonus = -10
 	justice_bonus = 20
 	slot = HELMET
+
+/datum/ego_gifts/discord/Initialize(mob/living/carbon/human/user)
+	.=..()
+	user.physiology.red_mod *= 0.96
+	user.physiology.white_mod *= 0.96
+	user.physiology.black_mod *= 0.96
+	user.physiology.pale_mod *= 0.96
+
+/datum/ego_gifts/discord/Remove(mob/living/carbon/human/user)
+	user.physiology.red_mod /= 0.96
+	user.physiology.white_mod /= 0.96
+	user.physiology.black_mod /= 0.96
+	user.physiology.pale_mod /= 0.96
+	.=..()
 
 /datum/ego_gifts/diffraction
 	name = "Diffraction"
@@ -1179,8 +1194,8 @@
 /datum/ego_gifts/swan
 	name = "Black Swan"
 	icon_state = "swan"
-	fortitude_bonus = -4
-	prudence_bonus = -4
+	fortitude_bonus = -2
+	prudence_bonus = -2
 	temperance_bonus = 10
 	slot = HAT
 
@@ -1202,7 +1217,7 @@
 /datum/ego_gifts/dacapo
 	name = "Da Capo"
 	icon_state = "dacapo"
-	temperance_bonus = 4
+	temperance_bonus = 10
 	slot = EYE
 
 /datum/ego_gifts/mimicry
@@ -1223,7 +1238,7 @@
 	icon_state = "amogus"
 	fortitude_bonus = -5
 	prudence_bonus = -5
-	justice_bonus = 15
+	justice_bonus = 20
 	slot = EYE
 
 /datum/ego_gifts/adoration
@@ -1312,10 +1327,10 @@
 /datum/ego_gifts/distortion
 	name = "Distortion"
 	icon_state = "distortion"
-	fortitude_bonus = 3
-	prudence_bonus = 3
-	temperance_bonus = 2
-	justice_bonus = 2
+	fortitude_bonus = 9
+	prudence_bonus = 9
+	temperance_bonus = 6
+	justice_bonus = 6
 	slot = BROOCH
 
 /datum/ego_gifts/mockery


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes the stats of the gifts magic bullet, black swan, de capo, discord, imposter, and distortion.

Changes black swan to -3/-3/10/0 due to temp being the strongest stat so there's a bit more cost for it. Magic bullet is now -3/-3/0/10 so that itstill reflect the max total of stats around he being 4. de capo gives 10 temp instead of 4 since why did it give the average gift stat total of he for an aleph(it could able be given alurine's gift effect but for sp instead of hp)? Multiplies distortions total by 3 from 3/3/2/2 to 9/9/6/6 giving it the same stat total as paradise lost since its also another aleph + abnormality. Imposter I noticed gave around a +5 stat total to aleph so I buffed the justice from 15 to 20 so its on par with other aleph gifts total wise. Discord now has -7/-7/0/20 so that it has a total of 6 like other waw gifts.

## Why It's Good For The Game
de capo discord and imposter had weird stat totals for aleph/aleph+ gifts. the other 3 was to either give it the average total of their tier. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: tweaked a ego gifts
balance: rebalanced some ego gifts
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
