### PR TITLE
Adds an option to generate typecaches as zebras, a TG mirror

### DIFF
--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -90,16 +90,49 @@
 
 			return "[output][and_text][input[index]]"
 
-//Checks for specific types in a list
-/proc/is_type_in_list(atom/A, list/L)
-	if(!LAZYLEN(L) || !A)
+/**
+ * Checks for specific types in a list.
+ *
+ * If using zebra mode the list should be an assoc list with truthy/falsey values.
+ * The check short circuits so earlier entries in the input list will take priority.
+ * Ergo, subtypes should come before parent types.
+ * Notice that this is the opposite priority of [/proc/typecacheof].
+ *
+ * Arguments:
+ * - [type_to_check][/datum]: An instance to check.
+ * - [list_to_check][/list]: A list of typepaths to check the type_to_check against.
+ * - zebra: Whether to use the value of the mathing type in the list instead of just returning true when a match is found.
+ */
+/proc/is_type_in_list(datum/type_to_check, list/list_to_check, zebra = FALSE)
+	if(!LAZYLEN(list_to_check) || !type_to_check)
 		return FALSE
-	for(var/type in L)
-		if(istype(A, type))
-			return TRUE
+	for(var/type in list_to_check)
+		if(istype(type_to_check, type))
+			return !zebra || list_to_check[type] // Subtypes must come first in zebra lists.
 	return FALSE
 
-//Checks for specific types in specifically structured (Assoc "type" = TRUE) lists ('typecaches')
+/**
+ * Checks for specific paths in a list.
+ *
+ * If using zebra mode the list should be an assoc list with truthy/falsey values.
+ * The check short circuits so earlier entries in the input list will take priority.
+ * Ergo, subpaths should come before parent paths.
+ * Notice that this is the opposite priority of [/proc/typecacheof].
+ *
+ * Arguments:
+ * - path_to_check: A typepath to check.
+ * - [list_to_check][/list]: A list of typepaths to check the path_to_check against.
+ * - zebra: Whether to use the value of the mathing path in the list instead of just returning true when a match is found.
+ */
+/proc/is_path_in_list(path_to_check, list/list_to_check, zebra = FALSE)
+	if(!LAZYLEN(list_to_check) || !path_to_check)
+		return FALSE
+	for(var/path in list_to_check)
+		if(ispath(path_to_check, path))
+			return !zebra || list_to_check[path]
+	return FALSE
+
+///Checks for specific types in specifically structured (Assoc "type" = TRUE|FALSE) lists ('typecaches')
 #define is_type_in_typecache(A, L) (A && length(L) && L[(ispath(A) ? A : A:type)])
 
 //returns a new list with only atoms that are in typecache L
@@ -126,33 +159,101 @@
 		if(typecache_include[A.type] && !typecache_exclude[A.type])
 			. += A
 
-//Like typesof() or subtypesof(), but returns a typecache instead of a list
-/proc/typecacheof(path, ignore_root_path, only_root_path = FALSE)
+/**
+ * Like typesof() or subtypesof(), but returns a typecache instead of a list.
+ *
+ * Arguments:
+ * - path: A typepath or list of typepaths.
+ * - only_root_path: Whether the typecache should be specifically of the passed types.
+ * - ignore_root_path: Whether to ignore the root path when caching subtypes.
+ */
+/proc/typecacheof(path, only_root_path = FALSE, ignore_root_path = FALSE)
+	if(isnull(path))
+		return
+
 	if(ispath(path))
-		var/list/types = list()
+		. = list()
 		if(only_root_path)
-			types = list(path)
-		else
-			types = ignore_root_path ? subtypesof(path) : typesof(path)
-		var/list/L = list()
-		for(var/T in types)
-			L[T] = TRUE
-		return L
-	else if(islist(path))
-		var/list/pathlist = path
-		var/list/L = list()
-		if(ignore_root_path)
-			for(var/P in pathlist)
-				for(var/T in subtypesof(P))
-					L[T] = TRUE
-		else
-			for(var/P in pathlist)
-				if(only_root_path)
-					L[P] = TRUE
-				else
-					for(var/T in typesof(P))
-						L[T] = TRUE
-		return L
+			.[path] = TRUE
+			return
+
+		for(var/subtype in (ignore_root_path ? subtypesof(path) : typesof(path)))
+			.[subtype] = TRUE
+		return
+
+	if(!islist(path))
+		CRASH("Tried to create a typecache of [path] which is neither a typepath nor a list.")
+
+	. = list()
+	var/list/pathlist = path
+	if(only_root_path)
+		for(var/current_path in pathlist)
+			.[current_path] = TRUE
+	else if(ignore_root_path)
+		for(var/current_path in pathlist)
+			for(var/subtype in subtypesof(current_path))
+				.[subtype] = TRUE
+	else
+		for(var/current_path in pathlist)
+			for(var/subpath in typesof(current_path))
+				.[subpath] = TRUE
+
+/**
+ * Like typesof() or subtypesof(), but returns a typecache instead of a list.
+ * This time it also uses the associated values given by the input list for the values of the subtypes.
+ *
+ * Latter values from the input list override earlier values.
+ * Thus subtypes should come _after_ parent types in the input list.
+ * Notice that this is the opposite priority of [/proc/is_type_in_list] and [/proc/is_path_in_list].
+ *
+ * Arguments:
+ * - path: A typepath or list of typepaths with associated values.
+ * - single_value: The assoc value used if only a single path is passed as the first variable.
+ * - only_root_path: Whether the typecache should be specifically of the passed types.
+ * - ignore_root_path: Whether to ignore the root path when caching subtypes.
+ * - clear_nulls: Whether to remove keys with null assoc values from the typecache after generating it.
+ */
+/proc/zebra_typecacheof(path, single_value = TRUE, only_root_path = FALSE, ignore_root_path = FALSE, clear_nulls = FALSE)
+	if(isnull(path))
+		return
+
+	if(ispath(path))
+		if (isnull(single_value))
+			return
+
+		. = list()
+		if(only_root_path)
+			.[path] = single_value
+			return
+
+		for(var/subtype in (ignore_root_path ? subtypesof(path) : typesof(path)))
+			.[subtype] = single_value
+		return
+
+	if(!islist(path))
+		CRASH("Tried to create a typecache of [path] which is neither a typepath nor a list.")
+
+	. = list()
+	var/list/pathlist = path
+	if(only_root_path)
+		for(var/current_path in pathlist)
+			.[current_path] = pathlist[current_path]
+	else if(ignore_root_path)
+		for(var/current_path in pathlist)
+			for(var/subtype in subtypesof(current_path))
+				.[subtype] = pathlist[current_path]
+	else
+		for(var/current_path in pathlist)
+			for(var/subpath in typesof(current_path))
+				.[subpath] = pathlist[current_path]
+
+	if(!clear_nulls)
+		return
+
+	for(var/cached_path in .)
+		if (isnull(.[cached_path]))
+			. -= cached_path
+
 
 //Removes any null entries from the list
 //Returns TRUE if the list had nulls, FALSE otherwise

--- a/code/datums/components/chasm.dm
+++ b/code/datums/components/chasm.dm
@@ -22,8 +22,10 @@
 		/obj/effect/light_emitter/tendril,
 		/obj/effect/collapse,
 		/obj/effect/particle_effect/ion_trails,
-		/obj/effect/dummy/phased_mob
-		))
+		/obj/effect/dummy/phased_mob,
+		/obj/effect/mapping_helpers,
+		/obj/effect/wisp,
+	))
 
 /datum/component/chasm/Initialize(turf/target)
 	RegisterSignal(parent, list(COMSIG_MOVABLE_CROSSED, COMSIG_ATOM_ENTERED), .proc/Entered)

--- a/code/datums/components/fantasy/suffixes.dm
+++ b/code/datums/components/fantasy/suffixes.dm
@@ -56,19 +56,18 @@
 	var/static/list/possible_mobtypes
 	if(!possible_mobtypes)
 		// The base list of allowed mob/species types
-		possible_mobtypes = typecacheof(list(
-			/mob/living/simple_animal,
-			/mob/living/carbon,
-			/datum/species,
-			))
+		possible_mobtypes = zebra_typecacheof(list(
+			/mob/living/simple_animal = TRUE,
+			/mob/living/carbon = TRUE,
+			/datum/species = TRUE,
+			// Some types to remove them and their subtypes
+			/mob/living/carbon/human/species = FALSE,
+		))
 		// Some particular types to disallow if they're too broad/abstract
+		// Not in the above typecache generator because it includes subtypes and this doesn't.
 		possible_mobtypes -= list(
 			/mob/living/simple_animal/hostile,
-			)
-		// Some types to remove them and their subtypes
-		possible_mobtypes -= typecacheof(list(
-			/mob/living/carbon/human/species,
-			))
+		)
 
 	var/mob/picked_mobtype = pick(possible_mobtypes)
 	// This works even with the species picks since we're only accessing the name
@@ -88,22 +87,21 @@
 	var/static/list/possible_mobtypes
 	if(!possible_mobtypes)
 		// The base list of allowed mob/species types
-		possible_mobtypes = typecacheof(list(
-			/mob/living/simple_animal,
-			/mob/living/carbon,
-			/datum/species,
-			))
+		possible_mobtypes = zebra_typecacheof(list(
+			/mob/living/simple_animal = TRUE,
+			/mob/living/carbon = TRUE,
+			/datum/species = TRUE,
+			// Some types to remove them and their subtypes
+			/mob/living/carbon/human/species = FALSE,
+			/mob/living/simple_animal/hostile/syndicate/mecha_pilot = FALSE,
+			/mob/living/simple_animal/hostile/asteroid/elite = FALSE,
+			/mob/living/simple_animal/hostile/megafauna = FALSE,
+		))
 		// Some particular types to disallow if they're too broad/abstract
+		// Not in the above typecache generator because it includes subtypes and this doesn't.
 		possible_mobtypes -= list(
 			/mob/living/simple_animal/hostile,
-			)
-		// Some types to remove them and their subtypes
-		possible_mobtypes -= typecacheof(list(
-			/mob/living/carbon/human/species,
-			/mob/living/simple_animal/hostile/syndicate/mecha_pilot,
-			/mob/living/simple_animal/hostile/asteroid/elite,
-			/mob/living/simple_animal/hostile/megafauna,
-			))
+		)
 
 	var/mob/picked_mobtype = pick(possible_mobtypes)
 	// This works even with the species picks since we're only accessing the name

--- a/code/datums/components/storage/concrete/pockets.dm
+++ b/code/datums/components/storage/concrete/pockets.dm
@@ -25,9 +25,12 @@
 /datum/component/storage/concrete/pockets/small/fedora/Initialize()
 	. = ..()
 	var/static/list/exception_cache = typecacheof(list(
-		/obj/item/katana, /obj/item/toy/katana, /obj/item/nullrod/claymore/katana,
-		/obj/item/energy_katana, /obj/item/gun/ballistic/automatic/tommygun
-		))
+		/obj/item/katana,
+		/obj/item/toy/katana,
+		/obj/item/nullrod/claymore/katana,
+		/obj/item/energy_katana,
+		/obj/item/gun/ballistic/automatic/tommygun,
+	))
 	exception_hold = exception_cache
 
 /datum/component/storage/concrete/pockets/small/fedora/detective

--- a/code/datums/components/thermite.dm
+++ b/code/datums/components/thermite.dm
@@ -8,18 +8,18 @@
 		/turf/open/lava,
 		/turf/open/space,
 		/turf/open/water,
-		/turf/open/chasm)
-		)
-
+		/turf/open/chasm,
+	))
+	///List of turfs that are immune to thermite
 	var/static/list/immunelist = typecacheof(list(
 		/turf/closed/wall/mineral/diamond,
 		/turf/closed/indestructible,
-		/turf/open/indestructible)
-		)
-
-	var/static/list/resistlist = typecacheof(
-		/turf/closed/wall/r_wall
-		)
+		/turf/open/indestructible,
+	))
+	///List of turfs that take extra thermite to burn through
+	var/static/list/resistlist = typecacheof(list(
+		/turf/closed/wall/r_wall,
+	))
 
 /datum/component/thermite/Initialize(_amount)
 	if(!istype(parent, /turf) || blacklist[parent.type])

--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -27,16 +27,14 @@
 	var/cooldown = 0.8 SECONDS
 
 /datum/emote/New()
-	if (ispath(mob_type_allowed_typecache))
-		switch (mob_type_allowed_typecache)
-			if (/mob)
-				mob_type_allowed_typecache = GLOB.typecache_mob
-			if (/mob/living)
-				mob_type_allowed_typecache = GLOB.typecache_living
-			else
-				mob_type_allowed_typecache = typecacheof(mob_type_allowed_typecache)
-	else
-		mob_type_allowed_typecache = typecacheof(mob_type_allowed_typecache)
+	switch(mob_type_allowed_typecache)
+		if(/mob)
+			mob_type_allowed_typecache = GLOB.typecache_mob
+		if(/mob/living)
+			mob_type_allowed_typecache = GLOB.typecache_living
+		else
+			mob_type_allowed_typecache = typecacheof(mob_type_allowed_typecache)
+
 	mob_type_blacklist_typecache = typecacheof(mob_type_blacklist_typecache)
 	mob_type_ignore_stat_typecache = typecacheof(mob_type_ignore_stat_typecache)
 

--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -10,14 +10,13 @@
 // forced: whether or not to ignore no_teleport
 /proc/do_teleport(atom/movable/teleatom, atom/destination, precision=null, forceMove = TRUE, datum/effect_system/effectin=null, datum/effect_system/effectout=null, asoundin=null, asoundout=null, no_effects=FALSE, channel=TELEPORT_CHANNEL_BLUESPACE, forced = FALSE)
 	// teleporting most effects just deletes them
-	var/static/list/delete_atoms = typecacheof(list(
-		/obj/effect,
-		)) - typecacheof(list(
-		/obj/effect/dummy/chameleon,
-		/obj/effect/wisp,
-		/obj/effect/mob_spawn,
-		/obj/effect/immovablerod,
-		))
+	var/static/list/delete_atoms = zebra_typecacheof(list(
+		/obj/effect = TRUE,
+		/obj/effect/dummy/chameleon = FALSE,
+		/obj/effect/wisp = FALSE,
+		/obj/effect/mob_spawn = FALSE,
+		/obj/effect/immovablerod = FALSE,
+	))
 	if(delete_atoms[teleatom.type])
 		qdel(teleatom)
 		return FALSE

--- a/code/datums/mutations/holy_mutation/honorbound.dm
+++ b/code/datums/mutations/holy_mutation/honorbound.dm
@@ -143,7 +143,7 @@
 		/obj/projectile/beam,
 		/obj/projectile/bullet,
 		/obj/projectile/magic,
-		))
+	))
 	if(!is_type_in_typecache(proj, guilty_projectiles))
 		return
 	if((proj.damage_type == STAMINA))

--- a/code/game/machinery/gulag_teleporter.dm
+++ b/code/game/machinery/gulag_teleporter.dm
@@ -33,7 +33,8 @@ The console is located at computer/gulag_teleporter.dm
 		/obj/item/clothing/gloves/color/plasmaman,
 		/obj/item/tank/internals,
 		/obj/item/clothing/mask/breath,
