### PR TITLE
The Great Fishing Chance Rework [DONE?]

### DIFF
--- a/ModularTegustation/fishing/code/fish/LC13_fish/saltwater_fish.dm
+++ b/ModularTegustation/fishing/code/fish/LC13_fish/saltwater_fish.dm
@@ -36,6 +36,7 @@
 	feeding_frequency = 25 MINUTES
 	microwaved_type = /obj/item/food/meat/crab
 	fillet_type = /obj/item/food/meat/rawcrab
+	food_reagents = list(/datum/reagent/consumable/nutriment/organ_tissue = 1, /datum/reagent/consumable/nutriment/vile_fluid = 1)
 
 /// Abnormalities
 

--- a/ModularTegustation/fishing/code/fish_market.dm
+++ b/ModularTegustation/fishing/code/fish_market.dm
@@ -21,6 +21,7 @@
 		new /datum/data/extraction_cargo("Reinforced Fishing Line ", 	/obj/item/fishing_component/line/reinforced,		500) = 1,
 		new /datum/data/extraction_cargo("Fishing Hat ",		 		/obj/item/clothing/head/beret/fishing_hat,			500) = 1,
 		new /datum/data/extraction_cargo("Aquarium Branch Office ",		/obj/item/aquarium_prop/lcorp,						500) = 1,
+		new /datum/data/extraction_cargo("Tier 1 Fishing Rod ",			/obj/item/fishing_rod/tier1,						500) = 1,
 		//Yes we are scamming you.
 		new /datum/data/extraction_cargo("Shiny Fishing Hook ", 		/obj/item/fishing_component/hook/shiny,				1000) = 1,
 	)
@@ -49,10 +50,10 @@
 		if(href_list["purchase"])
 			var/datum/data/extraction_cargo/product_datum = locate(href_list["purchase"]) in order_list //The href_list returns the individual number code and only works if we have it in the first column. -IP
 			if(!product_datum)
-				to_chat(usr, "<span class='warning'>ERROR.</span>")
+				to_chat(usr, span_warning("ERROR."))
 				return FALSE
 			if(fish_points < product_datum.cost)
-				to_chat(usr, "<span class='warning'>Yer lackin some points there lad.</span>")
+				to_chat(usr, span_warning("Yer lackin some points there lad."))
 				playsound(get_turf(src), 'sound/machines/terminal_prompt_deny.ogg', 50, TRUE)
 				return FALSE
 			new product_datum.equipment_path(get_turf(src))
@@ -78,7 +79,7 @@
 		return
 	if(istype(I, /obj/item/fishing_component/hook/bone))
 		AdjustPoints(5)
-		to_chat(user, "<span class='notice'>Thank you for notifying us of this object. 5 point reward.</span>")
+		to_chat(user, span_notice("Thank you for notifying us of this object. 5 point reward."))
 		playsound(get_turf(src), 'sound/machines/machine_vend.ogg', 10, TRUE)
 		qdel(I)
 		return
@@ -88,7 +89,6 @@
 		for(var/item in bag.contents)
 			if(istype(item, /obj/item/fishing_component/hook/bone))
 				fish_value += 5
-				to_chat(user, "<span class='notice'>Thank you for notifying us of this object. 5 point reward.</span>")
 
 			if(istype(item, /obj/item/food/fish))
 				fish_value += ValueFish(item)

--- a/ModularTegustation/fishing/code/fishing_items/fish_box.dm
+++ b/ModularTegustation/fishing/code/fishing_items/fish_box.dm
@@ -11,3 +11,4 @@
 	new /obj/item/fishing_component/hook(src)
 	new /obj/item/storage/bag/fish(src)
 	new /obj/item/fishing_net(src)
+	new /obj/item/book/granter/fish_skill(src)

--- a/ModularTegustation/fishing/code/fishing_items/fishing_net.dm
+++ b/ModularTegustation/fishing/code/fishing_items/fishing_net.dm
@@ -18,7 +18,6 @@
 	debris = list(/obj/item/fishing_net = 1)
 	var/fishin_cooldown = 25 SECONDS
 	var/fishin_cooldown_delay = 1 SECONDS
