### PR TITLE
N-Corp Representative now gets temporary attribute increasers

### DIFF
--- a/ModularTegustation/tegu_items/representative/items/ncorp.dm
+++ b/ModularTegustation/tegu_items/representative/items/ncorp.dm
@@ -64,6 +64,47 @@
 	allowed_roles = list("Records Officer", "Extraction Officer")
 
 //Temporary attributes
+#define STATUS_EFFECT_FORTITUDE /datum/status_effect/ncorp/fortitude
+#define STATUS_EFFECT_PRUDENCE /datum/status_effect/ncorp/prudence
+#define STATUS_EFFECT_TEMPERANCE /datum/status_effect/ncorp/temperance
+#define STATUS_EFFECT_JUSTICE /datum/status_effect/ncorp/justice
+
+/atom/movable/screen/alert/status_effect/ncorp
+	name = "N-Corp Fading Ampules"
+	desc = "Your attributes are temporarily buffed."
+	icon = 'ModularTegustation/Teguicons/status_sprites.dmi'
+	icon_state = "bg_template"
+
+/datum/status_effect/ncorp
+	id = "ncorptemp"
+	status_type = STATUS_EFFECT_UNIQUE
+	duration = 3000		//Lasts 5 minutes
+	alert_type = /atom/movable/screen/alert/status_effect/ncorp
+	var/attribute_buff = FORTITUDE_ATTRIBUTE
+
+/datum/status_effect/ncorp/on_apply()
+	. = ..()
+	if(ishuman(owner))
+		var/mob/living/carbon/human/L = owner
+		L.adjust_attribute_buff(attribute_buff, 15)
+
+/datum/status_effect/ncorp/on_remove()
+	. = ..()
+	if(ishuman(owner))
+		var/mob/living/carbon/human/L = owner
+		L.adjust_attribute_buff(attribute_buff, -15)
+
+/datum/status_effect/ncorp/fortitude
+
+/datum/status_effect/ncorp/prudence
+	attribute_buff = PRUDENCE_ATTRIBUTE
+
+/datum/status_effect/ncorp/temperance
+	attribute_buff = TEMPERANCE_ATTRIBUTE
+
+/datum/status_effect/ncorp/justice
+	attribute_buff = JUSTICE_ATTRIBUTE
+
 /obj/item/attribute_temporary/justicesmall
 	name = "ncorp small fading justice accelerator"
 	desc = "A fluid used to increase the user's justice temporarily. Use in hand to activate."
@@ -72,30 +113,8 @@
 
 /obj/item/attribute_temporary/justicesmall/attack_self(mob/living/carbon/human/user)
 	to_chat(user, span_nicegreen("You suddenly feel different."))
-	user.apply_status_effect(/datum/status_effect/njustice)
+	user.apply_status_effect(STATUS_EFFECT_JUSTICE)
 	qdel(src)
-
-/datum/status_effect/njustice
-	id = "NJUSTICE"
-	status_type = STATUS_EFFECT_UNIQUE
-	alert_type = /atom/movable/screen/alert/status_effect/njustice
-	duration = 300 SECONDS
-
-/atom/movable/screen/alert/status_effect/njustice
-	name = "N-Corp Experience"
-	desc = "Increases justice by 15."
-	icon = 'ModularTegustation/Teguicons/status_sprites.dmi'
-	icon_state = "bg_template"
-
-/datum/status_effect/njustice/on_apply()
-	. = ..()
-	var/mob/living/carbon/human/H = owner
-	H.adjust_attribute_buff(JUSTICE_ATTRIBUTE, 15)
-
-/datum/status_effect/njustice/on_remove()
-	. = ..()
-	var/mob/living/carbon/human/H = owner
-	H.adjust_attribute_buff(JUSTICE_ATTRIBUTE, -15)
 
 /obj/item/attribute_temporary/temperancesmall
 	name = "ncorp small fading temperance  accelerator"
@@ -105,30 +124,8 @@
 
 /obj/item/attribute_temporary/temperancesmall/attack_self(mob/living/carbon/human/user)
 	to_chat(user, span_nicegreen("You suddenly feel different."))
-	user.apply_status_effect(/datum/status_effect/ntemperance)
+	user.apply_status_effect(STATUS_EFFECT_TEMPERANCE)
 	qdel(src)
-
-/datum/status_effect/ntemperance
-	id = "NTEMPERANCE"
-	status_type = STATUS_EFFECT_UNIQUE
-	alert_type = /atom/movable/screen/alert/status_effect/ntemperance
-	duration = 300 SECONDS
-
-/atom/movable/screen/alert/status_effect/ntemperance
-	name = "N-Corp Experience"
-	desc = "Increases temperance by 15."
-	icon = 'ModularTegustation/Teguicons/status_sprites.dmi'
-	icon_state = "bg_template"
-
-/datum/status_effect/ntemperance/on_apply()
-	. = ..()
-	var/mob/living/carbon/human/H = owner
-	H.adjust_attribute_buff(TEMPERANCE_ATTRIBUTE, 15)
-
-/datum/status_effect/ntemperance/on_remove()
-	. = ..()
-	var/mob/living/carbon/human/H = owner
-	H.adjust_attribute_buff(TEMPERANCE_ATTRIBUTE, -15)
 
 /obj/item/attribute_temporary/fortitudesmall
 	name = "ncorp small fading fortitude accelerator"