-		/obj/item/clothing/mask/gas))
+		/obj/item/clothing/mask/gas,
+	))
 
 /obj/machinery/gulag_teleporter/Initialize()
 	. = ..()

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -11,11 +11,15 @@
 	var/mob/living/carbon/attached
 	var/mode = IV_INJECTING
 	var/dripfeed = FALSE
+	///Internal beaker
 	var/obj/item/reagent_containers/beaker
-	var/static/list/drip_containers = typecacheof(list(/obj/item/reagent_containers/blood,
-									/obj/item/reagent_containers/food,
-									/obj/item/reagent_containers/glass,
-									/obj/item/reagent_containers/chem_pack))
+	///Typecache of containers we accept
+	var/static/list/drip_containers = typecacheof(list(
+		/obj/item/reagent_containers/blood,
+		/obj/item/reagent_containers/food,
+		/obj/item/reagent_containers/glass,
+		/obj/item/reagent_containers/chem_pack,
+	))
 
 /obj/machinery/iv_drip/Initialize(mapload)
 	. = ..()

--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -17,7 +17,8 @@
 		/obj/item/melee/baton,
 		/obj/item/ammo_box/magazine/recharge,
 		/obj/item/modular_computer,
-		/obj/item/powered_gadget))
+		/obj/item/powered_gadget, // LOBOTOMYCORPORATION ADDITION - clerk gadgets
+	))
 
 /obj/machinery/recharger/RefreshParts()
 	for(var/obj/item/stock_parts/capacitor/C in component_parts)

--- a/code/game/objects/effects/effect_system/effects_foam.dm
+++ b/code/game/objects/effects/effect_system/effects_foam.dm
@@ -19,9 +19,10 @@
 	var/lifetime = 40
 	var/reagent_divisor = 7
 	var/static/list/blacklisted_turfs = typecacheof(list(
-	/turf/open/space/transit,
-	/turf/open/chasm,
-	/turf/open/lava))
+		/turf/open/space/transit,
+		/turf/open/chasm,
+		/turf/open/lava,
+	))
 	var/slippery_foam = TRUE
 
 /obj/effect/particle_effect/foam/firefighting

--- a/code/game/objects/effects/glowshroom.dm
+++ b/code/game/objects/effects/glowshroom.dm
@@ -26,8 +26,9 @@
 	var/max_failed_spreads = 5
 	/// Turfs where the glowshroom cannot spread to
 	var/static/list/blacklisted_glowshroom_turfs = typecacheof(list(
-	/turf/open/lava,
-	/turf/open/floor/plating/beach/water))
+		/turf/open/lava,
+		/turf/open/floor/plating/beach/water,
+	))
 
 /obj/structure/glowshroom/glowcap
 	name = "glowcap"

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -824,4 +824,4 @@ update_label()
 	icon_state = "car_budget" //saving up for a new tesla
 
 /obj/item/card/id/departmental_budget/AltClick(mob/living/user)
-	registered_account.bank_card_talk("<span class='warning'>Withdrawing is not compatible with this card design.</span>", TRUE) //prevents the vault bank machine being useless and putting money from the budget to your card to go over personal crates
+	registered_account.bank_card_talk(span_warning("Withdrawing is not compatible with this card design."), TRUE) //prevents the vault bank machine being useless and putting money from the budget to your card to go over personal crates

--- a/code/game/objects/items/devices/electroadaptive_pseudocircuit.dm
+++ b/code/game/objects/items/devices/electroadaptive_pseudocircuit.dm
@@ -8,8 +8,12 @@
 	custom_materials = list(/datum/material/iron = 50, /datum/material/glass = 300)
 	var/recharging = FALSE
 	var/circuits = 5 //How many circuits the pseudocircuit has left
-	var/static/recycleable_circuits = typecacheof(list(/obj/item/electronics/firelock, /obj/item/electronics/airalarm, /obj/item/electronics/firealarm, \
-	/obj/item/electronics/apc))//A typecache of circuits consumable for material
+	var/static/recycleable_circuits = typecacheof(list(
+		/obj/item/electronics/firelock,
+		/obj/item/electronics/airalarm,
+		/obj/item/electronics/firealarm,
+		/obj/item/electronics/apc,
+	))//A typecache of circuits consumable for material
 
 /obj/item/electroadaptive_pseudocircuit/Initialize()
 	. = ..()

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -727,235 +727,34 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 /obj/item/melee/flyswatter/Initialize()
 	. = ..()
 	strong_against = typecacheof(list(
-					/mob/living/simple_animal/hostile/poison/bees/,
-					/mob/living/simple_animal/butterfly,
-					/mob/living/simple_animal/hostile/cockroach,
-					/obj/item/queen_bee,
-					/obj/structure/spider/spiderling
+//		/mob/living/simple_animal/hostile/bee, REQUIRES PR#58882
+		/mob/living/simple_animal/hostile/poison/bees
+		/mob/living/simple_animal/butterfly,
+//		/mob/living/basic/cockroach, REQUIRES PR #60694
+		/mob/living/simple_animal/hostile/cockroach
+		/obj/item/queen_bee,
+		/obj/structure/spider/spiderling,
+//		/mob/living/simple_animal/ant, REQUIRES PR #59634
+//		/obj/effect/decal/cleanable/ants, REQUIRES PR #59634
 	))
 
 
 /obj/item/melee/flyswatter/afterattack(atom/target, mob/user, proximity_flag)
 	. = ..()
-	if(proximity_flag)
-		if(is_type_in_typecache(target, strong_against))
-			new /obj/effect/decal/cleanable/insectguts(target.drop_location())
-			to_chat(user, "<span class='warning'>You easily splat the [target].</span>")
-			if(istype(target, /mob/living/))
-				var/mob/living/bug = target
-				bug.death(1)
-			else
-				qdel(target)
-
-/obj/item/circlegame
-	name = "circled hand"
-	desc = "If somebody looks at this while it's below your waist, you get to bop them."
-	icon_state = "madeyoulook"
-	force = 0
-	throwforce = 0
-	item_flags = DROPDEL | ABSTRACT | HAND_ITEM
-	attack_verb_continuous = list("bops")
-	attack_verb_simple = list("bop")
-
-/obj/item/circlegame/Initialize()
-	. = ..()
-	var/mob/living/owner = loc
-	if(!istype(owner))
+	if(!proximity_flag)
 		return
-	RegisterSignal(owner, COMSIG_PARENT_EXAMINE, .proc/ownerExamined)
-
-/obj/item/circlegame/Destroy()
-	var/mob/owner = loc
-	if(istype(owner))
-		UnregisterSignal(owner, COMSIG_PARENT_EXAMINE)
-	return ..()
-
-/obj/item/circlegame/dropped(mob/user)
-	UnregisterSignal(user, COMSIG_PARENT_EXAMINE)		//loc will have changed by the time this is called, so Destroy() can't catch it
-	// this is a dropdel item.
-	return ..()
-
-/// Stage 1: The mistake is made
-/obj/item/circlegame/proc/ownerExamined(mob/living/owner, mob/living/sucker)
-	SIGNAL_HANDLER
-
-	if(!istype(sucker) || !in_range(owner, sucker))
+	if(!is_type_in_typecache(target, strong_against))
 		return
-	addtimer(CALLBACK(src, .proc/waitASecond, owner, sucker), 4)
-
-/// Stage 2: Fear sets in
-/obj/item/circlegame/proc/waitASecond(mob/living/owner, mob/living/sucker)
-	if(QDELETED(sucker) || QDELETED(src) || QDELETED(owner))
+	if (HAS_TRAIT(user, TRAIT_PACIFISM))
 		return
 
-	if(owner == sucker) // big mood
-		to_chat(owner, "<span class='danger'>Wait a second... you just looked at your own [src.name]!</span>")
-		addtimer(CALLBACK(src, .proc/selfGottem, owner), 10)
+	new /obj/effect/decal/cleanable/insectguts(target.drop_location())
+	to_chat(user, span_warning("You easily splat [target]."))
+	if(isliving(target))
+		var/mob/living/bug = target
+		bug.gib()
 	else
-		to_chat(sucker, "<span class='danger'>Wait a second... was that a-</span>")
-		addtimer(CALLBACK(src, .proc/GOTTEM, owner, sucker), 6)
-
-/// Stage 3A: We face our own failures
-/obj/item/circlegame/proc/selfGottem(mob/living/owner)
-	if(QDELETED(src) || QDELETED(owner))
-		return
-
-	playsound(get_turf(owner), 'sound/effects/hit_punch.ogg', 50, TRUE, -1)
-	owner.visible_message("<span class='danger'>[owner] shamefully bops [owner.p_them()]self with [owner.p_their()] [src.name].</span>", "<span class='userdanger'>You shamefully bop yourself with your [src.name].</span>", \
-		"<span class='hear'>You hear a dull thud!</span>")
-	log_combat(owner, owner, "bopped", src.name, "(self)")
-	owner.do_attack_animation(owner)
-	owner.apply_damage(100, STAMINA)
-	owner.Knockdown(10)
-	qdel(src)
-
-/// Stage 3B: We face our reckoning (unless we moved away or they're incapacitated)
-/obj/item/circlegame/proc/GOTTEM(mob/living/owner, mob/living/sucker)
-	if(QDELETED(sucker))
-		return
-
-	if(QDELETED(src) || QDELETED(owner))
-		to_chat(sucker, "<span class='warning'>Nevermind... must've been your imagination...</span>")
-		return
-
-	if(!in_range(owner, sucker) || !(owner.mobility_flags & MOBILITY_USE))
-		to_chat(sucker, "<span class='notice'>Phew... you moved away before [owner] noticed you saw [owner.p_their()] [src.name]...</span>")
-		return
-
-	to_chat(owner, "<span class='warning'>[sucker] looks down at your [src.name] before trying to avert [sucker.p_their()] eyes, but it's too late!</span>")
-	to_chat(sucker, "<span class='danger'><b>[owner] sees the fear in your eyes as you try to look away from [owner.p_their()] [src.name]!</b></span>")
-
-	owner.face_atom(sucker)
-	if(owner.client)
-		owner.client.give_award(/datum/award/achievement/misc/gottem, owner) // then everybody clapped
-
-	playsound(get_turf(owner), 'sound/effects/hit_punch.ogg', 50, TRUE, -1)
-	owner.do_attack_animation(sucker)
-
-	if(HAS_TRAIT(owner, TRAIT_HULK))
-		owner.visible_message("<span class='danger'>[owner] bops [sucker] with [owner.p_their()] [src.name] much harder than intended, sending [sucker.p_them()] flying!</span>", \
-			"<span class='danger'>You bop [sucker] with your [src.name] much harder than intended, sending [sucker.p_them()] flying!</span>", "<span class='hear'>You hear a sickening sound of flesh hitting flesh!</span>", ignored_mobs=list(sucker))
-		to_chat(sucker, "<span class='userdanger'>[owner] bops you incredibly hard with [owner.p_their()] [src.name], sending you flying!</span>")
-		sucker.apply_damage(50, STAMINA)
-		sucker.Knockdown(50)
-		log_combat(owner, sucker, "bopped", src.name, "(setup- Hulk)")
-		var/atom/throw_target = get_edge_target_turf(sucker, owner.dir)
-		sucker.throw_at(throw_target, 6, 3, owner)
-	else
-		owner.visible_message("<span class='danger'>[owner] bops [sucker] with [owner.p_their()] [src.name]!</span>", "<span class='danger'>You bop [sucker] with your [src.name]!</span>", \
-			"<span class='hear'>You hear a dull thud!</span>", ignored_mobs=list(sucker))
-		sucker.apply_damage(15, STAMINA)
-		log_combat(owner, sucker, "bopped", src.name, "(setup)")
-		to_chat(sucker, "<span class='userdanger'>[owner] bops you with [owner.p_their()] [src.name]!</span>")
-	qdel(src)
-
-/obj/item/slapper
-	name = "slapper"
-	desc = "This is how real men fight."
-	icon_state = "latexballon"
-	inhand_icon_state = "nothing"
-	force = 0
-	throwforce = 0
-	item_flags = DROPDEL | ABSTRACT | HAND_ITEM
-	attack_verb_continuous = list("slaps")
-	attack_verb_simple = list("slap")
-	hitsound = 'sound/effects/snap.ogg'
-
-/obj/item/slapper/attack(mob/M, mob/living/carbon/human/user)
-	if(ishuman(M))
-		var/mob/living/carbon/human/L = M
-		if(L && L.dna && L.dna.species)
-			L.dna.species.stop_wagging_tail(M)
-	user.do_attack_animation(M)
-	playsound(M, 'sound/weapons/slap.ogg', 50, TRUE, -1)
-	user.visible_message("<span class='danger'>[user] slaps [M]!</span>",
-	"<span class='notice'>You slap [M]!</span>",\
-	"<span class='hear'>You hear a slap.</span>")
-	return
-
-/obj/item/noogie
-	name = "noogie"
-	desc = "Get someone in an aggressive grab then use this on them to ruin their day."
-	icon_state = "latexballon"
-	inhand_icon_state = "nothing"
-	force = 0
-	throwforce = 0
-	item_flags = DROPDEL | ABSTRACT | HAND_ITEM
-
-/obj/item/noogie/attack(mob/living/carbon/target, mob/living/carbon/human/user)
-	if(!istype(target))
-		to_chat(user, "<span class='warning'>You don't think you can give this a noogie!</span>")
-		return
-
-	if(!(target?.get_bodypart(BODY_ZONE_HEAD)) || user.pulling != target || user.grab_state < GRAB_AGGRESSIVE || user.getStaminaLoss() > 80)
-		return FALSE
-
-	var/obj/item/bodypart/head/the_head = target.get_bodypart(BODY_ZONE_HEAD)
-	if((target.get_biological_state() != BIO_FLESH_BONE && target.get_biological_state() != BIO_JUST_FLESH) || !the_head.is_organic_limb())
-		to_chat(user, "<span class='warning'>You can't noogie [target], [target.p_they()] [target.p_have()] no skin on [target.p_their()] head!</span>")
-		return
-
-	// [user] gives [target] a [prefix_desc] noogie[affix_desc]!
-	var/prefix_desc = "rough"
-	var/affix_desc = ""
-	var/affix_desc_target = ""
-
-	if(HAS_TRAIT(target, TRAIT_ANTENNAE))
-		prefix_desc = "violent"
-		affix_desc = "on [target.p_their()] sensitive antennae"
-		affix_desc_target = "on your highly sensitive antennae"
-	if(user.dna?.check_mutation(HULK))
-		prefix_desc = "sickeningly brutal"
-
-	var/message_others = "[prefix_desc] noogie[affix_desc]"
-	var/message_target = "[prefix_desc] noogie[affix_desc_target]"
-
-	user.visible_message("<span class='danger'>[user] begins giving [target] a [message_others]!</span>", "<span class='warning'>You start giving [target] a [message_others]!</span>", vision_distance=COMBAT_MESSAGE_RANGE, ignored_mobs=target)
-	to_chat(target, "<span class='userdanger'>[user] starts giving you a [message_target]!</span>")
-
-	if(!do_after(user, 1.5 SECONDS, target))
-		to_chat(user, "<span class='warning'>You fail to give [target] a noogie!</span>")
-		to_chat(target, "<span class='danger'>[user] fails to give you a noogie!</span>")
-		return
-
-
-	noogie_loop(user, target, 0)
-
-/// The actual meat and bones of the noogie'ing
-/obj/item/noogie/proc/noogie_loop(mob/living/carbon/human/user, mob/living/carbon/target, iteration)
-	if(!(target?.get_bodypart(BODY_ZONE_HEAD)) || user.pulling != target)
-		return FALSE
-
-	if(user.getStaminaLoss() > 80)
-		to_chat(user, "<span class='warning'>You're too tired to continue giving [target] a noogie!</span>")
-		to_chat(target, "<span class='danger'>[user] is too tired to continue giving you a noogie!</span>")
-		return
-
-	var/damage = rand(1, 5)
-	if(HAS_TRAIT(target, TRAIT_ANTENNAE))
-		damage += rand(3,7)
-	if(user.dna?.check_mutation(HULK))
-		damage += rand(3,7)
-
-	if(damage >= 5)
-		target.emote("scream")
-
-	log_combat(user, target, "given a noogie to", addition = "([damage] brute before armor)")
-	target.apply_damage(damage, BRUTE, BODY_ZONE_HEAD)
-	user.adjustStaminaLoss(iteration + 5)
-	playsound(get_turf(user), pick('sound/effects/rustle1.ogg','sound/effects/rustle2.ogg','sound/effects/rustle3.ogg','sound/effects/rustle4.ogg','sound/effects/rustle5.ogg'), 50)
-
-	if(prob(33))
-		user.visible_message("<span class='danger'>[user] continues noogie'ing [target]!</span>", "<span class='warning'>You continue giving [target] a noogie!</span>", vision_distance=COMBAT_MESSAGE_RANGE, ignored_mobs=target)
-		to_chat(target, "<span class='userdanger'>[user] continues giving you a noogie!</span>")
-
-	if(!do_after(user, 1 SECONDS + (iteration * 2), target))
-		to_chat(user, "<span class='warning'>You fail to give [target] a noogie!</span>")
-		to_chat(target, "<span class='danger'>[user] fails to give you a noogie!</span>")
-		return
-
-	iteration++
-	noogie_loop(user, target, iteration)
+		qdel(target)
 
 /obj/item/proc/can_trigger_gun(mob/living/user)
 	if(!user.can_use_guns(src))

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -756,6 +756,219 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	else
 		qdel(target)
 