-	var/list/stuff_to_catch
 	var/turf/open/water/deep/open_waters
 
 /obj/structure/destructible/fishing_net/Initialize()
@@ -27,7 +26,6 @@
 	if(!istype(open_waters, /turf/open/water/deep))
 		qdel(src)
 		return
-	stuff_to_catch = open_waters.ReturnChanceList()
 	//will proc at least 5 times before the loop stops.
 	addtimer(CALLBACK(src, .proc/CatchFish), fishin_cooldown + fishin_cooldown_delay)
 
@@ -51,7 +49,7 @@
 /obj/structure/destructible/fishing_net/proc/CatchFish()
 	if(contents.len >= 5 || !open_waters)
 		return
-	var/atom/thing_caught = pickweight(stuff_to_catch)
+	var/atom/thing_caught = pickweight(open_waters.ReturnChanceList(0.8))
 	new thing_caught(src)
 	icon_state = "trawling_net_full"
 	update_icon()

--- a/ModularTegustation/fishing/code/fishing_items/fishing_rod.dm
+++ b/ModularTegustation/fishing/code/fishing_items/fishing_rod.dm
@@ -22,6 +22,11 @@
 	inhand_y_dimension = 64
 	slot_flags = ITEM_SLOT_BELT
 	w_class = WEIGHT_CLASS_HUGE
+	/* Inherent power of the rod. This may vary
+		due to quality meaning you will need to
+		counter a negative level with hooks, lines,
+		or skill. */
+	var/rod_level = 0.6
 	//Fishing Equipment
 	var/obj/item/fishing_component/line/line
 	var/obj/item/fishing_component/hook/hook
@@ -35,9 +40,15 @@
 	//do we override the default fishing speed? (should be used if you want to debug something or make a rod with unique speed)
 	var/speed_override = FALSE
 
+//Upgraded Varient
+/obj/item/fishing_rod/tier1
+	name = "fishing rod"
+	desc = "A tool used to dredge up aquatic entities. This rod is pretty reliable all things considered."
+	rod_level = 1
+
 /obj/item/fishing_rod/examine(mob/user)
 	. = ..()
-	. += "<span class='notice'>This rod has a effectiveness of [(FISH_RARITY_BASIC - FishCustomization(900))/10].</span>"
+	. += span_notice("This rod has a modifier of +[ReturnRodPower()].")
 
 /obj/item/fishing_rod/attackby(obj/item/attacking_item, mob/user, params)
 	if(SlotCheck(attacking_item,ROD_SLOT_LINE))
@@ -51,7 +62,7 @@
 /obj/item/fishing_rod/afterattack(atom/target, mob/user, proximity_flag)
 	if(istype(target, /turf/open/water/deep) && isliving(user) && !isfishing && user.z == target.z)
 		if(istype(user.get_inactive_held_item(), /obj/item/fishing_rod))
-			to_chat(user, "<span class='notice'>You attempt to cast two lines at once but they get tangled together.</span>")
+			to_chat(user, span_notice("You attempt to cast two lines at once but they get tangled together."))
 			return
 		//Multicasting is too chaotic
 		if(isfishing == TRUE)
@@ -64,49 +75,67 @@
 
 /obj/item/fishing_rod/proc/StartFishing(mob/living/user, turf/open/water/deep/fishing_spot)
 	isfishing = TRUE
-	user.visible_message("<span class='notice'>[user] begins fishing in [fishing_spot].</span>", "<span class='notice'>You begin fishing.</span>")
+	user.visible_message(span_notice("[user] begins fishing in [fishing_spot]."), span_notice("You begin fishing."))
 	playsound(get_turf(fishing_spot), 'sound/abnormalities/piscinemermaid/bigsplash.ogg', 20, 0, 3)
