### PR TITLE
Cleanup and belt buff

### DIFF
--- a/code/datums/abnormality/_ego_datum/he.dm
+++ b/code/datums/abnormality/_ego_datum/he.dm
@@ -333,12 +333,12 @@
 
 /datum/ego_datum/weapon/warp
 	item_category = "Weapon (Knife)"
-	item_path = /obj/item/ego_weapon/warp
+	item_path = /obj/item/ego_weapon/warp/knife
 	cost = 35
 
 /datum/ego_datum/weapon/warp/spear
 	item_category = "Weapon (Spear)"
-	item_path = /obj/item/ego_weapon/warp/spear
+	item_path = /obj/item/ego_weapon/warp
 	cost = 35
 
 //Missed Reaper - Grasp

--- a/code/game/objects/items/ego_weapons/_ego_weapon.dm
+++ b/code/game/objects/items/ego_weapons/_ego_weapon.dm
@@ -32,6 +32,9 @@
 	if(LAZYLEN(attribute_requirements))
 		. += "<span class='notice'>It has <a href='?src=[REF(src)];list_attributes=1'>certain requirements</a> for the wearer.</span>"
 
+	if(type in GLOB.small_ego)
+		. += "<span class='notice'>This weapon fits in an EGO belt.</span>"
+
 	if(reach>1)
 		. += "<span class='notice'>This weapon has a reach of [reach].</span>"
 
@@ -109,8 +112,3 @@
 /obj/item/ego_weapon/Destroy()
 	CleanUp()
 	return ..()
-
-//Examine text for mini weapons.
-/obj/item/ego_weapon/mini/examine(mob/user)
-	. = ..()
-	. += "<span class='notice'>This weapon fits in an ego weapon belt.</span>"

--- a/code/game/objects/items/ego_weapons/_lists.dm
+++ b/code/game/objects/items/ego_weapons/_lists.dm
@@ -1,7 +1,14 @@
 //Everything here fits in a belt
 GLOBAL_LIST_INIT(small_ego, list (
+		//EGO weapons
 		/obj/item/gun/ego_gun/pistol,
 		/obj/item/ego_weapon/mini,
+		/obj/item/ego_weapon/warp/knife,
+		/obj/item/ego_weapon/support/letter_opener,
+		/obj/item/ego_weapon/charge/warring,
+		/obj/item/gun/ego_gun/feather,
+
+		//Non-EGO weapons
 		/obj/item/ego_weapon/city/ncorp_mark,
 		/obj/item/ego_weapon/city/ncorp_nail,
 		/obj/item/ego_weapon/city/ncorp_brassnail,

--- a/code/game/objects/items/ego_weapons/he.dm
+++ b/code/game/objects/items/ego_weapons/he.dm
@@ -367,7 +367,7 @@
 	smashing = FALSE
 	return
 
-/obj/item/ego_weapon/courage
+/obj/item/ego_weapon/mini/courage
 	name = "courage"
 	desc = "Can I follow you forever? So I can tear them apart..."
 	special = "This weapon deals more damage the more allies you can see."
@@ -1022,16 +1022,16 @@
 	return TRUE
 
 /obj/item/ego_weapon/warp
-	name = "dimension shredder"
-	desc = "The path is intent on thwarting all attempts to memorize it."
-	special = "This weapon builds charge every 10 steps you've taken."
-	icon_state = "warp"
-	lefthand_file = 'icons/mob/inhands/64x64_lefthand.dmi'
-	righthand_file = 'icons/mob/inhands/64x64_righthand.dmi'
-	inhand_x_dimension = 64
-	inhand_y_dimension = 64
-	force = 24
-	attack_speed = 0.8
+	name = "dimensional ripple"
+	desc = "They should've died after bleeding so much. You usually don't quarantine a corpse...."
+	icon_state = "warp2"
+	lefthand_file = 'icons/mob/inhands/weapons/ego_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/weapons/ego_righthand.dmi'
+	inhand_x_dimension = 32
+	inhand_y_dimension = 32
+	attack_speed = 1
+	hitsound = 'sound/abnormalities/wayward_passenger/attack1.ogg'
+	reach = 2
 	damtype = RED_DAMAGE
 	attack_verb_continuous = list("stabs", "slashes", "attacks")
 	attack_verb_simple = list("stab", "slash", "attack")
@@ -1127,17 +1127,18 @@
 	QDEL_IN(src, 3 SECONDS)
 	..()
 
-/obj/item/ego_weapon/warp/spear//spear subtype of the above
-	name = "dimensional ripple"
-	desc = "They should've died after bleeding so much. You usually don't quarantine a corpse...."
-	icon_state = "warp2"
-	lefthand_file = 'icons/mob/inhands/weapons/ego_lefthand.dmi'
-	righthand_file = 'icons/mob/inhands/weapons/ego_righthand.dmi'
-	inhand_x_dimension = 32
-	inhand_y_dimension = 32
-	attack_speed = 1
-	hitsound = 'sound/abnormalities/wayward_passenger/attack1.ogg'
-	reach = 2
+/obj/item/ego_weapon/warp/knife		//knife subtype of the above. knife has to be the subtype because it fits in a belt
+	name = "dimension shredder"
+	desc = "The path is intent on thwarting all attempts to memorize it."
+	special = "This weapon builds charge every 10 steps you've taken."
+	icon_state = "warp"
+	lefthand_file = 'icons/mob/inhands/64x64_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/64x64_righthand.dmi'
+	inhand_x_dimension = 64
+	inhand_y_dimension = 64
+	force = 24
+	attack_speed = 0.8
+	reach = 1
 
 /obj/item/ego_weapon/marionette
 	name = "marionette"

--- a/code/modules/projectiles/guns/ego_gun/waw.dm
+++ b/code/modules/projectiles/guns/ego_gun/waw.dm
@@ -312,7 +312,7 @@
 	inhand_icon_state = "featherofhonor"
 	ammo_type = /obj/item/ammo_casing/caseless/ego_feather
 	weapon_weight = WEAPON_HEAVY
-	special = "This weapon deals 35 white in melee."
+	special = "This weapon deals 42 white in melee."
 	force = 42
 	damtype = WHITE_DAMAGE
 	fire_delay = 12

--- a/code/modules/projectiles/guns/ego_gun/waw.dm
+++ b/code/modules/projectiles/guns/ego_gun/waw.dm
@@ -313,9 +313,9 @@
 	ammo_type = /obj/item/ammo_casing/caseless/ego_feather
 	weapon_weight = WEAPON_HEAVY
 	special = "This weapon deals 35 white in melee."
-	force = 35
+	force = 42
 	damtype = WHITE_DAMAGE
-	fire_delay = 25
+	fire_delay = 12
 	attribute_requirements = list(
 							FORTITUDE_ATTRIBUTE = 60,
 							PRUDENCE_ATTRIBUTE = 60


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Cleans up code regarding the EGO belt, adds shortswords to the belt.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Mostly a code cleanup; and some weapons that SHOULD be able to go into the belt now can. 
Includes shortswords like Courage and Feather of Honor as well as Dimensional Shredder.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: More weapons fit into a belt.
code: EGO Weapon belt code is now better.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