+
+
+
+/obj/item/circlegame
+	name = "circled hand"
+	desc = "If somebody looks at this while it's below your waist, you get to bop them."
+	icon_state = "madeyoulook"
+	force = 0
+	throwforce = 0
+	item_flags = DROPDEL | ABSTRACT | HAND_ITEM
+	attack_verb_continuous = list("bops")
+	attack_verb_simple = list("bop")
+
+/obj/item/circlegame/Initialize()
+	. = ..()
+	var/mob/living/owner = loc
+	if(!istype(owner))
+		return
+	RegisterSignal(owner, COMSIG_PARENT_EXAMINE, .proc/ownerExamined)
+
+/obj/item/circlegame/Destroy()
+	var/mob/owner = loc
+	if(istype(owner))
+		UnregisterSignal(owner, COMSIG_PARENT_EXAMINE)
+	return ..()
+
+/obj/item/circlegame/dropped(mob/user)
+	UnregisterSignal(user, COMSIG_PARENT_EXAMINE)		//loc will have changed by the time this is called, so Destroy() can't catch it
+	// this is a dropdel item.
+	return ..()
+
+/// Stage 1: The mistake is made
+/obj/item/circlegame/proc/ownerExamined(mob/living/owner, mob/living/sucker)
+	SIGNAL_HANDLER
+
+	if(!istype(sucker) || !in_range(owner, sucker))
+		return
+	addtimer(CALLBACK(src, .proc/waitASecond, owner, sucker), 4)
+
+/// Stage 2: Fear sets in
+/obj/item/circlegame/proc/waitASecond(mob/living/owner, mob/living/sucker)
+	if(QDELETED(sucker) || QDELETED(src) || QDELETED(owner))
+		return
+
+	if(owner == sucker) // big mood
+		to_chat(owner, "<span class='danger'>Wait a second... you just looked at your own [src.name]!</span>")
+		addtimer(CALLBACK(src, .proc/selfGottem, owner), 10)
+	else
+		to_chat(sucker, "<span class='danger'>Wait a second... was that a-</span>")
+		addtimer(CALLBACK(src, .proc/GOTTEM, owner, sucker), 6)
+
+/// Stage 3A: We face our own failures
+/obj/item/circlegame/proc/selfGottem(mob/living/owner)
+	if(QDELETED(src) || QDELETED(owner))
+		return
+
+	playsound(get_turf(owner), 'sound/effects/hit_punch.ogg', 50, TRUE, -1)
+	owner.visible_message("<span class='danger'>[owner] shamefully bops [owner.p_them()]self with [owner.p_their()] [src.name].</span>", "<span class='userdanger'>You shamefully bop yourself with your [src.name].</span>", \
+		"<span class='hear'>You hear a dull thud!</span>")
+	log_combat(owner, owner, "bopped", src.name, "(self)")
+	owner.do_attack_animation(owner)
+	owner.apply_damage(100, STAMINA)
+	owner.Knockdown(10)
+	qdel(src)
+
+/// Stage 3B: We face our reckoning (unless we moved away or they're incapacitated)
+/obj/item/circlegame/proc/GOTTEM(mob/living/owner, mob/living/sucker)
+	if(QDELETED(sucker))
+		return
+
+	if(QDELETED(src) || QDELETED(owner))
+		to_chat(sucker, "<span class='warning'>Nevermind... must've been your imagination...</span>")
+		return
+
+	if(!in_range(owner, sucker) || !(owner.mobility_flags & MOBILITY_USE))
+		to_chat(sucker, "<span class='notice'>Phew... you moved away before [owner] noticed you saw [owner.p_their()] [src.name]...</span>")
+		return
+
+	to_chat(owner, "<span class='warning'>[sucker] looks down at your [src.name] before trying to avert [sucker.p_their()] eyes, but it's too late!</span>")
+	to_chat(sucker, "<span class='danger'><b>[owner] sees the fear in your eyes as you try to look away from [owner.p_their()] [src.name]!</b></span>")
+
+	owner.face_atom(sucker)
+	if(owner.client)
+		owner.client.give_award(/datum/award/achievement/misc/gottem, owner) // then everybody clapped
+
+	playsound(get_turf(owner), 'sound/effects/hit_punch.ogg', 50, TRUE, -1)
+	owner.do_attack_animation(sucker)
+
+	if(HAS_TRAIT(owner, TRAIT_HULK))
+		owner.visible_message("<span class='danger'>[owner] bops [sucker] with [owner.p_their()] [src.name] much harder than intended, sending [sucker.p_them()] flying!</span>", \
+			"<span class='danger'>You bop [sucker] with your [src.name] much harder than intended, sending [sucker.p_them()] flying!</span>", "<span class='hear'>You hear a sickening sound of flesh hitting flesh!</span>", ignored_mobs=list(sucker))
+		to_chat(sucker, "<span class='userdanger'>[owner] bops you incredibly hard with [owner.p_their()] [src.name], sending you flying!</span>")
+		sucker.apply_damage(50, STAMINA)
+		sucker.Knockdown(50)
+		log_combat(owner, sucker, "bopped", src.name, "(setup- Hulk)")
+		var/atom/throw_target = get_edge_target_turf(sucker, owner.dir)
+		sucker.throw_at(throw_target, 6, 3, owner)
+	else
+		owner.visible_message("<span class='danger'>[owner] bops [sucker] with [owner.p_their()] [src.name]!</span>", "<span class='danger'>You bop [sucker] with your [src.name]!</span>", \
+			"<span class='hear'>You hear a dull thud!</span>", ignored_mobs=list(sucker))
+		sucker.apply_damage(15, STAMINA)
+		log_combat(owner, sucker, "bopped", src.name, "(setup)")
+		to_chat(sucker, "<span class='userdanger'>[owner] bops you with [owner.p_their()] [src.name]!</span>")
+	qdel(src)
+
+/obj/item/slapper
+	name = "slapper"
+	desc = "This is how real men fight."
+	icon_state = "latexballon"
+	inhand_icon_state = "nothing"
+	force = 0
+	throwforce = 0
+	item_flags = DROPDEL | ABSTRACT | HAND_ITEM
+	attack_verb_continuous = list("slaps")
+	attack_verb_simple = list("slap")
+	hitsound = 'sound/effects/snap.ogg'
+
+/obj/item/slapper/attack(mob/M, mob/living/carbon/human/user)
+	if(ishuman(M))
+		var/mob/living/carbon/human/L = M
+		if(L && L.dna && L.dna.species)
+			L.dna.species.stop_wagging_tail(M)
+	user.do_attack_animation(M)
+	playsound(M, 'sound/weapons/slap.ogg', 50, TRUE, -1)
+	user.visible_message("<span class='danger'>[user] slaps [M]!</span>",
+	"<span class='notice'>You slap [M]!</span>",\
+	"<span class='hear'>You hear a slap.</span>")
+	return
+
+/obj/item/noogie
+	name = "noogie"
+	desc = "Get someone in an aggressive grab then use this on them to ruin their day."
+	icon_state = "latexballon"
+	inhand_icon_state = "nothing"
+	force = 0
+	throwforce = 0
+	item_flags = DROPDEL | ABSTRACT | HAND_ITEM
+
+/obj/item/noogie/attack(mob/living/carbon/target, mob/living/carbon/human/user)
+	if(!istype(target))
+		to_chat(user, "<span class='warning'>You don't think you can give this a noogie!</span>")
+		return
+
+	if(!(target?.get_bodypart(BODY_ZONE_HEAD)) || user.pulling != target || user.grab_state < GRAB_AGGRESSIVE || user.getStaminaLoss() > 80)
+		return FALSE
+
+	var/obj/item/bodypart/head/the_head = target.get_bodypart(BODY_ZONE_HEAD)
+	if((target.get_biological_state() != BIO_FLESH_BONE && target.get_biological_state() != BIO_JUST_FLESH) || !the_head.is_organic_limb())
+		to_chat(user, "<span class='warning'>You can't noogie [target], [target.p_they()] [target.p_have()] no skin on [target.p_their()] head!</span>")
+		return
+
+	// [user] gives [target] a [prefix_desc] noogie[affix_desc]!
+	var/prefix_desc = "rough"
+	var/affix_desc = ""
+	var/affix_desc_target = ""
+
+	if(HAS_TRAIT(target, TRAIT_ANTENNAE))
+		prefix_desc = "violent"
+		affix_desc = "on [target.p_their()] sensitive antennae"
+		affix_desc_target = "on your highly sensitive antennae"
+	if(user.dna?.check_mutation(HULK))
+		prefix_desc = "sickeningly brutal"
+
+	var/message_others = "[prefix_desc] noogie[affix_desc]"
+	var/message_target = "[prefix_desc] noogie[affix_desc_target]"
+
+	user.visible_message("<span class='danger'>[user] begins giving [target] a [message_others]!</span>", "<span class='warning'>You start giving [target] a [message_others]!</span>", vision_distance=COMBAT_MESSAGE_RANGE, ignored_mobs=target)
+	to_chat(target, "<span class='userdanger'>[user] starts giving you a [message_target]!</span>")
+
+	if(!do_after(user, 1.5 SECONDS, target))
+		to_chat(user, "<span class='warning'>You fail to give [target] a noogie!</span>")
+		to_chat(target, "<span class='danger'>[user] fails to give you a noogie!</span>")
+		return
+
+
+	noogie_loop(user, target, 0)
+
+/// The actual meat and bones of the noogie'ing
+/obj/item/noogie/proc/noogie_loop(mob/living/carbon/human/user, mob/living/carbon/target, iteration)
+	if(!(target?.get_bodypart(BODY_ZONE_HEAD)) || user.pulling != target)
+		return FALSE
+
+	if(user.getStaminaLoss() > 80)
+		to_chat(user, "<span class='warning'>You're too tired to continue giving [target] a noogie!</span>")
+		to_chat(target, "<span class='danger'>[user] is too tired to continue giving you a noogie!</span>")
+		return
+
+	var/damage = rand(1, 5)
+	if(HAS_TRAIT(target, TRAIT_ANTENNAE))
+		damage += rand(3,7)
+	if(user.dna?.check_mutation(HULK))
+		damage += rand(3,7)
+
+	if(damage >= 5)
+		target.emote("scream")
+
+	log_combat(user, target, "given a noogie to", addition = "([damage] brute before armor)")
+	target.apply_damage(damage, BRUTE, BODY_ZONE_HEAD)
+	user.adjustStaminaLoss(iteration + 5)
+	playsound(get_turf(user), pick('sound/effects/rustle1.ogg','sound/effects/rustle2.ogg','sound/effects/rustle3.ogg','sound/effects/rustle4.ogg','sound/effects/rustle5.ogg'), 50)
+
+	if(prob(33))
+		user.visible_message("<span class='danger'>[user] continues noogie'ing [target]!</span>", "<span class='warning'>You continue giving [target] a noogie!</span>", vision_distance=COMBAT_MESSAGE_RANGE, ignored_mobs=target)
+		to_chat(target, "<span class='userdanger'>[user] continues giving you a noogie!</span>")
+
+	if(!do_after(user, 1 SECONDS + (iteration * 2), target))
+		to_chat(user, "<span class='warning'>You fail to give [target] a noogie!</span>")
+		to_chat(target, "<span class='danger'>[user] fails to give you a noogie!</span>")
+		return
+
+	iteration++
+	noogie_loop(user, target, iteration)
+
 /obj/item/proc/can_trigger_gun(mob/living/user)
 	if(!user.can_use_guns(src))
 		return FALSE

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -728,10 +728,10 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	. = ..()
 	strong_against = typecacheof(list(
 //		/mob/living/simple_animal/hostile/bee, REQUIRES PR#58882
-		/mob/living/simple_animal/hostile/poison/bees
+		/mob/living/simple_animal/hostile/poison/bees,
 		/mob/living/simple_animal/butterfly,
 //		/mob/living/basic/cockroach, REQUIRES PR #60694
-		/mob/living/simple_animal/hostile/cockroach
+		/mob/living/simple_animal/hostile/cockroach,
 		/obj/item/queen_bee,
 		/obj/structure/spider/spiderling,
 //		/mob/living/simple_animal/ant, REQUIRES PR #59634

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -756,9 +756,6 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	else
 		qdel(target)
 
-
-
-
 /obj/item/circlegame
 	name = "circled hand"
 	desc = "If somebody looks at this while it's below your waist, you get to bop them."

--- a/code/game/objects/structures/traps.dm
+++ b/code/game/objects/structures/traps.dm
@@ -28,7 +28,8 @@
 	if(!ignore_typecache)
 		ignore_typecache = typecacheof(list(
 			/obj/effect,
-			/mob/dead))
+			/mob/dead,
+		))
 
 /obj/structure/trap/Destroy()
 	qdel(spark_system)

