### PR TITLE
Allows ghosts to drag-click themselfes onto abnormalities to possess them. Ghosting no longer bricks abnormalities -- The PR that all event players needed

### DIFF
--- a/ModularTegustation/misc_procs.dm
+++ b/ModularTegustation/misc_procs.dm
@@ -1,3 +1,11 @@
+/**
+ * This proc gets called when a ghost drags themselfes onto an abnormality and passess several checks to make sure they can do that
+ * This proc allows a ghost to take over an abnormality, mainly used in the playables events
+ * Its called AFTER the admin proc to force ghosts into mobs, so admins will need to dead-min to access this like a player would
+ *
+ * Called by /mob/dead/observer/MouseDrop(atom/over)
+ */
+
 /datum/proc/try_take_abnormality(mob/dead/observer/possessing_player, mob/abnormality)
 	if(!SSlobotomy_corp.enable_possession) // uhhhh, how did you even access this proc?
 		to_chat(usr, span_userdanger("Abnormality possession is not enabled!"))
@@ -9,7 +17,7 @@
 		return
 
 	if(abnormality.ckey)
-		to_chat(possessing_player, span_userdanger("This abnormality already has a ghost in control of it, you cant possess it!"))
+		to_chat(possessing_player, span_userdanger("This abnormality already has a ghost in control of it, you can't possess it!"))
 		return
 
 	var/title = "Do you wish to possess this abnormality?"

--- a/ModularTegustation/misc_procs.dm
+++ b/ModularTegustation/misc_procs.dm
@@ -1,0 +1,34 @@
+/datum/proc/try_take_abnormality(mob/dead/observer/possessing_player, mob/abnormality)
+	if(!SSlobotomy_corp.enable_possession) // uhhhh, how did you even access this proc?
+		to_chat(usr, span_userdanger("Abnormality possession is not enabled!"))
+		message_admins(span_adminnotice("[possessing_player.key] has accessed the try_take_abnormality proc whilst possession is disabled."))
+		return
+
+	if(!possessing_player.ckey) // safety check
+		to_chat(possessing_player, span_userdanger("You dont have a valid ckey, this should not show up!"))
+		return
+
+	if(abnormality.ckey)
+		to_chat(possessing_player, span_userdanger("This abnormality already has a ghost in control of it, you cant possess it!"))
+		return
+
+	var/title = "Do you wish to possess this abnormality?"
+	var/message = "Are you sure you want to possess [abnormality.name]?"
+
+	var/ask = tgui_alert(usr, message, title, list("Yes", "No"))
+	if(ask != "Yes")
+		return
+
+	if(!possessing_player || !abnormality) //make sure the mobs didnt get deleted while we waited for a response, else this could end badly
+		return
+
+	if(abnormality.ckey) // and then make sure someone wasnt faster than you
+		to_chat(possessing_player, span_userdanger("This abnormality already has a ghost in control of it, seems like you were too slow!"))
+		return
+
+	message_admins(span_adminnotice("[possessing_player.key] has possessed [abnormality.name]."))
+	log_admin("[possessing_player.key] has possessed [abnormality.name].")
+
+	abnormality.key = possessing_player.key
+	abnormality.client?.init_verbs()
+	qdel(possessing_player)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -695,7 +695,31 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		if (usr.client.holder.cmd_ghost_drag(src,over))
 			return
 
