### PR TITLE
Fixes book's paper abno health

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/teth/book.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/book.dm
@@ -117,7 +117,8 @@
 	spawnedmob.desc = "It looks like a [spawnedmob.name] but made of paper."
 	spawnedmob.name = "Paper [initial(spawnedmob.name)]"
 	spawnedmob.faction = list("hostile")
-	spawnedmob.health = (spawnedmob.maxHealth / 10)
+	spawnedmob.maxHealth = (spawnedmob.maxHealth / 10)
+	spawnedmob.health = spawnedmob.maxHealth
 	spawnedmob.deathmessage = "collapses into a bunch of writing material."
 	spawnedmob.filters += filter(type="drop_shadow", x=0, y=0, size=1, offset=0, color=rgb(0, 0, 0))
 	src.visible_message(span_warning("Pages of [src] fold into [spawnedmob]!"))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Since health was being set without inflicting any actual damage when updateHealth is called health was resetting to maxHealth.
![paper cleaner hp](https://github.com/vlggms/lobotomy-corp13/assets/23573057/142f8aff-5355-4a31-8f08-12d725e85976)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Book breach will no longer obliterate your early game facility.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixed paper abnormality health.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
