### PR TITLE
Fixes holomaps sometimes not having cursors

### DIFF
--- a/code/game/machinery/facility_holomap.dm
+++ b/code/game/machinery/facility_holomap.dm
@@ -63,13 +63,13 @@
 
 /obj/machinery/facility_holomap/proc/update_map_data()
 	var/turf/T = get_turf(src)
-	if(forced_zLevel)
+	original_zLevel = T.z
+	var/forced = FALSE
+	if(forced_zLevel && original_zLevel != forced_zLevel) //in case a holomap is forced to the level its already on
 		T = locate(T.x,T.y,forced_zLevel)
 		original_zLevel = forced_zLevel
-	else
-		original_zLevel = T.z
+		forced = TRUE
 
-	var/forced = forced_zLevel ? TRUE : FALSE
 	holomap_datum.initialize_holomap(T, reinit = TRUE, is_forced = forced)
 
 	//Small map for icon


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Holomaps now check if their forced_zLevel is the same as their actual z level to add the cursor overlay. This is more of a QOL change for mappers forgetting to change the forced_zLevel.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
They may be forced to a z level, but they're still there.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: holomap cursor
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
