### PR TITLE
Health calculation fixes and Red damage spread

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -558,9 +558,9 @@
 	var/total_stamina = 0
 	for(var/X in bodyparts)	//hardcoded to streamline things a bit
 		var/obj/item/bodypart/BP = X
-		total_brute	+= (BP.brute_dam * BP.body_damage_coeff)
-		total_burn	+= (BP.burn_dam * BP.body_damage_coeff)
-		total_stamina += (BP.stamina_dam * BP.stam_damage_coeff)
+		total_brute	+= BP.brute_dam
+		total_burn	+= BP.burn_dam
+		total_stamina += BP.stamina_dam
 	set_health(round(maxHealth - getOxyLoss() - getToxLoss() - getCloneLoss() - total_burn - total_brute, DAMAGE_PRECISION))
 	staminaloss = round(total_stamina, DAMAGE_PRECISION)
 	update_stat()

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1631,14 +1631,9 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 		if(BRAIN)
 			var/damage_amount = forced ? damage : damage * hit_percent * H.physiology.brain_mod
 			H.adjustOrganLoss(ORGAN_SLOT_BRAIN, damage_amount)
-		if(RED_DAMAGE) // TODO
-			H.damageoverlaytemp = 20
+		if(RED_DAMAGE)
 			var/damage_amount = forced ? damage : damage * hit_percent * redmod * H.physiology.red_mod
-			if(BP)
-				if(BP.receive_damage(damage_amount, 0, wound_bonus = wound_bonus, bare_wound_bonus = bare_wound_bonus, sharpness = sharpness))
-					H.update_damage_overlays()
-			else//no bodypart, we deal damage with a more general method.
-				H.adjustBruteLoss(damage_amount)
+			H.adjustRedLoss(damage_amount, forced = forced)
 		if(WHITE_DAMAGE)
 			var/damage_amount = forced ? damage : damage * hit_percent * whitemod * H.physiology.white_mod
 			H.adjustWhiteLoss(damage_amount, forced = forced, white_healable = white_healable)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Legs and arms contribute only 75% of their damage to total health damage and since all our damage is spread over all limbs it ends up increasing human effective health by 20%.
Pale damage is calculated based on 100% of human health but since all humans have 120% effective health it ends up being wrong.
![health-before](https://github.com/vlggms/lobotomy-corp13/assets/23573057/d9fe818f-dda5-441c-82f2-82207b533217)
For example here it requires 240 red damage or 120 pale damage to reduce 200 unarmored health to 0.

Additionally made red damage behave the same way black and pale do: it now always spreads damage over all limbs.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Removes obscure and hidden damage resistance.
Pale damage will actually deal correct amount of damage.
Black damage is no longer almost guaranteed to deplete sanity before critting a human.
Red and pale damage will be scarier due to fixed health.

Red damage spreading over all limbs improves consistency with other damage types.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
code: removed limb coefficients from health calculation reducing effective human health from what it used to be.
code: red damage is spread over all limbs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
