### PR TITLE
Moves Attributes to the Brain

### DIFF
--- a/code/datums/abnormality/datum/abnormality.dm
+++ b/code/datums/abnormality/datum/abnormality.dm
@@ -169,7 +169,8 @@
 	var/attribute_given = 0
 	if(pe > 0) // Work did not fail
 		attribute_type = current.work_attribute_types[work_type]
-		var/datum/attribute/user_attribute = user.attributes[attribute_type]
+		var/list/attributes = user.get_attribute_list()
+		var/datum/attribute/user_attribute = attributes[attribute_type]
 		if(user_attribute) //To avoid runtime if it's a custom work type like "Release".
 			var/user_attribute_level = max(1, user_attribute.level)
 			attribute_given = clamp(((maximum_attribute_level / (user_attribute_level * 0.25)) * (0.25 + (pe / max_boxes))), 0, 16)

--- a/code/datums/attributes/_attribute.dm
+++ b/code/datums/attributes/_attribute.dm
@@ -77,12 +77,18 @@ GLOBAL_LIST_INIT(attribute_types, list(
 /mob/living/carbon/human/proc/adjust_attribute_level(attribute, addition)
 	if(!attribute)
 		return 0
+	var/list/attributes = get_attribute_list()
+	if(!attributes)
+		return 0
 	var/datum/attribute/atr = attributes[attribute]
 	if(!istype(atr))
 		return 0
 	return atr.adjust_level(src, addition)
 
 /mob/living/carbon/human/proc/adjust_all_attribute_levels(addition)
+	var/list/attributes = get_attribute_list()
+	if(!attributes)
+		return 0
 	for(var/atr_type in attributes)
 		var/datum/attribute/atr = attributes[atr_type]
 		if(!istype(atr))
@@ -94,7 +100,10 @@ GLOBAL_LIST_INIT(attribute_types, list(
 /proc/get_attribute_level(mob/living/carbon/human/user, attribute)
 	if(!istype(user) || !attribute)
 		return 1
-	var/datum/attribute/atr = user.attributes[attribute]
+	var/list/attributes = user.get_attribute_list()
+	if(!attributes)
+		return 1
+	var/datum/attribute/atr = attributes[attribute]
 	if(!istype(atr))
 		return 1
 	return max(1, atr.get_level())
@@ -103,7 +112,10 @@ GLOBAL_LIST_INIT(attribute_types, list(
 /proc/get_modified_attribute_level(mob/living/carbon/human/user, attribute)
 	if(!istype(user) || !attribute)
 		return 1
-	var/datum/attribute/atr = user.attributes[attribute]
+	var/list/attributes = user.get_attribute_list()
+	if(!attributes)
+		return 1
+	var/datum/attribute/atr = attributes[attribute]
 	if(!istype(atr))
 		return 1
 	return max(1, atr.get_modified_level())
@@ -112,7 +124,10 @@ GLOBAL_LIST_INIT(attribute_types, list(
 /proc/get_raw_level(mob/living/carbon/human/user, attribute)
 	if(!istype(user) || !attribute)
 		return 1
-	var/datum/attribute/atr = user.attributes[attribute]
+	var/list/attributes = user.get_attribute_list()
+	if(!attributes)
+		return 1
+	var/datum/attribute/atr = attributes[attribute]
 	if(!istype(atr))
 		return 1
 	return max(1, atr.get_raw_level())
@@ -121,7 +136,10 @@ GLOBAL_LIST_INIT(attribute_types, list(
 /proc/get_level_buff(mob/living/carbon/human/user, attribute)
 	if(!istype(user) || !attribute)
 		return 1
-	var/datum/attribute/atr = user.attributes[attribute]
+	var/list/attributes = user.get_attribute_list()
+	if(!attributes)
+		return 1
+	var/datum/attribute/atr = attributes[attribute]
 	if(!istype(atr))
 		return 1
 	return max(1, atr.get_level_buff())
@@ -129,7 +147,10 @@ GLOBAL_LIST_INIT(attribute_types, list(
 /proc/get_level_bonus(mob/living/carbon/human/user, attribute)
 	if(!istype(user) || !attribute)
 		return 1
-	var/datum/attribute/atr = user.attributes[attribute]
+	var/list/attributes = user.get_attribute_list()
+	if(!attributes)
+		return 1
+	var/datum/attribute/atr = attributes[attribute]
 	if(!istype(atr))
 		return 1
 	return max(1, atr.get_level_bonus())
@@ -138,12 +159,18 @@ GLOBAL_LIST_INIT(attribute_types, list(
 /mob/living/carbon/human/proc/adjust_attribute_buff(attribute, addition)
 	if(!attribute)
 		return 0
+	var/list/attributes = get_attribute_list()
+	if(!attributes)
+		return 0
 	var/datum/attribute/atr = attributes[attribute]
 	if(!istype(atr))
 		return 0
 	return atr.adjust_buff(src, addition)
 
 /mob/living/carbon/human/proc/adjust_all_attribute_buffs(addition)
+	var/list/attributes = get_attribute_list()
+	if(!attributes)
+		return 0
 	for(var/atr_type in attributes)
 		var/datum/attribute/atr = attributes[atr_type]
 		if(!istype(atr))
@@ -155,12 +182,18 @@ GLOBAL_LIST_INIT(attribute_types, list(
 /mob/living/carbon/human/proc/adjust_attribute_bonus(attribute, addition)
 	if(!attribute)
 		return 0
+	var/list/attributes = get_attribute_list()
+	if(!attributes)
+		return 0
 	var/datum/attribute/atr = attributes[attribute]
 	if(!istype(atr))
 		return 0
 	return atr.adjust_bonus(src, addition)
 
 /mob/living/carbon/human/proc/adjust_all_attribute_bonuses(addition)
+	var/list/attributes = get_attribute_list()
+	if(!attributes)
+		return FALSE
 	for(var/atr_type in attributes)
 		var/datum/attribute/atr = attributes[atr_type]
 		if(!istype(atr))
@@ -170,6 +203,9 @@ GLOBAL_LIST_INIT(attribute_types, list(
 
 //Set attribute levels
 /mob/living/carbon/human/proc/set_attribute_limit(attribute_set)
+	var/list/attributes = get_attribute_list()
+	if(!attributes)
+		return 0
 	for(var/atr_type in attributes)
 		var/datum/attribute/atr = attributes[atr_type]
 		if(!istype(atr))
@@ -178,6 +214,9 @@ GLOBAL_LIST_INIT(attribute_types, list(
 	return TRUE
 
 /mob/living/carbon/human/proc/adjust_attribute_limit(attribute_set)
+	var/list/attributes = get_attribute_list()
+	if(!attributes)
+		return 0
 	for(var/atr_type in attributes)
 		var/datum/attribute/atr = attributes[atr_type]
 		if(!istype(atr))
@@ -189,18 +228,23 @@ GLOBAL_LIST_INIT(attribute_types, list(
 /proc/get_user_level(mob/living/carbon/human/user)
 	if(!istype(user))
 		return 0
+	var/list/attributes = user.get_attribute_list()
+	if(!attributes)
+		return 0
 	var/collective_levels = 0
-	for(var/a in user.attributes)
-		var/datum/attribute/atr = user.attributes[a]
+	for(var/a in attributes)
+		var/datum/attribute/atr = attributes[a]
 		collective_levels += atr.level
 	return clamp(round(collective_levels / 70), 1, 5)
 
 // Returns a level for the show_attributes proc as a roman numeral I - V, or EX if level is too high.
 /mob/living/carbon/human/proc/get_text_level()
 	var/collective_levels = 0
-	for(var/a in attributes)
-		var/datum/attribute/atr = attributes[a]
-		collective_levels += atr.level
+	var/list/attributes = get_attribute_list()
+	if(attributes)
+		for(var/a in attributes)
+			var/datum/attribute/atr = attributes[a]
+			collective_levels += atr.level
 	switch(clamp(round(collective_levels / 70), 1, 6))
 		if(1) // 70
 			return "I"

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -91,10 +91,15 @@
 	///Assoc list of key active addictions and value amount of cycles that it has been active.
 	var/list/active_addictions
 
+	/// Assoc list of attributes. Starts with 4.
+	var/list/attributes = list()
+
 /datum/mind/New(_key)
 	key = _key
 	martial_art = default_martial_art
 	init_known_skills()
+	if(!LAZYLEN(attributes))
+		init_attributes()
 
 /datum/mind/Destroy()
 	SSticker.minds -= src
@@ -136,6 +141,8 @@
 	if(iscarbon(new_character))
 		var/mob/living/carbon/C = new_character
 		C.last_mind = src
+		for(var/datum/attribute/attribute in attributes)
+			attribute.on_update(new_character)
 	transfer_antag_huds(hud_to_transfer)				//inherit the antag HUD
 	transfer_actions(new_character)
 	transfer_martial_arts(new_character)
@@ -150,6 +157,13 @@
 /datum/mind/proc/init_known_skills()
 	for (var/type in GLOB.skill_types)
 		known_skills[type] = list(SKILL_LEVEL_NONE, 0)
+
+/datum/mind/proc/init_attributes()
+	for(var/type in GLOB.attribute_types)
+		if(ispath(type, /datum/attribute))
+			var/datum/attribute/atr = new type
+			attributes[atr.name] = atr
+			atr.on_update(src)
 
 ///Return the amount of EXP needed to go to the next level. Returns 0 if max level
 /datum/mind/proc/exp_needed_to_level_up(skill)
@@ -831,6 +845,7 @@
 		mind.key = key
 
 	else
+		to_chat(world, "Making new Mind")
 		mind = new /datum/mind(key)
 		SSticker.minds += mind
 	if(!mind.name)

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -93,13 +93,14 @@
 
 	/// Assoc list of attributes. Starts with 4.
 	var/list/attributes = list()
+	/// Variable for if job should replace our attributes, used for Respawn and Admin Respawn
+	var/set_job_attributes = TRUE
 
 /datum/mind/New(_key)
 	key = _key
 	martial_art = default_martial_art
 	init_known_skills()
-	if(!LAZYLEN(attributes))
-		init_attributes()
+	init_attributes()
 
 /datum/mind/Destroy()
 	SSticker.minds -= src
@@ -142,7 +143,7 @@
 		var/mob/living/carbon/C = new_character
 		C.last_mind = src
 		for(var/datum/attribute/attribute in attributes)
-			attribute.on_update(new_character)
+			attribute.on_update(current)
 	transfer_antag_huds(hud_to_transfer)				//inherit the antag HUD
 	transfer_actions(new_character)
 	transfer_martial_arts(new_character)
@@ -845,7 +846,6 @@
 		mind.key = key
 
 	else
-		to_chat(world, "Making new Mind")
 		mind = new /datum/mind(key)
 		SSticker.minds += mind
 	if(!mind.name)

--- a/code/game/objects/items/ego_weapons/zayin.dm
+++ b/code/game/objects/items/ego_weapons/zayin.dm
@@ -275,35 +275,37 @@
 	var/msg = stripped_input(usr, "What do you wish to tell [M]?", null, "")
 	if(!msg)
 		return
-	to_chat(M, "<span class='warning'>[user] has sent you a message!</span>")
+	to_chat(M, span_notice("[user] has sent you a message!"))
 	var/obj/item/paper/P = new(get_turf(M))
 	P.setText(msg)
 	P.icon_state = "mail"
 	var/mob/living/carbon/human/H = M
-	var/datum/attribute/highest_attribute = null
-	for(var/datum/attribute/A in H.attributes)
-		if(isnull(highest_attribute))
-			highest_attribute = A
-			continue
-		if(A.get_level() > highest_attribute.get_level())
-			highest_attribute = A
-	switch(highest_attribute)
-		if(/datum/attribute/fortitude)
-			new /obj/item/mailpaper/instinct(get_turf(H), H)
-		if(/datum/attribute/prudence)
-			new /obj/item/mailpaper/insight(get_turf(H), H)
-		if(/datum/attribute/temperance)
-			new /obj/item/mailpaper/coupon(get_turf(H))
-		if(/datum/attribute/justice) // "These two seem to be backwards?" Yes. Justice is the one stat that does basically nothing for grinding, this buffs those who want to be able to do damage AND work.
-			new /obj/item/mailpaper/attachment(get_turf(H), H)
+	var/list/attributes = H.get_attribute_list()
+	if(attributes)
+		var/datum/attribute/highest_attribute = null
+		for(var/datum/attribute/A in attributes)
+			if(isnull(highest_attribute))
+				highest_attribute = A
+				continue
+			if(A.get_level() > highest_attribute.get_level())
+				highest_attribute = A
+		switch(highest_attribute)
+			if(/datum/attribute/fortitude)
+				new /obj/item/mailpaper/instinct(get_turf(H), H)
+			if(/datum/attribute/prudence)
+				new /obj/item/mailpaper/insight(get_turf(H), H)
+			if(/datum/attribute/temperance)
+				new /obj/item/mailpaper/coupon(get_turf(H))
+			if(/datum/attribute/justice) // "These two seem to be backwards?" Yes. Justice is the one stat that does basically nothing for grinding, this buffs those who want to be able to do damage AND work.
+				new /obj/item/mailpaper/attachment(get_turf(H), H)
 	QDEL_IN(P, 30 SECONDS)
-	to_chat(user, "<span class='boldnotice'>You transmit to [M]:</span> <span class='notice'>[msg]</span>")
+	to_chat(user, "[span_boldnotice("You transmit to [M]:")] [span_notice(msg)]")
 	for(var/ded in GLOB.dead_mob_list)
 		if(!isobserver(ded))
 			continue
 		var/follow_rev = FOLLOW_LINK(ded, user)
 		var/follow_whispee = FOLLOW_LINK(ded, M)
-		to_chat(ded, "[follow_rev] <span class='boldnotice'>[user] [name]:</span> <span class='notice'>\"[msg]\" to</span> [follow_whispee] <span class='name'>[M]</span>")
+		to_chat(ded, "[follow_rev] [span_boldnotice("[user] [name]:")] [span_notice("\"[msg]\" to")] [follow_whispee] [span_name(M)]")
 
 /obj/item/ego_weapon/support/letter_opener/proc/GetPlayers(mob/living/carbon/human/user)
 	. = list()

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -418,12 +418,16 @@ Traitors and the like can also be revived with the previous role mostly intact.
 		record_found = find_record("id", id, GLOB.data_core.locked)
 
 	if(record_found)//If they have a record we can determine a few things.
-		for(var/rec in record_found.fields)
-			to_chat(world, rec)
 		new_character.real_name = record_found.fields["name"]
 		new_character.gender = record_found.fields["gender"]
 		new_character.age = record_found.fields["age"]
-		new_character.hardset_dna(record_found.fields["identity"], record_found.fields["enzymes"], null, record_found.fields["name"], record_found.fields["blood_type"], record_found.fields["species"], record_found.fields["features"])
+		var/datum/species/nc_race = record_found.fields["species"]
+		if(!istype(nc_race) && !ispath(nc_race))
+			stack_trace("[new_character]'s respawned race isn't valid")
+			nc_race = null
+		else
+			nc_race = new nc_race()
+		new_character.hardset_dna(record_found.fields["identity"], record_found.fields["enzymes"], null, record_found.fields["name"], record_found.fields["blood_type"], nc_race, record_found.fields["features"])
 	else
 		var/datum/preferences/A = new()
 		A.copy_to(new_character)
@@ -433,6 +437,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	new_character.name = new_character.real_name
 
 	if(G_found.mind && !G_found.mind.active)
+		G_found.mind.set_job_attributes = FALSE
 		G_found.mind.transfer_to(new_character)	//be careful when doing stuff like this! I've already checked the mind isn't in use
 	else
 		new_character.mind_initialize()

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -418,10 +418,12 @@ Traitors and the like can also be revived with the previous role mostly intact.
 		record_found = find_record("id", id, GLOB.data_core.locked)
 
 	if(record_found)//If they have a record we can determine a few things.
+		for(var/rec in record_found.fields)
+			to_chat(world, rec)
 		new_character.real_name = record_found.fields["name"]
 		new_character.gender = record_found.fields["gender"]
 		new_character.age = record_found.fields["age"]
-		new_character.hardset_dna(record_found.fields["identity"], record_found.fields["enzymes"], null, record_found.fields["name"], record_found.fields["blood_type"], new record_found.fields["species"], record_found.fields["features"])
+		new_character.hardset_dna(record_found.fields["identity"], record_found.fields["enzymes"], null, record_found.fields["name"], record_found.fields["blood_type"], record_found.fields["species"], record_found.fields["features"])
 	else
 		var/datum/preferences/A = new()
 		A.copy_to(new_character)

--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -122,8 +122,11 @@ GLOBAL_LIST_EMPTY(antagonists)
 		var/mob/living/carbon/human/H = owner.current
 		if(!istype(H))
 			return
+		var/list/attributes = H.get_attribute_list()
+		if(!attributes)
+			return
 		for(var/atrib in antag_attributes)
-			var/datum/attribute/atr = H?.attributes[atrib]
+			var/datum/attribute/atr = attributes[atrib]
 			if(istype(atr))
 				atr.level = antag_attributes[atrib]
 				atr.on_update(H)

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -151,11 +151,13 @@
 	if(roundstart_attributes.len)
 		var/mob/living/carbon/human/HA = H
 		HA.set_attribute_limit(job_attribute_limit)
-		for(var/atrib in roundstart_attributes)
-			var/datum/attribute/atr = HA?.attributes[atrib]
-			if(istype(atr))
-				atr.level = roundstart_attributes[atrib]
-				atr.on_update(HA)
+		var/list/attributes = HA.get_attribute_list()
+		if(attributes)
+			for(var/atrib in roundstart_attributes)
+				var/datum/attribute/atr = attributes[atrib]
+				if(istype(atr))
+					atr.level = roundstart_attributes[atrib]
+					atr.on_update(HA)
 
 
 	if(job_important)

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -149,15 +149,19 @@
 			experiencer.mind.adjust_experience(i, roundstart_experience[i], TRUE)
 
 	if(roundstart_attributes.len)
-		var/mob/living/carbon/human/HA = H
-		HA.set_attribute_limit(job_attribute_limit)
-		var/list/attributes = HA.get_attribute_list()
-		if(attributes)
-			for(var/atrib in roundstart_attributes)
-				var/datum/attribute/atr = attributes[atrib]
-				if(istype(atr))
-					atr.level = roundstart_attributes[atrib]
-					atr.on_update(HA)
+		if(H.mind)
+			if(H.mind.set_job_attributes)
+				var/mob/living/carbon/human/HA = H
+				HA.set_attribute_limit(job_attribute_limit)
+				var/list/attributes = HA.get_attribute_list()
+				if(attributes)
+					for(var/atrib in roundstart_attributes)
+						var/datum/attribute/atr = attributes[atrib]
+						if(istype(atr))
+							atr.level = roundstart_attributes[atrib]
+							atr.on_update(HA)
+			else
+				H.mind.set_job_attributes = TRUE // Reset it so that next time we respawn, unless told otherwise we use our starting stats.
 
 
 	if(job_important)

--- a/code/modules/jobs/job_types/city/civilian.dm
+++ b/code/modules/jobs/job_types/city/civilian.dm
@@ -40,11 +40,13 @@ Civilian
 		H.equip_to_slot_or_del(random_book,ITEM_SLOT_BACKPACK, TRUE)
 
 /proc/get_civilian_level(mob/living/carbon/human/user)
-	var/collective_levels = 0
-	for(var/a in user.attributes)
-		var/datum/attribute/atr = user.attributes[a]
-		collective_levels += atr.level
-	var/level = collective_levels / 4
+	var/level = 0
+	var/list/attributes = user.get_attribute_list()
+	if(attributes)
+		for(var/a in attributes)
+			var/datum/attribute/atr = attributes[a]
+			level += atr?.level
+	level /= 4
 	if (level < 40)
 		return 0
 	else if (level >= 40 && level < 60 )
@@ -53,8 +55,7 @@ Civilian
 		return 2
 	else if (level >= 100 && level < 120 )
 		return 3
-	else
-		return 4
+	return 4
 
 /datum/job/civilian/after_spawn(mob/living/carbon/human/H, mob/M, latejoin = FALSE)
 	ADD_TRAIT(H, TRAIT_COMBATFEAR_IMMUNE, JOB_TRAIT)

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -27,6 +27,9 @@
 
 	var/list/datum/brain_trauma/traumas = list()
 
+	/// Assoc list of attributes. Starts with 4.
+	var/list/attributes = list()
+
 	/// List of skillchip items, their location should be this brain.
 	var/list/obj/item/skillchip/skillchips
 	/// Maximum skillchip complexity we can support before they stop working. Do not reference this var directly and instead call get_max_skillchip_complexity()
@@ -44,6 +47,12 @@
 	..()
 
 	name = "brain"
+
+	if(!attributes.len)
+		init_attributes()
+	else
+		for(var/datum/attribute/attribute in attributes)
+			attribute.on_update(C)
 
 	if(C.mind && C.mind.has_antag_datum(/datum/antagonist/changeling) && !no_id_transfer)	//congrats, you're trapped in a body you don't control
 		if(brainmob && !(C.stat == DEAD || (HAS_TRAIT(C, TRAIT_DEATHCOMA))))
@@ -90,6 +99,13 @@
 	if((!gc_destroyed || (owner && !owner.gc_destroyed)) && !no_id_transfer)
 		transfer_identity(C)
 	C.update_hair()
+
+/obj/item/organ/brain/proc/init_attributes()
+	for(var/type in GLOB.attribute_types)
+		if(ispath(type, /datum/attribute))
+			var/datum/attribute/atr = new type
+			attributes[atr.name] = atr
+			atr.on_update(src)
 
 /obj/item/organ/brain/proc/transfer_identity(mob/living/L)
 	name = "[L.name]'s brain"

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -27,9 +27,6 @@
 
 	var/list/datum/brain_trauma/traumas = list()
 
-	/// Assoc list of attributes. Starts with 4.
-	var/list/attributes = list()
-
 	/// List of skillchip items, their location should be this brain.
 	var/list/obj/item/skillchip/skillchips
 	/// Maximum skillchip complexity we can support before they stop working. Do not reference this var directly and instead call get_max_skillchip_complexity()
@@ -47,12 +44,6 @@
 	..()
 
 	name = "brain"
-
-	if(!attributes.len)
-		init_attributes()
-	else
-		for(var/datum/attribute/attribute in attributes)
-			attribute.on_update(C)
 
 	if(C.mind && C.mind.has_antag_datum(/datum/antagonist/changeling) && !no_id_transfer)	//congrats, you're trapped in a body you don't control
 		if(brainmob && !(C.stat == DEAD || (HAS_TRAIT(C, TRAIT_DEATHCOMA))))
@@ -100,12 +91,6 @@
 		transfer_identity(C)
 	C.update_hair()
 
-/obj/item/organ/brain/proc/init_attributes()
-	for(var/type in GLOB.attribute_types)
-		if(ispath(type, /datum/attribute))
-			var/datum/attribute/atr = new type
-			attributes[atr.name] = atr
-			atr.on_update(src)
 
 /obj/item/organ/brain/proc/transfer_identity(mob/living/L)
 	name = "[L.name]'s brain"

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -1325,3 +1325,8 @@
 
 /mob/living/carbon/proc/attach_rot(mapload)
 	AddComponent(/datum/component/rot/corpse)
+
+/mob/living/carbon/proc/get_attribute_list()
+	if(!mind)
+		return FALSE
+	return mind.attributes

--- a/code/modules/mob/living/carbon/human/damage_procs.dm
+++ b/code/modules/mob/living/carbon/human/damage_procs.dm
@@ -12,6 +12,7 @@
 	return damage_amt
 
 /mob/living/carbon/human/proc/adjustSanityLoss(amount)
+	var/list/attributes = get_attribute_list()
 	if((status_flags & GODMODE) || !attributes || stat == DEAD)
 		return FALSE
 	sanityloss = clamp(sanityloss + amount, 0, maxSanity)
@@ -38,7 +39,7 @@
 		var/highest_atr = PRUDENCE_ATTRIBUTE
 		if(LAZYLEN(attributes))
 			var/highest_level = -1
-			for(var/i in shuffle(attributes))
+			for(var/i in shuffle(attributes.Copy()))
 				var/datum/attribute/atr = attributes[i]
 				if(atr.get_level() > highest_level)
 					highest_level = atr.get_level()

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -94,7 +94,7 @@
 	if(wear_id && !(wear_id.item_flags & EXAMINE_SKIP))
 		. += "[t_He] [t_is] wearing [wear_id.get_examine_string(user)]. <A href='byond://?src=[REF(wear_id)];examine=[user.ckey]'>Examine</A>"
 
-	if(LAZYLEN(attributes) && (isobserver(user) || HAS_TRAIT(user, TRAIT_ATTRIBUTES_VISION)))
+	if(LAZYLEN(get_attribute_list()) && (isobserver(user) || HAS_TRAIT(user, TRAIT_ATTRIBUTES_VISION)))
 		. += "<A href='byond://?src=[REF(src)];see_attributes=1'>Check Attributes</A>"
 
 	//Status effects

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -14,8 +14,6 @@
 
 	setup_human_dna()
 
-	init_attributes()
-
 	if(dna.species)
 		INVOKE_ASYNC(src, .proc/set_species, dna.species.type)
 
@@ -32,13 +30,6 @@
 	AddComponent(/datum/component/bloodysoles/feet)
 	AddElement(/datum/element/ridable, /datum/component/riding/creature/human)
 	GLOB.human_list += src
-
-/mob/living/carbon/human/proc/init_attributes()
-	for(var/type in GLOB.attribute_types)
-		if(ispath(type, /datum/attribute))
-			var/datum/attribute/atr = new type
-			attributes[atr.name] = atr
-			atr.on_update(src)
 
 /mob/living/carbon/human/proc/init_gifts_slots()
 	for(var/gift_slot in list(HAT, HELMET, EYE, FACE, MOUTH_1, MOUTH_2, CHEEK, BROOCH, NECKWEAR, LEFTBACK, RIGHTBACK, HAND_1, HAND_2, SPECIAL))
@@ -70,6 +61,7 @@
 		to_chat(src, "<span class='notice'>You must remain in place to show someone your attributes!</span>")
 
 /mob/living/carbon/human/proc/show_attributes(mob/viewer = src)
+	var/list/attributes = get_attribute_list()
 	if(!LAZYLEN(attributes))
 		to_chat(viewer, "<span class='warning'>[src] has no attributes!</span>")
 		return
@@ -1286,6 +1278,7 @@
 	return ..()
 
 /mob/living/carbon/human/updatehealth()
+	var/list/attributes = get_attribute_list()
 	if(LAZYLEN(attributes))
 		maxHealth = DEFAULT_HUMAN_MAX_HEALTH + round(get_attribute_level(src, FORTITUDE_ATTRIBUTE) * FORTITUDE_MOD + get_level_bonus(src, FORTITUDE_ATTRIBUTE))
 		maxSanity = DEFAULT_HUMAN_MAX_SANITY + round(get_attribute_level(src, PRUDENCE_ATTRIBUTE) * PRUDENCE_MOD + get_level_bonus(src, PRUDENCE_ATTRIBUTE))

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -84,9 +84,6 @@
 	///Exposure to damaging heat levels increases stacks, stacks clean over time when temperatures are lower. Stack is consumed to add a wound.
 	var/heat_exposure_stacks = 0
 
-	/// Assoc list of attributes. Starts with 4.
-	var/list/attributes = list()
-
 	/// Boolean for sanity points loss effects
 	var/sanity_lost = FALSE
 

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -243,10 +243,3 @@
 	destination.undershirt = undershirt
 	destination.socks = socks
 	destination.jumpsuit_style = jumpsuit_style
-
-/mob/living/carbon/human/proc/get_attribute_list()
-	. = list()
-	var/obj/item/organ/brain/brain = getorganslot(ORGAN_SLOT_BRAIN)
-	if(!brain)
-		return FALSE
-	return brain.attributes

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -243,3 +243,10 @@
 	destination.undershirt = undershirt
 	destination.socks = socks
 	destination.jumpsuit_style = jumpsuit_style
+
+/mob/living/carbon/human/proc/get_attribute_list()
+	. = list()
+	var/obj/item/organ/brain/brain = getorganslot(ORGAN_SLOT_BRAIN)
+	if(!brain)
+		return FALSE
+	return brain.attributes

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -310,9 +310,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 			if(slot == ORGAN_SLOT_BRAIN)
 				var/obj/item/organ/brain/brain = oldorgan
 				if(!brain.decoy_override)//"Just keep it if it's fake" - confucius, probably
-					var/obj/item/organ/brain/newbrain = neworgan
 					brain.before_organ_replacement(neworgan)
-					newbrain.attributes = brain.attributes.Copy() // Copy the old ones to move them over.
 					brain.Remove(C,TRUE, TRUE) //brain argument used so it doesn't cause any... sudden death.
 					QDEL_NULL(brain)
 					oldorgan = null //now deleted

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -310,7 +310,9 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 			if(slot == ORGAN_SLOT_BRAIN)
 				var/obj/item/organ/brain/brain = oldorgan
 				if(!brain.decoy_override)//"Just keep it if it's fake" - confucius, probably
+					var/obj/item/organ/brain/newbrain = neworgan
 					brain.before_organ_replacement(neworgan)
+					newbrain.attributes = brain.attributes.Copy() // Copy the old ones to move them over.
 					brain.Remove(C,TRUE, TRUE) //brain argument used so it doesn't cause any... sudden death.
 					QDEL_NULL(brain)
 					oldorgan = null //now deleted

--- a/code/modules/mob/living/simple_animal/abnormality/_tools/he/dr_jekyll.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_tools/he/dr_jekyll.dm
@@ -83,11 +83,14 @@
 
 /datum/status_effect/dr_jekyll/proc/HydeTakeover()
 	var/mob/living/carbon/human/H = owner
+	var/list/attributes = H.get_attribute_list()
+	if(!attributes)
+		return FALSE
 	to_chat(H, span_notice("You feel strange... Yet... Free?"))
 	takeover = TRUE
 	level = get_user_level(owner) // we only update when the debuff is inflicted
 	level_mod = (level * 5)
-	for(var/attribute in H.attributes)
+	for(var/attribute in attributes)
 		AttributeCalc(attribute, H)
 
 	H.adjust_attribute_bonus(lowest, 2 * level_mod)

--- a/code/modules/mob/living/simple_animal/abnormality/_tools/zayin/mirror.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_tools/zayin/mirror.dm
@@ -7,8 +7,13 @@
 /obj/structure/toolabnormality/mirror/attack_hand(mob/living/carbon/human/user)
 	. = ..()
 
+	var/list/attributes = user.get_attribute_list()
+	if(!attributes)
+		to_chat(user, span_blob("If I only had a brain...")) // Little chance this gets seen, but...
+		return
+
 	var/stat_total = 0 // Start from nothing.
-	for(var/attribute in user.attributes)
+	for(var/attribute in attributes)
 		stat_total += get_raw_level(user, attribute)
 
 	if(stat_total <= 80) // Don't go under 80, I want to keep this clean and keep it from
@@ -16,7 +21,7 @@
 		return
 
 	var/total_addition // Just for the message upon using it
-	for(var/attribute in user.attributes)
+	for(var/attribute in attributes)
 		var/addition = rand(-20, 20)
 		if(user in gazers) // Why are you rerolling your stats twice!?
 			addition -= 10

--- a/code/modules/mob/living/simple_animal/abnormality/_tools/zayin/realizer.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_tools/zayin/realizer.dm
@@ -128,8 +128,12 @@
 		to_chat(user, span_warning("You have realized your full potential already."))
 		return
 
+	var/list/attributes = user.get_attribute_list()
+	if(!attributes)
+		return
+
 	var/stat_total = 0
-	for(var/attribute in user.attributes)
+	for(var/attribute in attributes)
 		stat_total += get_raw_level(user, attribute)
 
 	if(stat_total <= 500) // ~125 in all stats required

--- a/code/modules/mob/living/simple_animal/abnormality/_tools/zayin/wishwell.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_tools/zayin/wishwell.dm
@@ -310,7 +310,8 @@
 		return
 	var/deathgift
 	var/stat_total
-	for(var/attribute in M.attributes)
+
+	for(var/attribute in M.get_attribute_list())
 		stat_total += round(get_raw_level(M, attribute))
 
 	switch(stat_total)

--- a/code/modules/mob/living/simple_animal/abnormality/he/puss_in_boots.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/puss_in_boots.dm
@@ -329,7 +329,7 @@
 	user.physiology.white_mod /= 0.8
 	user.physiology.black_mod /= 0.8
 	user.physiology.pale_mod /= 0.8
-	for(var/attribute in user.attributes)
+	for(var/attribute in user.get_attribute_list())
 		user.adjust_attribute_buff(attribute, -attribute_bonus)
 	QDEL_IN(chosen_arms, 30)
 	return ..()
@@ -357,7 +357,7 @@
 		new_bonus = 20
 	if(new_bonus <= attribute_bonus)
 		return
-	for(var/attribute in user.attributes)
+	for(var/attribute in user.get_attribute_list())
 		user.adjust_attribute_buff(attribute, (new_bonus - attribute_bonus)) //should keep the bonus dynamically updated
 	attribute_bonus = new_bonus
 	return

--- a/code/modules/mob/living/simple_animal/abnormality/waw/pygmalion.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/pygmalion.dm
@@ -154,12 +154,15 @@
 /mob/living/simple_animal/hostile/abnormality/pygmalion/Life()
 	. = ..()
 	if (IsContained() && sculptor && (sculptor.health/sculptor.maxHealth < 0.5 || sculptor.sanityhealth/sculptor.maxSanity < 0.5) )
+		var/list/attributes = sculptor.get_attribute_list()
+		if(!attributes)
+			return
 		BreachEffect()
 		if(client)
 			to_chat(src, span_userdanger("The sculptor is in danger. It is now your duty to protect them!"))
 
 		threat_level = TETH_LEVEL
-		var/datum/attribute/user_attribute = sculptor.attributes[PRUDENCE_ATTRIBUTE]
+		var/datum/attribute/user_attribute = attributes[PRUDENCE_ATTRIBUTE]
 		var/user_attribute_level = max(1, user_attribute.level)
 		if (user_attribute_level > PRUDENCE_CAP)
 			missing_prudence = user_attribute_level - PRUDENCE_CAP

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/hammer_light.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/hammer_light.dm
@@ -272,7 +272,7 @@
 	if(target.type in banned_list)
 		return
 	var/statbonus
-	for(var/attribute in user.attributes)
+	for(var/attribute in user.get_attribute_list())
 		var/attribute_level = get_raw_level(user, attribute)
 		statbonus += attribute_level
 	var/damage_multiplier = (clamp(statbonus * 0.25,0, 130) * 0.01)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Attributes get moved to the brain. This allows for exploded people to get put in new bodies and keep their stats.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Useful for City of Light.
Useful for Admins trying to give someone who exploded a revive without manually changing each exact stat, they're saved in the brain so it's easier to just plonk the old brain in then aHeal them.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
refactor: Attributes are now stored in the brain object as opposed to the human mob itself.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
