### PR TITLE
Clerkbot Change

### DIFF
--- a/ModularTegustation/tegu_items/gadgets/powered.dm
+++ b/ModularTegustation/tegu_items/gadgets/powered.dm
@@ -219,55 +219,6 @@
 	inuse = FALSE
 	update_icon()
 
-/obj/item/powered_gadget/clerkbot_gadget
-	name = "Instant Clerkbot Constructor"
-	desc = "An instant constructor for Clerkbots. Loyal little things that attack hostile creatures. Only for clerks."
-	icon_state = "clerkbot2_deactivated"
-	batterycost = 10000
-
-/obj/item/powered_gadget/clerkbot_gadget/attack_self(mob/user)
-	..()
-	if(cell && cell.charge >= batterycost)
-		cell.charge = cell.charge - batterycost
-		if(!istype(user) || !(user?.mind?.assigned_role in GLOB.service_positions))
-			to_chat(user, span_notice("The Gadget's light flashes red. You aren't a clerk. Check the label before use."))
-			return
-		new /mob/living/simple_animal/hostile/clerkbot(get_turf(user))
-		to_chat(user, span_nicegreen("The Gadget turns warm and sparks."))
-
-/mob/living/simple_animal/hostile/clerkbot/Initialize()
-	..()
-	icon = 'ModularTegustation/Teguicons/32x32.dmi'
-	icon_state = "clerkbot2"
-	icon_living = "clerkbot2"
-	if(prob(50))
-		icon_state = "clerkbot1"
-		icon_living = "clerkbot1"
-
-/mob/living/simple_animal/hostile/clerkbot
-	name = "A Well Rounded Clerkbot"
-	desc = "Trusted and loyal best friend."
-	icon = 'ModularTegustation/Teguicons/32x32.dmi'
-	icon_state = "clerkbot2"
-	icon_living = "clerkbot2"
-	faction = list("neutral")
-	health = 150
-	maxHealth = 150
-	melee_damage_type = RED_DAMAGE
-	damage_coeff = list(RED_DAMAGE = 0.9, WHITE_DAMAGE = 0.9, BLACK_DAMAGE = 0.9, PALE_DAMAGE = 1.5)
-	melee_damage_lower = 12
-	melee_damage_upper = 14
-	robust_searching = TRUE
-	stat_attack = HARD_CRIT
-	del_on_death = TRUE
-	attack_verb_continuous = "buzzes"
-	attack_verb_simple = "buzz"
-	attack_sound = 'sound/weapons/bite.ogg'
-
-/mob/living/simple_animal/hostile/clerkbot/Initialize()
-	..()
-	QDEL_IN(src, (120 SECONDS))
-
 //The taser
 /obj/item/powered_gadget/handheld_taser
 	name = "Handheld Taser"

--- a/ModularTegustation/tegu_items/gadgets/unpowered.dm
+++ b/ModularTegustation/tegu_items/gadgets/unpowered.dm
@@ -499,3 +499,71 @@
 	)
 	mid_length = 2 SECONDS
 	volume = 20
+
+//Clerkbot Spawner
+/obj/item/clerkbot_gadget
+	name = "Instant Clerkbot Constructor"
+	desc = "An instant constructor for Clerkbots. Loyal little things that attack hostile creatures. In order to prevent \
+		abnormalities infesting the clerkbots, only those registered as a Lobotomy Corp clerk can activate them. Clerkbot \
+		will last for 2 minutes before it preforms auto shutdown."
+	icon = 'ModularTegustation/Teguicons/teguitems.dmi'
+	icon_state = "clerkbot2_deactivated"
+
+/obj/item/clerkbot_gadget/attack_self(mob/user)
+	..()
+	if(!istype(user) || !(user?.mind?.assigned_role in GLOB.service_positions))
+		to_chat(user, span_notice("The Gadget's light flashes red. You aren't a clerk. Check the label before use."))
+		return
+	new /mob/living/simple_animal/hostile/clerkbot(get_turf(user))
+	to_chat(user, span_nicegreen("The Gadget turns warm and sparks."))
+	qdel(src)
+
+	//Clerkbot spawned by the Clerkbot Spawner
+/mob/living/simple_animal/hostile/clerkbot
+	name = "A Well Rounded Clerkbot"
+	desc = "Trusted and loyal best friend."
+	icon = 'ModularTegustation/Teguicons/32x32.dmi'
+	icon_state = "clerkbot2"
+	icon_living = "clerkbot2"
+	gender = NEUTER
+	mob_biotypes = MOB_ROBOTIC
+	faction = list("neutral")
+	health = 150
+	maxHealth = 150
+	healable = FALSE
+	melee_damage_type = RED_DAMAGE
+	damage_coeff = list(RED_DAMAGE = 0.9, WHITE_DAMAGE = 0.9, BLACK_DAMAGE = 0.9, PALE_DAMAGE = 1.5)
+	melee_damage_lower = 12
+	melee_damage_upper = 14
+	robust_searching = TRUE
+	stat_attack = HARD_CRIT
+	del_on_death = TRUE
+	attack_verb_continuous = "buzzes"
+	attack_verb_simple = "buzz"
+	attack_sound = 'sound/weapons/etherealhit.ogg'
+	verb_say = "states"
+	verb_ask = "queries"
+	verb_exclaim = "declares"
+	verb_yell = "alarms"
+	bubble_icon = "machine"
+	speech_span = SPAN_ROBOT
+
+/mob/living/simple_animal/hostile/clerkbot/Initialize()
+	..()
+	QDEL_IN(src, (120 SECONDS))
+	if(prob(50))
+		icon_state = "clerkbot1"
+		icon_living = "clerkbot1"
+
+/mob/living/simple_animal/hostile/clerkbot/Login()
+	. = ..()
+	if(!. || !client)
+		return FALSE
+	to_chat(src, "<b>WARNING:THIS CREATURE IS TEMPORARY AND WILL DELETE ITSELF AFTER A GIVEN TIME!</b>")
+
+/mob/living/simple_animal/hostile/clerkbot/Destroy()
+	new /obj/item/clerkbot_gadget(get_turf(src))
+	return ..()
+
+/mob/living/simple_animal/hostile/clerkbot/spawn_gibs()
+	new /obj/effect/gibspawner/robot(drop_location(), src)