-	//default fishing skill
-	var/fishing_skill = 1
-	//fishing visuals, first make a bobber.
+	//Fishing visuals, first make a bobber.
 	FishShapes("bobber", fishing_spot)
 	var/list/fishing_turf = RegisterFishingArea(fishing_spot)
-	//redundant check for safety concerns.
+	//Redundant check for safety concerns.
 	if(!fishing_turf.len)
 		return StopFishing()
-	//copy turf enviorment list
-	var/things_to_fish = fishing_spot.ReturnChanceList(FishCustomization(900))
 	//MAKE VISUALS
-	var/list/no_overlap_fish_turf = fishing_turf.Copy()
-	//do not spawn a fish visual ontop of the bobber
-	no_overlap_fish_turf -= fishing_spot
-	var/list/visuals_list = list("fish_dancing", "fish_pacing", "fish_pacing2", "fish_mass")
-		//Polluted water should not have fish that can be seen easily.
-	if(istype(fishing_spot, /turf/open/water/deep/polluted))
-		visuals_list = list("fish_mass")
-	for(var/visable_feesh = 0 to 3)
-		if(!no_overlap_fish_turf.len)
-			break
-		FishShapes(pick(visuals_list), pick_n_take(no_overlap_fish_turf), TRUE)
+	StirWaterVisuals(fishing_turf, fishing_spot)
+
+	//copy turf loottables
+	var/things_to_fish = ReturnLootTable(user, fishing_spot)
 
 		//~~~FISHING BEGINS~~~
 	for(var/i = 1 to 100)
-		var/fishing_time
-		//random extra time to the fishing for a unpredictable feel rather than making a chance to just not fish up anything.
-		if(!speed_override)
-			fishing_time = ((10 SECONDS) * fishing_skill) + (rand(1,3) SECONDS)
-		else
-			fishing_time = speed_override
-		if(!do_after(user, fishing_time, target = fishing_spot))
-			isfishing = FALSE
+		if(!FishCycle(user, fishing_spot, things_to_fish))
 			break
-		//Do we have the skill? Do we even have a mind?
-		if(user.mind)
-			fishing_skill = (user.mind.get_skill_modifier(/datum/skill/fishing, SKILL_SPEED_MODIFIER))
-			FISHSKILLEXP(5)
-		//Fishing successful
-		FishLoot(pickweight(things_to_fish), user, get_turf(fishing_spot))
+		//Randomizes the rarity of the list every time its complete. Might be a blight on processing and needs improvement or rework. -IP
+		things_to_fish = ReturnLootTable(user, fishing_spot)
+
 	return StopFishing()
