### PR TITLE
More Wrathful Servant

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/waw/wrath_servant.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/wrath_servant.dm
@@ -16,7 +16,7 @@
 	ranged = TRUE
 	maxHealth = 1800
 	health = 1800
-	damage_coeff = list(RED_DAMAGE = 0.3, WHITE_DAMAGE = 1.5, BLACK_DAMAGE = 0.7, PALE_DAMAGE = 1.5)
+	damage_coeff = list(RED_DAMAGE = 0.3, WHITE_DAMAGE = 1.2, BLACK_DAMAGE = 0.7, PALE_DAMAGE = 1.5)
 
 	move_to_delay = 6
 	is_flying_animal = TRUE
@@ -339,6 +339,8 @@
 
 /mob/living/simple_animal/hostile/abnormality/wrath_servant/BreachEffect(mob/living/carbon/human/user, breach_type)
 	. = TRUE
+	if(!(status_flags & GODMODE))
+		return FALSE
 	if(!datum_reference)
 		friendly = FALSE
 	if(nihil_present) //nihil is here and we must fight them!
@@ -404,16 +406,20 @@
 	say("EMBODIMENTS OF EVIL!!!")
 	desc = "A large red monster with white bandages hanging from it. Its flesh oozes a bubble acid."
 	can_act = TRUE
-	GiveTarget(user)
 	if(!datum_reference)
 		can_patrol = TRUE
 		return
+	var/turf/target_turf
 	for(var/turf/dep in GLOB.department_centers)
-		if(get_dist(src, dep) < 30)
+		if(!target_turf)
+			target_turf = dep
 			continue
-		new /mob/living/simple_animal/hostile/azure_hermit(dep)
-		playsound(dep, 'sound/abnormalities/wrath_servant/hermit_magic.ogg', 60, FALSE, 10)
-		break
+		if(get_dist(src, dep) < get_dist(src, target_turf))
+			continue
+		target_turf = dep
+	new /mob/living/simple_animal/hostile/azure_hermit(target_turf)
+	playsound(target_turf, 'sound/abnormalities/wrath_servant/hermit_magic.ogg', 60, FALSE, 10)
+	patrol_to(get_closest_atom(/turf, GLOB.xeno_spawn, src))
 
 /mob/living/simple_animal/hostile/abnormality/wrath_servant/proc/Dash()
 	visible_message(span_warning("[src] sprints toward [target]!"), span_notice("You quickly dash!"), span_notice("You hear heavy footsteps speed up."))
@@ -667,6 +673,8 @@
 	health = 1500
 	damage_coeff = list(RED_DAMAGE = 0.5, WHITE_DAMAGE = 1.5, BLACK_DAMAGE = 0.8, PALE_DAMAGE = 1.2)
 
+	alpha = 0
+
 	a_intent = INTENT_HARM
 	move_resist = MOVE_FORCE_STRONG
 	move_to_delay = 5
@@ -675,8 +683,8 @@
 	ranged = TRUE
 	ranged_cooldown = 15 SECONDS
 
-	melee_damage_lower = 20
-	melee_damage_upper = 30
+	melee_damage_lower = 25
+	melee_damage_upper = 40
 	rapid_melee = 2
 	melee_damage_type = WHITE_DAMAGE
 	attack_sound = 'sound/abnormalities/wrath_servant/hermit_attack.ogg'
@@ -691,6 +699,7 @@
 /mob/living/simple_animal/hostile/azure_hermit/Initialize()
 	. = ..()
 	COOLDOWN_START(src, conjure, conjure_cooldown)
+	animate(src, 10, alpha = 255)
 
 /mob/living/simple_animal/hostile/azure_hermit/Found(atom/A)
 	if(!istype(A, /mob/living/simple_animal/hostile/abnormality/wrath_servant))
@@ -795,13 +804,13 @@
 	show_area |= view(4, src)
 	for(var/turf/sT in show_area)
 		new /obj/effect/temp_visual/cult/sparks(sT)
-	SLEEP_CHECK_DEATH(1.5 SECONDS)
+	SLEEP_CHECK_DEATH(1.25 SECONDS)
 	playsound(src, 'sound/abnormalities/wrath_servant/hermit_magic.ogg', 75, FALSE, 10)
-	for(var/mob/living/L in view(4, src))
+	for(var/mob/living/L in show_area)
 		if(faction_check_mob(L))
 			continue
 		new /obj/effect/temp_visual/small_smoke/halfsecond(get_turf(L))
-		L.deal_damage(40, WHITE_DAMAGE)
+		L.deal_damage(60, WHITE_DAMAGE)
 	can_act = TRUE
 	return
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Buffs Servant of Wrath in the following ways:
Increased White Resistance (lower White damage_coeff)
Patrols to nearest Xenospawn on breach

Buffs Hermit of the Azure Forest in the following ways:
Increased melee damage (+5-10, from 20-30 to 25-40)
Increased AoE damage (+20, from 40 to 60)
Reduced AoE delay (-0.25 seconds, 1.25 seconds from 1.5 seconds)

Fixes issue where Hermit would calculate AoE area twice, blinding her after she declares the initial area no longer prevents her from hitting.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Servant's breach wasn't scary enough. This ideally helps fix that.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: editted values for SoW and Hermit of the Azure Forest
fix: Azure hermit AoE should be more consistent
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
