### PR TITLE
Sphinx is less picky about what constitutes a vessel

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/waw/sphinx.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/sphinx.dm
@@ -160,7 +160,7 @@
 			say("Atan eblak esm quistra utast.")//Bring me an armor EGO
 		if(/obj/item/ego_weapon)
 			say("Atan eblak esm sommel utast.")//Bring me an weapon EGO
-		if(/obj/item/reagent_containers/food/drinks)
+		if(/obj/item/reagent_containers/)
 			say("Kom eblak mina brit hethre.")//Find me a water with vessel
 		if(/obj/item/food)
 			say("Atan eblak gorno tai por prin enum gorno.")//Bring me what the beggar consumes and needs (Its food)
@@ -173,7 +173,7 @@
 			to_chat(user, span_warning("[src] is not waiting for an offering at the moment."))
 		return
 
-	if(demand == /obj/item/reagent_containers/food/drinks)
+	if(demand == /obj/item/reagent_containers/)
 		if(I.reagents.has_reagent(/datum/reagent/water))
 			qdel(I)
 		else

--- a/code/modules/mob/living/simple_animal/abnormality/waw/sphinx.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/sphinx.dm
@@ -160,7 +160,7 @@
 			say("Atan eblak esm quistra utast.")//Bring me an armor EGO
 		if(/obj/item/ego_weapon)
 			say("Atan eblak esm sommel utast.")//Bring me an weapon EGO
-		if(/obj/item/reagent_containers/)
+		if(/obj/item/reagent_containers)
 			say("Kom eblak mina brit hethre.")//Find me a water with vessel
 		if(/obj/item/food)
 			say("Atan eblak gorno tai por prin enum gorno.")//Bring me what the beggar consumes and needs (Its food)
@@ -173,7 +173,7 @@
 			to_chat(user, span_warning("[src] is not waiting for an offering at the moment."))
 		return
 
-	if(demand == /obj/item/reagent_containers/)
+	if(demand == /obj/item/reagent_containers)
 		if(I.reagents.has_reagent(/datum/reagent/water))
 			qdel(I)
 		else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I am salt coding and I will not apologise
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
A bucket of water is a vessel of water and I refuse to be gaslit about this
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Sphinx now considers any reagent container to be valid for the "vessel of water" riddle, so long as it contains water
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
