### PR TITLE
City of Light Carnival and Butcher changes

### DIFF
--- a/code/modules/jobs/job_types/city/backstreets_butcher.dm
+++ b/code/modules/jobs/job_types/city/backstreets_butcher.dm
@@ -4,8 +4,8 @@ Backstreets Butcher
 /datum/job/butcher
 	title = "Backstreets Butcher"
 	faction = "Station"
-	total_positions = 2
-	spawn_positions = 2
+	total_positions = 0
+	spawn_positions = 0
 	supervisors = "your stomach."
 	selection_color = "#555555"
 	access = list(ACCESS_GENETICS)

--- a/code/modules/jobs/job_types/city/carnival.dm
+++ b/code/modules/jobs/job_types/city/carnival.dm
@@ -1,8 +1,8 @@
 /datum/job/carnival
 	title = "Carnival"
 	faction = "Station"
-	total_positions = 3
-	spawn_positions = 3
+	total_positions = 2
+	spawn_positions = 2
 	supervisors = "your self."
 	selection_color = "#555555"
 	access = list(ACCESS_CARGO)
@@ -26,9 +26,10 @@
 
 
 
-/datum/job/butcher/after_spawn(mob/living/carbon/human/H, mob/M, latejoin = FALSE)
+/datum/job/carnival/after_spawn(mob/living/carbon/human/H, mob/M, latejoin = FALSE)
 	ADD_TRAIT(H, TRAIT_WORK_FORBIDDEN, JOB_TRAIT)
 	ADD_TRAIT(H, TRAIT_COMBATFEAR_IMMUNE, JOB_TRAIT)
+	H.set_species(/datum/species/synth)
 	job_important = "If there is an L-Corp facility nearby, do not enter it. Fixers are not inherently hostile to you, but they can find a reason to put you down. \
 			Your primary goal is to kill monsters in the backstreets and/or humans to weave silk so you can then sell it to the humans. \
 			You have a base on the left side of the nest."
@@ -41,7 +42,7 @@
 	belt = /obj/item/ego_weapon/city/carnival_spear	//So they can catch prey
 	suit = null
 	l_pocket = null
-	ears = /obj/item/radio/headset/syndicatecity
+	ears = /obj/item/radio/headset/wcorp/safety
 	glasses = /obj/item/clothing/glasses/hud/health/night
 	mask = /obj/item/clothing/mask/carnival_mask
 	gloves = /obj/item/clothing/gloves/color/black

--- a/code/modules/jobs/job_types/city/syndicate/blade_lineage/cutthroat.dm
+++ b/code/modules/jobs/job_types/city/syndicate/blade_lineage/cutthroat.dm
@@ -39,6 +39,10 @@
 	for(var/datum/job/processing in SSjob.occupations)
 		if(istype(processing, /datum/job/salsu))
 			processing.total_positions = 2
+
+	//Someone for them to fight, and give the fixers a scare.
+		if(istype(processing, /datum/job/butcher))
+			processing.total_positions = 2
 	. = ..()
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes Carnival to have Safety comms instead of Discipline, and reduces their slots to 2
Carnival is now synthetic and therefore by default a target for Nagel Und Hammer
Butchers no longer spawn by default.
Blade Lineage spawns butchers to fight.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Carnival had a serious issue where they would instantly team up with the antag of the day due to having the same comms.
Along with this, They didn't really have any natural enemies, and had really bulky armor. 
Now, Nagel Und Hammer has justification to punt their ass.

Butchers were really an issue due to again, having no natural enemies. They've been shafted to a side-antag with Blade Lineage, to both give action and a real (but small) threat to Blade Lineage rounds.
This has a side effect of also giving Blade Lineage someone to fight.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Butcher now only spawns with Blade Lineage
tweak: Carnival uses Safety Comms.
tweak: Carnival is now no longer a human
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