-	return ..()
+	//LOBOTOMYCORPORATION ADDITION START
+	if(usr != src) // dont give chat feedback, dragging others onto an abnormality is probably just a silly mistake
+		return ..()
+
+	if(!isobserver(usr)) // safety check
+		to_chat(usr, span_userdanger("you are not an observer despite being an observer, silly. You cant possess abnormalities!"))
+		return ..()
+
+	if(!usr.client) // who are we talking to again...? whatever
+		to_chat(usr, span_userdanger("You dont exist, so you cant possess!"))
+		return ..()
+
+	if(!SSlobotomy_corp.enable_possession) // if admins dont want us to fuck around, lets not fuck around
+		to_chat(usr, span_userdanger("Abnormality possession is not enabled!"))
+		return ..()
+
+	if(!isabnormalitymob(over)) // we want them to ONLY be able to possess abnormalities
+		to_chat(usr, span_userdanger("You can only possess abnormalities!"))
+		return ..()
+
+	try_take_abnormality(src, over)
+	return
+	//LOBOTOMYCORPORATION ADDITION END
+
+//	return ..() LOBOTOMYCORPORATION REMOVAL -- we dont need this anymore since we do safety checks instead
 
 /mob/dead/observer/Topic(href, href_list)
 	..()

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -695,8 +695,13 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		if (usr.client.holder.cmd_ghost_drag(src,over))
 			return
 
-	//LOBOTOMYCORPORATION ADDITION START
+	//LOBOTOMYCORPORATION ADDITION START -- drag-clicking your ghost onto abnormalities to possess them
+
 	if(usr != src) // dont give chat feedback, dragging others onto an abnormality is probably just a silly mistake
+		return ..()
+
+	if(!SSlobotomy_corp.enable_possession) // if admins dont want us to fuck around, lets not fuck around
+		to_chat(usr, span_userdanger("Abnormality possession is not enabled!"))
 		return ..()
 
 	if(!isobserver(usr)) // safety check
@@ -707,10 +712,6 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		to_chat(usr, span_userdanger("You dont exist, so you cant possess!"))
 		return ..()
 
-	if(!SSlobotomy_corp.enable_possession) // if admins dont want us to fuck around, lets not fuck around
-		to_chat(usr, span_userdanger("Abnormality possession is not enabled!"))
-		return ..()
-
 	if(!isabnormalitymob(over)) // we want them to ONLY be able to possess abnormalities
 		to_chat(usr, span_userdanger("You can only possess abnormalities!"))
 		return ..()
@@ -719,7 +720,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	return
 	//LOBOTOMYCORPORATION ADDITION END
 
-//	return ..() LOBOTOMYCORPORATION REMOVAL -- we dont need this anymore since we do safety checks instead
+//	return ..() LOBOTOMYCORPORATION REMOVAL -- we dont need this anymore since we do safety checks with early returns instead
 
 /mob/dead/observer/Topic(href, href_list)
 	..()

--- a/lobotomy-corp13.dme
+++ b/lobotomy-corp13.dme
@@ -3854,6 +3854,7 @@
 #include "ModularTegustation\lc13_spawners.dm"
 #include "ModularTegustation\lc13_structures.dm"
 #include "ModularTegustation\looc.dm"
+#include "ModularTegustation\misc_procs.dm"
 #include "ModularTegustation\resindoor.dm"
 #include "ModularTegustation\t5_parts.dm"
 #include "ModularTegustation\tegu_boxes.dm"


### PR DESCRIPTION
## About The Pull Request

This PR makes it so you can drag-click yourself onto abnormalities instead of going through the ghost tab, then the ugly long list and finding the needle in a haystack thats an abnormality, to then learn someone else possessed it

Drag-clicking also checks if the abnormality has a ckey or not, making abnormalities that previously had a player but were ghosted no longer bricked until they are killed/deleted

Le video of it working (i would also show the message for when abnormalities cant be possessed, but too lazy)

https://github.com/vlggms/lobotomy-corp13/assets/82319946/8bd00cf7-b2b3-454c-a6bd-461d0e37c2c2

## Why It's Good For The Game

The about section speaks for itself, lots of QoL and makes playable abnos much more enjoyable

## Changelog
:cl:
add: You can now drag-click yourself onto an abnormality to possess them, if possession is enabled
fix: ghosting no longer makes abnormalities un-possessable, that one guy who possess all abnormalities and ghosts wont bully you anymore
/:cl:
