### PR TITLE
Skittish goes from 4 to 2 points

### DIFF
--- a/code/datums/quirks/good.dm
+++ b/code/datums/quirks/good.dm
@@ -195,7 +195,7 @@
 /datum/quirk/skittish
 	name = "Skittish"
 	desc = "You're easy to startle, and hide frequently. Run into a closed locker to jump into it, as long as you have access. You can walk to avoid this."
-	value = 4
+	value = 2
 	mob_trait = TRAIT_SKITTISH
 	medical_record_text = "Patient demonstrates a high aversion to danger and has described hiding in containers out of fear."
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Skittish Trait goes from 4 to 2 points

## Why It's Good For The Game

Skittish trait is on par with other traits like night vision, having it be 4 points was too much and putting it to 2 should better reflect it's impact.

## Changelog
:cl:
balance: Skittish trait reduced from 4 to 2 trait points

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
