### PR TITLE
Fixes EMAIS to now work with Support officers

### DIFF
--- a/code/game/objects/items/clerks/hypo/hypo.dm
+++ b/code/game/objects/items/clerks/hypo/hypo.dm
@@ -167,7 +167,7 @@
 
 
 /obj/item/reagent_containers/hypospray/emais/proc/clerk_check(mob/living/carbon/human/H)
-	var/list/allowed_roles = list("Clerk", "Operations Officer")
+	var/list/allowed_roles = list("Clerk", "Operations Officer", "Support Officer")
 	var/datum/status_effect/chosen/C = H.has_status_effect(/datum/status_effect/chosen)
 	if(C)
 		to_chat(H, "<span class='notice'>A mysterious force prevents you from using this!</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Support officers can use EMAIS.
This was a bug initially, they are supposed to be mechanically identical to Operations Officer.
This was a minor oversight

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
## Changelog
:cl:
fix: fixed Support Officers being unable to use EMAIS
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