@@ -138,30 +135,8 @@
 
 /obj/item/attribute_temporary/fortitudesmall/attack_self(mob/living/carbon/human/user)
 	to_chat(user, span_nicegreen("You suddenly feel different."))
-	user.apply_status_effect(/datum/status_effect/nfortitude)
+	user.apply_status_effect(STATUS_EFFECT_FORTITUDE)
 	qdel(src)
-
-/datum/status_effect/nfortitude
-	id = "NFORTITUDE"
-	status_type = STATUS_EFFECT_UNIQUE
-	alert_type = /atom/movable/screen/alert/status_effect/nfortitude
-	duration = 300 SECONDS
-
-/atom/movable/screen/alert/status_effect/nfortitude
-	name = "N-Corp Experience"
-	desc = "Increases fortitude by 15."
-	icon = 'ModularTegustation/Teguicons/status_sprites.dmi'
-	icon_state = "bg_template"
-
-/datum/status_effect/nfortitude/on_apply()
-	. = ..()
-	var/mob/living/carbon/human/H = owner
-	H.adjust_attribute_buff(FORTITUDE_ATTRIBUTE, 15)
-
-/datum/status_effect/nfortitude/on_remove()
-	. = ..()
-	var/mob/living/carbon/human/H = owner
-	H.adjust_attribute_buff(FORTITUDE_ATTRIBUTE, -15)
 
 /obj/item/attribute_temporary/prudencesmall
 	name = "ncorp small fading prudence accelerator"
@@ -171,30 +146,8 @@
 
 /obj/item/attribute_temporary/prudencesmall/attack_self(mob/living/carbon/human/user)
 	to_chat(user, span_nicegreen("You suddenly feel different."))
-	user.apply_status_effect(/datum/status_effect/nprudence)
+	user.apply_status_effect(STATUS_EFFECT_PRUDENCE)
 	qdel(src)
-
-/datum/status_effect/nprudence
-	id = "NPRUDENCE"
-	status_type = STATUS_EFFECT_UNIQUE
-	alert_type = /atom/movable/screen/alert/status_effect/nprudence
-	duration = 300 SECONDS
-
-/atom/movable/screen/alert/status_effect/nprudence
-	name = "N-Corp Experience"
-	desc = "Increases prudence by 15."
-	icon = 'ModularTegustation/Teguicons/status_sprites.dmi'
-	icon_state = "bg_template"
-
-/datum/status_effect/nprudence/on_apply()
-	. = ..()
-	var/mob/living/carbon/human/H = owner
-	H.adjust_attribute_buff(PRUDENCE_ATTRIBUTE, 15)
-
-/datum/status_effect/nprudence/on_remove()
-	. = ..()
-	var/mob/living/carbon/human/H = owner
-	H.adjust_attribute_buff(PRUDENCE_ATTRIBUTE, -15)
 
 //Generalized temporary ampules
 /obj/item/attribute_temporary/stattemporary
@@ -209,18 +162,12 @@
 	qdel(src)
 
 /datum/status_effect/nstats
-	id = "NSTATS"
+	id = "nstats"
 	status_type = STATUS_EFFECT_UNIQUE
-	alert_type = /atom/movable/screen/alert/status_effect/nstats
-	duration = 120 SECONDS
+	alert_type = /atom/movable/screen/alert/status_effect/ncorp
+	duration = 1200
 
-/atom/movable/screen/alert/status_effect/nstats
-	name = "N-Corp Experience"
-	desc = "Increases all stats by 15."
-	icon = 'ModularTegustation/Teguicons/status_sprites.dmi'
-	icon_state = "bg_template"
-
-/datum/status_effect/njustice/on_apply()
+/datum/status_effect/nstats/on_apply()
 	. = ..()
 	var/mob/living/carbon/human/H = owner
 	H.adjust_attribute_buff(JUSTICE_ATTRIBUTE, 15)
@@ -228,13 +175,49 @@
 	H.adjust_attribute_buff(FORTITUDE_ATTRIBUTE, 15)
 	H.adjust_attribute_buff(PRUDENCE_ATTRIBUTE, 15)
 
-/datum/status_effect/njustice/on_remove()
+/datum/status_effect/nstats/on_remove()
 	. = ..()
 	var/mob/living/carbon/human/H = owner
 	H.adjust_attribute_buff(JUSTICE_ATTRIBUTE, -15)
 	H.adjust_attribute_buff(TEMPERANCE_ATTRIBUTE, -15)
 	H.adjust_attribute_buff(FORTITUDE_ATTRIBUTE, -15)
 	H.adjust_attribute_buff(PRUDENCE_ATTRIBUTE, -15)
