### PR TITLE
Expands flesh idol's blacklist

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/waw/flesh_idol.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/flesh_idol.dm
@@ -33,8 +33,8 @@
 	var/damage_amount = 7
 	var/run_num = 2		//How many things you breach
 
-	var/list/blacklist = list(/mob/living/simple_animal/hostile/abnormality/melting_love,
-				/mob/living/simple_animal/hostile/abnormality/white_night)
+	var/list/blacklist = list(/mob/living/simple_animal/hostile/abnormality/melting_love, /mob/living/simple_animal/hostile/abnormality/distortedform,
+				/mob/living/simple_animal/hostile/abnormality/white_night, /mob/living/simple_animal/hostile/abnormality/nihil)
 
 /mob/living/simple_animal/hostile/abnormality/flesh_idol/WorkComplete(mob/living/carbon/human/user, work_type, pe)
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds distorted form and jester of nihil to the blacklist of things flesh idol can breach.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
They're both bosses.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: removed bosses from the list of things flesh idol can breach
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