+
+/* FishCycle is one cycle of fishing. You catch a fish
+	when this is over and then cycle to this proc again.
+	If this proc returns FALSE you will stop cycling.*/
+/obj/item/fishing_rod/proc/FishCycle(mob/living/user, turf/open/water/deep/fishing_spot, list/loottable)
+	//If no one is there to pull the reel who really is fishin now mmmm?
+	if(!user.client)
+		return FALSE
+
+	//Time required for fishing
+	var/fishing_time
+	//default fishing skill
+	var/fishing_skill = 0
+	//Do we have the skill? Do we even have a mind?
+	if(user.mind)
+		fishing_skill = user.mind.get_skill_level(/datum/skill/fishing)
+	//random extra time to the fishing for a unpredictable feel rather than making a chance to just not fish up anything.
+	if(!speed_override)
+		fishing_time = (8 + rand(0,2) - fishing_skill) SECONDS
+	else
+		fishing_time = speed_override
+
+	if(!do_after(user, fishing_time, target = fishing_spot))
+		isfishing = FALSE
+		return FALSE
+	//Redundant repeat of Fish skill check in order to apply EXP
+	if(user.mind)
+		FISHSKILLEXP(5)
+	if(loottable.len)
+		//Fishing successful
+		FishLoot(pickweight(loottable), user, get_turf(fishing_spot))
+	else
+		to_chat(user, span_notice("The water remains still. You dont catch anything."))
+	return TRUE
+
+//Proc for returning loot table chances.
+/obj/item/fishing_rod/proc/ReturnLootTable(mob/living/wielder, turf/open/water/deep/water_turf)
+	var/fishing_power = ReturnRodPower()
+	return water_turf.ReturnChanceList(fishing_power)
 
 /*Tgstation uses signals and projectiles for their fishing rods
 	but im not too familiar with signals so for now
@@ -115,7 +144,7 @@
 	var/turf/target_turf = get_turf(bobber_target)
 	var/fish_distance = get_dist_euclidian(get_turf(target_turf), get_turf(src))
 	if(fish_distance >= 7)
-		to_chat(user, "<span class='notice'>The bobber is [round(fish_distance - 7) + 1] tiles short of its destination.</span>")
+		to_chat(user, span_notice("The bobber is [round(fish_distance - 7) + 1] tiles short of its destination."))
 		return FALSE
 	/*Cycles 7 times until it returns. Wallcheck checks the turf after
 		this turf and if that turf equals the target turf we return TRUE.
@@ -128,7 +157,7 @@
 			return TRUE
 		wallcheck = get_step(this_turf, get_dir(this_turf, target_turf))
 		if(!ClearSky(wallcheck))
-			to_chat(user, "<span class='notice'>The bobber donks off of an obstacle.</span>")
+			to_chat(user, span_notice("The bobber donks off of an obstacle."))
 			return FALSE
 		this_turf = wallcheck
 
@@ -152,12 +181,10 @@
 		var/size_modifier = rand(1, 4) * 0.1
 		//Size modifier has to be a decimal in order to keep it from making massive fish.
 		fishie.randomize_weight_and_size(size_modifier)
-		to_chat(user, "<span class='nicegreen'>You caught [fishie.name].</span>")
+		to_chat(user, span_nicegreen("You caught [fishie.name]."))
 		if(user.mind)
 			FISHSKILLEXP(10)
 	playsound(fish_land, 'sound/effects/fish_splash.ogg', 18, 0, 3)
-
-#undef FISHSKILLEXP
 
 	//Icon Stuff
 /obj/item/fishing_rod/update_overlays()
@@ -212,6 +239,24 @@
 	if(water_tiles.len)
 		return water_tiles
 
+//Core proc for visual effects
+/obj/item/fishing_rod/proc/StirWaterVisuals(list/water_body, turf/open/fishing_tile)
+	var/list/no_overlap_fish_turf = water_body.Copy()
+	//do not spawn a fish visual ontop of the bobber
+	no_overlap_fish_turf -= fishing_tile
+
+	var/list/visuals_list = list("fish_dancing", "fish_pacing", "fish_pacing2", "fish_mass")
+		//Polluted water should not have fish that can be seen easily.
+	if(istype(fishing_tile, /turf/open/water/deep/polluted))
+		visuals_list = list("fish_mass")
+	for(var/visable_feesh = 0 to 3)
+		if(!no_overlap_fish_turf.len || !visuals_list.len)
+			break
+		FishShapes(pick(visuals_list), pick_n_take(no_overlap_fish_turf), TRUE)
+
+/* Applys overlays of fish shadows to water tiles.
+	Do not fear for we have a list of the overlays
+	we apply so we can remove them at will.*/
 /obj/item/fishing_rod/proc/FishShapes(icon_shape, turf/presence_in_water, underwater_shadow = FALSE)
 	if(!isturf(presence_in_water))
 		return
@@ -278,14 +323,15 @@
 	return TRUE
 
 	//Calculates fishing power
-/obj/item/fishing_rod/proc/FishCustomization(fishing_rod_power = 1000)
+/obj/item/fishing_rod/proc/ReturnRodPower()
+	. = rod_level
 	if(hook)
 		if(istype(hook,/obj/item/fishing_component/hook))
-			fishing_rod_power -= hook.fishing_value
+			. += hook.fishing_value
 	if(line)
 		if(istype(line,/obj/item/fishing_component/line))
