### PR TITLE
Adds better radio jamming

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -829,12 +829,18 @@
 /turf/open/floor/plasteel/white,
 /area/facility_hallway/manager)
 "dr" = (
-/obj/item/jammer/self_activated{
-	alpha = 0;
-	range = 20
+/obj/effect/turf_decal/weather/snow/corner,
+/obj/effect/radiojammer{
+	range = 14
 	},
-/turf/open/water/deep/saltwater/extradeep,
-/area/fishboat)
+/turf/open/floor/plasteel/dark{
+	icon = 'icons/turf/snow.dmi';
+	icon_state = "snow-ice";
+	name = "ice";
+	initial_gas_mix = "o2=22;n2=82;TEMP=270.15";
+	base_icon_state = "snow-ice"
+	},
+/area/snowqueen)
 "dv" = (
 /obj/structure/flora/iceshards{
 	pixel_y = -12;
@@ -3077,13 +3083,6 @@
 	dir = 1
 	},
 /area/tdome/tdomeobserve)
-"lW" = (
-/obj/item/jammer/self_activated{
-	alpha = 0;
-	range = 20
-	},
-/turf/open/space/basic,
-/area/space)
 "lX" = (
 /turf/closed/indestructible/abductor{
 	icon_state = "alien10"
@@ -3378,12 +3377,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/evac)
-"ns" = (
-/obj/item/jammer/self_activated{
-	alpha = 0
-	},
-/turf/open/water/deep/saltwater/extradeep,
-/area/fishboat)
 "nx" = (
 /obj/structure/flora/bush,
 /turf/open/floor/plating/asteroid/snow/airless,
@@ -8345,10 +8338,6 @@
 	},
 /turf/closed/mineral/snowmountain/cavern,
 /area/snowqueen)
-"Gh" = (
-/obj/item/jammer/self_activated,
-/turf/closed/indestructible/rock,
-/area/shelter)
 "Gj" = (
 /obj/effect/turf_decal/siding/white/corner{
 	dir = 8
@@ -10262,6 +10251,9 @@
 /turf/open/floor/carpet/green,
 /area/facility_hallway/manager)
 "Nk" = (
+/obj/effect/radiojammer{
+	range = 15
+	},
 /turf/closed/indestructible/wood,
 /area/fishboat)
 "Nm" = (
@@ -11060,6 +11052,9 @@
 /area/centcom/holding)
 "QG" = (
 /obj/effect/landmark/snowqueen_playerspawn,
+/obj/effect/radiojammer{
+	range = 6
+	},
 /turf/open/floor/plasteel/dark{
 	icon = 'icons/turf/snow.dmi';
 	icon_state = "snow-ice";
@@ -12760,6 +12755,9 @@
 "XJ" = (
 /obj/structure/toolabnormality/shelter/exit,
 /obj/effect/shelter_forcefield,
+/obj/effect/radiojammer{
+	range = 8
+	},
 /turf/open/floor/shelter,
 /area/shelter)
 "XL" = (
@@ -64006,7 +64004,7 @@ Sg
 Sg
 Sg
 Sg
-ns
+Sg
 Sg
 Sg
 Sg
@@ -66565,7 +66563,7 @@ aa
 tF
 Sg
 Sg
-ns
+Sg
 Sg
 Sg
 Sg
@@ -66588,7 +66586,7 @@ CH
 Sg
 Sg
 Sg
-dr
+Sg
 Sg
 Sg
 tF
@@ -69146,7 +69144,7 @@ Sg
 Sg
 Sg
 Sg
-ns
+Sg
 Sg
 Sg
 Sg
@@ -70408,7 +70406,7 @@ aa
 aa
 aa
 aa
-lW
+aa
 aa
 aa
 aa
@@ -74249,7 +74247,7 @@ aa
 aa
 aa
 aa
-lW
+aa
 qu
 qu
 rB
@@ -74264,7 +74262,7 @@ rB
 rB
 Ho
 TF
-Ow
+dr
 rB
 rB
 tl
@@ -74297,7 +74295,7 @@ eM
 XJ
 sI
 wU
-Gh
+FI
 FI
 aa
 aa
@@ -75562,7 +75560,7 @@ rB
 Yb
 qu
 qu
-lW
+aa
 qu
 qu
 qu
@@ -78118,7 +78116,7 @@ aa
 aa
 aa
 aa
-lW
+aa
 aa
 aa
 aa

--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -505,3 +505,18 @@ INITIALIZE_IMMEDIATE(/obj/effect/landmark/start/new_player)
 /obj/effect/landmark/abnormality_spawn/tutorial/fairy
 	name = "tutorial spawn (fairy)"
 	chosen = /mob/living/simple_animal/hostile/abnormality/fairy_swarm
+
+/obj/effect/radiojammer
+	name = "radio jammer"
+	desc = "Device used to disrupt nearby radio communication."
+	icon = 'icons/obj/device.dmi'
+	icon_state = "gangtool-blue"
+	anchored = TRUE
+	layer = MID_LANDMARK_LAYER
+	invisibility = INVISIBILITY_ABSTRACT
+	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
+	var/range = 12
+
+/obj/effect/radiojammer/Initialize()
+	. = ..()
+	GLOB.active_jammers |= src

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -260,10 +260,8 @@
 
 	// Nearby active jammers prevent the message from transmitting
 	var/turf/position = get_turf(src)
-	for(var/obj/item/jammer/jammer in GLOB.active_jammers)
-		var/turf/jammer_turf = get_turf(jammer)
-		if(position.z == jammer_turf.z && (get_dist(position, jammer_turf) <= jammer.range))
-			return
+	if(check_jammed(position))
+		return
 
 	// Determine the identity information which will be attached to the signal.
 	var/atom/movable/virtualspeaker/speaker = new(null, M, src)
@@ -289,6 +287,17 @@
 	// Non-subspace radios will check in a couple of seconds, and if the signal
 	// was never received, send a mundane broadcast (no headsets).
 	addtimer(CALLBACK(src, .proc/backup_transmission, signal), 20)
+
+/obj/item/radio/proc/check_jammed(turf/position)
+	for(var/obj/item/jammer/jammer in GLOB.active_jammers)
+		var/turf/jammer_turf = get_turf(jammer)
+		if(position.z == jammer_turf.z && (get_dist(position, jammer_turf) <= jammer.range))
+			return TRUE
+	for(var/obj/effect/radiojammer/radiojammer in GLOB.active_jammers)
+		var/turf/radiojammer_turf = get_turf(radiojammer)
+		if(position.z == radiojammer_turf.z && (get_dist(position, radiojammer_turf) <= radiojammer.range))
+			return TRUE
+	return FALSE
 
 /obj/item/radio/proc/backup_transmission(datum/signal/subspace/vocal/signal)
 	var/turf/T = get_turf(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds mapped radio jammers. They are invisible to players and invincible, just like any other landmark. Except they aren't landmarks. Neat!
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Prevents a recent bug related to the item version of radio jammers and also just keeps things cleaner overall.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added mapped radio jammers
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