--- a/code/game/turfs/open/dirtystation.dm
+++ b/code/game/turfs/open/dirtystation.dm
@@ -24,11 +24,14 @@
 	//The code below here isn't exactly optimal, but because of the individual decals that each area uses it's still applicable.
 
 				//high dirt - 1/3 chance.
-	var/static/list/high_dirt_areas = typecacheof(list(/area/science/test_area,
-														/area/mine/production,
-														/area/mine/living_quarters,
-														/area/vacant_room/office,
-														/area/ruin/space))
+	var/static/list/high_dirt_areas = typecacheof(list(
+		/area/science/test_area,
+		/area/mine/production,
+		/area/mine/living_quarters,
+//		/area/commons/vacant_room/office, REQUIRES TG PR
+		/area/vacant_room/office, // REQUIRES TG PR
+		/area/ruin/space,
+	))
 	if(is_type_in_typecache(A, high_dirt_areas))
 		new /obj/effect/decal/cleanable/dirt(src)	//vanilla, but it works
 		return
@@ -38,13 +41,18 @@
 		return
 
 		//Construction zones. Blood, sweat, and oil.  Oh, and dirt.
-	var/static/list/engine_dirt_areas = typecacheof(list(/area/engine,
-														/area/crew_quarters/heads/chief,
-														/area/science/robotics,
-														/area/maintenance,
-														/area/construction,
-														/area/vacant_room/commissary,
-														/area/survivalpod))
+	var/static/list/engine_dirt_areas = typecacheof(list(
+//		/area/engineering, REQUIRES TG PR
+		/area/engine, // REQUIRES TG PR
+//		/area/command/heads_quarters/ce, REQUIRES TG PR
+		/area/crew_quarters/heads/chief, //REQUIRES TG PR
+		/area/science/robotics,
+		/area/maintenance,
+		/area/construction,
+//		/area/commons/vacant_room/commissary, REQUIRES TG PR
+		/area/vacant_room/commissary, //REQUIRES TG PR
+		/area/survivalpod,
+	))
 	if(is_type_in_typecache(A, engine_dirt_areas))
 		if(prob(3))
 			new /obj/effect/decal/cleanable/blood/old(src)
@@ -59,8 +67,11 @@
 		return
 
 		//Bathrooms. Blood, vomit, and shavings in the sinks.
-	var/static/list/bathroom_dirt_areas = typecacheof(list(	/area/crew_quarters/toilet,
-															/area/awaymission/research/interior/bathroom))
+	var/static/list/bathroom_dirt_areas = typecacheof(list(
+//		/area/commons/toilet, REQUIRES TG PR
+		/area/crew_quarters/toilet, // REQUIRES TG PR
+		/area/awaymission/research/interior/bathroom,
+	))
 	if(is_type_in_typecache(A, bathroom_dirt_areas))
 		if(prob(40))
 			if(prob(90))
@@ -81,9 +92,12 @@
 		return
 
 		//Areas where gibs will be present. Robusting probably happened some time ago.
-	var/static/list/gib_covered_areas = typecacheof(list(/area/ai_monitored/turret_protected,
-														/area/security,
-														/area/crew_quarters/heads/hos))
+	var/static/list/gib_covered_areas = typecacheof(list(
+		/area/ai_monitored/turret_protected,
+		/area/security,
+//		/area/command/heads_quarters/hos, REQUIRES TG PR
+		/area/crew_quarters/heads/hos, // REQUIRES TG PR
+	))
 	if(is_type_in_typecache(A, gib_covered_areas))
 		if(prob(20))
 			if(prob(5))
@@ -93,8 +107,12 @@
 		return
 
 		//Kitchen areas. Broken eggs, flour, spilled milk (no crying allowed.)
-	var/static/list/kitchen_dirt_areas = typecacheof(list(/area/crew_quarters/kitchen,
-														/area/crew_quarters/cafeteria))
+	var/static/list/kitchen_dirt_areas = typecacheof(list(
+//		/area/service/kitchen, REQUIRES TG PR
+		/area/crew_quarters/kitchen, // REQUIRES TG PR
+//		/area/service/cafeteria, REQUIRES TG PR
+		/area/crew_quarters/cafeteria, // REQUIRES TG PR
+	))
 	if(is_type_in_typecache(A, kitchen_dirt_areas))
 		if(prob(60))
 			if(prob(50))
@@ -104,8 +122,11 @@
 		return
 
 		//Medical areas. Mostly clean by space-OSHA standards, but has some blood and oil spread about.
-	var/static/list/medical_dirt_areas = typecacheof(list(/area/medical,
-														/area/crew_quarters/heads/cmo))
+	var/static/list/medical_dirt_areas = typecacheof(list(
+		/area/medical,
+//		/area/command/heads_quarters/cmo, REQUIRES TG PR
+		/area/crew_quarters/heads/cmo // REQUIRES TG PR
+	))
 	if(is_type_in_typecache(A, medical_dirt_areas))
 		if(prob(66))
 			if(prob(5))
@@ -120,8 +141,11 @@
 		return
 
 		//Science messes. Mostly green glowy stuff -WHICH YOU SHOULD NOT INJEST-.
-	var/static/list/science_dirt_areas = typecacheof(list(/area/science,
-														/area/crew_quarters/heads/hor))
+	var/static/list/science_dirt_areas = typecacheof(list(
+		/area/science,
+//		/area/command/heads_quarters/rd, REQUIRES TG PR
+		/area/crew_quarters/heads/hor // REQUIRES TG PR
+	))
 	if(is_type_in_typecache(A, science_dirt_areas))
 		if(prob(20))
 			new /obj/effect/decal/cleanable/greenglow/filled(src)	//this cleans itself up but it might startle you when you see it.

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -43,7 +43,8 @@
 	var/datum/cellular_emporium/cellular_emporium
 	var/datum/action/innate/cellular_emporium/emporium_action
 
-	var/static/list/all_powers = typecacheof(/datum/action/changeling,TRUE)
+	/// Static typecache of all changeling powers that are usable.
+	var/static/list/all_powers = typecacheof(/datum/action/changeling, ignore_root_path = TRUE)
 
 /datum/antagonist/changeling/New()
 	. = ..()

--- a/code/modules/antagonists/cult/cult_structures.dm
+++ b/code/modules/antagonists/cult/cult_structures.dm
@@ -223,7 +223,8 @@
 				/turf/open/floor/engine/cult,
 				/turf/open/space,
 				/turf/open/lava,
-				/turf/open/chasm))
+				/turf/open/chasm,
+			))
 			if(is_type_in_typecache(T, blacklisted_pylon_turfs))
 				continue
 			else

--- a/code/modules/antagonists/eldritch_cult/eldritch_book.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_book.dm
@@ -10,7 +10,7 @@
 	///how many charges do we have?
 	var/charge = 1
 	///Where we cannot create the rune?
-	var/static/list/blacklisted_turfs = typecacheof(list(/turf/closed,/turf/open/space,/turf/open/lava))
+	var/static/list/blacklisted_turfs = typecacheof(list(/turf/closed, /turf/open/space, /turf/open/lava))
 
 /obj/item/forbidden_book/Destroy()
 	last_user = null

--- a/code/modules/antagonists/eldritch_cult/eldritch_items.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_items.dm
@@ -302,7 +302,7 @@
 	attack_verb_continuous = list("attacks", "slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "rends")
 	attack_verb_simple = list("attack", "slash", "stab", "slice", "tear", "lacerate", "rip", "dice", "rend")
 	///turfs that you cannot draw carvings on
-	var/static/list/blacklisted_turfs = typecacheof(list(/turf/closed,/turf/open/space,/turf/open/lava))
+	var/static/list/blacklisted_turfs = typecacheof(list(/turf/closed, /turf/open/space, /turf/open/lava))
 	///A check to see if you are in process of drawing a rune
 	var/drawing = FALSE
 	///A list of current runes

--- a/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/rust_lore.dm
@@ -171,7 +171,14 @@
 	var/list/edge_turfs = list()
 	var/list/turfs = list()
 	var/turf/centre
-	var/static/list/blacklisted_turfs = typecacheof(list(/turf/open/indestructible,/turf/closed/indestructible,/turf/open/space,/turf/open/lava,/turf/open/chasm))
+	/// Static blacklist of turfs we can't spread to.
+	var/static/list/blacklisted_turfs = typecacheof(list(
+		/turf/open/indestructible,
+		/turf/closed/indestructible,
+		/turf/open/space,
+		/turf/open/lava,
+		/turf/open/chasm,
+	))
 	var/spread_per_sec = 6
 
 

--- a/code/modules/antagonists/morph/morph.dm
+++ b/code/modules/antagonists/morph/morph.dm
@@ -36,12 +36,13 @@
 	var/eat_while_disguised = FALSE
 	var/atom/movable/form = null
 	var/static/list/blacklist_typecache = typecacheof(list(
-	/atom/movable/screen,
-	/obj/singularity,
-	/obj/energy_ball,
-	/obj/narsie,
-	/mob/living/simple_animal/hostile/morph,
-	/obj/effect))
+		/atom/movable/screen,
+		/obj/singularity,
+		/obj/energy_ball,
+		/obj/narsie,
+		/mob/living/simple_animal/hostile/morph,
+		/obj/effect,
+	))
 
 /mob/living/simple_animal/hostile/morph/examine(mob/user)
 	if(morphed)

--- a/code/modules/cargo/bounties/assistant.dm
+++ b/code/modules/cargo/bounties/assistant.dm
@@ -2,127 +2,134 @@
 	name = "Strange Object"
 	description = "Nanotrasen has taken an interest in strange objects. Find one in maint, and ship it off to CentCom right away."
 	reward = CARGO_CRATE_VALUE * 2.4
-	wanted_types = list(/obj/item/relic)
+	wanted_types = list(/obj/item/relic = TRUE)
 
 /datum/bounty/item/assistant/scooter
 	name = "Scooter"
 	description = "Nanotrasen has determined walking to be wasteful. Ship a scooter to CentCom to speed operations up."
 	reward = CARGO_CRATE_VALUE * 2.16 // the mat hoffman
-	wanted_types = list(/obj/vehicle/ridden/scooter)
+	wanted_types = list(/obj/vehicle/ridden/scooter = TRUE)
 	include_subtypes = FALSE
 
 /datum/bounty/item/assistant/skateboard
 	name = "Skateboard"
 	description = "Nanotrasen has determined walking to be wasteful. Ship a skateboard to CentCom to speed operations up."
 	reward = CARGO_CRATE_VALUE * 1.8 // the tony hawk
-	wanted_types = list(/obj/vehicle/ridden/scooter/skateboard, /obj/item/melee/skateboard)
+	wanted_types = list(
+		/obj/vehicle/ridden/scooter/skateboard = TRUE,
+		/obj/item/melee/skateboard = TRUE,
+	)
 
 /datum/bounty/item/assistant/stunprod
 	name = "Stunprod"
 	description = "CentCom demands a stunprod to use against dissidents. Craft one, then ship it."
 	reward = CARGO_CRATE_VALUE * 2.6
-	wanted_types = list(/obj/item/melee/baton/cattleprod)
+//	wanted_types = list(/obj/item/melee/baton/security/cattleprod = TRUE) REQUIRES TG PR
+	wanted_types = list(/obj/item/melee/baton/cattleprod = TRUE) // REQUIRES TG PR
 
 /datum/bounty/item/assistant/soap
 	name = "Soap"
 	description = "Soap has gone missing from CentCom's bathrooms and nobody knows who took it. Replace it and be the hero CentCom needs."
 	reward = CARGO_CRATE_VALUE * 4
 	required_count = 3
-	wanted_types = list(/obj/item/soap)
+	wanted_types = list(/obj/item/soap = TRUE)
 
 /datum/bounty/item/assistant/spear
 	name = "Spears"
 	description = "CentCom's security forces are going through budget cuts. You will be paid if you ship a set of spears."
 	reward = CARGO_CRATE_VALUE * 4
 	required_count = 5
-	wanted_types = list(/obj/item/spear)
+	wanted_types = list(/obj/item/spear = TRUE)
 
 /datum/bounty/item/assistant/toolbox
 	name = "Toolboxes"
 	description = "There's an absence of robustness at Central Command. Hurry up and ship some toolboxes as a solution."
 	reward = CARGO_CRATE_VALUE * 4
 	required_count = 6
-	wanted_types = list(/obj/item/storage/toolbox)
+	wanted_types = list(/obj/item/storage/toolbox = TRUE)
 
 /datum/bounty/item/assistant/statue
 	name = "Statue"
 	description = "Central Command would like to commision an artsy statue for the lobby. Ship one out, when possible."
 	reward = CARGO_CRATE_VALUE * 4
-	wanted_types = list(/obj/structure/statue)
+	wanted_types = list(/obj/structure/statue = TRUE)
 
 /datum/bounty/item/assistant/clown_box
 	name = "Clown Box"
 	description = "The universe needs laughter. Stamp cardboard with a clown stamp and ship it out."
 	reward = CARGO_CRATE_VALUE * 3
-	wanted_types = list(/obj/item/storage/box/clown)
+	wanted_types = list(/obj/item/storage/box/clown = TRUE)
 
 /datum/bounty/item/assistant/cheesiehonkers
 	name = "Cheesie Honkers"
 	description = "Apparently the company that makes Cheesie Honkers is going out of business soon. CentCom wants to stock up before it happens!"
 	reward = CARGO_CRATE_VALUE * 2.4
 	required_count = 3
-	wanted_types = list(/obj/item/food/cheesiehonkers)
+	wanted_types = list(/obj/item/food/cheesiehonkers = TRUE)
 
 /datum/bounty/item/assistant/baseball_bat
 	name = "Baseball Bat"
 	description = "Baseball fever is going on at CentCom! Be a dear and ship them some baseball bats, so that management can live out their childhood dream."
 	reward = CARGO_CRATE_VALUE * 4
 	required_count = 5
-	wanted_types = list(/obj/item/melee/baseball_bat)
+	wanted_types = list(/obj/item/melee/baseball_bat = TRUE)
 
 /datum/bounty/item/assistant/extendohand
 	name = "Extendo-Hand"
 	description = "Commander Betsy is getting old, and can't bend over to get the telescreen remote anymore. Management has requested an extendo-hand to help her out."
 	reward = CARGO_CRATE_VALUE * 5
-	wanted_types = list(/obj/item/extendohand)
+	wanted_types = list(/obj/item/extendohand = TRUE)
 
 /datum/bounty/item/assistant/donut
 	name = "Donuts"
 	description = "CentCom's security forces are facing heavy losses against the Syndicate. Ship donuts to raise morale."
 	reward = CARGO_CRATE_VALUE * 6
 	required_count = 10
-	wanted_types = list(/obj/item/food/donut)
+	wanted_types = list(/obj/item/food/donut = TRUE)
 
 /datum/bounty/item/assistant/donkpocket
 	name = "Donk-Pockets"
 	description = "Consumer safety recall: Warning. Donk-Pockets manufactured in the past year contain hazardous lizard biomatter. Return units to CentCom immediately."
 	reward = CARGO_CRATE_VALUE * 6
 	required_count = 10
-	wanted_types = list(/obj/item/food/donkpocket)
+	wanted_types = list(/obj/item/food/donkpocket = TRUE)
 
 /datum/bounty/item/assistant/briefcase
 	name = "Briefcase"
 	description = "Central Command will be holding a business convention this year. Ship a few briefcases in support."
 	reward = CARGO_CRATE_VALUE * 5
 	required_count = 5
-	wanted_types = list(/obj/item/storage/briefcase, /obj/item/storage/secure/briefcase)
+	wanted_types = list(
+		/obj/item/storage/briefcase = TRUE,
+		/obj/item/storage/secure/briefcase = TRUE,
+	)
 
 /datum/bounty/item/assistant/sunglasses
 	name = "Sunglasses"
 	description = "A famous blues duo is passing through the sector, but they've lost their shades and they can't perform. Ship new sunglasses to CentCom to rectify this."
 	reward = CARGO_CRATE_VALUE * 6
 	required_count = 2
-	wanted_types = list(/obj/item/clothing/glasses/sunglasses)
+	wanted_types = list(/obj/item/clothing/glasses/sunglasses = TRUE)
 
 /datum/bounty/item/assistant/monkey_hide
 	name = "Monkey Hide"
 	description = "One of the scientists at CentCom is interested in testing products on monkey skin. Your mission is to acquire monkey's hide and ship it."
 	reward = CARGO_CRATE_VALUE * 3
-	wanted_types = list(/obj/item/stack/sheet/animalhide/monkey)
+	wanted_types = list(/obj/item/stack/sheet/animalhide/monkey = TRUE)
 
 /datum/bounty/item/assistant/comfy_chair
 	name = "Comfy Chairs"
 	description = "Commander Pat is unhappy with his chair. He claims it hurts his back. Ship some alternatives out to humor him."
 	reward = CARGO_CRATE_VALUE * 3
 	required_count = 5
-	wanted_types = list(/obj/structure/chair/comfy)
+	wanted_types = list(/obj/structure/chair/comfy = TRUE)
 
 /datum/bounty/item/assistant/geranium
 	name = "Geraniums"
 	description = "Commander Zot has the hots for Commander Zena. Send a shipment of geraniums - her favorite flower - and he'll happily reward you."
 	reward = CARGO_CRATE_VALUE * 8
 	required_count = 3
-	wanted_types = list(/obj/item/food/grown/poppy/geranium)
+	wanted_types = list(/obj/item/food/grown/poppy/geranium = TRUE)
 	include_subtypes = FALSE
 
 /datum/bounty/item/assistant/poppy
@@ -130,62 +137,62 @@
 	description = "Commander Zot really wants to sweep Security Officer Olivia off her feet. Send a shipment of Poppies - her favorite flower - and he'll happily reward you."
 	reward = CARGO_CRATE_VALUE * 2
 	required_count = 3
-	wanted_types = list(/obj/item/food/grown/poppy)
+	wanted_types = list(/obj/item/food/grown/poppy = TRUE)
 	include_subtypes = FALSE
 
 /datum/bounty/item/assistant/shadyjims
 	name = "Shady Jim's"
 	description = "There's an irate officer at CentCom demanding that he receive a box of Shady Jim's cigarettes. Please ship one. He's starting to make threats."
 	reward = CARGO_CRATE_VALUE
-	wanted_types = list(/obj/item/storage/fancy/cigarettes/cigpack_shadyjims)
+	wanted_types = list(/obj/item/storage/fancy/cigarettes/cigpack_shadyjims = TRUE)
 
 /datum/bounty/item/assistant/potted_plants
 	name = "Potted Plants"
 	description = "Central Command is looking to commission a new BirdBoat-class station. You've been ordered to supply the potted plants."
 	reward = CARGO_CRATE_VALUE * 4
 	required_count = 8
-	wanted_types = list(/obj/item/kirbyplants)
+	wanted_types = list(/obj/item/kirbyplants = TRUE)
 
 /datum/bounty/item/assistant/monkey_cubes
 	name = "Monkey Cubes"
 	description = "Due to a recent genetics accident, Central Command is in serious need of monkeys. Your mission is to ship monkey cubes."
 	reward = CARGO_CRATE_VALUE * 4
 	required_count = 3
-	wanted_types = list(/obj/item/food/monkeycube)
+	wanted_types = list(/obj/item/food/monkeycube = TRUE)
 
 /datum/bounty/item/assistant/ied
 	name = "IED"
 	description = "Nanotrasen's maximum security prison at CentCom is undergoing personnel training. Ship a handful of IEDs to serve as a training tools."
 	reward = CARGO_CRATE_VALUE * 4
 	required_count = 3
-	wanted_types = list(/obj/item/grenade/iedcasing)
+	wanted_types = list(/obj/item/grenade/iedcasing = TRUE)
 
 /datum/bounty/item/assistant/corgimeat
 	name = "Raw Corgi Meat"
 	description = "The Syndicate recently stole all of CentCom's Corgi meat. Ship out a replacement immediately."
 	reward = CARGO_CRATE_VALUE * 6
-	wanted_types = list(/obj/item/food/meat/slab/corgi)
+	wanted_types = list(/obj/item/food/meat/slab/corgi = TRUE)
 
 /datum/bounty/item/assistant/action_figures
 	name = "Action Figures"
 	description = "The vice president's son saw an ad for action figures on the telescreen and now he won't shut up about them. Ship some to ease his complaints."
 	reward = CARGO_CRATE_VALUE * 8
 	required_count = 5
-	wanted_types = list(/obj/item/toy/figure)
+	wanted_types = list(/obj/item/toy/figure = TRUE)
 
 /datum/bounty/item/assistant/dead_mice
 	name = "Dead Mice"
 	description = "Station 14 ran out of freeze-dried mice. Ship some fresh ones so their janitor doesn't go on strike."
 	reward = CARGO_CRATE_VALUE * 10
 	required_count = 5
-	wanted_types = list(/obj/item/food/deadmouse)
+	wanted_types = list(/obj/item/food/deadmouse = TRUE)
 
 /datum/bounty/item/assistant/paper_bin
 	name = "Paper Bins"
 	description = "Our accounting division is all out of paper. We need a new shipment immediately."
 	reward = CARGO_CRATE_VALUE * 5
 	required_count = 5
-	wanted_types = list(/obj/item/paper_bin)
+	wanted_types = list(/obj/item/paper_bin = TRUE)
 
 
 /datum/bounty/item/assistant/crayons
@@ -193,7 +200,7 @@
 	description = "Dr Jones' kid ate all our crayons again. Please send us yours."
 	reward = CARGO_CRATE_VALUE * 4
 	required_count = 24
-	wanted_types = list(/obj/item/toy/crayon)
+	wanted_types = list(/obj/item/toy/crayon = TRUE)
 
 /datum/bounty/item/assistant/pens
 	name = "Pens"
@@ -201,4 +208,4 @@
 	reward = CARGO_CRATE_VALUE * 4
 	required_count = 10
 	include_subtypes = FALSE
-	wanted_types = list(/obj/item/pen)
+	wanted_types = list(/obj/item/pen = TRUE)

--- a/code/modules/cargo/bounties/botany.dm
+++ b/code/modules/cargo/bounties/botany.dm
@@ -12,133 +12,140 @@
 
 /datum/bounty/item/botany/ambrosia_gaia
 	name = "Ambrosia Gaia Leaves"
-	wanted_types = list(/obj/item/food/grown/ambrosia/gaia)
+	wanted_types = list(/obj/item/food/grown/ambrosia/gaia = TRUE)
 	multiplier = 4
 	foodtype = "stew"
 
 /datum/bounty/item/botany/apple_golden
 	name = "Golden Apples"
-	wanted_types = list(/obj/item/food/grown/apple/gold)
+	wanted_types = list(/obj/item/food/grown/apple/gold = TRUE)
 	multiplier = 4
 	foodtype = "dessert"
 
 /datum/bounty/item/botany/banana
 	name = "Bananas"
-	wanted_types = list(/obj/item/food/grown/banana)
+	wanted_types = list(/obj/item/food/grown/banana = TRUE)
 	foodtype = "banana split"
 
 /datum/bounty/item/botany/beans_koi
 	name = "Koi Beans"
-	wanted_types = list(/obj/item/food/grown/koibeans)
+	wanted_types = list(/obj/item/food/grown/koibeans = TRUE)
 	multiplier = 2
 
 /datum/bounty/item/botany/berries_glow
 	name = "Glow-Berries"
-	wanted_types = list(/obj/item/food/grown/berries/glow)
+	wanted_types = list(/obj/item/food/grown/berries/glow = TRUE)
 	multiplier = 2
 	foodtype = "sorbet"
 
 /datum/bounty/item/botany/cannabis
 	name = "Cannabis Leaves"
-	wanted_types = list(/obj/item/food/grown/cannabis)
-	exclude_types = list(/obj/item/food/grown/cannabis/white)
+	wanted_types = list(
+		/obj/item/food/grown/cannabis = TRUE,
+		/obj/item/food/grown/cannabis/white = FALSE,
+	)
 	multiplier = 4 //hush money
 	bonus_desc = "Do not mention this shipment to security."
 	foodtype = "batch of \"muffins\""
 
 /datum/bounty/item/botany/cannabis_white
 	name = "Lifeweed Leaves"
-	wanted_types = list(/obj/item/food/grown/cannabis/white)
+	wanted_types = list(/obj/item/food/grown/cannabis/white = TRUE)
 	multiplier = 6
 	bonus_desc = "Do not mention this shipment to security."
 	foodtype = "\"meal\""
 
 /datum/bounty/item/botany/wheat
 	name = "Wheat Grains"
-	wanted_types = list(/obj/item/food/grown/wheat)
+	wanted_types = list(/obj/item/food/grown/wheat = TRUE)
 
 /datum/bounty/item/botany/rice
 	name = "Rice Grains"
-	wanted_types = list(/obj/item/food/grown/rice)
+	wanted_types = list(/obj/item/food/grown/rice = TRUE)
 
 /datum/bounty/item/botany/chili
 	name = "Chili Peppers"
-	wanted_types = list(/obj/item/food/grown/chili)
+	wanted_types = list(/obj/item/food/grown/chili = TRUE)
 
 /datum/bounty/item/botany/ice_chili
 	name = "Chilly Peppers"
-	wanted_types = list(/obj/item/food/grown/icepepper)
+	wanted_types = list(/obj/item/food/grown/icepepper = TRUE)
 	multiplier = 2
 
 /datum/bounty/item/botany/ghost_chili
 	name = "Ghost Chili Peppers"
-	wanted_types = list(/obj/item/food/grown/ghost_chili)
+	wanted_types = list(/obj/item/food/grown/ghost_chili = TRUE)
 	multiplier = 2
 
 /datum/bounty/item/botany/citrus_lime
 	name = "Limes"
-	wanted_types = list(/obj/item/food/grown/citrus/lime)
+	wanted_types = list(/obj/item/food/grown/citrus/lime = TRUE)
 	foodtype = "sorbet"
 
 /datum/bounty/item/botany/citrus_lemon
 	name = "Lemons"
-	wanted_types = list(/obj/item/food/grown/citrus/lemon)
+	wanted_types = list(/obj/item/food/grown/citrus/lemon = TRUE)
 	foodtype = "sorbet"
 
 /datum/bounty/item/botany/citrus_oranges
 	name = "Oranges"
-	wanted_types = list(/obj/item/food/grown/citrus/orange)
+	wanted_types = list(/obj/item/food/grown/citrus/orange = TRUE)
 	bonus_desc = "Do not ship lemons or limes." //I vanted orahnge!
 	foodtype = "sorbet"
 
 /datum/bounty/item/botany/eggplant
 	name = "Eggplants"
-	wanted_types = list(/obj/item/food/grown/eggplant)
+	wanted_types = list(/obj/item/food/grown/eggplant = TRUE)
 	bonus_desc = "Not to be confused with egg-plants."
 
 /datum/bounty/item/botany/eggplant_eggy
 	name = "Egg-plants"
-	wanted_types = list(/obj/item/food/grown/shell/eggy)
+	wanted_types = list(/obj/item/food/grown/shell/eggy = TRUE)
 	bonus_desc = "Not to be confused with eggplants."
 	multiplier = 2
 
 /datum/bounty/item/botany/watermelon
 	name = "Watermelons"
-	wanted_types = list(/obj/item/food/grown/watermelon)
+	wanted_types = list(/obj/item/food/grown/watermelon = TRUE)
 	foodtype = "dessert"
 
 /datum/bounty/item/botany/glowshroom
 	name = "Glowshrooms"
-	wanted_types = list(/obj/item/food/grown/mushroom/glowshroom)
-	exclude_types = list(/obj/item/food/grown/mushroom/glowshroom/glowcap, /obj/item/food/grown/mushroom/glowshroom/shadowshroom)
+	wanted_types = list(
+		/obj/item/food/grown/mushroom/glowshroom = TRUE,
+		/obj/item/food/grown/mushroom/glowshroom/glowcap = FALSE,
+		/obj/item/food/grown/mushroom/glowshroom/shadowshroom = FALSE,
+	)
 	foodtype = "omelet"
 
 /datum/bounty/item/botany/glowshroom_cap
 	name = "Glowcaps"
-	wanted_types = list(/obj/item/food/grown/mushroom/glowshroom/glowcap)
+	wanted_types = list(/obj/item/food/grown/mushroom/glowshroom/glowcap = TRUE)
 	multiplier = 2
 	foodtype = "omelet"
 
 /datum/bounty/item/botany/glowshroom_shadow
 	name = "Shadowshrooms"
-	wanted_types = list(/obj/item/food/grown/mushroom/glowshroom/shadowshroom)
+	wanted_types = list(/obj/item/food/grown/mushroom/glowshroom/shadowshroom = TRUE)
 	multiplier = 2
 	foodtype = "omelet"
 
 /datum/bounty/item/botany/pineapples
 	name = "Pineapples"
-	wanted_types = list(/obj/item/food/grown/pineapple)
+	wanted_types = list(/obj/item/food/grown/pineapple = TRUE)
 	bonus_desc = "Not for human consumption."
 	foodtype = "ashtray"
 
 /datum/bounty/item/botany/tomato
 	name = "Tomatoes"
-	wanted_types = list(/obj/item/food/grown/tomato)
-	exclude_types = list(/obj/item/food/grown/tomato/blue)
+	wanted_types = list(
+		/obj/item/food/grown/tomato = TRUE,
+		/obj/item/food/grown/tomato/blue = FALSE,
+	)
 
 /datum/bounty/item/botany/oatz
 	name = "Oats"
-	wanted_types = list(/obj/item/food/grown/oat)
+	wanted_types = list(/obj/item/food/grown/oat = TRUE)
 	multiplier = 2
 	foodtype = "batch of oatmeal"
 	bonus_desc = "Squats and oats. We're all out of oats."
@@ -146,7 +153,7 @@
 /datum/bounty/item/botany/bonfire
 	name = "Lit Bonfire"
 	description = "Space heaters are malfunctioning and the cargo crew of Central Command is starting to feel cold. Grow some logs and Ship a lit bonfire to warm them up."