-			fishing_rod_power -= line.fishing_value
-	return fishing_rod_power
+			. += line.fishing_value
 
 #undef ROD_SLOT_LINE
 #undef ROD_SLOT_HOOK
+#undef FISHSKILLEXP

--- a/ModularTegustation/fishing/code/fishing_skill.dm
+++ b/ModularTegustation/fishing/code/fishing_skill.dm
@@ -1,15 +1,47 @@
 /datum/skill/fishing
 	name = "Fishing"
 	title =  "Fisher"
-	desc = "A terror that lurks outside the world of fish."
-	modifiers = list(SKILL_SPEED_MODIFIER = list(1, 0.9, 0.8, 0.7, 0.6, 0.5, 0.36))
+	desc = "A terror that lurks outside the world of fish. \
+			Each level decreases the time it takes to fish by 1 second."
+	modifiers = list(SKILL_SPEED_MODIFIER = list(0, 1, 2, 3, 4, 5, 6))
 	skill_cape_path = /obj/item/clothing/neck/cloak/skill_reward/fishing
 
 /datum/skill/fishing/New()
 	. = ..() //may have to change these to be Lobotomy Corp lore later instead of general mythology
-	levelUpMessages[1] = "<span class='nicegreen'>You understand the stillness that calms your prey...</span>"
-	levelUpMessages[2] = "<span class='nicegreen'>Your fishing mastery gives you some insight into the aquatic world...</span>"
-	levelUpMessages[3] = "<span class='nicegreen'>For a moment you swear you saw a large shrimp head watching you from the water...</span>"
-	levelUpMessages[4] = "<span class='nicegreen'>One of the fish you catch tells you about how a signet ring that could command demons was once swallowed by a fish...</span>"
-	levelUpMessages[5] = "<span class='nicegreen'>Your recent catch tells you of Nyami Nyami and how they cared for the Tonga people...</span>"
-	levelUpMessages[6] = "<span class='nicegreen'>Written on a fish you catch is a message from S-corp, it says they noticed your progress and may have a offer for you at district 19 when your shift is over...</span>"
+	levelUpMessages[1] = span_nicegreen("You understand the stillness that calms your prey...")
+	levelUpMessages[2] = span_nicegreen("Your fishing mastery gives you some insight into the aquatic world...")
+	levelUpMessages[3] = span_nicegreen("For a moment you swear you saw a large shrimp head watching you from the water...")
+	levelUpMessages[4] = span_nicegreen("One of the fish you catch tells you about how a signet ring that could command demons was once swallowed by a fish...")
+	levelUpMessages[5] = span_nicegreen("Your recent catch tells you of Nyami Nyami and how they cared for the Tonga people...")
+	levelUpMessages[6] = span_nicegreen("Written on a fish you catch is a message from S-corp, it says they noticed your progress and may have a offer for you at district 19 when your shift is over...")
+
+//Skill xp granter. Ill make this a more generalized root if its more widely used. -IP
+/obj/item/book/granter/fish_skill
+	name = "Fishin tips for Beginners"
+	desc = "A book that can grant some experience for the aspiring fishermin."
+	icon_state = "fishbook"
+	var/granted_skill = /datum/skill/fishing
+	var/skillname = "beginner level fishing" //might not seem nessesary but this makes it so you can safely name action buttons toggle this or that without it fucking up the granter, also caps
+	remarks = list("Dont eat fish raw due to the vile fluid that they have inside...",
+					"The more you fish the higher your fishing skill goes and the faster you fish...",
+					"This page just has the image of a front facing fish...",
+					"This page is covered in numerous stickers for wellcheers soda...",
+					"The Great Lake is seperated into numerous smaller lakes that each have their own laws...",
+					"The Great Lake is a large waterbody south of the city...",
+					"Sailing past the coast of U corp is unadvised without a sailor and maybe 4 fixers...",
+					"The next book will expand on the dangers of whales and their mermaids...")
+
+/obj/item/book/granter/fish_skill/already_known(mob/user)
+	if(user.mind?.get_skill_level(granted_skill) >= 2)
+		to_chat(user, span_warning("You already know all about [skillname]!"))
+		return TRUE
+	return FALSE
+
+/obj/item/book/granter/fish_skill/on_reading_start(mob/user)
+	to_chat(user, span_notice("You start reading about [skillname]..."))
+
+/obj/item/book/granter/fish_skill/on_reading_finished(mob/user)
+	to_chat(user, span_notice("You feel like you've got a good handle on [skillname]! <br>\
+		When you read the last sentence the copyright self-destruct activates"))
+	user.mind?.set_level(granted_skill, 2)
+	qdel(src)

