### PR TITLE
Particle Emitter Fadeout Proc

### DIFF
--- a/code/game/objects/effects/particles/particles.dm
+++ b/code/game/objects/effects/particles/particles.dm
@@ -119,6 +119,13 @@
 	else
 		particles.spawning = 0
 
+/obj/particle_emitter/proc/fadeout()
+	enable(FALSE)
+	if(istype(particles))
+		QDEL_IN(src, initial(particles.lifespan))
+	else
+		QDEL_NULL(src)
+
 /obj/particle_emitter/sparks
 	particles = new/particles/drill_sparks
 	plane = ABOVE_LIGHTING_PLANE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a proc to turn off particle emissions and then delete the emitter after all particles have, in theory, been deleted. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This allows for emitters to not just "vanish" all of their VFX the moment they need to be disposed of, allowing for lingering effects without the production of more. While this was previously easy to do this simplifies it further into a singular proc.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: fadeout() proc for particle_emitter objects
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
