### PR TITLE
The great 9 armor massacre of 2023-2024(And red and black fixer nerfs)

### DIFF
--- a/code/modules/clothing/suits/ego_gear/aleph.dm
+++ b/code/modules/clothing/suits/ego_gear/aleph.dm
@@ -63,7 +63,7 @@ Any attempt to code risk class armor will result in a 10 day Github ban.*/
 	name = "mimicry"
 	desc = "It takes human hide to protect human flesh. To protect humans, you need something made out of humans."
 	icon_state = "mimicry"
-	armor = list(RED_DAMAGE = 90, WHITE_DAMAGE = 50, BLACK_DAMAGE = 30, PALE_DAMAGE = 50) // 220
+	armor = list(RED_DAMAGE = 80, WHITE_DAMAGE = 50, BLACK_DAMAGE = 50, PALE_DAMAGE = 60) // 240
 	attribute_requirements = list(
 							FORTITUDE_ATTRIBUTE = 100,
 							PRUDENCE_ATTRIBUTE = 80,
@@ -102,7 +102,7 @@ Any attempt to code risk class armor will result in a 10 day Github ban.*/
 	desc = "It is holding all of the laughter of those who cannot be seen here."
 	icon_state = "smile"
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT
-	armor = list(RED_DAMAGE = 30, WHITE_DAMAGE = 50, BLACK_DAMAGE = 90, PALE_DAMAGE = 50) // 220
+	armor = list(RED_DAMAGE = 50, WHITE_DAMAGE = 50, BLACK_DAMAGE = 80, PALE_DAMAGE = 60) // 240
 	attribute_requirements = list(
 							FORTITUDE_ATTRIBUTE = 80,
 							PRUDENCE_ATTRIBUTE = 80,
@@ -376,7 +376,7 @@ Any attempt to code risk class armor will result in a 10 day Github ban.*/
 	name = "flesh is willing"
 	desc = "Is it immoral if you want it to happen?"
 	icon_state = "willing"
-	armor = list(RED_DAMAGE = 90, WHITE_DAMAGE = 30, BLACK_DAMAGE = 50, PALE_DAMAGE = 50) // 220
+	armor = list(RED_DAMAGE = 80, WHITE_DAMAGE = 60, BLACK_DAMAGE = 60, PALE_DAMAGE = 40) // 240
 	attribute_requirements = list(
 							FORTITUDE_ATTRIBUTE = 100,
 							PRUDENCE_ATTRIBUTE = 80,

--- a/code/modules/mob/living/simple_animal/hostile/ordeal/white.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/white.dm
@@ -11,8 +11,8 @@
 	health = 3000
 	melee_damage_type = BLACK_DAMAGE
 	rapid_melee = 2
-	melee_damage_lower = 40
-	melee_damage_upper = 50
+	melee_damage_lower = 30
+	melee_damage_upper = 40
 	move_to_delay = 2.6
 	ranged = TRUE
 	attack_verb_continuous = "bashes"
@@ -27,14 +27,14 @@
 	var/busy = FALSE
 	var/pulse_cooldown
 	var/pulse_cooldown_time = 20 SECONDS
-	var/pulse_damage = 20 // Dealt consistently across the entire room 5 times
+	var/pulse_damage = 18 // Dealt consistently across the entire room 5 times
 	/// Default range of triggering meltdowns during pulse attack
 	var/pulse_range = 24
 	/// The actual range of triggering meltdowns. Gets decreased with each attack during pulse attack
 	var/current_pulse_range = 24
 	var/hammer_cooldown
 	var/hammer_cooldown_time = 6 SECONDS
-	var/hammer_damage = 250
+	var/hammer_damage = 200
 	var/list/been_hit = list()
 
 /mob/living/simple_animal/hostile/ordeal/black_fixer/Initialize()
@@ -351,8 +351,8 @@
 	health = 3000
 	melee_damage_type = RED_DAMAGE
 	rapid_melee = 4
-	melee_damage_lower = 30
-	melee_damage_upper = 40
+	melee_damage_lower = 15
+	melee_damage_upper = 35
 	move_to_delay = 2.2
 	ranged = TRUE
 	attack_verb_continuous = "slashes"
@@ -366,7 +366,7 @@
 	var/busy = FALSE
 	var/multislash_cooldown
 	var/multislash_cooldown_time = 4 SECONDS
-	var/multislash_damage = 75
+	var/multislash_damage = 60
 	var/multislash_range = 6
 	var/beam_cooldown
 	var/beam_cooldown_time = 10 SECONDS
@@ -470,7 +470,7 @@
 			been_hit |= L
 			new /obj/effect/temp_visual/cult/sparks(get_turf(L))
 	playsound(src, 'sound/effects/ordeals/white/red_beam_fire.ogg', 100, FALSE, 32)
-	SLEEP_CHECK_DEATH(0.5 SECONDS)
+	SLEEP_CHECK_DEATH(1.5 SECONDS)
 	beam_cooldown = world.time + beam_cooldown_time
 	busy = FALSE
 	icon_state = icon_living


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Nerfs all 3 aleph armors that have 9 in one of their stats.

Mimicry has 8/5/5/6(I DID IT KIRIE I TOUCHED MIMICRY!!!)
Smile has 5/5/8/6
Flesh is Willing has 8/6/6/4

Also does these changes to red and black fixer
Black Fixer:
Melee Damage -10 (Upper and Lower, it has Rapid Melee 2 so it still swings for a good chunk) (New Range 30-40, Rapid Melee 2, 60-80 from 80-100)
Hammer Damage -50 (200 from 250)
Pulse Damage -2 (effective -10 total damage nerf)

Red Fixer:
Melee Damage Lower -15
Melee Damage Upper -5 (New Range 15-35, Rapid Melee 4, 60-140 from 120-160)
Multislash Damage -15 (60 x2, from 75 x2)
Beam Stun Time +1 Second (Sleep Check Death from 0.5 Seconds to 1.5, deadly ability but stops him from chasing *and* lets you get in on him)
## Why It's Good For The Game

9 red and black was honestly overpowered in my eyes for 3 reasons:
1. Red and Black are the 2 most common damage types.
2. having 90% damage reduction made many threats way too easy unless you balanced late game around those but then those threats would deal way too much damage to people without 90% dr.
3. Kod's blessing make them 95% which practically made you immune and allow for silly shit like face tanking claw with mimicry scythe.

This isn't as much a nerf to the abnormalities that have it since even with out 9s on the armor Nothing There and Mosb would still be some of the most picked alephs due to easy of work and their weapons being some of the best in the game.(It might make Til the Last Shot less picked due to buffing agent stats can cause no-one to have the stats to work it and that with it not having 9 armor really makes it less useful to have.).

Does not change Flowering nights even though it has pale 9 due to it being both aleph+, it bein the second most expensive item an abnormality has, only one person can work on rose at a time, people using rose's pe for the 100 pe armor and weapon, pale being the rarest damage type to be fighting against, and it coming with a downside of black 3. If anything maybe make kod blessing quadruple pale taken when with pale 9 since that's the only real reason why pale 9 can be broke at times. Also doesn't change De capo since white immunity is balanced by the fact white can't kill you unlike red, black, and pale. Does not also change the red 9 of nagel und hammer grosshammer and the pale 9 of Jacket of Blue since both are from gacha and I don't want to piss off Kirie from changing those stats.

Kirie wanted me to nerf fixers also and lance gave me what I should nerf about them
## Changelog
:cl:
balance: rebalanced Mimicry, Smile, and Flesh is Willing, nerfs red and black fixer also
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
