### PR TITLE
Make Piscine Mermaid less needy

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/he/pisc_mermaid.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/pisc_mermaid.dm
@@ -257,7 +257,7 @@
 	worn_icon = 'icons/mob/clothing/ego_gear/head.dmi'
 	var/success_mod = 1.15
 	var/love_cooldown
-	var/love_cooldown_time = 1 MINUTES //It takes around 3 minutes for mermaid to breach if left unchecked
+	var/love_cooldown_time = 3 MINUTES //It takes around 9 minutes for mermaid to breach if left unchecked
 	var/mob/living/simple_animal/hostile/abnormality/pisc_mermaid/mermaid
 	var/mob/living/carbon/human/loved //What's wrong anon? Unconditional love is what you wanted right?
 


### PR DESCRIPTION
## About The Pull Request

Piscine Mermaid's Qliphoth Counter reduction cooldown due to her Lover (crown wearer) not working with her is now 3 minutes instead of 1. She's now much less needy and breaches in 9 minutes instead of 3.

## Why It's Good For The Game

Piscine Mermaid's gift is actually a pretty solid item, but the fact it turned you into a sacrificial lamb for the mermaid made it not worth the danger, along with the quick drop in the counter negating the viability of the crown (+5% work success per counter). Now it makes the crown much more viable to use and doesnt strip down the lover of their free will, being able to work on other abnorms, breaches or ordeals while still needing to give attention to the Mermaid.
