### PR TITLE
Gives Error Messages to Vitals Visualizer Gadget

### DIFF
--- a/ModularTegustation/tegu_items/gadgets/powered.dm
+++ b/ModularTegustation/tegu_items/gadgets/powered.dm
@@ -360,7 +360,10 @@
 	. = ..()
 	if(!chosen_target_type)
 		to_chat(user, span_warning("Use in-hand to set the target type!"))
-	if(cell && cell.charge >= batterycost && target_check(target))
+	if(cell && cell.charge >= batterycost)
+		if(isliving(target) && !target_check(target))
+			to_chat(user, span_warning("The projector fails to scan [target] with its current setting."))
+			return
 		cell.charge -= batterycost
 		var/mob/living/L = target
 		to_chat(user, span_notice("Projection of [target] Vitals Initializing."))


### PR DESCRIPTION
## About The Pull Request
Places a error message on vitals visualizer if the target is not scannable with the current setting.

## Why It's Good For The Game
Helps let players know the monster is not a abnormality if it does not work on it.

## Changelog
:cl:
tweak: vitals visualizer
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