+
+//Focused Ncorp ampules
+#define STATUS_EFFECT_FORTITUDE_FOCUS /datum/status_effect/nfocus/fortitude
+#define STATUS_EFFECT_PRUDENCE_FOCUS /datum/status_effect/nfocus/prudence
+#define STATUS_EFFECT_TEMPERANCE_FOCUS /datum/status_effect/nfocus/temperance
+#define STATUS_EFFECT_JUSTICE_FOCUS /datum/status_effect/nfocus/justice
+
+/datum/status_effect/nfocus
+	id = "nfocus"
+	status_type = STATUS_EFFECT_UNIQUE
+	duration = 3000		//Lasts 5 minutes
+	alert_type = /atom/movable/screen/alert/status_effect/ncorp
+	var/attribute_buff = FORTITUDE_ATTRIBUTE
+
+/datum/status_effect/ncorp/on_apply()
+	. = ..()
+	if(ishuman(owner))
+		var/mob/living/carbon/human/L = owner
+		L.adjust_attribute_buff(attribute_buff, 20)
+
+/datum/status_effect/ncorp/on_remove()
+	. = ..()
+	if(ishuman(owner))
+		var/mob/living/carbon/human/L = owner
+		L.adjust_attribute_buff(attribute_buff, -20)
+
+/datum/status_effect/nfocus/fortitude
+
+/datum/status_effect/nfocus/prudence
+	attribute_buff = PRUDENCE_ATTRIBUTE
+
+/datum/status_effect/nfocus/temperance
+	attribute_buff = TEMPERANCE_ATTRIBUTE
+
+/datum/status_effect/nfocus/justice
+	attribute_buff = JUSTICE_ATTRIBUTE
 
 /obj/item/attribute_temporary/justicebig
 	name = "ncorp large fading justice accelerator"
@@ -244,30 +227,8 @@
 
 /obj/item/attribute_temporary/justicebig/attack_self(mob/living/carbon/human/user)
 	to_chat(user, span_nicegreen("You suddenly feel different."))
-	user.apply_status_effect(/datum/status_effect/njusticebig)
+	user.apply_status_effect(STATUS_EFFECT_JUSTICE_FOCUS)
 	qdel(src)
-
-/datum/status_effect/njusticebig
-	id = "NJUSTICEBIG"
-	status_type = STATUS_EFFECT_UNIQUE
-	alert_type = /atom/movable/screen/alert/status_effect/njusticebig
-	duration = 300 SECONDS
-
-/atom/movable/screen/alert/status_effect/njusticebig
-	name = "N-Corp Experience"
-	desc = "Increases justice by 20."
-	icon = 'ModularTegustation/Teguicons/status_sprites.dmi'
-	icon_state = "bg_template"
-
-/datum/status_effect/njustice/on_apply()
-	. = ..()
-	var/mob/living/carbon/human/H = owner
-	H.adjust_attribute_buff(JUSTICE_ATTRIBUTE, 20)
-
-/datum/status_effect/njustice/on_remove()
-	. = ..()
-	var/mob/living/carbon/human/H = owner
-	H.adjust_attribute_buff(JUSTICE_ATTRIBUTE, -20)
 
 /obj/item/attribute_temporary/temperancebig
 	name = "ncorp large fading temperance  accelerator"
@@ -277,30 +238,8 @@
 
 /obj/item/attribute_temporary/temperancebig/attack_self(mob/living/carbon/human/user)
 	to_chat(user, span_nicegreen("You suddenly feel different."))
-	user.apply_status_effect(/datum/status_effect/ntemperancebig)
+	user.apply_status_effect(STATUS_EFFECT_TEMPERANCE_FOCUS)
 	qdel(src)
-
-/datum/status_effect/ntemperancebig
-	id = "NTEMPERANCEBIG"
-	status_type = STATUS_EFFECT_UNIQUE
-	alert_type = /atom/movable/screen/alert/status_effect/ntemperancebig
-	duration = 300 SECONDS
-
-/atom/movable/screen/alert/status_effect/ntemperancebig
-	name = "N-Corp Experience"
-	desc = "Increases temperance by 20."
-	icon = 'ModularTegustation/Teguicons/status_sprites.dmi'
-	icon_state = "bg_template"
-
-/datum/status_effect/ntemperancebig/on_apply()
-	. = ..()
-	var/mob/living/carbon/human/H = owner
-	H.adjust_attribute_buff(TEMPERANCE_ATTRIBUTE, 20)
-
-/datum/status_effect/ntemperancebig/on_remove()
-	. = ..()
-	var/mob/living/carbon/human/H = owner
-	H.adjust_attribute_buff(TEMPERANCE_ATTRIBUTE, -20)
 
 /obj/item/attribute_temporary/fortitudebig
 	name = "ncorp large fading fortitude accelerator"
@@ -310,30 +249,8 @@
 
 /obj/item/attribute_temporary/fortitudebig/attack_self(mob/living/carbon/human/user)
 	to_chat(user, span_nicegreen("You suddenly feel different."))
-	user.apply_status_effect(/datum/status_effect/nfortitudebig)
+	user.apply_status_effect(STATUS_EFFECT_FORTITUDE_FOCUS)
 	qdel(src)