--- a/ModularTegustation/tegu_items/refinery/crates/corporation.dm
+++ b/ModularTegustation/tegu_items/refinery/crates/corporation.dm
@@ -7,7 +7,7 @@
 	lootlist =	list(
 		/obj/item/powered_gadget/detector_gadget/abnormality,
 		/obj/item/powered_gadget/slowingtrapmk1,
-		/obj/item/powered_gadget/clerkbot_gadget,
+		/obj/item/clerkbot_gadget,
 		/obj/item/powered_gadget/handheld_taser,
 		/obj/item/storage/box/minertracker,
 		/obj/item/forcefield_projector,

--- a/ModularTegustation/tegu_items/representative/console.dm
+++ b/ModularTegustation/tegu_items/representative/console.dm
@@ -185,7 +185,7 @@
 				new /datum/data/extraction_cargo("L Corp Regeneration Augmentation Kit", /obj/item/safety_kit, 400, L_CORP_REP) = 1,
 				new /datum/data/extraction_cargo("L Corp Slowing Trap Generator", /obj/item/powered_gadget/slowingtrapmk1, 400, L_CORP_REP) = 1,
 				new /datum/data/extraction_cargo("L Corp Vitals Projector", /obj/item/powered_gadget/vitals_projector, 400, L_CORP_REP) = 1,
-				new /datum/data/extraction_cargo("L Corp Clerkbot Kit", /obj/item/powered_gadget/clerkbot_gadget, 400, L_CORP_REP) = 1,
+				new /datum/data/extraction_cargo("L Corp Clerkbot Kit", /obj/item/clerkbot_gadget, 400, L_CORP_REP) = 1,
 				new /datum/data/extraction_cargo("L Corp Taser", /obj/item/powered_gadget/handheld_taser, 700, L_CORP_REP) = 1,
 				)
 

--- a/code/game/machinery/computer/extraction_cargo.dm
+++ b/code/game/machinery/computer/extraction_cargo.dm
@@ -25,7 +25,7 @@
 		new /datum/data/extraction_cargo("Keen-Sense Rangefinder ",		/obj/item/powered_gadget/detector_gadget/ordeal,					200, CAT_GADGET) = 1,
 		new /datum/data/extraction_cargo("EMAIS	Capacity Upgrade ",		/obj/item/hypo_upgrade/cap_increase,								200, CAT_GADGET) = 1,
 		new /datum/data/extraction_cargo("Prototype Enkephalin Injector ",/obj/item/powered_gadget/enkephalin_injector,						200, CAT_GADGET) = 1,
-		new /datum/data/extraction_cargo("Instant Clerkbot Constructor ",/obj/item/powered_gadget/clerkbot_gadget,							250, CAT_GADGET) = 1,
+		new /datum/data/extraction_cargo("Instant Clerkbot Constructor ",/obj/item/clerkbot_gadget,							250, CAT_GADGET) = 1,
 		//new /datum/data/extraction_cargo("C-Fear Protection Injector ",	/obj/item/trait_injector/clerk_fear_immunity_injector,			300, CAT_GADGET) = 1,
 		new /datum/data/extraction_cargo("Handheld Taser",				/obj/item/powered_gadget/handheld_taser,							300, CAT_GADGET) = 1,
 		new /datum/data/extraction_cargo("Vitals Projector ",			/obj/item/powered_gadget/vitals_projector,							300, CAT_GADGET) = 1,

--- a/code/modules/jobs/job_types/assistant.dm
+++ b/code/modules/jobs/job_types/assistant.dm
@@ -55,7 +55,7 @@ GLOBAL_LIST_EMPTY(spawned_clerks)
 	/obj/item/powered_gadget/detector_gadget/abnormality,
 	/obj/item/powered_gadget/detector_gadget/ordeal,
 	/obj/item/powered_gadget/enkephalin_injector,
-	/obj/item/powered_gadget/clerkbot_gadget,
+	/obj/item/clerkbot_gadget,
 	/obj/item/powered_gadget/handheld_taser,
 	/obj/item/powered_gadget/vitals_projector,
 	/obj/item/reagent_containers/hypospray/emais,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes clerkbot gadgets to be one use and be dropped by clerkbots on death. Strangely enough this makes clerkbots more like pokemon or consumable bodygaurd spawners.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I was slightly bothered by a gadget spawning 6 seperate clerkbots within a instant.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: clerkbot_gadget
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
