### PR TITLE
PE Runoff

### DIFF
--- a/ModularTegustation/tegu_items/refinery/sales.dm
+++ b/ModularTegustation/tegu_items/refinery/sales.dm
@@ -11,6 +11,7 @@
 	var/power_timer = 120 	//How long does the box last for? You get 1 point every second
 	var/crate_timer = 180	//How much time until a crate?
 	var/crates_per_box		//Just used to calculate examine text
+	var/our_corporation		// Whatever Representative we may be linked to
 
 	var/generating
 	var/icon_full = "machinelcb_full"
@@ -54,6 +55,15 @@
 		var/obj/item/holochip/C = new (get_turf(src))
 		C.credits = rand(ahn_amount/4,ahn_amount)
 		SSlobotomy_corp.AdjustGoalBoxes(100) // 50 PE for 100 PE, not including the cost of filters. This eventually gets us positive in spendable PE, once we reach goal...
+		var/found_rep = FALSE
+		if(our_corporation) // Don't bother trying to loop if we don't have one set.
+			for(var/obj/structure/representative_console/rep_console in GLOB.lobotomy_devices)
+				if(rep_console.our_corporation != our_corporation)
+					continue
+				rep_console.AdjustPoints(1)
+				found_rep = TRUE
+		if(!found_rep) // No rep? Bit of a refund, but not as valuable as the rep.
+			SSlobotomy_corp.AdjustAvailableBoxes(25)
 
 	//gacha time
 	if(crate_timer  <= 0)
@@ -70,6 +80,7 @@
 	crate = /obj/structure/lootcrate/l_corp
 	power_timer = 60 	//L Corp is where you drain your power
 	crate_timer = 60	//And it's super cheap
+	our_corporation = L_CORP_REP
 
 /obj/structure/pe_sales/limbus
 	name = "Limbus Company Power Input"
@@ -83,6 +94,7 @@
 	icon_state = "machinek"
 	crate = /obj/structure/lootcrate/k_corp
 	crate_timer = 60	//2 per, because you get one bullet per crate
+	our_corporation = K_CORP_REP
 
 /obj/structure/pe_sales/r_corp
 	name = "R-Corp Power Input"

--- a/ModularTegustation/tegu_items/refinery/sales.dm
+++ b/ModularTegustation/tegu_items/refinery/sales.dm
@@ -102,6 +102,7 @@
 	icon_state = "machiner"
 	crate = /obj/structure/lootcrate/r_corp
 	crate_timer = 360	//The most expensive because it's R corp stuff
+	our_corporation = R_CORP_REP
 
 /obj/structure/pe_sales/s_corp
 	name = "S-Corp Power Input"
@@ -116,6 +117,7 @@
 	crate = /obj/structure/lootcrate/w_corp
 	power_timer = 60 	//W Corp uses a lot of power
 	crate_timer = 120
+	our_corporation = W_CORP_REP
 
 /obj/structure/pe_sales/n_corp
 	name = "N-Corp Power Input"

--- a/ModularTegustation/tegu_items/refinery/sales.dm
+++ b/ModularTegustation/tegu_items/refinery/sales.dm
@@ -88,6 +88,7 @@
 	desc = "A machine used to send PE to limbus company."
 	icon_state = "machinelcb"
 	crate = /obj/structure/lootcrate/limbus
+	our_corporation = P_CORP_REP // Extremely questionable P-Corp~
 
 /obj/structure/pe_sales/k_corp
 	name = "K-Corp Power Input"
@@ -125,6 +126,7 @@
 	desc = "A machine used to send PE to N-Corp."
 	icon_state = "machinen"
 	crate = /obj/structure/lootcrate/n_corp
+	our_corporation = N_CORP_REP
 
 /obj/structure/pe_sales/leaflet
 	name = "Leaflet Workshop Power Input"
@@ -190,6 +192,7 @@
 	icon_state = "machinesyndicate"
 	crate = /obj/structure/lootcrate/syndicate
 	crate_timer = 360	//The most expensive sales, takes about 3.5 boxes. The worst you'll get is still extremely good
+	our_corporation = P_CORP_REP // Extremely questionable P-Corp~
 
 /obj/structure/pe_sales/backstreet
 	name = "Backstreets Workshop Power Input"
@@ -198,6 +201,7 @@
 	crate = /obj/structure/lootcrate/backstreets
 	power_timer = 180 	//Takes a bit
 	crate_timer = 180	//And it's super cheap
+	our_corporation = P_CORP_REP // Extremely questionable P-Corp~
 
 /obj/structure/pe_sales/jcorp
 	name = "J-corp Syndicate Power Input"

--- a/ModularTegustation/tegu_items/refinery/sales.dm
+++ b/ModularTegustation/tegu_items/refinery/sales.dm
@@ -61,6 +61,7 @@
 				if(rep_console.our_corporation != our_corporation)
 					continue
 				rep_console.AdjustPoints(1)
+				playsound(rep_console, 'sound/machines/terminal_success.ogg', 20, 1)
 				found_rep = TRUE
 		if(!found_rep) // No rep? Bit of a refund, but not as valuable as the rep.
 			SSlobotomy_corp.AdjustAvailableBoxes(25)

--- a/ModularTegustation/tegu_items/refinery/sales.dm
+++ b/ModularTegustation/tegu_items/refinery/sales.dm
@@ -81,14 +81,14 @@
 	crate = /obj/structure/lootcrate/l_corp
 	power_timer = 60 	//L Corp is where you drain your power
 	crate_timer = 60	//And it's super cheap
-	our_corporation = L_CORP_REP
+	our_corporation = "L corp"
 
 /obj/structure/pe_sales/limbus
 	name = "Limbus Company Power Input"
 	desc = "A machine used to send PE to limbus company."
 	icon_state = "machinelcb"
 	crate = /obj/structure/lootcrate/limbus
-	our_corporation = P_CORP_REP // Extremely questionable P-Corp~
+	our_corporation = "P corp" // Extremely questionable P-Corp~
 
 /obj/structure/pe_sales/k_corp
 	name = "K-Corp Power Input"
@@ -96,7 +96,7 @@
 	icon_state = "machinek"
 	crate = /obj/structure/lootcrate/k_corp
 	crate_timer = 60	//2 per, because you get one bullet per crate
-	our_corporation = K_CORP_REP
+	our_corporation = "K corp"
 
 /obj/structure/pe_sales/r_corp
 	name = "R-Corp Power Input"
@@ -104,7 +104,7 @@
 	icon_state = "machiner"
 	crate = /obj/structure/lootcrate/r_corp
 	crate_timer = 360	//The most expensive because it's R corp stuff
-	our_corporation = R_CORP_REP
+	our_corporation = "R corp"
 
 /obj/structure/pe_sales/s_corp
 	name = "S-Corp Power Input"
@@ -119,14 +119,14 @@
 	crate = /obj/structure/lootcrate/w_corp
 	power_timer = 60 	//W Corp uses a lot of power
 	crate_timer = 120
-	our_corporation = W_CORP_REP
+	our_corporation = "W corp"
 
 /obj/structure/pe_sales/n_corp
 	name = "N-Corp Power Input"
 	desc = "A machine used to send PE to N-Corp."
 	icon_state = "machinen"
 	crate = /obj/structure/lootcrate/n_corp
-	our_corporation = N_CORP_REP
+	our_corporation = "N corp"
 
 /obj/structure/pe_sales/leaflet
 	name = "Leaflet Workshop Power Input"
@@ -192,7 +192,7 @@
 	icon_state = "machinesyndicate"
 	crate = /obj/structure/lootcrate/syndicate
 	crate_timer = 360	//The most expensive sales, takes about 3.5 boxes. The worst you'll get is still extremely good
-	our_corporation = P_CORP_REP // Extremely questionable P-Corp~
+	our_corporation = "P corp" // Extremely questionable P-Corp~
 
 /obj/structure/pe_sales/backstreet
 	name = "Backstreets Workshop Power Input"
@@ -201,7 +201,7 @@
 	crate = /obj/structure/lootcrate/backstreets
 	power_timer = 180 	//Takes a bit
 	crate_timer = 180	//And it's super cheap
-	our_corporation = P_CORP_REP // Extremely questionable P-Corp~
+	our_corporation = "P corp" // Extremely questionable P-Corp~
 
 /obj/structure/pe_sales/jcorp
 	name = "J-corp Syndicate Power Input"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Sales machines will grant relevant Representative consoles 1 PE. So if you spend a refined PE box on a W-Corp machine with a W-Corp Rep in the facility, they get 1 PE. Otherwise, you get 25 spendable PE back so you can keep refining, roughly half the value.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Why did sending them energy not count as handing them energy?
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
code: adds an `our_corporation` variable to sales machines, if it exists we'll try and find related representative consoles.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