-
-/datum/status_effect/nfortitudebig
-	id = "NFORTITUDEBIG"
-	status_type = STATUS_EFFECT_UNIQUE
-	alert_type = /atom/movable/screen/alert/status_effect/nfortitudebig
-	duration = 300 SECONDS
-
-/atom/movable/screen/alert/status_effect/nfortitudebig
-	name = "N-Corp Experience"
-	desc = "Increases fortitude by 20."
-	icon = 'ModularTegustation/Teguicons/status_sprites.dmi'
-	icon_state = "bg_template"
-
-/datum/status_effect/nfortitudebig/on_apply()
-	. = ..()
-	var/mob/living/carbon/human/H = owner
-	H.adjust_attribute_buff(FORTITUDE_ATTRIBUTE, 20)
-
-/datum/status_effect/nfortitudebig/on_remove()
-	. = ..()
-	var/mob/living/carbon/human/H = owner
-	H.adjust_attribute_buff(FORTITUDE_ATTRIBUTE, -20)
 
 /obj/item/attribute_temporary/prudencebig
 	name = "ncorp large fading prudence accelerator"
@@ -343,28 +260,6 @@
 
 /obj/item/attribute_temporary/prudencebig/attack_self(mob/living/carbon/human/user)
 	to_chat(user, span_nicegreen("You suddenly feel different."))
-	user.apply_status_effect(/datum/status_effect/nprudencebig)
+	user.apply_status_effect(STATUS_EFFECT_PRUDENCE_FOCUS)
 	qdel(src)
-
-/datum/status_effect/nprudencebig
-	id = "NPRUDENCEBIG"
-	status_type = STATUS_EFFECT_UNIQUE
-	alert_type = /atom/movable/screen/alert/status_effect/nprudencebig
-	duration = 300 SECONDS
-
-/atom/movable/screen/alert/status_effect/nprudencebig
-	name = "N-Corp Experience"
-	desc = "Increases prudence by 20."
-	icon = 'ModularTegustation/Teguicons/status_sprites.dmi'
-	icon_state = "bg_template"
-
-/datum/status_effect/nprudencebig/on_apply()
-	. = ..()
-	var/mob/living/carbon/human/H = owner
-	H.adjust_attribute_buff(PRUDENCE_ATTRIBUTE, 20)
-
-/datum/status_effect/nprudencebig/on_remove()
-	. = ..()
-	var/mob/living/carbon/human/H = owner
-	H.adjust_attribute_buff(PRUDENCE_ATTRIBUTE, -20)
 

--- a/ModularTegustation/tegu_items/representative/items/ncorp.dm
+++ b/ModularTegustation/tegu_items/representative/items/ncorp.dm
@@ -63,3 +63,308 @@
 	amount = 80
 	allowed_roles = list("Records Officer", "Extraction Officer")
 
