### PR TITLE
W-Corp Killteam

### DIFF
--- a/ModularTegustation/tegu_items/representative/outfits.dm
+++ b/ModularTegustation/tegu_items/representative/outfits.dm
@@ -3,6 +3,10 @@
 	equip_slowdown = 0
 	attribute_requirements = list()
 
+/obj/item/clothing/suit/armor/ego_gear/wcorp/ert/kill
+	desc = "A light armor vest worn by W corp L3 Cleanup Staff. It's light as a feather."
+	armor = list(RED_DAMAGE = 50, WHITE_DAMAGE = 50, BLACK_DAMAGE = 50, PALE_DAMAGE = 50)
+
 /datum/outfit/wcorp
 	name = "W Corp L1"
 	ears = /obj/item/radio/headset/headset_cent
@@ -26,6 +30,31 @@
 
 	H.equip_to_slot_or_del(new belt(H),ITEM_SLOT_BELT, TRUE)
 
+/datum/outfit/wcorp/level3
+	name = "W Corp L3"
+	belt = null
+	suit = /obj/item/clothing/suit/armor/ego_gear/wcorp/ert/kill
+	gloves = /obj/item/clothing/gloves/combat
+	glasses = /obj/item/clothing/glasses/hud/health/night
+	l_pocket = /obj/item/reagent_containers/hypospray/medipen/salacid
+	r_pocket = /obj/item/reagent_containers/hypospray/medipen/mental
+
+/datum/outfit/wcorp/level3/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	var/belt = pick(/obj/item/ego_weapon/city/charge/wcorp/fist,
+		/obj/item/ego_weapon/city/charge/wcorp/axe,
+		/obj/item/ego_weapon/city/charge/wcorp/spear,
+		/obj/item/ego_weapon/city/charge/wcorp/dagger,
+		/obj/item/ego_weapon/city/charge/wcorp/hatchet,
+		/obj/item/ego_weapon/city/charge/wcorp/hammer,
+		/obj/item/ego_weapon/city/charge/wcorp/shield,
+		/obj/item/ego_weapon/city/charge/wcorp/shield/spear,
+		/obj/item/ego_weapon/city/charge/wcorp/shield/club,
+		/obj/item/ego_weapon/city/charge/wcorp/shield/axe)
+
+	H.equip_to_slot_or_del(new belt(H),ITEM_SLOT_BELT, TRUE)
+
+// KCORP BABEYYYY
+
 /obj/item/clothing/suit/armor/ego_gear/city/kcorp_l1/ert
 	equip_slowdown = 0
 	attribute_requirements = list()
@@ -34,7 +63,6 @@
 	equip_slowdown = 0
 	attribute_requirements = list()
 
-// KCORP BABEYYYY
 /datum/outfit/kcorp
 	name = "K Corp Class 1"
 	ears = /obj/item/radio/headset/headset_cent

--- a/ModularTegustation/tegu_items/representative/research/wcorp.dm
+++ b/ModularTegustation/tegu_items/representative/research/wcorp.dm
@@ -45,6 +45,18 @@
 	mobspawner_type = /obj/effect/mob_spawn/human/supplypod/r_corp/wcorp_call/level2
 	required_research = /datum/data/lc13research/mobspawner/wcorp
 
+/datum/data/lc13research/mobspawner/wcorpl3
+	research_name = "W-Corp L3 Cleanup Team"
+	research_desc = "Currently there are no trains requiring trains requiring major cleanup so we have nearby L3 available for contingency measures, only use this if corporation assets are claimed by another Wing. <br>They'll clean up any problems you have."
+	cost = 0
+	corp = W_CORP_REP
+	mobspawner_type = /obj/effect/mob_spawn/human/supplypod/r_corp/wcorp_call/level3
+	required_research = /datum/data/lc13research/mobspawner/wcorp
+
+/datum/data/lc13research/mobspawner/wcorpl3/ResearchEffect(obj/structure/representative_console/caller)
+	minor_announce("A notice to all L-Corp clientele, we have the saddening news that this facility is in need of cleanup due to a breach of contract, remain seated as W-Corp Staff resolve the issue.", "W Corp HQ Update:", TRUE)
+	..()
+
 //Teleporters
 /datum/data/lc13research/teleporter
 	research_name = "Prototype Quantum Pads"

--- a/ModularTegustation/tegu_items/representative/spawners.dm
+++ b/ModularTegustation/tegu_items/representative/spawners.dm
@@ -106,6 +106,15 @@
 	spawn_level = 80
 	uses = 4	//Not at much.
 
+/obj/effect/mob_spawn/human/supplypod/r_corp/wcorp_call/level3
+	name = "Wcorp L3 teleport zone"
+	desc = "A authorized zone for teleporting in wcorp L3 agents."
+	flavour_text = "Your team is here for a special kind of cleanup. Clean any L-Corp personnel within the facility and retrieve stolen company property."
+	outfit = /datum/outfit/wcorp/level3
+	assignedrole = "L3"
+	spawn_level = 130 //They need it badly
+	uses = 20
+
 //Fixers
 /obj/effect/mob_spawn/human/supplypod/r_corp/zwei_call
 	name = "Zwei teleport zone"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
W-Corp is the only representative to get its own ERT and not have a killteam, this gives them a kill team with V,V,V,V armor, 130 stats and W-Corp weaponry and two pens
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I wouldnt really killing the whole server and restarting the round good for the game but it standardizes representatives.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: W-Corp Killteam
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
