### PR TITLE
Partial Revert of 1829's chatmessage fix

### DIFF
--- a/code/datums/chatmessage.dm
+++ b/code/datums/chatmessage.dm
@@ -104,7 +104,6 @@
 	var/static/list/language_icons
 
 	// Register client who owns this message
-	// /datum/chatmessage/New ensures this is non-null, add a nullcheck if this is ever called elsewhere without a check before it.
 	owned_by = owner.client
 	RegisterSignal(owned_by, COMSIG_PARENT_QDELETING, .proc/on_parent_qdel)
 
@@ -171,11 +170,10 @@
 
 	// Translate any existing messages upwards, apply exponential decay factors to timers
 	message_loc = get_atom_on_turf(target)
-	var/list/seen_messages = owned_by?.seen_messages // Check for owned_by again, since it could've been nulled after MeasureText(), then cache it so it doesn't vanish.
-	if (seen_messages)
+	if (owned_by?.seen_messages) // Check for owned_by again, since it could've been nulled after MeasureText()
 		var/idx = 1
 		var/combined_height = approx_lines
-		for(var/msg in seen_messages[message_loc])
+		for(var/msg in owned_by?.seen_messages[message_loc])
 			var/datum/chatmessage/m = msg
 			animate(m.message, pixel_y = m.message.pixel_y + mheight, time = CHAT_MESSAGE_SPAWN_TIME)
 			combined_height += m.approx_lines
@@ -203,7 +201,7 @@
 	message.maptext = MAPTEXT(complete_text)
 
 	// View the message
-	LAZYADDASSOCLIST(seen_messages, message_loc, src) // This still modifies the client's list, since it's a reference to the list object. It saves us an owned_by nullcheck.
+	LAZYADDASSOCLIST(owned_by?.seen_messages, message_loc, src)
 	owned_by?.images |= message // We can't save a nullcheck here, though, since animate() may lead to owned_by being nulled.
 	animate(message, alpha = 255, time = CHAT_MESSAGE_SPAWN_TIME)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Reverts the use of `var/list/seen_messages` and uses `owned_by?.seen_messages` instead. In theory this resolves the issue. Otherwise a full revert will be made.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Runechat wasn't deleting. Should resolve.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: broken fix gets fixed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