+//Temporary attributes
+/obj/item/attribute_temporary/justicesmall
+	name = "ncorp small fading justice accelerator"
+	desc = "A fluid used to increase the user's justice temporarily. Use in hand to activate."
+	icon = 'ModularTegustation/Teguicons/teguitems.dmi'
+	icon_state = "tcorp_syringe"
+
+/obj/item/attribute_temporary/justicesmall/attack_self(mob/living/carbon/human/user)
+	to_chat(user, span_nicegreen("You suddenly feel different."))
+	user.apply_status_effect(/datum/status_effect/njustice)
+	qdel(src)
+
+/datum/status_effect/njustice
+	id = "NJUSTICE"
+	status_type = STATUS_EFFECT_UNIQUE
+	alert_type = /atom/movable/screen/alert/status_effect/njustice
+	duration = 300 SECONDS
+
+/atom/movable/screen/alert/status_effect/njustice
+	name = "N-Corp Experience"
+	desc = "Increases justice by 15."
+	icon = 'ModularTegustation/Teguicons/status_sprites.dmi'
+	icon_state = "bg_template"
+
+/datum/status_effect/njustice/on_apply()
+	. = ..()
+	var/mob/living/carbon/human/H = owner
+	H.adjust_attribute_buff(JUSTICE_ATTRIBUTE, 15)
+
+/datum/status_effect/njustice/on_remove()
+	. = ..()
+	var/mob/living/carbon/human/H = owner
+	H.adjust_attribute_buff(JUSTICE_ATTRIBUTE, -15)
+
+/obj/item/attribute_temporary/temperancesmall
+	name = "ncorp small fading temperance  accelerator"
+	desc = "A fluid used to increase the user's temperance temporarily. Use in hand to activate."
+	icon = 'ModularTegustation/Teguicons/teguitems.dmi'
+	icon_state = "tcorp_syringe"
+
+/obj/item/attribute_temporary/temperancesmall/attack_self(mob/living/carbon/human/user)
+	to_chat(user, span_nicegreen("You suddenly feel different."))
+	user.apply_status_effect(/datum/status_effect/ntemperance)
+	qdel(src)
+
+/datum/status_effect/ntemperance
+	id = "NTEMPERANCE"
+	status_type = STATUS_EFFECT_UNIQUE
+	alert_type = /atom/movable/screen/alert/status_effect/ntemperance
+	duration = 300 SECONDS
+
+/atom/movable/screen/alert/status_effect/ntemperance
+	name = "N-Corp Experience"
+	desc = "Increases temperance by 15."
+	icon = 'ModularTegustation/Teguicons/status_sprites.dmi'
+	icon_state = "bg_template"
+
+/datum/status_effect/ntemperance/on_apply()
+	. = ..()
+	var/mob/living/carbon/human/H = owner
+	H.adjust_attribute_buff(TEMPERANCE_ATTRIBUTE, 15)
+
+/datum/status_effect/ntemperance/on_remove()
+	. = ..()
+	var/mob/living/carbon/human/H = owner
+	H.adjust_attribute_buff(TEMPERANCE_ATTRIBUTE, -15)
+
+/obj/item/attribute_temporary/fortitudesmall
+	name = "ncorp small fading fortitude accelerator"
+	desc = "A fluid used to increase the user's fortitude temporarily. Use in hand to activate."
+	icon = 'ModularTegustation/Teguicons/teguitems.dmi'
+	icon_state = "tcorp_syringe"
+
+/obj/item/attribute_temporary/fortitudesmall/attack_self(mob/living/carbon/human/user)
+	to_chat(user, span_nicegreen("You suddenly feel different."))
+	user.apply_status_effect(/datum/status_effect/nfortitude)
+	qdel(src)
+
+/datum/status_effect/nfortitude
+	id = "NFORTITUDE"
+	status_type = STATUS_EFFECT_UNIQUE
+	alert_type = /atom/movable/screen/alert/status_effect/nfortitude
+	duration = 300 SECONDS
+
+/atom/movable/screen/alert/status_effect/nfortitude
+	name = "N-Corp Experience"
+	desc = "Increases fortitude by 15."
+	icon = 'ModularTegustation/Teguicons/status_sprites.dmi'
+	icon_state = "bg_template"
+
+/datum/status_effect/nfortitude/on_apply()
+	. = ..()
+	var/mob/living/carbon/human/H = owner
+	H.adjust_attribute_buff(FORTITUDE_ATTRIBUTE, 15)
+
+/datum/status_effect/nfortitude/on_remove()
+	. = ..()
+	var/mob/living/carbon/human/H = owner
+	H.adjust_attribute_buff(FORTITUDE_ATTRIBUTE, -15)
+
+/obj/item/attribute_temporary/prudencesmall
+	name = "ncorp small fading prudence accelerator"
+	desc = "A fluid used to increase the user's prudence temporarily. Use in hand to activate."
+	icon = 'ModularTegustation/Teguicons/teguitems.dmi'
+	icon_state = "tcorp_syringe"
+
+/obj/item/attribute_temporary/prudencesmall/attack_self(mob/living/carbon/human/user)
+	to_chat(user, span_nicegreen("You suddenly feel different."))
+	user.apply_status_effect(/datum/status_effect/nprudence)
+	qdel(src)
+
+/datum/status_effect/nprudence
+	id = "NPRUDENCE"
+	status_type = STATUS_EFFECT_UNIQUE
+	alert_type = /atom/movable/screen/alert/status_effect/nprudence
+	duration = 300 SECONDS
+
+/atom/movable/screen/alert/status_effect/nprudence
+	name = "N-Corp Experience"
+	desc = "Increases prudence by 15."
+	icon = 'ModularTegustation/Teguicons/status_sprites.dmi'
+	icon_state = "bg_template"
+
+/datum/status_effect/nprudence/on_apply()
+	. = ..()
+	var/mob/living/carbon/human/H = owner
+	H.adjust_attribute_buff(PRUDENCE_ATTRIBUTE, 15)
+
+/datum/status_effect/nprudence/on_remove()
+	. = ..()
+	var/mob/living/carbon/human/H = owner
+	H.adjust_attribute_buff(PRUDENCE_ATTRIBUTE, -15)
+
+//Generalized temporary ampules
+/obj/item/attribute_temporary/stattemporary
+	name = "ncorp medium fading accelerator"
+	desc = "A fluid used to increase the user's stats temporarily. Use in hand to activate."
+	icon = 'ModularTegustation/Teguicons/teguitems.dmi'
+	icon_state = "ncorp_syringe2"
+
+/obj/item/attribute_temporary/stattemporary/attack_self(mob/living/carbon/human/user)
+	to_chat(user, span_nicegreen("You suddenly feel different."))
+	user.apply_status_effect(/datum/status_effect/nstats)
+	qdel(src)
+
+/datum/status_effect/nstats
+	id = "NSTATS"
+	status_type = STATUS_EFFECT_UNIQUE
+	alert_type = /atom/movable/screen/alert/status_effect/nstats
+	duration = 120 SECONDS
+
+/atom/movable/screen/alert/status_effect/nstats
+	name = "N-Corp Experience"
+	desc = "Increases all stats by 15."
+	icon = 'ModularTegustation/Teguicons/status_sprites.dmi'
+	icon_state = "bg_template"
+
+/datum/status_effect/njustice/on_apply()
+	. = ..()
+	var/mob/living/carbon/human/H = owner
+	H.adjust_attribute_buff(JUSTICE_ATTRIBUTE, 15)
+	H.adjust_attribute_buff(TEMPERANCE_ATTRIBUTE, 15)
+	H.adjust_attribute_buff(FORTITUDE_ATTRIBUTE, 15)
+	H.adjust_attribute_buff(PRUDENCE_ATTRIBUTE, 15)
+
+/datum/status_effect/njustice/on_remove()
+	. = ..()
+	var/mob/living/carbon/human/H = owner
+	H.adjust_attribute_buff(JUSTICE_ATTRIBUTE, -15)
+	H.adjust_attribute_buff(TEMPERANCE_ATTRIBUTE, -15)
+	H.adjust_attribute_buff(FORTITUDE_ATTRIBUTE, -15)
+	H.adjust_attribute_buff(PRUDENCE_ATTRIBUTE, -15)
+
+/obj/item/attribute_temporary/justicebig
+	name = "ncorp large fading justice accelerator"
+	desc = "A fluid used to increase the user's justice temporarily. Use in hand to activate."
+	icon = 'ModularTegustation/Teguicons/teguitems.dmi'
+	icon_state = "ncorp_syringe3"
+
+/obj/item/attribute_temporary/justicebig/attack_self(mob/living/carbon/human/user)
+	to_chat(user, span_nicegreen("You suddenly feel different."))
+	user.apply_status_effect(/datum/status_effect/njusticebig)
+	qdel(src)
+
+/datum/status_effect/njusticebig
+	id = "NJUSTICEBIG"
+	status_type = STATUS_EFFECT_UNIQUE
+	alert_type = /atom/movable/screen/alert/status_effect/njusticebig
+	duration = 300 SECONDS
+
+/atom/movable/screen/alert/status_effect/njusticebig
+	name = "N-Corp Experience"
+	desc = "Increases justice by 20."
+	icon = 'ModularTegustation/Teguicons/status_sprites.dmi'
+	icon_state = "bg_template"
+
+/datum/status_effect/njustice/on_apply()
+	. = ..()
+	var/mob/living/carbon/human/H = owner
+	H.adjust_attribute_buff(JUSTICE_ATTRIBUTE, 20)
+
+/datum/status_effect/njustice/on_remove()
+	. = ..()
+	var/mob/living/carbon/human/H = owner
+	H.adjust_attribute_buff(JUSTICE_ATTRIBUTE, -20)
+
+/obj/item/attribute_temporary/temperancebig
+	name = "ncorp large fading temperance  accelerator"
+	desc = "A fluid used to increase the user's temperance temporarily. Use in hand to activate."
+	icon = 'ModularTegustation/Teguicons/teguitems.dmi'
+	icon_state = "ncorp_syringe3"
+
+/obj/item/attribute_temporary/temperancebig/attack_self(mob/living/carbon/human/user)
+	to_chat(user, span_nicegreen("You suddenly feel different."))
+	user.apply_status_effect(/datum/status_effect/ntemperancebig)
+	qdel(src)
+
+/datum/status_effect/ntemperancebig
+	id = "NTEMPERANCEBIG"
+	status_type = STATUS_EFFECT_UNIQUE
+	alert_type = /atom/movable/screen/alert/status_effect/ntemperancebig
+	duration = 300 SECONDS
+
+/atom/movable/screen/alert/status_effect/ntemperancebig
+	name = "N-Corp Experience"
+	desc = "Increases temperance by 20."
+	icon = 'ModularTegustation/Teguicons/status_sprites.dmi'
+	icon_state = "bg_template"
+
+/datum/status_effect/ntemperancebig/on_apply()
+	. = ..()
+	var/mob/living/carbon/human/H = owner
+	H.adjust_attribute_buff(TEMPERANCE_ATTRIBUTE, 20)
+
+/datum/status_effect/ntemperancebig/on_remove()
+	. = ..()
+	var/mob/living/carbon/human/H = owner
+	H.adjust_attribute_buff(TEMPERANCE_ATTRIBUTE, -20)
+
+/obj/item/attribute_temporary/fortitudebig
+	name = "ncorp large fading fortitude accelerator"
+	desc = "A fluid used to increase the user's fortitude temporarily. Use in hand to activate."
+	icon = 'ModularTegustation/Teguicons/teguitems.dmi'
+	icon_state = "ncorp_syringe3"
+
+/obj/item/attribute_temporary/fortitudebig/attack_self(mob/living/carbon/human/user)
+	to_chat(user, span_nicegreen("You suddenly feel different."))
+	user.apply_status_effect(/datum/status_effect/nfortitudebig)
+	qdel(src)
+
+/datum/status_effect/nfortitudebig
+	id = "NFORTITUDEBIG"
+	status_type = STATUS_EFFECT_UNIQUE
+	alert_type = /atom/movable/screen/alert/status_effect/nfortitudebig
+	duration = 300 SECONDS
+
+/atom/movable/screen/alert/status_effect/nfortitudebig
+	name = "N-Corp Experience"
+	desc = "Increases fortitude by 20."
+	icon = 'ModularTegustation/Teguicons/status_sprites.dmi'
+	icon_state = "bg_template"
+
+/datum/status_effect/nfortitudebig/on_apply()
+	. = ..()
+	var/mob/living/carbon/human/H = owner
+	H.adjust_attribute_buff(FORTITUDE_ATTRIBUTE, 20)
+
+/datum/status_effect/nfortitudebig/on_remove()
+	. = ..()
+	var/mob/living/carbon/human/H = owner
+	H.adjust_attribute_buff(FORTITUDE_ATTRIBUTE, -20)
+
+/obj/item/attribute_temporary/prudencebig
+	name = "ncorp large fading prudence accelerator"
+	desc = "A fluid used to increase the user's prudence temporarily. Use in hand to activate."
+	icon = 'ModularTegustation/Teguicons/teguitems.dmi'
+	icon_state = "ncorp_syringe3"
+
+/obj/item/attribute_temporary/prudencebig/attack_self(mob/living/carbon/human/user)
+	to_chat(user, span_nicegreen("You suddenly feel different."))
+	user.apply_status_effect(/datum/status_effect/nprudencebig)
+	qdel(src)
+
+/datum/status_effect/nprudencebig
+	id = "NPRUDENCEBIG"
+	status_type = STATUS_EFFECT_UNIQUE
+	alert_type = /atom/movable/screen/alert/status_effect/nprudencebig
+	duration = 300 SECONDS
+
+/atom/movable/screen/alert/status_effect/nprudencebig
+	name = "N-Corp Experience"
+	desc = "Increases prudence by 20."
+	icon = 'ModularTegustation/Teguicons/status_sprites.dmi'
+	icon_state = "bg_template"
+
+/datum/status_effect/nprudencebig/on_apply()
+	. = ..()
+	var/mob/living/carbon/human/H = owner
+	H.adjust_attribute_buff(PRUDENCE_ATTRIBUTE, 20)
+
+/datum/status_effect/nprudencebig/on_remove()
+	. = ..()
+	var/mob/living/carbon/human/H = owner
+	H.adjust_attribute_buff(PRUDENCE_ATTRIBUTE, -20)
+

