### PR TITLE
Experimental Temperance update

### DIFF
--- a/code/__DEFINES/attributes.dm
+++ b/code/__DEFINES/attributes.dm
@@ -17,8 +17,8 @@
 /// Same as above, but for sanity and prudence
 #define PRUDENCE_MOD 1
 
-/// How much temperance affects the success rate of the works; Higher = better.
-#define TEMPERANCE_SUCCESS_MOD 0.2
+/// What the temperance scaling modifier is. Roughly, this is the temperance at infinite temperance. Higher is better.
+#define TEMPERANCE_SUCCESS_MOD 40
 
 /// The justice attribute is divided by this number to decide the movement speed buff; The higher it is - the lower is maximum speed
 #define JUSTICE_MOVESPEED_DIVISER 230

--- a/code/datums/abnormality/datum/abnormality.dm
+++ b/code/datums/abnormality/datum/abnormality.dm
@@ -255,7 +255,10 @@
 		if(ABNORMALITY_WORK_REPRESSION)
 			acquired_chance += user.physiology.repression_success_mod
 	acquired_chance *= user.physiology.work_success_mod
-	acquired_chance += get_modified_attribute_level(user, TEMPERANCE_ATTRIBUTE) * TEMPERANCE_SUCCESS_MOD
+
+	//Calculating workchance. This is meant to be somewhat log
+	var/player_temperance = get_modified_attribute_level(user, TEMPERANCE_ATTRIBUTE)
+	acquired_chance += TEMPERANCE_SUCCESS_MOD *((0.07*player_temperance-1.4)/(0.07*player_temperance+4))
 	acquired_chance += understanding // Adds up to 6-10% [Threat Based] work chance based off works done on it. This simulates Observation Rating which we lack ENTIRELY and as such has inflated the overall failure rate of abnormalities.
 	if(overload_chance[user.ckey])
 		acquired_chance += overload_chance[user.ckey]


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Updates Temperance to scale to the following formula with workrates:
![image](https://github.com/vlggms/lobotomy-corp13/assets/77302679/d71f8405-646d-460e-abde-ebf6f8484537)

The work speed has not been changed.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Currently, we have issues with temperance being additive, along with the extremely high temperance of lategame after records core. 
You can very easily reach 100% workrates on abnormalities such as Nobody is, and Nothing There.

This does not heavily affect earlygame very much, and affects lategame very minimally.
Here's a couple milestones:
0 Temperance > +0% > -14%
This is fine as if you get to 20 temperance below your spawn stats, what the fuck are you doing?
Or you're playing training core.

20 Temperance > +4% > +0%
40 Temperance > +8% > +8.2%
60 Temperance > +12% > +13.4%
100 Temperance > +20% > +20.4%
130 Temperance > +26% > +23.5%

150 Temperance > +30% > +25.1%
180 Temperance > +36% > +27%
200 Temperance > +40% > +28%
250 Temperance (Possible) > +50% > +30%

Normal Gameplay Graph
![image](https://github.com/vlggms/lobotomy-corp13/assets/77302679/ed4e308d-5377-43b4-8a1c-fbf8fdaef3da)

Zoomed out Graph
![image](https://github.com/vlggms/lobotomy-corp13/assets/77302679/6e94a960-0365-4351-af72-fd82009a24fa)


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Changed temperance scaling
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
