### PR TITLE
Captain agents now have 20 stats instead of 21.

### DIFF
--- a/code/modules/jobs/job_types/agent.dm
+++ b/code/modules/jobs/job_types/agent.dm
@@ -126,7 +126,7 @@
 	spawn_positions = 2
 	outfit = /datum/outfit/job/agent/captain
 	display_order = JOB_DISPLAY_ORDER_CAPTAIN
-	normal_attribute_level = 21 // :)
+	normal_attribute_level = 20 // Used to have 21, but it was just picked for the roundstart +1 stat to instantly mirror. - Kirie/Kitsunemitsu
 
 	access = list(ACCESS_COMMAND) // LC13:To-Do
 	exp_requirements = 6000


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## Why It's Good For The Game
Players would play captain to join, then mirror, then cryo to do it again.
Removing the +1 stat because it's necessary.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: agent captains now have 20 stats.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
