### PR TITLE
Gamemode Weights

### DIFF
--- a/code/controllers/subsystem/abnormality_queue.dm
+++ b/code/controllers/subsystem/abnormality_queue.dm
@@ -4,7 +4,6 @@ SUBSYSTEM_DEF(abnormality_queue)
 	name = "Abnormality Queue"
 	flags = SS_KEEP_TIMING | SS_BACKGROUND
 	runlevels = RUNLEVEL_GAME
-	init_order = INIT_ORDER_PERSISTENCE - 1 // Always after Persistence, as that's where we get our abno list from.
 	wait = 10 SECONDS
 
 	/// List of(preferably) 3 abnormalities available for manager to choose from.
@@ -30,10 +29,6 @@ SUBSYSTEM_DEF(abnormality_queue)
 	var/hardcore_roll_enabled = FALSE
 
 /datum/controller/subsystem/abnormality_queue/Initialize(timeofday)
-	if(LAZYLEN(possible_abnormalities))
-		pick_abno()
-	else
-		stack_trace("[src] initialized before Persistence subsystem!")
 	rooms_start = GLOB.abnormality_room_spawners.len
 	next_abno_spawn_time -= min(2, rooms_start * 0.05) MINUTES // 20 rooms will decrease wait time by 1 minute
 	..()

--- a/code/game/gamemodes/management/management.dm
+++ b/code/game/gamemodes/management/management.dm
@@ -19,11 +19,15 @@
 	var/list/gamemode_abnos = list(ZAYIN_LEVEL = list(), TETH_LEVEL = list(), HE_LEVEL = list(), WAW_LEVEL = list(), ALEPH_LEVEL = list())
 
 /datum/game_mode/management/post_setup()
+	SSpersistence.LoadAbnoPicks() // Persistence system WILL have loaded at this point. Functionally means 0 abnos are slotted/loaded before the game itself is ready.
 	var/list/all_abnos = SSpersistence.abno_rates
 	var/highest = max(all_abnos[ReturnHighestValue(all_abnos)] + 1, 2) // Ensures no 0 results
 	for(var/i in all_abnos)
 		var/mob/living/simple_animal/hostile/abnormality/abno = i
 		if(initial(abno.can_spawn) && (initial(abno.abnormality_origin) in abno_types))
+			if(abno in gamemode_abnos[initial(abno.threat_level)])
+				stack_trace("WARNING! Duplicate [abno] found in Persistent Abno Rates!")
+				continue
 			gamemode_abnos[initial(abno.threat_level)] += abno
 			var/rate = (all_abnos[i] * -1) + highest
 			gamemode_abnos[initial(abno.threat_level)][abno] = rate


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Abnormality Weights are now separated by gamemodes, so they don't get biased by things like the inability to appear.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Should reduce irregularity with abno weights.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: abnormality weights are in different files now.
refactor: Gamemodes now handle the entirety of abno list filling. This works because they already get picked at game start, so it's filled then picked from in order. Actual effect of this is the pickable abno list no longer populates until round start.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
