### PR TITLE
Fix a number of runtime errors

### DIFF
--- a/ModularTegustation/tegu_items/workshop/forging.dm
+++ b/ModularTegustation/tegu_items/workshop/forging.dm
@@ -11,9 +11,9 @@
 	icon = 'ModularTegustation/Teguicons/workshop.dmi'
 	icon_state = "anvil"
 	resistance_flags = INDESTRUCTIBLE
-	smoothing_flags = null
-	smoothing_groups = list()
-	canSmoothWith = list()
+	smoothing_flags = NONE
+	smoothing_groups = null
+	canSmoothWith = null
 
 
 /obj/structure/forge

--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -104,6 +104,7 @@
 	var/static/list/language_icons
 
 	// Register client who owns this message
+	// /datum/chatmessage/New ensures this is non-null, add a nullcheck if this is ever called elsewhere without a check before it.
 	owned_by = owner.client
 	RegisterSignal(owned_by, COMSIG_PARENT_QDELETING, .proc/on_parent_qdel)
 
@@ -163,15 +164,18 @@
 
 	// Approximate text height
 	var/complete_text = "<span class='center [extra_classes.Join(" ")]' style='color: [tgt_color]'>[owner.say_emphasis(text)]</span>"
+	if(!owned_by) // The client has been nulled after disconnecting, so we need to stop early.
+		return
 	var/mheight = WXH_TO_HEIGHT(owned_by.MeasureText(complete_text, null, CHAT_MESSAGE_WIDTH))
 	approx_lines = max(1, mheight / CHAT_MESSAGE_APPROX_LHEIGHT)
 
 	// Translate any existing messages upwards, apply exponential decay factors to timers
 	message_loc = get_atom_on_turf(target)
-	if (owned_by.seen_messages)
+	var/list/seen_messages = owned_by?.seen_messages // Check for owned_by again, since it could've been nulled after MeasureText(), then cache it so it doesn't vanish.
+	if (seen_messages)
 		var/idx = 1
 		var/combined_height = approx_lines
-		for(var/msg in owned_by.seen_messages[message_loc])
+		for(var/msg in seen_messages[message_loc])
 			var/datum/chatmessage/m = msg
 			animate(m.message, pixel_y = m.message.pixel_y + mheight, time = CHAT_MESSAGE_SPAWN_TIME)
 			combined_height += m.approx_lines
@@ -199,8 +203,8 @@
 	message.maptext = MAPTEXT(complete_text)
 
 	// View the message
-	LAZYADDASSOCLIST(owned_by.seen_messages, message_loc, src)
-	owned_by.images |= message
+	LAZYADDASSOCLIST(seen_messages, message_loc, src) // This still modifies the client's list, since it's a reference to the list object. It saves us an owned_by nullcheck.
+	owned_by?.images |= message // We can't save a nullcheck here, though, since animate() may lead to owned_by being nulled.
 	animate(message, alpha = 255, time = CHAT_MESSAGE_SPAWN_TIME)
 
 	// Register with the runechat SS to handle EOL and destruction

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -66,7 +66,7 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 	var/badge_data = badge_parse(get_badges())
 	//The linkify span classes and linkify=TRUE below make ooc text get clickable chat href links if you pass in something resembling a url
 	for(var/client/C in GLOB.clients)
-		if(C.prefs.chat_toggles & CHAT_OOC)
+		if(C.prefs?.chat_toggles & CHAT_OOC)
 			if(holder?.fakekey in C.prefs.ignoring)
 				continue
 			if(holder)

--- a/code/modules/keybindings/bindings_client.dm
+++ b/code/modules/keybindings/bindings_client.dm
@@ -74,8 +74,9 @@
 			break
 
 	holder?.key_down(_key, src)
-	mob.focus?.key_down(_key, src)
-	mob.update_mouse_pointer()
+	if(mob)
+		mob.focus?.key_down(_key, src)
+		mob.update_mouse_pointer()
 
 
 /client/verb/keyUp(_key as text)
@@ -104,11 +105,12 @@
 		if(kb.can_use(src) && kb.up(src))
 			break
 	holder?.key_up(_key, src)
-	mob.focus?.key_up(_key, src)
-	mob.update_mouse_pointer()
+	if(mob)
+		mob.focus?.key_up(_key, src)
+		mob.update_mouse_pointer()
 
 
 // Called every game tick
 /client/keyLoop()
 	holder?.keyLoop(src)
-	mob.focus?.keyLoop(src)
+	mob?.focus?.keyLoop(src)

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -405,8 +405,8 @@
 
 	if(!LAZYLEN(possible_traumas))
 		return
-	
-	if(owner.has_quirk(/datum/quirk/brainproblems))
+
+	if(owner?.has_quirk(/datum/quirk/brainproblems))
 		possible_traumas -= tumor_immune_traumas
 
 	var/trauma_type = pick(possible_traumas)


### PR DESCRIPTION
## About The Pull Request
Fixes a runtime in smoothing code due to anvils having improperly set smoothing values. I used table racks as a reference for the new ones.
Fixes a runtime when an owner-less brain gets brain trauma.
Fixes many runtimes due to null client and null client variables.

## Why It's Good For The Game
Some of these were in important code, like the chatmessage runtimes. Hopefully this will fix some of the issues reported in the new player round.