-	wanted_types = list(/obj/structure/bonfire)
+	wanted_types = list(/obj/structure/bonfire = TRUE)
 
 /datum/bounty/item/botany/bonfire/applies_to(obj/O)
 	if(!..())

--- a/code/modules/cargo/bounties/chef.dm
+++ b/code/modules/cargo/bounties/chef.dm
@@ -2,143 +2,152 @@
 	name = "Birthday Cake"
 	description = "Nanotrasen's birthday is coming up! Ship them a birthday cake to celebrate!"
 	reward = CARGO_CRATE_VALUE * 8
-	wanted_types = list(/obj/item/food/cake/birthday, /obj/item/food/cakeslice/birthday)
+	wanted_types = list(
+		/obj/item/food/cake/birthday = TRUE,
+		/obj/item/food/cakeslice/birthday = TRUE
+	)
 
 /datum/bounty/item/chef/soup
 	name = "Soup"
 	description = "To quell the homeless uprising, Nanotrasen will be serving soup to all underpaid workers. Ship any type of soup."
 	reward = CARGO_CRATE_VALUE * 6
 	required_count = 3
-	wanted_types = list(/obj/item/food/soup)
+	wanted_types = list(/obj/item/food/soup = TRUE)
 
 /datum/bounty/item/chef/popcorn
 	name = "Popcorn Bags"
 	description = "Upper management wants to host a movie night. Ship bags of popcorn for the occasion."
 	reward = CARGO_CRATE_VALUE * 6
 	required_count = 3
-	wanted_types = list(/obj/item/food/popcorn)
+	wanted_types = list(/obj/item/food/popcorn = TRUE)
 
 /datum/bounty/item/chef/onionrings
 	name = "Onion Rings"
 	description = "Nanotrasen is remembering Saturn day. Ship onion rings to show the station's support."
 	reward = CARGO_CRATE_VALUE * 6
 	required_count = 3
-	wanted_types = list(/obj/item/food/onionrings)
+	wanted_types = list(/obj/item/food/onionrings = TRUE)
 
 /datum/bounty/item/chef/icecreamsandwich
 	name = "Ice Cream Sandwiches"
 	description = "Upper management has been screaming non-stop for ice cream. Please send some."
 	reward = CARGO_CRATE_VALUE * 8
 	required_count = 3
-	wanted_types = list(/obj/item/food/icecreamsandwich)
+	wanted_types = list(/obj/item/food/icecreamsandwich = TRUE)
 
 /datum/bounty/item/chef/strawberryicecreamsandwich
 	name = " Strawberry Ice Cream Sandwiches"
 	description = "Upper management has been screaming non-stop for more flavourful ice cream. Please send some."
 	reward = CARGO_CRATE_VALUE * 10
 	required_count = 3
-	wanted_types = list(/obj/item/food/strawberryicecreamsandwich)
+	wanted_types = list(/obj/item/food/strawberryicecreamsandwich = TRUE)
 
 /datum/bounty/item/chef/bread
 	name = "Bread"
 	description = "Problems with central planning have led to bread prices skyrocketing. Ship some bread to ease tensions."
 	reward = CARGO_CRATE_VALUE * 2
-	wanted_types = list(/obj/item/food/bread, /obj/item/food/breadslice, /obj/item/food/bun, /obj/item/food/pizzabread, /obj/item/food/rawpastrybase)
+	wanted_types = list(
+		/obj/item/food/bread = TRUE,
+		/obj/item/food/breadslice = TRUE,
+		/obj/item/food/bun = TRUE,
+		/obj/item/food/pizzabread = TRUE,
+		/obj/item/food/rawpastrybase = TRUE,
+	)
 
 /datum/bounty/item/chef/pie
 	name = "Pie"
 	description = "3.14159? No! CentCom management wants edible pie! Ship a whole one."
 	reward = 3142 //Screw it I'll do this one by hand
-	wanted_types = list(/obj/item/food/pie)
+	wanted_types = list(/obj/item/food/pie = TRUE)
 
 /datum/bounty/item/chef/salad
 	name = "Salad or Rice Bowls"
 	description = "CentCom management is going on a health binge. Your order is to ship salad or rice bowls."
 	reward = CARGO_CRATE_VALUE * 6
 	required_count = 3
-	wanted_types = list(/obj/item/food/salad)
+	wanted_types = list(/obj/item/food/salad = TRUE)
 
 /datum/bounty/item/chef/carrotfries
 	name = "Carrot Fries"
 	description = "Night sight can mean life or death! A shipment of carrot fries is the order."
 	reward = CARGO_CRATE_VALUE * 7
 	required_count = 3
-	wanted_types = list(/obj/item/food/carrotfries)
+	wanted_types = list(/obj/item/food/carrotfries = TRUE)
 
 /datum/bounty/item/chef/superbite
 	name = "Super Bite Burger"
 	description = "Commander Tubbs thinks he can set a competitive eating world record. All he needs is a super bite burger shipped to him."
 	reward = CARGO_CRATE_VALUE * 24
-	wanted_types = list(/obj/item/food/burger/superbite)
+	wanted_types = list(/obj/item/food/burger/superbite = TRUE)
 
 /datum/bounty/item/chef/poppypretzel
 	name = "Poppy Pretzel"
 	description = "Central Command needs a reason to fire their HR head. Send over a poppy pretzel to force a failed drug test."
 	reward = CARGO_CRATE_VALUE * 6
-	wanted_types = list(/obj/item/food/poppypretzel)
+	wanted_types = list(/obj/item/food/poppypretzel = TRUE)
 
 /datum/bounty/item/chef/cubancarp
 	name = "Cuban Carp"
 	description = "To celebrate the birth of Castro XXVII, ship one cuban carp to CentCom."
 	reward = CARGO_CRATE_VALUE * 16
-	wanted_types = list(/obj/item/food/cubancarp)
+	wanted_types = list(/obj/item/food/cubancarp = TRUE)
 
 /datum/bounty/item/chef/hotdog
 	name = "Hot Dog"
 	description = "Nanotrasen is conducting taste tests to determine the best hot dog recipe. Ship your station's version to participate."
 	reward = CARGO_CRATE_VALUE * 16
-	wanted_types = list(/obj/item/food/hotdog)
+	wanted_types = list(/obj/item/food/hotdog = TRUE)
 
 /datum/bounty/item/chef/eggplantparm
 	name = "Eggplant Parmigianas"
 	description = "A famous singer will be arriving at CentCom, and their contract demands that they only be served Eggplant Parmigiana. Ship some, please!"
 	reward = CARGO_CRATE_VALUE * 7
 	required_count = 3
-	wanted_types = list(/obj/item/food/eggplantparm)
+	wanted_types = list(/obj/item/food/eggplantparm = TRUE)
 
 /datum/bounty/item/chef/muffin
 	name = "Muffins"
 	description = "The Muffin Man is visiting CentCom, but he's forgotten his muffins! Your order is to rectify this."
 	reward = CARGO_CRATE_VALUE * 6
 	required_count = 3
-	wanted_types = list(/obj/item/food/muffin)
+	wanted_types = list(/obj/item/food/muffin = TRUE)
 
 /datum/bounty/item/chef/chawanmushi
 	name = "Chawanmushi"
 	description = "Nanotrasen wants to improve relations with its sister company, Japanotrasen. Ship Chawanmushi immediately."
 	reward = CARGO_CRATE_VALUE * 16
-	wanted_types = list(/obj/item/food/chawanmushi)
+	wanted_types = list(/obj/item/food/chawanmushi = TRUE)
 
 /datum/bounty/item/chef/kebab
 	name = "Kebabs"
 	description = "Remove all kebab from station you are best food. Ship to CentCom to remove from the premises."
 	reward = CARGO_CRATE_VALUE * 7
 	required_count = 3
-	wanted_types = list(/obj/item/food/kebab)
+	wanted_types = list(/obj/item/food/kebab = TRUE)
 
 /datum/bounty/item/chef/soylentgreen
 	name = "Soylent Green"
 	description = "CentCom has heard wonderful things about the product 'Soylent Green', and would love to try some. If you endulge them, expect a pleasant bonus."
 	reward = CARGO_CRATE_VALUE * 10
-	wanted_types = list(/obj/item/food/soylentgreen)
+	wanted_types = list(/obj/item/food/soylentgreen = TRUE)
 
 /datum/bounty/item/chef/pancakes
 	name = "Pancakes"
 	description = "Here at Nanotrasen we consider employees to be family. And you know what families love? Pancakes. Ship a baker's dozen."
 	reward = CARGO_CRATE_VALUE * 10
 	required_count = 13
-	wanted_types = list(/obj/item/food/pancakes)
+	wanted_types = list(/obj/item/food/pancakes = TRUE)
 
 /datum/bounty/item/chef/nuggies
 	name = "Chicken Nuggets"
 	description = "The vice president's son won't shut up about chicken nuggies. Would you mind shipping some?"
 	reward = CARGO_CRATE_VALUE * 8
 	required_count = 6
-	wanted_types = list(/obj/item/food/nugget)
+	wanted_types = list(/obj/item/food/nugget = TRUE)
 
 /datum/bounty/item/chef/corgifarming //Butchering is a chef's job.
 	name = "Corgi Hides"
 	description = "Admiral Weinstein's space yacht needs new upholstery. A dozen Corgi furs should do just fine."
 	reward = CARGO_CRATE_VALUE * 60 //that's a lot of dead dogs
 	required_count = 12
-	wanted_types = list(/obj/item/stack/sheet/animalhide/corgi)
+	wanted_types = list(/obj/item/stack/sheet/animalhide/corgi = TRUE)

--- a/code/modules/cargo/bounties/engineering.dm
+++ b/code/modules/cargo/bounties/engineering.dm
@@ -2,7 +2,7 @@
 	name = "Full Tank of Pluoxium"
 	description = "CentCom RnD is researching extra compact internals. Ship us a tank full of Pluoxium and you'll be compensated."
 	reward = CARGO_CRATE_VALUE * 15
-	wanted_types = list(/obj/item/tank)
+	wanted_types = list(/obj/item/tank = TRUE)
 	var/moles_required = 20 // A full tank is 28 moles, but CentCom ignores that fact.
 	var/gas_type = /datum/gas/pluoxium
 
@@ -44,10 +44,10 @@
 	name = "Emitter"
 	description = "We think there may be a defect in your station's emitter designs, based on the sheer number of delaminations your sector seems to see. Ship us one of yours."
 	reward = CARGO_CRATE_VALUE * 5
-	wanted_types = list(/obj/machinery/power/emitter)
+	wanted_types = list(/obj/machinery/power/emitter = TRUE)
 
 /datum/bounty/item/engineering/hydro_tray
 	name = "Hydroponics Tray"
 	description = "The lab technicians are trying to figure out how to lower the power drain of hydroponics trays, but we fried our last one. Mind building one for us?"
 	reward = CARGO_CRATE_VALUE * 4
-	wanted_types = list(/obj/machinery/hydroponics/constructable)
+	wanted_types = list(/obj/machinery/hydroponics/constructable = TRUE)

--- a/code/modules/cargo/bounties/item.dm
+++ b/code/modules/cargo/bounties/item.dm
@@ -3,26 +3,14 @@
 	var/required_count = 1
 	///How many items have been shipped for the bounty so far
 	var/shipped_count = 0
-	///Types accepted by the bounty (including all subtypes, unless include_subtypes is set to FALSE)
+	///Types accepted|denied by the bounty. (including all subtypes, unless include_subtypes is set to FALSE)
 	var/list/wanted_types
 	///Set to FALSE to make the bounty not accept subtypes of the wanted_types
 	var/include_subtypes = TRUE
-	///Types that should not be accepted by the bounty, also excluding all their subtypes
-	var/list/exclude_types
-	///Individual types that should be accepted even if their supertypes are excluded (yes, apparently this is necessary)
-	var/list/special_include_types
 
 /datum/bounty/item/New()
 	..()
-	wanted_types = typecacheof(wanted_types, only_root_path = !include_subtypes)
-	if (exclude_types)
-		exclude_types = string_assoc_list(typecacheof(exclude_types))
-		for (var/e_type in exclude_types)
-			wanted_types[e_type] = FALSE
-	if (special_include_types)
-		for (var/i_type in special_include_types)
-			wanted_types[i_type] = TRUE
-	wanted_types = string_assoc_list(wanted_types)
+	wanted_types = string_assoc_list(zebra_typecacheof(wanted_types, only_root_path = !include_subtypes))
 
 /datum/bounty/item/can_claim()
 	return ..() && shipped_count >= required_count

--- a/code/modules/cargo/bounties/mech.dm
+++ b/code/modules/cargo/bounties/mech.dm
@@ -13,24 +13,24 @@
 /datum/bounty/item/mech/ripleymk2
 	name = "APLU MK-II \"Ripley\""
 	reward = CARGO_CRATE_VALUE * 26
-	wanted_types = list(/obj/vehicle/sealed/mecha/working/ripley/mk2)
+	wanted_types = list(/obj/vehicle/sealed/mecha/working/ripley/mk2 = TRUE)
 
 /datum/bounty/item/mech/clarke
 	name = "Clarke"
 	reward = CARGO_CRATE_VALUE * 32
-	wanted_types = list(/obj/vehicle/sealed/mecha/working/clarke)
+	wanted_types = list(/obj/vehicle/sealed/mecha/working/clarke = TRUE)
 
 /datum/bounty/item/mech/odysseus
 	name = "Odysseus"
 	reward = CARGO_CRATE_VALUE * 22
-	wanted_types = list(/obj/vehicle/sealed/mecha/medical/odysseus)
+	wanted_types = list(/obj/vehicle/sealed/mecha/medical/odysseus = TRUE)
 
 /datum/bounty/item/mech/gygax
 	name = "Gygax"
 	reward = CARGO_CRATE_VALUE * 56
-	wanted_types = list(/obj/vehicle/sealed/mecha/combat/gygax)
+	wanted_types = list(/obj/vehicle/sealed/mecha/combat/gygax = TRUE)
 
 /datum/bounty/item/mech/durand
 	name = "Durand"
 	reward = CARGO_CRATE_VALUE * 40
-	wanted_types = list(/obj/vehicle/sealed/mecha/combat/durand)
+	wanted_types = list(/obj/vehicle/sealed/mecha/combat/durand = TRUE)

--- a/code/modules/cargo/bounties/medical.dm
+++ b/code/modules/cargo/bounties/medical.dm
@@ -2,90 +2,103 @@
 	name = "Heart"
 	description = "Commander Johnson is in critical condition after suffering yet another heart attack. Doctors say he needs a new heart fast. Ship one, pronto! We'll take a better cybernetic one, if need be."
 	reward = CARGO_CRATE_VALUE * 6