--- a/ModularTegustation/tegu_items/representative/research/kcorp.dm
+++ b/ModularTegustation/tegu_items/representative/research/kcorp.dm
@@ -36,7 +36,7 @@
 //Misc stuff.
 /datum/data/lc13research/bullets
 	research_name = "Manager Bullet Permits"
-	research_desc = "Due to your efforts, we are granting you the privilage of <br>purchasing low level hp ampules at a 90% discount."
+	research_desc = "Due to your efforts, we are granting you the privilage of <br>purchasing managerial bullets at a 90% discount."
 	cost = AVERAGE_RESEARCH_PRICE
 	corp = K_CORP_REP
 

--- a/ModularTegustation/tegu_items/representative/research/ncorp.dm
+++ b/ModularTegustation/tegu_items/representative/research/ncorp.dm
@@ -78,7 +78,7 @@
 //Temporary line
 /datum/data/lc13research/ntemp1
 	research_name = "N-Corporation Temporary Experience Ampules"
-	research_desc = "A permit to sell temporarily stat increasing experience ampules. <br>Through a bit of experimentation we have found out to repeatedly extract segmented experience from prisioners for mass production, however the repeated draining of their experiences causes these memories to become fragile and fade. I'm sure however you can still easily market these for some profit."
+	research_desc = "A permit to sell temporarily stat increasing experience ampules. <br>Through a bit of experimentation we have found out to repeatedly extract segmented experience from prisioners for mass production, <br>however the repeated draining of their experiences causes these memories to become fragile and fade. <br>I'm sure however you can still easily market these for some profit."
 	cost = AVERAGE_RESEARCH_PRICE
 	corp = N_CORP_REP
 	required_research = /datum/data/lc13research/nbuff1