--- a/ModularTegustation/fishing/code/rod_components/_fishing_component.dm
+++ b/ModularTegustation/fishing/code/rod_components/_fishing_component.dm
@@ -5,4 +5,4 @@
 	icon_state = "reel_blue"
 	w_class = WEIGHT_CLASS_SMALL
 	// the bonus value that gets added onto fishing rods when the component is used on them
-	var/fishing_value = 100
+	var/fishing_value = 0.2

--- a/ModularTegustation/fishing/code/rod_components/fishing_hooks.dm
+++ b/ModularTegustation/fishing/code/rod_components/fishing_hooks.dm
@@ -18,7 +18,7 @@
 	name = "bone hook"
 	desc = "a simple hook carved from sharpened bone"
 	icon_state = "bone"
-	fishing_value = 200
+	fishing_value = 0.3
 
 /datum/crafting_recipe/bone_hook
 	name = "Bone Hook"
@@ -30,11 +30,11 @@
 /obj/item/fishing_component/hook/weighted
 	name = "weighted hook"
 	icon_state = "weighted"
-	fishing_value = 300
+	fishing_value = 0.4
 	rod_overlay_icon_state = "hook_weighted_overlay"
 
 /obj/item/fishing_component/hook/shiny
 	name = "shiny lure hook"
 	icon_state = "shiny"
 	rod_overlay_icon_state = "hook_shiny_overlay"
-	fishing_value = 500
+	fishing_value = 0.6

--- a/ModularTegustation/fishing/code/rod_components/fishing_lines.dm
+++ b/ModularTegustation/fishing/code/rod_components/fishing_lines.dm
@@ -17,7 +17,7 @@
 	name = "fishing sinew line"
 	desc = "An all-natural fishing line made of stretched out sinew."
 	icon_state = "sinew"
-	fishing_value = 200
+	fishing_value = 0.3
 	line_color = "#d1cca3"
 
 /datum/crafting_recipe/sinew_line
@@ -31,5 +31,5 @@
 	name = "reinforced fishing line reel"
 	desc = "Essential for fishing in extreme environments."
 	icon_state = "green"
-	fishing_value = 400
+	fishing_value = 0.4
 	line_color = "#2b9c2b"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Reworking fishing chance on previous complaints about the chances being too large or too small.

- Changes to how fishing chance is calculated. Now a rod has a fishing chance modifier that is improved additivly by hooks and reel. 0.6 basic rod + basic hook 0.2 + basic line 0.2 = 1 chance modifier. 
- The formula for a rare fish is (15 - (5 * [amount of times we succeeded])) * [chance modifier] Basically there is a 85% chance for basic and a 15% chance for uncommon. If you roll uncommon it will roll again to see if you get rare which would be 1.5%.
- Fishing delay has been reduced to around 8 seconds and fishing skill now reduces the time it takes to fish by a flat second based on level.
- Adds a book that grants the reader the first level in fishing. The fishing skill book is included in the fishing tacklebox from the fish_market.
- Dough, canned peaches, and  space cash has been removed from the saltwater and freshwater loot table.
- Common, Uncommon, and Rare loot have been put into separate loot tables that have item values that each add up to 100%.
- Small edit to shrimp to make them contain only 2 units of reagents.

## Why It's Good For The Game
Fixes up and improves a small part of the game.

## Changelog
:cl:
tweak: fishing chance.
tweak: shrimp reagents
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