-	wanted_types = list(/obj/item/organ/heart)
-	exclude_types = list(/obj/item/organ/heart/cybernetic)//Excluding tier 1s, no cheesing.
-	special_include_types = list(/obj/item/organ/heart/cybernetic/tier2, /obj/item/organ/heart/cybernetic/tier3)
+	wanted_types = list(
+		/obj/item/organ/heart = TRUE,
+		/obj/item/organ/heart/cybernetic = FALSE,
+		/obj/item/organ/heart/cybernetic/tier2 = TRUE,
+		/obj/item/organ/heart/cybernetic/tier3 = TRUE,
+	)
 
 /datum/bounty/item/medical/lung
 	name = "Lungs"
 	description = "A recent explosion at Central Command has left multiple staff with punctured lungs. Ship spare lungs to be rewarded.  We'll take a better cybernetic one, if need be."
 	reward = CARGO_CRATE_VALUE * 20
 	required_count = 3
-	wanted_types = list(/obj/item/organ/lungs)
-	exclude_types = list(/obj/item/organ/lungs/cybernetic)//As above, for all printable organs.
-	special_include_types = list(/obj/item/organ/lungs/cybernetic/tier2, /obj/item/organ/lungs/cybernetic/tier3)
+	wanted_types = list(
+		/obj/item/organ/lungs = TRUE,
+		/obj/item/organ/lungs/cybernetic = FALSE,
+		/obj/item/organ/lungs/cybernetic/tier2 = TRUE,
+		/obj/item/organ/lungs/cybernetic/tier3 = TRUE,
+	)
 
 /datum/bounty/item/medical/appendix
 	name = "Appendix"
 	description = "Chef Gibb of Central Command wants to prepare a meal using a very special delicacy: an appendix. If you ship one, he'll pay.  We'll take a better cybernetic one, if need be."
 	reward = CARGO_CRATE_VALUE * 10 //there are no synthetic appendixes
-	wanted_types = list(/obj/item/organ/appendix)
+	wanted_types = list(/obj/item/organ/appendix = TRUE)
 
 /datum/bounty/item/medical/ears
 	name = "Ears"
 	description = "Multiple staff at Station 12 have been left deaf due to unauthorized clowning. Ship them new ears. "
 	reward = CARGO_CRATE_VALUE * 10
 	required_count = 3
-	wanted_types = list(/obj/item/organ/ears)
-	exclude_types = list(/obj/item/organ/ears/cybernetic)
-	special_include_types = list(/obj/item/organ/ears/cybernetic/upgraded)
+	wanted_types = list(
+		/obj/item/organ/ears = TRUE,
+		/obj/item/organ/ears/cybernetic = FALSE,
+		/obj/item/organ/ears/cybernetic/upgraded = TRUE,
+	)
 
 /datum/bounty/item/medical/liver
 	name = "Livers"
 	description = "Multiple high-ranking CentCom diplomats have been hospitalized with liver failure after a recent meeting with Third Soviet Union ambassadors. Help us out, will you? We'll take better cybernetic ones, if need be."
 	reward = CARGO_CRATE_VALUE * 10
 	required_count = 3
-	wanted_types = list(/obj/item/organ/liver)
-	exclude_types = list(/obj/item/organ/liver/cybernetic)
-	special_include_types = list(/obj/item/organ/liver/cybernetic/tier2, /obj/item/organ/liver/cybernetic/tier3)
+	wanted_types = list(
+		/obj/item/organ/liver = TRUE,
+		/obj/item/organ/liver/cybernetic = FALSE,
+		/obj/item/organ/liver/cybernetic/tier2 = TRUE,
+		/obj/item/organ/liver/cybernetic/tier3 = TRUE,
+	)
 
 /datum/bounty/item/medical/eye
 	name = "Organic Eyes"
 	description = "Station 5's Research Director Willem is requesting a few pairs of non-robotic eyes. Don't ask questions, just ship them."
 	reward = CARGO_CRATE_VALUE * 20
 	required_count = 3
-	wanted_types = list(/obj/item/organ/eyes)
-	exclude_types = list(/obj/item/organ/eyes/robotic)
+	wanted_types = list(
+		/obj/item/organ/eyes = TRUE,
+		/obj/item/organ/eyes/robotic = FALSE,
+	)
 
 /datum/bounty/item/medical/tongue
 	name = "Tongues"
 	description = "A recent attack by Mime extremists has left staff at Station 23 speechless. Ship some spare tongues."
 	reward = CARGO_CRATE_VALUE * 20
 	required_count = 3
-	wanted_types = list(/obj/item/organ/tongue)
+	wanted_types = list(/obj/item/organ/tongue = TRUE)
 
 /datum/bounty/item/medical/lizard_tail
 	name = "Lizard Tail"
 	description = "The Wizard Federation has made off with Nanotrasen's supply of lizard tails. While CentCom is dealing with the wizards, can the station spare a tail of their own?"
 	reward = CARGO_CRATE_VALUE * 6
-	wanted_types = list(/obj/item/organ/tail/lizard)
+	wanted_types = list(/obj/item/organ/tail/lizard = TRUE)
 
 /datum/bounty/item/medical/cat_tail
 	name = "Cat Tail"
 	description = "Central Command has run out of heavy duty pipe cleaners. Can you ship over a cat tail to help us out?"
 	reward = CARGO_CRATE_VALUE * 6
-	wanted_types = list(/obj/item/organ/tail/cat)
+	wanted_types = list(/obj/item/organ/tail/cat = TRUE)
 
 /datum/bounty/item/medical/chainsaw
 	name = "Chainsaw"
 	description = "A CMO at CentCom is having trouble operating on golems. She requests one chainsaw, please."
 	reward = CARGO_CRATE_VALUE * 5
-	wanted_types = list(/obj/item/chainsaw)
+	wanted_types = list(/obj/item/chainsaw = TRUE)
 
 /datum/bounty/item/medical/tail_whip //Like the cat tail bounties, with more processing.
 	name = "Nine Tails whip"
 	description = "Commander Jackson is looking for a fine addition to her exotic weapons collection. She will reward you handsomely for either a Cat or Liz o' Nine Tails."
 	reward = CARGO_CRATE_VALUE * 8
-	wanted_types = list(/obj/item/melee/chainofcommand/tailwhip)
+	wanted_types = list(/obj/item/melee/chainofcommand/tailwhip = TRUE)
 
 /datum/bounty/item/medical/surgerycomp
 	name = "Surgery Computer"
 	description = "After another freak bombing incident at our annual cheesefest at centcom, we have a massive stack of injured crew on our end. Please send us a fresh surgery computer, if at all possible."
 	reward = CARGO_CRATE_VALUE * 12
-	wanted_types = list(/obj/machinery/computer/operating)
+	wanted_types = list(/obj/machinery/computer/operating = TRUE)
 
 /datum/bounty/item/medical/surgerytable
 	name = "Operating Table"
 	description = "After a recent influx of infected crew members recently, we've seen that masks just aren't cutting it alone. Silver Operating tables might just do the trick though, send us one to use."
 	reward = CARGO_CRATE_VALUE * 6
-	wanted_types = list(/obj/structure/table/optable)
+	wanted_types = list(/obj/structure/table/optable = TRUE)

--- a/code/modules/cargo/bounties/mining.dm
+++ b/code/modules/cargo/bounties/mining.dm
@@ -3,26 +3,26 @@
 	description = "Admiral Pavlov has gone on hunger strike ever since the canteen started serving only monkey and monkey byproducts. She is demanding lava-cooked Goliath steaks."
 	reward = CARGO_CRATE_VALUE * 10
 	required_count = 3
-	wanted_types = list(/obj/item/food/meat/steak/goliath)
+	wanted_types = list(/obj/item/food/meat/steak/goliath = TRUE)
 
 /datum/bounty/item/mining/goliath_boat
 	name = "Goliath Hide Boat"
 	description = "Commander Menkov wants to participate in the annual Lavaland Regatta. He is asking your shipwrights to build the swiftest boat known to man."
 	reward = CARGO_CRATE_VALUE * 20
-	wanted_types = list(/obj/vehicle/ridden/lavaboat)
+	wanted_types = list(/obj/vehicle/ridden/lavaboat = TRUE)
 
 /datum/bounty/item/mining/bone_oar
 	name = "Bone Oars"
 	description = "Commander Menkov requires oars to participate in the annual Lavaland Regatta. Ship a pair over."
 	reward = CARGO_CRATE_VALUE * 8
 	required_count = 2
-	wanted_types = list(/obj/item/oar)
+	wanted_types = list(/obj/item/oar = TRUE)
 
 /datum/bounty/item/mining/bone_axe
 	name = "Bone Axe"
 	description = "Station 12 has had their fire axes stolen by marauding clowns. Ship them a bone axe as a replacement."
 	reward = CARGO_CRATE_VALUE * 15
-	wanted_types = list(/obj/item/fireaxe/boneaxe)
+	wanted_types = list(/obj/item/fireaxe/boneaxe = TRUE)
 
 /datum/bounty/item/mining/bone_bow
 	name = "Bone Bow"
@@ -34,44 +34,45 @@
 	name = "Bone Armor"
 	description = "Station 14 has volunteered their lizard crew for ballistic armor testing. Ship over some bone armor."
 	reward = CARGO_CRATE_VALUE * 10
-	wanted_types = list(/obj/item/clothing/suit/armor/bone)
+	wanted_types = list(/obj/item/clothing/suit/armor/bone = TRUE)
 
 /datum/bounty/item/mining/skull_helmet
 	name = "Skull Helmet"
 	description = "Station 42's Head of Security has her birthday tomorrow! We want to suprise her with a fashionable skull helmet."
 	reward = CARGO_CRATE_VALUE * 8
-	wanted_types = list(/obj/item/clothing/head/helmet/skull)
+	wanted_types = list(/obj/item/clothing/head/helmet/skull = TRUE)
 
 /datum/bounty/item/mining/bone_talisman
 	name = "Bone Talismans"
 	description = "Station 14's Research Director claims that pagan bone talismans protect their wearer. Ship them a few so they can start testing."
 	reward = CARGO_CRATE_VALUE * 15
 	required_count = 3
-	wanted_types = list(/obj/item/clothing/accessory/talisman)
+	wanted_types = list(/obj/item/clothing/accessory/talisman = TRUE)
 
 /datum/bounty/item/mining/bone_dagger
 	name = "Bone Daggers"
 	description = "Central Command's canteen is undergoing budget cuts. Ship over some bone daggers so our Chef can keep working."
 	reward = CARGO_CRATE_VALUE * 10
 	required_count = 3
-	wanted_types = list(/obj/item/kitchen/knife/combat/bone)
+//	wanted_types = list(/obj/item/knife/combat/bone = TRUE) REQUIRES TG PR
+	wanted_types = list(/obj/item/kitchen/knife/combat/bone = TRUE) // REQUIRES TG PR
 
 /datum/bounty/item/mining/polypore_mushroom
 	name = "Mushroom Bowl"
 	description = "Lieutenant Jeb dropped his favorite mushroom bowl. Cheer him up by shipping a new one, will you?"
 	reward = CARGO_CRATE_VALUE * 15 //5x mushroom shavings
-	wanted_types = list(/obj/item/reagent_containers/glass/bowl/mushroom_bowl)
+	wanted_types = list(/obj/item/reagent_containers/glass/bowl/mushroom_bowl = TRUE)
 
 /datum/bounty/item/mining/inocybe_mushroom
 	name = "Mushroom Caps"
 	description = "Our botanist claims that he can distill tasty liquor from absolutely any plant. Let's see what he'll do with Inocybe mushroom caps."
 	reward = CARGO_CRATE_VALUE * 9
 	required_count = 3
-	wanted_types = list(/obj/item/food/grown/ash_flora/mushroom_cap)
+	wanted_types = list(/obj/item/food/grown/ash_flora/mushroom_cap = TRUE)
 
 /datum/bounty/item/mining/porcini_mushroom
 	name = "Mushroom Leaves"
 	description = "Porcini mushroom leaves are rumored to have healing properties. Our researchers want to put that claim to the test."
 	reward = CARGO_CRATE_VALUE * 9
 	required_count = 3
-	wanted_types = list(/obj/item/food/grown/ash_flora/mushroom_leaf)
+	wanted_types = list(/obj/item/food/grown/ash_flora/mushroom_leaf = TRUE)

--- a/code/modules/cargo/bounties/science.dm
+++ b/code/modules/cargo/bounties/science.dm
@@ -3,7 +3,7 @@
 	name = "E.X.P.E.R.I-MENTORially Discovered Devices"
 	description = "Psst, hey. Don't tell the assistants, but we're undercutting them on the value of those 'strange objects' they've been finding. Fish one up and send us a discovered one by using the E.X.P.E.R.I-MENTOR."
 	reward = CARGO_CRATE_VALUE * 8
-	wanted_types = list(/obj/item/relic)
+	wanted_types = list(/obj/item/relic = TRUE)
 
 /datum/bounty/item/science/relic/applies_to(obj/O)
 	if(!..())
@@ -17,13 +17,16 @@
 	name = "Reformatted Tech Disk"
 	description = "It turns out the diskettes the BEPIS prints experimental nodes on are extremely space-efficient. Send us one of your spares when you're done with it."
 	reward = CARGO_CRATE_VALUE * 8
-	wanted_types = list(/obj/item/disk/tech_disk/major, /obj/item/disk/tech_disk/spaceloot)
+	wanted_types = list(
+		/obj/item/disk/tech_disk/major = TRUE,
+		/obj/item/disk/tech_disk/spaceloot = TRUE,
+	)
 
 /datum/bounty/item/science/genetics
 	name = "Genetics Disability Mutator"
 	description = "Understanding the humanoid genome is the first step to curing many spaceborn genetic defects, and exceeding our basest limits."
 	reward = CARGO_CRATE_VALUE * 2
-	wanted_types = list(/obj/item/dnainjector)
+	wanted_types = list(/obj/item/dnainjector = TRUE)
 	///What's the instability
 	var/desired_instability = 0
 
@@ -55,21 +58,21 @@
 	description = "Turns out that NTNet wasn't actually a fad afterall, who knew. Ship us some fully constructed tablets and send it turned on."
 	reward = CARGO_CRATE_VALUE * 6
 	required_count = 4
-	wanted_types = list(/obj/item/modular_computer/tablet)
+	wanted_types = list(/obj/item/modular_computer/tablet = TRUE)
 
 /datum/bounty/item/science/NTNet/laptops
 	name = "Modular Laptops"
 	description = "Central command brass need something more powerful than a tablet, but more portable than a console. Help these old fogeys out by shipping us some working laptops. Send it turned on."
 	reward = CARGO_CRATE_VALUE * 3
 	required_count = 2
-	wanted_types = list(/obj/item/modular_computer/laptop)
+	wanted_types = list(/obj/item/modular_computer/laptop = TRUE)
 
 /datum/bounty/item/science/NTNet/console
 	name = "Modular Computer Console"
 	description = "Our big data devision needs more powerful hardware to play 'Outbomb Cuban Pe-', err, to closely monitor threats in your sector. Send us a working modular computer console."
 	reward = CARGO_CRATE_VALUE * 6
 	required_count = 1
-	wanted_types = list(/obj/machinery/modular_computer/console)
+	wanted_types = list(/obj/machinery/modular_computer/console = TRUE)
 
 /datum/bounty/item/science/NTnet/applies_to(obj/O)
 	. = ..()

