### PR TITLE
dash ability fixes

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/he/helper.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/helper.dm
@@ -137,10 +137,11 @@
 	for(var/obj/structure/window/W in T.contents)
 		W.obj_destruction("spinning blades")
 	for(var/obj/machinery/door/D in T.contents)
-		if(istype(D, /obj/machinery/door/poddoor))
-			continue
+		if(!D.CanAStarPass(null))
+			stop_charge = TRUE
+			break
 		if(D.density)
-			D.open(2)
+			INVOKE_ASYNC(D, /obj/machinery/door/proc/open, 2)
 	if(stop_charge)
 		playsound(src, 'sound/abnormalities/helper/disable.ogg', 75, 1)
 		SLEEP_CHECK_DEATH(5 SECONDS)

--- a/code/modules/mob/living/simple_animal/abnormality/waw/clouded_monk.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/clouded_monk.dm
@@ -183,16 +183,17 @@
 		stop_charge = TRUE
 	for(var/obj/structure/window/W in T.contents)
 		stop_charge = TRUE
-	for(var/obj/machinery/door/poddoor/P in T.contents)//FIXME: Still opens the "poddoor" secure shutters
-		stop_charge = TRUE
-		continue
+		break
+	for(var/obj/machinery/door/D in T.contents)
+		if(!D.CanAStarPass(null))
+			stop_charge = TRUE
+			break
+		if(D.density)
+			INVOKE_ASYNC(D, /obj/machinery/door/proc/open, 2)
 	if(stop_charge)
 		charging = FALSE
 		icon_state = icon_aggro
 		return
-	for(var/obj/machinery/door/D in T.contents)
-		if(D.density)
-			D.open(2)
 	forceMove(T)
 	playsound(src, 'sound/abnormalities/clouded_monk/monk_groggy.ogg', 150, 1)
 	for(var/turf/TF in range(1, T))//Smash AOE visual

--- a/code/modules/mob/living/simple_animal/abnormality/waw/thunder_bird.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/thunder_bird.dm
@@ -174,14 +174,13 @@
 		stop_charge = TRUE
 	for(var/obj/structure/window/W in T.contents)
 		stop_charge = TRUE
-	for(var/obj/machinery/door/poddoor/P in T.contents)
-		stop_charge = TRUE
-		continue
+		break
 	for(var/obj/machinery/door/D in T.contents)
-		if(istype(D, /obj/machinery/door/poddoor))	//Should fix.
-			continue
+		if(!D.CanAStarPass(null))
+			stop_charge = TRUE
+			break
 		if(D.density)
-			D.open(2)
+			INVOKE_ASYNC(D, /obj/machinery/door/proc/open, 2)
 	if(stop_charge)
 		playsound(src, 'sound/abnormalities/thunderbird/tbird_bolt.ogg', 75, 1)
 		charging = FALSE

--- a/code/modules/spells/ability_types/realized_aimed.dm
+++ b/code/modules/spells/ability_types/realized_aimed.dm
@@ -14,8 +14,21 @@
 	var/turf/target_turf = get_turf(user)
 	var/list/line_turfs = list(target_turf)
 	var/list/mobs_to_hit = list()
+	var/stop_charge = FALSE
 	for(var/turf/T in getline(user, get_ranged_target_turf_direct(user, target, dash_range)))
 		if(!dash_ignore_walls && T.density)
+			break
+		if(!dash_ignore_walls)
+			for(var/obj/structure/window/W in T.contents)
+				stop_charge = TRUE
+				break
+			for(var/obj/machinery/door/MD in T.contents)
+				if(!MD.CanAStarPass(null))
+					stop_charge = TRUE
+					break
+				if(MD.density)
+					INVOKE_ASYNC(MD, /obj/machinery/door/proc/open, 2)
+		if(stop_charge)
 			break
 		target_turf = T
 		line_turfs += T
@@ -35,9 +48,6 @@
 		D.alpha = min(150 + i*15, 255)
 		animate(D, alpha = 0, time = 2 + i*2)
 		playsound(D, "sound/abnormalities/helper/move0[pick(1,2,3)].ogg", rand(10, 30), 1, 3)
-		for(var/obj/machinery/door/MD in T.contents)
-			if(MD.density)
-				addtimer(CALLBACK (MD, .obj/machinery/door/proc/open))
 	// Damage
 	for(var/mob/living/L in mobs_to_hit)
 		if(user.faction_check_mob(L))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
All dash abilities can now pass through open shutters, stop properly before closed shutters, cant open id locked doors (sephira, representative, r corp hq), dont wait for door open animation to finish before continuing the dash.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The abilities now work as you would expect them to and prevents exploiting them to gain access to secure areas. Looks a lot less jank when dashing through closed doors.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixed dash ability interactions with various doors
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
