### PR TITLE
meat lantern fix

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/teth/meat_lantern.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/meat_lantern.dm
@@ -75,7 +75,7 @@
 	if(!isliving(AM))
 		return
 	var/mob/living/L = AM
-	if(L.stat == DEAD)
+	if(L.stat == DEAD || faction_check_mob(L))
 		return
 	if(!can_act || (chop_cooldown > world.time))
 		return
@@ -94,7 +94,7 @@
 	pixel_x = base_pixel_x - 40
 	for(var/mob/living/L in oview(1, src))
 		if(faction_check_mob(L))
-			return
+			continue
 		L.apply_damage(chop_damage, RED_DAMAGE, null, L.run_armor_check(null, RED_DAMAGE), spread_damage = TRUE)
 		if(L.health < 0)
 			L.gib(FALSE,FALSE,TRUE)
@@ -108,6 +108,8 @@
 /mob/living/simple_animal/hostile/abnormality/meat_lantern/proc/ProximityCheck()
 	for(var/mob/living/L in range(1,src)) //hidden istype() call
 		if(L == src)
+			continue
+		if(faction_check_mob(L))
 			continue
 		BigChop()
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Meat lantern was bugging out turning invisible and unkillable when trying to attack a same faction creature.
This pr fixes that and also makes it stop revealing its location by trying to chomp allies.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bugfixes yay
Pink midnight wont break due to it anymore
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: meat lantern doesnt attempt to attack allies anymore
fix: meat lantern doesnt break anymore
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