@@ -92,7 +92,7 @@
 
 /datum/data/lc13research/ntemp2
 	research_name = "N-Corporation Strengthened Temporary Experience Ampules"
-	research_desc = "A permit to sell more potent temporary stat increasing experience ampules. <br>Through trial and error we have managed to increase the amount of experience that can be repeatedly gathered from a individual at the cost of heightened fading, though it's duration is ineffective for long-term use it can be efficiently deployed in emergencies. I believe you already know the drill, I'm sure these ones will sell far better than our previous ampules."
+	research_desc = "A permit to sell more potent temporary stat increasing experience ampules. <br>Through trial and error we have managed to increase the amount of experience that can be repeatedly gathered from a individual at the cost of heightened fading, <br>though it's duration is ineffective for long-term use it can be efficiently deployed in emergencies. I believe you already know the drill, <br>I'm sure these ones will sell far better than our previous ampules."
 	cost = AVERAGE_RESEARCH_PRICE+5
 	corp = N_CORP_REP
 	required_research = /datum/data/lc13research/ntemp1
@@ -103,7 +103,7 @@
 
 /datum/data/lc13research/ntemp3
 	research_name = "N-Corporation Focused Temporary Experience Ampules"
-	research_desc = "A permit to sell focused temporary stat increasing experience ampules. <br>While losing a few impure guinea pigs in the attempt to make it we have finally suceeded, this ampule is the pinnacle of our research, capable of being infinitely produced out of repeated draining at 33% higher efficiency, learning from the failure of past fading ampules however this one will not grant experience in more than one area to avoid rapid fading. I'm sure you can put the remains of that mechanical filth to good use."
+	research_desc = "A permit to sell focused temporary stat increasing experience ampules. <br>While losing a few impure guinea pigs in the attempt to make it we have finally suceeded, <br>this ampule is the pinnacle of our research, capable of being infinitely produced out of repeated draining at 33% higher efficiency, <br>learning from the failure of past fading ampules however this one will not grant experience in more than one area to avoid rapid fading. I'm sure you can put the remains of that mechanical filth to good use."
 	cost = HIGH_RESEARCH_PRICE
 	corp = N_CORP_REP
 	required_research = /datum/data/lc13research/ntemp2

