### PR TITLE
Nav Beacon added to Gamma Corp due to CL bot issue

### DIFF
--- a/_maps/map_files/Gamma/gammacorp.dmm
+++ b/_maps/map_files/Gamma/gammacorp.dmm
@@ -2097,6 +2097,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/navbeacon/wayfinding/centralcommanddepartment,
 /turf/open/floor/facility/white,
 /area/department_main/command)
 "ow" = (
@@ -3283,6 +3284,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/facility_hallway/north)
+"vI" = (
+/obj/machinery/navbeacon/wayfinding/trainingdepartment,
+/turf/open/floor/carpet/orange,
+/area/department_main/training)
 "vM" = (
 /obj/structure/chair/office/light,
 /turf/open/floor/carpet/stellar,
@@ -3336,6 +3341,7 @@
 /obj/effect/landmark/department_center,
 /obj/structure/disposalpipe/junction/flip,
 /mob/living/simple_animal/bot/cleanbot,
+/obj/machinery/navbeacon/wayfinding/informationdepartment,
 /turf/open/floor/plasteel,
 /area/department_main/information)
 "wp" = (
@@ -6173,6 +6179,7 @@
 	dir = 4
 	},
 /mob/living/simple_animal/bot/cleanbot,
+/obj/machinery/navbeacon/wayfinding/disciplinarydepartment,
 /turf/open/floor/facility/dark,
 /area/department_main/discipline)
 "Oz" = (
@@ -6354,6 +6361,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/navbeacon/wayfinding/welfaredepartment,
 /turf/open/floor/carpet/royalblue,
 /area/department_main/welfare)
 "PZ" = (
@@ -33245,7 +33253,7 @@ DF
 YP
 YP
 pk
-YP
+vI
 zz
 Zq
 Rs


### PR DESCRIPTION
Nav Beacon added to welfare, training, information, central command and disciplinary to prevent clean bots getting stuck in respective departments

## About The Pull Request

Nav Beacons added to the center of the departments as with all other maps in order to solve the clean bot navigation issue found in this map only. Exception being training main room due to location of the regenerator.

## Why It's Good For The Game

A pr to resolve the Gamma Corp clean bot navigation issue.

## Changelog
:cl:
add: Added nav beacons to training, information, disciplinary, central command, and welfare.
/:cl: