### PR TITLE
Butcher spawns with hook

### DIFF
--- a/_maps/map_files/Event/city.dmm
+++ b/_maps/map_files/Event/city.dmm
@@ -1936,15 +1936,6 @@
 /obj/structure/bed,
 /turf/open/floor/carpet/donk,
 /area/city/house)
-"vN" = (
-/obj/structure/table/wood,
-/obj/item/gun/magic/hook,
-/obj/item/gun/magic/hook{
-	pixel_x = 3;
-	pixel_y = 4
-	},
-/turf/open/floor/wood,
-/area/city/shop)
 "vQ" = (
 /obj/structure/table/greyscale,
 /obj/item/stack/medical/aloe{
@@ -47008,7 +46999,7 @@ OT
 xe
 lk
 lk
-vN
+Gb
 OT
 HF
 Gb

--- a/code/modules/jobs/job_types/city/backstreets_butcher.dm
+++ b/code/modules/jobs/job_types/city/backstreets_butcher.dm
@@ -36,12 +36,13 @@ Backstreets Butcher
 	name = "Backstreets Butcher"
 	jobtype = /datum/job/butcher
 	uniform = /obj/item/clothing/under/rank/civilian/chef
-	belt = /obj/item/melee/classic_baton	//So they can catch prey
+	belt = /obj/item/gun/magic/hook
 	suit = /obj/item/clothing/suit/apron/chef
 	l_pocket = /obj/item/restraints/handcuffs
 	ears = null
 
 	backpack_contents = list(
 		/obj/item/clothing/mask/muzzle = 1,
+		/obj/item/melee/classic_baton = 1,	//So they can catch prey
 		/obj/item/kitchen/knife/butcher/deadly = 1)
 	implants = list(/obj/item/organ/cyberimp/eyes/hud/medical)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes the meathook which spawns on the bistro, makes butchers spawn with their meathooks instead
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I don't think it's healthy for CoL to have rats and syndicates metarush the strongest stun weapon currently available to win any combat while ignoring level difference (unless you get solar flared for 10 seconds but that only applies to fixer combat)
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Butchers spawn with their meathooks on them
del: Removed bistro meathook
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