--- a/ModularTegustation/tegu_items/representative/research/ncorp.dm
+++ b/ModularTegustation/tegu_items/representative/research/ncorp.dm
@@ -75,4 +75,44 @@
 	new /obj/item/limit_increase(get_turf(caller))
 	..()
 
+//Temporary line
+/datum/data/lc13research/ntemp1
+	research_name = "N-Corporation Temporary Experience Ampules"
+	research_desc = "A permit to sell temporarily stat increasing experience ampules. <br>Through a bit of experimentation we have found out to repeatedly extract segmented experience from prisioners for mass production, however the repeated draining of their experiences causes these memories to become fragile and fade. I'm sure however you can still easily market these for some profit."
+	cost = AVERAGE_RESEARCH_PRICE
+	corp = N_CORP_REP
+	required_research = /datum/data/lc13research/nbuff1
+
+/datum/data/lc13research/ntemp1/ResearchEffect(obj/structure/representative_console/caller)
+	ItemUnlock(caller.order_list, "Fading Fortitude Ampule",	/obj/item/attribute_temporary/fortitudesmall, 500)
+	ItemUnlock(caller.order_list, "Fading Temperance Ampule",	/obj/item/attribute_temporary/temperancesmall, 500)
+	ItemUnlock(caller.order_list, "Fading Prudence Ampule",	/obj/item/attribute_temporary/prudencesmall, 500)
+	ItemUnlock(caller.order_list, "Fading Justice Ampule",	/obj/item/attribute_temporary/justicesmall, 500)
+	..()
+
+/datum/data/lc13research/ntemp2
+	research_name = "N-Corporation Strengthened Temporary Experience Ampules"
+	research_desc = "A permit to sell more potent temporary stat increasing experience ampules. <br>Through trial and error we have managed to increase the amount of experience that can be repeatedly gathered from a individual at the cost of heightened fading, though it's duration is ineffective for long-term use it can be efficiently deployed in emergencies. I believe you already know the drill, I'm sure these ones will sell far better than our previous ampules."
+	cost = AVERAGE_RESEARCH_PRICE+5
+	corp = N_CORP_REP
+	required_research = /datum/data/lc13research/ntemp1
+
+/datum/data/lc13research/ntemp2/ResearchEffect(obj/structure/representative_console/caller)
+	ItemUnlock(caller.order_list, "Fading Attribute Ampule",	/obj/item/attribute_temporary/stattemporary, 1000)
+	..()
+
+/datum/data/lc13research/ntemp3
+	research_name = "N-Corporation Focused Temporary Experience Ampules"
+	research_desc = "A permit to sell focused temporary stat increasing experience ampules. <br>While losing a few impure guinea pigs in the attempt to make it we have finally suceeded, this ampule is the pinnacle of our research, capable of being infinitely produced out of repeated draining at 33% higher efficiency, learning from the failure of past fading ampules however this one will not grant experience in more than one area to avoid rapid fading. I'm sure you can put the remains of that mechanical filth to good use."
+	cost = HIGH_RESEARCH_PRICE
+	corp = N_CORP_REP
+	required_research = /datum/data/lc13research/ntemp2
+
+/datum/data/lc13research/ntemp1/ResearchEffect(obj/structure/representative_console/caller)
+	ItemUnlock(caller.order_list, "Focused Fading Fortitude Ampule",	/obj/item/attribute_temporary/fortitudebig, 1500)
+	ItemUnlock(caller.order_list, "Focused Fading Temperance Ampule",	/obj/item/attribute_temporary/temperancebig, 1500)
+	ItemUnlock(caller.order_list, "Focused Fading Prudence Ampule",	/obj/item/attribute_temporary/prudencebig, 1500)
+	ItemUnlock(caller.order_list, "Focused Fading Justice Ampule",	/obj/item/attribute_temporary/justicebig, 1500)
+	..()
+
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
As the title says N-Corp rep gets three variants of attribute increasers, one lasts for 5 minutes and buffs a specific stat by 15, the other lasts for 2 minutes but buffs all stats by 15 last one is the same as the first one but 20 stats instead of 15. (Im going to give them sprites eventually though theyll likely just look like the ampules but blue)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
N-Corp rep should not become the most useless rep in the game after all the ampules are used, also Ahn should be used in every representative so it is not a useless currency.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added temporary attribute increasers that buff one stat by 15 for 5 minutes
add: Added temporary attribute increasers that buff all stats by 15 for 2 minutes
add: Added temporary attribute increasers that buff one stat by 20 for 5 minutes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