--- a/code/modules/cargo/bounties/security.dm
+++ b/code/modules/cargo/bounties/security.dm
@@ -3,41 +3,41 @@
 	description = "Nanotrasen military academy is conducting marksmanship exercises. They request that rechargers be shipped."
 	reward = CARGO_CRATE_VALUE * 4
 	required_count = 3
-	wanted_types = list(/obj/machinery/recharger)
+	wanted_types = list(/obj/machinery/recharger = TRUE)
 
 /datum/bounty/item/security/pepperspray
 	name = "Pepperspray"
 	description = "We've been having a bad run of riots on Space Station 76. We could use some new pepperspray cans."
 	reward = CARGO_CRATE_VALUE * 6
 	required_count = 4
-	wanted_types = list(/obj/item/reagent_containers/spray/pepper)
+	wanted_types = list(/obj/item/reagent_containers/spray/pepper = TRUE)
 
 /datum/bounty/item/security/prison_clothes
 	name = "Prison Uniforms"
 	description = "Citygov has been unable to source any new prisoner uniforms, so if you have any spares, we'll take them off your hands."
 	reward = CARGO_CRATE_VALUE * 4
 	required_count = 4
-	wanted_types = list(/obj/item/clothing/under/rank/prisoner)
+	wanted_types = list(/obj/item/clothing/under/rank/prisoner = TRUE)
 
 /datum/bounty/item/security/plates
 	name = "License Plates"
 	description = "As a result of a bad clown car crash, we could use an advance on some of your prisoner's license plates."
 	reward = CARGO_CRATE_VALUE * 2
 	required_count = 10
-	wanted_types = list(/obj/item/stack/license_plates/filled)
+	wanted_types = list(/obj/item/stack/license_plates/filled = TRUE)
 
 /datum/bounty/item/security/earmuffs
 	name = "Earmuffs"
 	description = "Central Command is getting tired of your station's messages. They've ordered that you ship some earmuffs to lessen the annoyance."
 	reward = CARGO_CRATE_VALUE * 2
-	wanted_types = list(/obj/item/clothing/ears/earmuffs)
+	wanted_types = list(/obj/item/clothing/ears/earmuffs = TRUE)
 
 /datum/bounty/item/security/handcuffs
 	name = "Handcuffs"
 	description = "A large influx of escaped convicts have arrived at Central Command. Now is the perfect time to ship out spare handcuffs (or restraints)."
 	reward = CARGO_CRATE_VALUE * 2
 	required_count = 5
-	wanted_types = list(/obj/item/restraints/handcuffs)
+	wanted_types = list(/obj/item/restraints/handcuffs = TRUE)
 
 
 ///Bounties that require you to perform documentation and inspection of your department to send to centcom.
@@ -45,7 +45,8 @@
 	name = "Routine Security Inspection"
 	description = "Perform a routine security inspection using an in-spect scanner on the following general area on station:"
 	required_count = 1
-	wanted_types = list(/obj/item/report)
+//	wanted_types = list(/obj/item/paper/report = TRUE) REQUIRES TG PR
+	wanted_types = list(/obj/item/report = TRUE) // REQUIRES TG PR
 	reward = CARGO_CRATE_VALUE * 5
 	var/area/demanded_area
 

--- a/code/modules/cargo/bounties/slime.dm
+++ b/code/modules/cargo/bounties/slime.dm
@@ -8,32 +8,32 @@
 
 /datum/bounty/item/slime/green
 	name = "Green Slime Extract"
-	wanted_types = list(/obj/item/slime_extract/green)
+	wanted_types = list(/obj/item/slime_extract/green = TRUE)
 
 /datum/bounty/item/slime/pink
 	name = "Pink Slime Extract"
-	wanted_types = list(/obj/item/slime_extract/pink)
+	wanted_types = list(/obj/item/slime_extract/pink = TRUE)
 
 /datum/bounty/item/slime/gold
 	name = "Gold Slime Extract"
-	wanted_types = list(/obj/item/slime_extract/gold)
+	wanted_types = list(/obj/item/slime_extract/gold = TRUE)
 
 /datum/bounty/item/slime/oil
 	name = "Oil Slime Extract"
-	wanted_types = list(/obj/item/slime_extract/oil)
+	wanted_types = list(/obj/item/slime_extract/oil = TRUE)
 
 /datum/bounty/item/slime/black
 	name = "Black Slime Extract"
-	wanted_types = list(/obj/item/slime_extract/black)
+	wanted_types = list(/obj/item/slime_extract/black = TRUE)
 
 /datum/bounty/item/slime/lightpink
 	name = "Light Pink Slime Extract"
-	wanted_types = list(/obj/item/slime_extract/lightpink)
+	wanted_types = list(/obj/item/slime_extract/lightpink = TRUE)
 
 /datum/bounty/item/slime/adamantine
 	name = "Adamantine Slime Extract"
-	wanted_types = list(/obj/item/slime_extract/adamantine)
+	wanted_types = list(/obj/item/slime_extract/adamantine = TRUE)
 
 /datum/bounty/item/slime/rainbow
 	name = "Rainbow Slime Extract"
-	wanted_types = list(/obj/item/slime_extract/rainbow)
+	wanted_types = list(/obj/item/slime_extract/rainbow = TRUE)

--- a/code/modules/cargo/bounties/special.dm
+++ b/code/modules/cargo/bounties/special.dm
@@ -3,13 +3,23 @@
 	description = "Nanotrasen is interested in studying Xenomorph biology. Ship a set of organs to be thoroughly compensated."
 	reward = CARGO_CRATE_VALUE * 50
 	required_count = 3
-	wanted_types = list(/obj/item/organ/brain/alien, /obj/item/organ/alien, /obj/item/organ/body_egg/alien_embryo, /obj/item/organ/liver/alien, /obj/item/organ/tongue/alien, /obj/item/organ/eyes/night_vision/alien)
+	wanted_types = list(
+		/obj/item/organ/brain/alien = TRUE,
+		/obj/item/organ/alien = TRUE,
+		/obj/item/organ/body_egg/alien_embryo = TRUE,
+		/obj/item/organ/liver/alien = TRUE,
+		/obj/item/organ/tongue/alien = TRUE,
+		/obj/item/organ/eyes/night_vision/alien = TRUE,
+	)
 
 /datum/bounty/item/syndicate_documents
 	name = "Syndicate Documents"
 	description = "Intel regarding the syndicate is highly prized at CentCom. If you find syndicate documents, ship them. You could save lives."
 	reward = CARGO_CRATE_VALUE * 30
-	wanted_types = list(/obj/item/documents/syndicate, /obj/item/documents/photocopy)
+	wanted_types = list(
+		/obj/item/documents/syndicate = TRUE,
+		/obj/item/documents/photocopy = TRUE,
+	)
 
 /datum/bounty/item/syndicate_documents/applies_to(obj/O)
 	if(!..())
@@ -24,11 +34,11 @@
 	description = "Nanotrasen's anomalous materials division is in desparate need for Adamantine. Send them a large shipment and we'll make it worth your while."
 	reward = CARGO_CRATE_VALUE * 70
 	required_count = 10
-	wanted_types = list(/obj/item/stack/sheet/mineral/adamantine)
+	wanted_types = list(/obj/item/stack/sheet/mineral/adamantine = TRUE)
 
 /datum/bounty/item/trash
 	name = "Trash"
 	description = "Recently a group of janitors have run out of trash to clean up, without any trash CentCom wants to fire them to cut costs. Send a shipment of trash to keep them employed, and they'll give you a small compensation."
 	reward = CARGO_CRATE_VALUE * 2
 	required_count = 10
-	wanted_types = list(/obj/item/trash)
+	wanted_types = list(/obj/item/trash = TRUE)

--- a/code/modules/cargo/exports.dm
+++ b/code/modules/cargo/exports.dm
@@ -81,7 +81,7 @@ Then the player gets the profit from selling his own wasted time.
 	..()
 	SSprocessing.processing += src
 	init_cost = cost
-	export_types = typecacheof(export_types, FALSE, !include_subtypes)
+	export_types = typecacheof(export_types, only_root_path = !include_subtypes, ignore_root_path = FALSE)
 	exclude_types = typecacheof(exclude_types)
 
 /datum/export/Destroy()

--- a/code/modules/events/anomaly.dm
+++ b/code/modules/events/anomaly.dm
@@ -24,8 +24,8 @@
 		/area/holodeck,
 		/area/shuttle,
 		/area/maintenance,
-		/area/science/test_area)
-		)
+		/area/science/test_area,
+	))
 
 		//Subtypes from the above that actually should explode.
 		var/list/unsafe_area_subtypes = typecacheof(list(/area/engine/break_room))

--- a/code/modules/events/sentience.dm
+++ b/code/modules/events/sentience.dm
@@ -13,7 +13,7 @@ GLOBAL_LIST_INIT(high_priority_sentience, typecacheof(list(
 	/mob/living/simple_animal/hostile/retaliate/poison/snake,
 	/mob/living/simple_animal/hostile/retaliate/goose/vomit,
 	/mob/living/simple_animal/bot/mulebot,
-	/mob/living/simple_animal/bot/secbot/beepsky
+	/mob/living/simple_animal/bot/secbot/beepsky,
 )))
 
 /datum/round_event_control/sentience

--- a/code/modules/events/stray_cargo.dm
+++ b/code/modules/events/stray_cargo.dm
@@ -70,9 +70,10 @@
 		var/list/safe_area_types = typecacheof(list(
 		/area/ai_monitored/turret_protected/ai,
 		/area/ai_monitored/turret_protected/ai_upload,
-		/area/engine,
-		/area/shuttle)
-		)
+//		/area/engineering, REQUIRES TG PR
+		/area/engine, // REQUIRES TG PR
+		/area/shuttle,
+	))
 
 		///Subtypes from the above that actually should explode.
 		var/list/unsafe_area_subtypes = typecacheof(list(/area/engine/break_room))

--- a/code/modules/hydroponics/grown/towercap.dm
+++ b/code/modules/hydroponics/grown/towercap.dm
@@ -47,11 +47,14 @@
 	attack_verb_simple = list("bash", "batter", "bludgeon", "whack")
 	var/plank_type = /obj/item/stack/sheet/mineral/wood
 	var/plank_name = "wooden planks"
-	var/static/list/accepted = typecacheof(list(/obj/item/food/grown/tobacco,
-	/obj/item/food/grown/tea,
-	/obj/item/food/grown/ambrosia/vulgaris,
-	/obj/item/food/grown/ambrosia/deus,
-	/obj/item/food/grown/wheat))
+	var/static/list/accepted = typecacheof(list(
+		/obj/item/food/grown/tobacco,
+		/obj/item/food/grown/tea,
+//		/obj/item/food/grown/ash_flora/mushroom_leaf, REQUIRES TG PR
+		/obj/item/food/grown/ambrosia/vulgaris,
+		/obj/item/food/grown/ambrosia/deus,
+		/obj/item/food/grown/wheat,
+	))
 
 /obj/item/grown/log/attackby(obj/item/W, mob/user, params)
 	if(W.get_sharpness())

--- a/code/modules/mining/aux_base.dm
+++ b/code/modules/mining/aux_base.dm
@@ -188,13 +188,12 @@
 		to_chat(user, "<span class='warning'>This station is not equipped with an auxiliary base. Please contact your Nanotrasen contractor.</span>")
 		return
 	if(!no_restrictions)
-		var/static/list/disallowed_turf_types = typecacheof(list(
-			/turf/closed,
-			/turf/open/lava,
-			/turf/open/indestructible,
-			)) - typecacheof(list(
-			/turf/closed/mineral,
-			))
+		var/static/list/disallowed_turf_types = zebra_typecacheof(list(
+			/turf/closed = TRUE,
+			/turf/open/lava = TRUE,
+			/turf/open/indestructible = TRUE,
+			/turf/closed/mineral = FALSE,
+		))
 
 		if(!is_mining_level(T.z))
 			return BAD_ZLEVEL

--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -211,22 +211,30 @@
 	*/
 	var/atom/closest_atom
 	var/closest_type = 0
-	var/static/things_to_shock = typecacheof(list(/obj/machinery, /mob/living, /obj/structure, /obj/vehicle/ridden))
-	var/static/blacklisted_tesla_types = typecacheof(list(/obj/machinery/atmospherics,
-										/obj/machinery/portable_atmospherics,
-										/obj/machinery/power/emitter,
-										/obj/machinery/field/generator,
-										/mob/living/simple_animal,
-										/obj/machinery/field/containment,
-										/obj/structure/disposalpipe,
-										/obj/structure/disposaloutlet,
-										/obj/machinery/disposal/delivery_chute,
-										/obj/machinery/camera,
-										/obj/structure/sign,
-										/obj/machinery/gateway,
-										/obj/structure/lattice,
-										/obj/structure/grille,
-										/obj/structure/frame/machine))
+	var/static/list/things_to_shock = zebra_typecacheof(list(
+		// Things that we want to shock.
+		/obj/machinery = TRUE,
+		/mob/living = TRUE,
+		/obj/structure = TRUE,
+		/obj/vehicle/ridden = TRUE,
+
+		// Things that we don't want to shock.
+		/obj/machinery/atmospherics = FALSE,
+		/obj/machinery/portable_atmospherics = FALSE,
+		/obj/machinery/power/emitter = FALSE,
+		/obj/machinery/field/generator = FALSE,
+		/obj/machinery/field/containment = FALSE,
+		/obj/machinery/camera = FALSE,
+		/obj/machinery/gateway = FALSE,
+		/mob/living/simple_animal = FALSE,
+		/obj/structure/disposalpipe = FALSE,
+		/obj/structure/disposaloutlet = FALSE,
+		/obj/machinery/disposal/delivery_chute = FALSE,
+		/obj/structure/sign = FALSE,
+		/obj/structure/lattice = FALSE,
+		/obj/structure/grille = FALSE,
+		/obj/structure/frame/machine = FALSE,
+	))
 
 	//Ok so we are making an assumption here. We assume that view() still calculates from the center out.
 	//This means that if we find an object we can assume it is the closest one of its type. This is somewhat of a speed increase.
@@ -234,7 +242,7 @@
 
 	//Darkness fucks oview up hard. I've tried dview() but it doesn't seem to work
 	//I hate existance
-	for(var/a in typecache_filter_multi_list_exclusion(oview(zap_range+2, source), things_to_shock, blacklisted_tesla_types))
+	for(var/a in typecache_filter_list(oview(zap_range+2, source), things_to_shock))
 		var/atom/A = a
 		if(!(zap_flags & ZAP_ALLOW_DUPLICATES) && LAZYACCESS(shocked_targets, A))
 			continue


### PR DESCRIPTION
## Original PR: https://github.com/tgstation/tgstation/pull/63710

## About The Pull Request

TG creator's comments:
Adds an argument to typecache generation that allows specifying the whether to include/exclude types in the input list.
Also adds another argument to specify whether to remove falsey values after the typecache is generated.

I also added in some small changes to code TG had and we didnt, like /proc/is_type_in_list having single-letter variables. Only those that conflicted were admitted

## Why It's Good For The Game

TG creator's comments:
Might make zaps slightly faster???
Honestly I just thought it would be a good way to condense some whitelist/blacklist typecache sets.

## Changelog
:cl:
code: a lot of lists now dont look like shit
/:cl:
