### PR TITLE
Zeta Map Bug Fixes

### DIFF
--- a/_maps/map_files/Zeta/zetacorp.dmm
+++ b/_maps/map_files/Zeta/zetacorp.dmm
@@ -453,6 +453,9 @@
 	},
 /turf/open/floor/facility/dark,
 /area/facility_hallway/east)
+"bu" = (
+/turf/closed/indestructible/fakeglass,
+/area/facility_hallway/safety)
 "bv" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 1
@@ -2462,6 +2465,9 @@
 	color = "#ccc8c0"
 	},
 /area/department_main/safety)
+"hf" = (
+/turf/closed/indestructible/fakeglass,
+/area/facility_hallway/west)
 "hg" = (
 /obj/effect/turf_decal/siding/thinplating/corner{
 	dir = 8
@@ -4546,6 +4552,19 @@
 	},
 /turf/open/floor/facility/dark,
 /area/department_main/training)
+"mS" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/machinery/button/door/indestructible{
+	id = "extraction";
+	name = "Extraction Access Shutters";
+	pixel_y = 4;
+	req_one_access_txt = "19";
+	pixel_x = 22
+	},
+/turf/open/floor/plasteel/dark,
+/area/department_main/extraction)
 "mU" = (
 /obj/machinery/door/airlock{
 	name = "restroom"
@@ -4673,9 +4692,6 @@
 /obj/machinery/navbeacon/wayfinding/informationdepartment,
 /turf/open/floor/plasteel/dark,
 /area/department_main/information)
-"nm" = (
-/turf/closed/indestructible/fakeglass,
-/area/facility_hallway/safety)
 "nn" = (
 /obj/effect/turf_decal/box/corners{
 	dir = 4
@@ -7053,7 +7069,7 @@
 /area/facility_hallway/central)
 "ts" = (
 /turf/closed/indestructible/fakeglass,
-/area/facility_hallway/control)
+/area/facility_hallway/training)
 "tu" = (
 /obj/structure/bodycontainer,
 /obj/machinery/light{
@@ -7863,23 +7879,6 @@
 	},
 /turf/open/floor/facility/dark,
 /area/department_main/information)
-"vM" = (
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/machinery/vending/hydronutrients{
-	pixel_y = 19;
-	density = 0
-	},
-/turf/open/floor/plasteel/sepia,
-/area/facility_hallway/training)
 "vP" = (
 /obj/structure/chair/plastic{
 	dir = 8
@@ -8605,7 +8604,10 @@
 	pixel_x = 9;
 	pixel_y = 4
 	},
-/turf/open/floor/plasteel/dark,
+/obj/machinery/regenerator/safety,
+/turf/open/floor/plasteel/dark{
+	color = "#ccc8c0"
+	},
 /area/department_main/extraction)
 "xE" = (
 /obj/effect/turf_decal/siding/thinplating/corner,
@@ -9057,9 +9059,6 @@
 	},
 /turf/open/floor/carpet/royalblue,
 /area/department_main/command)
-"zf" = (
-/turf/closed/indestructible/fakeglass,
-/area/facility_hallway/west)
 "zh" = (
 /obj/machinery/telecomms/broadcaster/preset_right,
 /obj/effect/turf_decal/bot,
@@ -10513,9 +10512,6 @@
 	},
 /turf/open/floor/facility/dark,
 /area/facility_hallway/training)
-"CJ" = (
-/turf/closed/indestructible/fakeglass,
-/area/facility_hallway/east)
 "CM" = (
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 4
@@ -10760,6 +10756,9 @@
 	},
 /turf/open/floor/facility/dark,
 /area/department_main/extraction)
+"Dv" = (
+/turf/closed/indestructible/fakeglass,
+/area/facility_hallway/east)
 "Dw" = (
 /obj/machinery/light{
 	dir = 4;
@@ -11528,7 +11527,7 @@
 /area/facility_hallway/south)
 "FH" = (
 /turf/closed/indestructible/fakeglass,
-/area/facility_hallway/training)
+/area/facility_hallway/control)
 "FL" = (
 /obj/effect/turf_decal/siding/green{
 	color = "#006400";
@@ -17450,6 +17449,23 @@
 	},
 /turf/open/floor/carpet/royalblue,
 /area/department_main/command)
+"XW" = (
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/machinery/vending/hydronutrients{
+	pixel_y = 19;
+	density = 0
+	},
+/turf/open/floor/plasteel/sepia,
+/area/facility_hallway/training)
 "XX" = (
 /obj/effect/turf_decal/box/red,
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -40783,8 +40799,8 @@ Pr
 Qo
 Qo
 Qo
-FH
-FH
+ts
+ts
 Qo
 Qo
 Qo
@@ -40793,9 +40809,9 @@ RY
 RY
 Qo
 Qo
-FH
-FH
-FH
+ts
+ts
+ts
 Qo
 Qo
 RY
@@ -41563,7 +41579,7 @@ KV
 Pt
 LQ
 Qo
-vM
+XW
 Se
 Jj
 Se
@@ -43082,9 +43098,9 @@ fv
 CZ
 fv
 zS
-ts
-ts
-ts
+FH
+FH
+FH
 Qo
 qN
 qN
@@ -43367,7 +43383,7 @@ TZ
 ii
 vZ
 rN
-FH
+ts
 RY
 RY
 rg
@@ -43624,7 +43640,7 @@ Cg
 we
 vZ
 Qb
-FH
+ts
 RY
 RY
 rg
@@ -43881,7 +43897,7 @@ TZ
 qb
 vZ
 dC
-FH
+ts
 RY
 RY
 rg
@@ -45418,7 +45434,7 @@ tC
 qn
 qS
 tb
-zf
+hf
 RY
 RY
 RY
@@ -45675,7 +45691,7 @@ TV
 Vb
 GH
 cX
-zf
+hf
 RY
 RY
 RY
@@ -47735,7 +47751,7 @@ wK
 Oh
 Ac
 Ba
-zf
+hf
 RY
 RY
 RY
@@ -47992,7 +48008,7 @@ Bf
 eI
 Ej
 Rl
-zf
+hf
 RY
 Sb
 Sb
@@ -48249,7 +48265,7 @@ uX
 uX
 Np
 UA
-zf
+hf
 RY
 Sb
 Sb
@@ -53357,7 +53373,7 @@ of
 Nd
 Nd
 xD
-Nd
+mS
 Nd
 bm
 OJ
@@ -54658,7 +54674,7 @@ rg
 RY
 RY
 RY
-CJ
+Dv
 Ph
 EA
 rA
@@ -54915,7 +54931,7 @@ RY
 RY
 RY
 RY
-CJ
+Dv
 ap
 HX
 bt
@@ -54935,7 +54951,7 @@ IJ
 IJ
 vd
 gc
-CJ
+Dv
 ya
 PZ
 TF
@@ -55172,7 +55188,7 @@ RY
 RY
 RY
 RY
-CJ
+Dv
 BH
 UX
 Pk
@@ -55192,7 +55208,7 @@ Zf
 WX
 IJ
 Cf
-CJ
+Dv
 tr
 Er
 Er
@@ -55426,8 +55442,8 @@ rg
 RY
 RY
 iL
-nm
-nm
+bu
+bu
 iL
 It
 It
@@ -55449,7 +55465,7 @@ Jn
 Hh
 IJ
 Nt
-CJ
+Dv
 sx
 sx
 sx
@@ -55682,7 +55698,7 @@ rg
 rg
 RY
 RY
-nm
+bu
 UN
 QD
 yR
@@ -55939,7 +55955,7 @@ rg
 rg
 RY
 RY
-nm
+bu
 XM
 Ci
 Kj
@@ -57248,7 +57264,7 @@ iL
 gX
 FY
 oW
-nm
+bu
 Er
 nJ
 sx
@@ -57505,7 +57521,7 @@ iL
 bX
 IV
 dc
-nm
+bu
 sx
 sx
 sx
@@ -57762,7 +57778,7 @@ iL
 vS
 ft
 Eh
-nm
+bu
 sx
 sx
 sx
@@ -57995,7 +58011,7 @@ RY
 RY
 RY
 RY
-nm
+bu
 XM
 UJ
 Kj
@@ -58252,7 +58268,7 @@ RY
 RY
 RY
 RY
-nm
+bu
 UN
 Ql
 yR
@@ -58790,7 +58806,7 @@ Ok
 Dr
 ft
 xe
-nm
+bu
 RY
 RY
 RY
@@ -59047,7 +59063,7 @@ qH
 kt
 zW
 xe
-nm
+bu
 RY
 RY
 RY
@@ -59304,7 +59320,7 @@ AA
 Ov
 ft
 xe
-nm
+bu
 RY
 RY
 rg
@@ -59798,8 +59814,8 @@ RY
 iL
 iL
 iL
-nm
-nm
+bu
+bu
 iL
 iL
 iL
@@ -60332,7 +60348,7 @@ iL
 AD
 ft
 xe
-nm
+bu
 RY
 RY
 rg
@@ -60589,7 +60605,7 @@ iL
 Zl
 ft
 dc
-nm
+bu
 RY
 RY
 rg
@@ -60846,7 +60862,7 @@ iL
 wY
 dQ
 Eh
-nm
+bu
 RY
 RY
 rg

--- a/_maps/map_files/Zeta/zetacorp.dmm
+++ b/_maps/map_files/Zeta/zetacorp.dmm
@@ -2150,13 +2150,6 @@
 "gl" = (
 /turf/closed/indestructible/reinforced,
 /area/facility_hallway/training)
-"gn" = (
-/turf/open/water/deep/freshwater{
-	safe = 1;
-	environment = list(/obj/item/food/fish/fresh_water = 1000, /obj/item/food/fish/fresh_water/angelfish = 1000, /obj/item/food/fish/fresh_water/guppy = 1000, /obj/item/food/fish/fresh_water/plasmatetra = 1000, /obj/item/food/fish/fresh_water/catfish = 400, /obj/item/food/fish/fresh_water/ratfish = 200, /obj/item/food/fish/fresh_water/waterflea = 200, /obj/item/food/fish/fresh_water/yin = 200, /obj/item/food/fish/fresh_water/yang = 200, /obj/item/stack/spacecash/c1 = 700, /obj/item/stack/fish_points = 600, /obj/item/food/dough = 500, /obj/item/food/canned/peaches = 300, /obj/item/food/breadslice/moldy = 300, /obj/item/clothing/head/beret/fishing_hat = 200, /obj/item/food/grown/harebell = 200, /obj/item/reagent_containers/food/drinks/bottle/wine/unlabeled = 200, /obj/item/fishing_component/hook/bone = 100);
-	color = "#dddddd"
-	},
-/area/facility_hallway/central)
 "gp" = (
 /obj/machinery/light{
 	dir = 1;
@@ -4680,6 +4673,9 @@
 /obj/machinery/navbeacon/wayfinding/informationdepartment,
 /turf/open/floor/plasteel/dark,
 /area/department_main/information)
+"nm" = (
+/turf/closed/indestructible/fakeglass,
+/area/facility_hallway/safety)
 "nn" = (
 /obj/effect/turf_decal/box/corners{
 	dir = 4
@@ -6680,11 +6676,7 @@
 	},
 /area/facility_hallway/information)
 "sc" = (
-/obj/structure/window/reinforced/fulltile{
-	max_integrity = 500;
-	armor = list("melee" = 30, "bullet" = 30, "laser" = 20, "energy" = 20, "bomb" = 10, "bio" = 100, "rad" = 100, "fire" = 80, "acid" = 70)
-	},
-/turf/open/floor/facility/dark,
+/turf/closed/indestructible/fakeglass,
 /area/facility_hallway/information)
 "sf" = (
 /obj/effect/turf_decal/siding/thinplating/dark,
@@ -7060,16 +7052,8 @@
 	},
 /area/facility_hallway/central)
 "ts" = (
-/obj/structure/railing{
-	resistance_flags = 115;
-	name = "wing-grade railing";
-	desc = "Indestructible railing created in a vain attempt of fool-proofing the wing's workplace.";
-	dir = 8
-	},
-/turf/open/water/deep/saltwater/safe{
-	environment = list(/obj/item/food/fish/salt_water/marine_shrimp = 1000, /obj/item/food/fish/salt_water/clownfish = 1000, /obj/item/food/fish/salt_water/greenchromis = 1000, /obj/item/food/fish/salt_water/firefish = 1000, /obj/item/food/fish/salt_water/cardinal = 400, /obj/item/food/fish/salt_water = 400, /obj/item/food/fish/salt_water/sheephead = 400, /obj/item/food/fish/salt_water/lanternfish = 200, /obj/item/stack/spacecash/c1 = 700, /obj/item/fishing_component/hook/bone = 700, /obj/item/stack/fish_points = 600, /obj/item/food/canned/beans = 600, /obj/item/food/canned/peaches = 600, /obj/item/clothing/head/beret/fishing_hat = 200, /obj/item/reagent_containers/food/drinks/bottle/wine/unlabeled = 100)
-	},
-/area/facility_hallway/central)
+/turf/closed/indestructible/fakeglass,
+/area/facility_hallway/control)
 "tu" = (
 /obj/structure/bodycontainer,
 /obj/machinery/light{
@@ -7879,6 +7863,23 @@
 	},
 /turf/open/floor/facility/dark,
 /area/department_main/information)
+"vM" = (
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/machinery/vending/hydronutrients{
+	pixel_y = 19;
+	density = 0
+	},
+/turf/open/floor/plasteel/sepia,
+/area/facility_hallway/training)
 "vP" = (
 /obj/structure/chair/plastic{
 	dir = 8
@@ -9056,6 +9057,9 @@
 	},
 /turf/open/floor/carpet/royalblue,
 /area/department_main/command)
+"zf" = (
+/turf/closed/indestructible/fakeglass,
+/area/facility_hallway/west)
 "zh" = (
 /obj/machinery/telecomms/broadcaster/preset_right,
 /obj/effect/turf_decal/bot,
@@ -9225,11 +9229,7 @@
 	},
 /area/department_main/command)
 "zz" = (
-/obj/structure/window/reinforced/fulltile{
-	max_integrity = 500;
-	armor = list("melee" = 30, "bullet" = 30, "laser" = 20, "energy" = 20, "bomb" = 10, "bio" = 100, "rad" = 100, "fire" = 80, "acid" = 70)
-	},
-/turf/open/floor/facility/dark,
+/turf/closed/indestructible/fakeglass,
 /area/department_main/records)
 "zC" = (
 /obj/effect/turf_decal/siding/thinplating{
@@ -10513,6 +10513,9 @@
 	},
 /turf/open/floor/facility/dark,
 /area/facility_hallway/training)
+"CJ" = (
+/turf/closed/indestructible/fakeglass,
+/area/facility_hallway/east)
 "CM" = (
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 4
@@ -11024,11 +11027,7 @@
 	},
 /area/facility_hallway/human)
 "En" = (
-/obj/structure/window/reinforced/fulltile{
-	max_integrity = 500;
-	armor = list("melee" = 30, "bullet" = 30, "laser" = 20, "energy" = 20, "bomb" = 10, "bio" = 100, "rad" = 100, "fire" = 80, "acid" = 70)
-	},
-/turf/open/floor/facility/dark,
+/turf/closed/indestructible/fakeglass,
 /area/facility_hallway/manager)
 "Ep" = (
 /obj/item/instrument/guitar,
@@ -11528,14 +11527,8 @@
 /turf/open/floor/facility/halls,
 /area/facility_hallway/south)
 "FH" = (
-/obj/structure/railing/corner{
-	name = "wing-grade railing";
-	dir = 8
-	},
-/turf/open/water/deep/saltwater/safe{
-	environment = list(/obj/item/food/fish/salt_water/marine_shrimp = 1000, /obj/item/food/fish/salt_water/clownfish = 1000, /obj/item/food/fish/salt_water/greenchromis = 1000, /obj/item/food/fish/salt_water/firefish = 1000, /obj/item/food/fish/salt_water/cardinal = 400, /obj/item/food/fish/salt_water = 400, /obj/item/food/fish/salt_water/sheephead = 400, /obj/item/food/fish/salt_water/lanternfish = 200, /obj/item/stack/spacecash/c1 = 700, /obj/item/fishing_component/hook/bone = 700, /obj/item/stack/fish_points = 600, /obj/item/food/canned/beans = 600, /obj/item/food/canned/peaches = 600, /obj/item/clothing/head/beret/fishing_hat = 200, /obj/item/reagent_containers/food/drinks/bottle/wine/unlabeled = 100)
-	},
-/area/facility_hallway/central)
+/turf/closed/indestructible/fakeglass,
+/area/facility_hallway/training)
 "FL" = (
 /obj/effect/turf_decal/siding/green{
 	color = "#006400";
@@ -12861,13 +12854,10 @@
 /obj/effect/turf_decal/siding/yellow{
 	dir = 8
 	},
-/obj/machinery/facility_holomap{
-	dir = 1;
-	forced_zLevel = 2
-	},
 /obj/effect/turf_decal/arrows/red{
 	dir = 8
 	},
+/obj/machinery/facility_holomap,
 /turf/open/floor/plasteel/dark{
 	color = "#ccc8c0"
 	},
@@ -13631,11 +13621,7 @@
 /turf/open/floor/plasteel/white,
 /area/facility_hallway/training)
 "MF" = (
-/obj/structure/window/reinforced/fulltile{
-	max_integrity = 500;
-	armor = list("melee" = 30, "bullet" = 30, "laser" = 20, "energy" = 20, "bomb" = 10, "bio" = 100, "rad" = 100, "fire" = 80, "acid" = 70)
-	},
-/turf/open/floor/facility/dark,
+/turf/closed/indestructible/fakeglass,
 /area/department_main/extraction)
 "MH" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -14367,7 +14353,8 @@
 /area/department_main/information)
 "OG" = (
 /obj/machinery/facility_holomap{
-	dir = 8
+	dir = 4;
+	forced_zLevel = 2
 	},
 /turf/open/floor/facility/dark{
 	color = "#ccc8c0"
@@ -16736,7 +16723,7 @@
 	dir = 1
 	},
 /obj/machinery/chem_dispenser/fullupgrade{
-	dispensable_reagents = list(/datum/reagent/consumable/enzyme,/datum/reagent/consumable/eggyolk,/datum/reagent/consumable/flour,/datum/reagent/consumable/rice,/datum/reagent/consumable/sugar,/datum/reagent/consumable/caramel,/datum/reagent/consumable/honey,/datum/reagent/consumable/salt,/datum/reagent/consumable/blackpepper,/datum/reagent/consumable/soysauce,/datum/reagent/consumable/bbqsauce,/datum/reagent/consumable/ketchup,/datum/reagent/consumable/capsaicin,/datum/reagent/consumable/frostoil,/datum/reagent/consumable/garlic,/datum/reagent/consumable/cherryjelly,/datum/reagent/consumable/bluecherryjelly,/datum/reagent/consumable/vanilla,/datum/reagent/consumable/coco,/datum/reagent/consumable/cornoil,/datum/reagent/consumable/corn_syrup,/datum/reagent/consumable/corn_starch,/datum/reagent/consumable/dry_ramen,/datum/reagent/consumable/clownstears,/datum/reagent/consumable/astrotame,/datum/reagent/consumable/secretsauce,/datum/reagent/consumable/laughsyrup,/datum/reagent/consumable/pancakebatter,/datum/reagent/water/holywater,/datum/reagent/fuel);
+	dispensable_reagents = list(/datum/reagent/consumable/enzyme,/datum/reagent/consumable/eggyolk,/datum/reagent/consumable/flour,/datum/reagent/consumable/rice,/datum/reagent/consumable/sugar,/datum/reagent/consumable/caramel,/datum/reagent/consumable/honey,/datum/reagent/consumable/salt,/datum/reagent/consumable/blackpepper,/datum/reagent/consumable/soysauce,/datum/reagent/consumable/bbqsauce,/datum/reagent/consumable/ketchup,/datum/reagent/consumable/capsaicin,/datum/reagent/consumable/frostoil,/datum/reagent/consumable/garlic,/datum/reagent/consumable/cherryjelly,/datum/reagent/consumable/bluecherryjelly,/datum/reagent/consumable/vanilla,/datum/reagent/consumable/coco,/datum/reagent/consumable/cornoil,/datum/reagent/consumable/corn_syrup,/datum/reagent/consumable/corn_starch,/datum/reagent/consumable/dry_ramen,/datum/reagent/consumable/clownstears,/datum/reagent/consumable/astrotame,/datum/reagent/consumable/secretsauce,/datum/reagent/consumable/laughsyrup,/datum/reagent/consumable/pancakebatter,/datum/reagent/water/holywater,/datum/reagent/fuel,/datum/reagent/consumable/soymilk,/datum/reagent/consumable/milk);
 	name = "Industrial Foodstuff Dispenser";
 	desc = "Creates and dispenses a variety of kitchen ingredients.";
 	emagged_reagents = null
@@ -40283,12 +40270,12 @@ LM
 ll
 RY
 RY
-Sb
-Sb
 RY
 RY
 RY
-gn
+RY
+RY
+rg
 RY
 RY
 RY
@@ -40796,8 +40783,8 @@ Pr
 Qo
 Qo
 Qo
-Pr
-Pr
+FH
+FH
 Qo
 Qo
 Qo
@@ -40806,9 +40793,9 @@ RY
 RY
 Qo
 Qo
-Pr
-Pr
-Pr
+FH
+FH
+FH
 Qo
 Qo
 RY
@@ -41576,7 +41563,7 @@ KV
 Pt
 LQ
 Qo
-So
+vM
 Se
 Jj
 Se
@@ -43095,9 +43082,9 @@ fv
 CZ
 fv
 zS
-fv
-fv
-fv
+ts
+ts
+ts
 Qo
 qN
 qN
@@ -43380,7 +43367,7 @@ TZ
 ii
 vZ
 rN
-Pr
+FH
 RY
 RY
 rg
@@ -43637,7 +43624,7 @@ Cg
 we
 vZ
 Qb
-Pr
+FH
 RY
 RY
 rg
@@ -43894,7 +43881,7 @@ TZ
 qb
 vZ
 dC
-Pr
+FH
 RY
 RY
 rg
@@ -44876,7 +44863,7 @@ pm
 rg
 rg
 rg
-gn
+rg
 rg
 rg
 rg
@@ -45134,8 +45121,8 @@ rg
 rg
 rg
 rg
-gn
-gn
+rg
+rg
 RY
 el
 LM
@@ -45431,14 +45418,14 @@ tC
 qn
 qS
 tb
-tC
+zf
 RY
 RY
 RY
 RY
 RY
 RY
-Sb
+RY
 rg
 rg
 rg
@@ -45688,14 +45675,14 @@ TV
 Vb
 GH
 cX
-tC
+zf
 RY
 RY
 RY
 el
 LM
 ll
-Sb
+RY
 rg
 rg
 rg
@@ -47445,7 +47432,7 @@ pm
 pm
 rg
 rg
-Sb
+RY
 RY
 zS
 zS
@@ -47507,8 +47494,8 @@ RY
 RY
 ah
 ah
-ZL
-ZL
+sc
+sc
 ah
 ah
 RY
@@ -47702,7 +47689,7 @@ pm
 pm
 rg
 rg
-Sb
+RY
 RY
 RY
 RY
@@ -47748,7 +47735,7 @@ wK
 Oh
 Ac
 Ba
-tC
+zf
 RY
 RY
 RY
@@ -48005,7 +47992,7 @@ Bf
 eI
 Ej
 Rl
-tC
+zf
 RY
 Sb
 Sb
@@ -48262,7 +48249,7 @@ uX
 uX
 Np
 UA
-tC
+zf
 RY
 Sb
 Sb
@@ -49295,11 +49282,11 @@ uY
 MD
 pm
 Hn
-VQ
+Kc
 Ns
 ZJ
 An
-Kc
+VQ
 cm
 Oa
 Gl
@@ -54146,8 +54133,8 @@ RY
 RY
 RY
 RY
-Sb
-Sb
+RY
+RY
 RY
 rg
 rg
@@ -54403,7 +54390,7 @@ RY
 RY
 RY
 RY
-Sb
+RY
 rg
 rg
 rg
@@ -54671,7 +54658,7 @@ rg
 RY
 RY
 RY
-EL
+CJ
 Ph
 EA
 rA
@@ -54928,7 +54915,7 @@ RY
 RY
 RY
 RY
-EL
+CJ
 ap
 HX
 bt
@@ -54948,7 +54935,7 @@ IJ
 IJ
 vd
 gc
-EL
+CJ
 ya
 PZ
 TF
@@ -55185,7 +55172,7 @@ RY
 RY
 RY
 RY
-EL
+CJ
 BH
 UX
 Pk
@@ -55205,7 +55192,7 @@ Zf
 WX
 IJ
 Cf
-EL
+CJ
 tr
 Er
 Er
@@ -55439,8 +55426,8 @@ rg
 RY
 RY
 iL
-pU
-pU
+nm
+nm
 iL
 It
 It
@@ -55462,7 +55449,7 @@ Jn
 Hh
 IJ
 Nt
-EL
+CJ
 sx
 sx
 sx
@@ -55693,9 +55680,9 @@ rg
 rg
 rg
 rg
-Sb
 RY
-pU
+RY
+nm
 UN
 QD
 yR
@@ -55735,7 +55722,7 @@ ah
 Wn
 dx
 NI
-ZL
+sc
 RY
 RY
 RY
@@ -55950,9 +55937,9 @@ rg
 rg
 rg
 rg
-Sb
 RY
-pU
+RY
+nm
 XM
 Ci
 Kj
@@ -55992,10 +55979,10 @@ dI
 Mo
 dx
 Ft
-ZL
+sc
 RY
 RY
-rg
+RY
 rg
 rg
 rg
@@ -56249,7 +56236,7 @@ oA
 uI
 dj
 fc
-ZL
+sc
 RY
 RY
 RY
@@ -57021,7 +57008,7 @@ ah
 sb
 GA
 ev
-ZL
+sc
 RY
 RY
 rg
@@ -57261,7 +57248,7 @@ iL
 gX
 FY
 oW
-pU
+nm
 Er
 nJ
 sx
@@ -57278,7 +57265,7 @@ lg
 rd
 mc
 dU
-ZL
+sc
 RY
 RY
 rg
@@ -57518,7 +57505,7 @@ iL
 bX
 IV
 dc
-pU
+nm
 sx
 sx
 sx
@@ -57535,7 +57522,7 @@ ah
 Xt
 yM
 FV
-ZL
+sc
 RY
 RY
 rg
@@ -57775,7 +57762,7 @@ iL
 vS
 ft
 Eh
-pU
+nm
 sx
 sx
 sx
@@ -58008,7 +57995,7 @@ RY
 RY
 RY
 RY
-pU
+nm
 XM
 UJ
 Kj
@@ -58265,7 +58252,7 @@ RY
 RY
 RY
 RY
-pU
+nm
 UN
 Ql
 yR
@@ -58803,9 +58790,9 @@ Ok
 Dr
 ft
 xe
-pU
+nm
 RY
-rg
+RY
 RY
 RY
 ah
@@ -59060,10 +59047,10 @@ qH
 kt
 zW
 xe
-pU
+nm
 RY
-rg
-rg
+RY
+RY
 RY
 RY
 RY
@@ -59317,9 +59304,9 @@ AA
 Ov
 ft
 xe
-pU
+nm
 RY
-rg
+RY
 rg
 rg
 rg
@@ -59811,8 +59798,8 @@ RY
 iL
 iL
 iL
-pU
-pU
+nm
+nm
 iL
 iL
 iL
@@ -60345,7 +60332,7 @@ iL
 AD
 ft
 xe
-pU
+nm
 RY
 RY
 rg
@@ -60602,7 +60589,7 @@ iL
 Zl
 ft
 dc
-pU
+nm
 RY
 RY
 rg
@@ -60859,7 +60846,7 @@ iL
 wY
 dQ
 Eh
-pU
+nm
 RY
 RY
 rg
@@ -61882,8 +61869,8 @@ WE
 Nw
 gv
 RY
-FH
-ts
+jl
+WE
 WE
 WE
 WE

--- a/_maps/map_files/Zeta/zetacorp.dmm
+++ b/_maps/map_files/Zeta/zetacorp.dmm
@@ -383,13 +383,22 @@
 	},
 /area/facility_hallway/information)
 "bm" = (
-/obj/effect/turf_decal/siding/thinplating/dark/corner{
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark{
-	color = "#ccc8c0"
+/obj/machinery/vending/hydronutrients{
+	pixel_y = 19;
+	density = 0
 	},
-/area/department_main/extraction)
+/turf/open/floor/plasteel/sepia,
+/area/facility_hallway/training)
 "bn" = (
 /obj/effect/turf_decal/siding/green{
 	color = "#006400";
@@ -453,9 +462,6 @@
 	},
 /turf/open/floor/facility/dark,
 /area/facility_hallway/east)
-"bu" = (
-/turf/closed/indestructible/fakeglass,
-/area/facility_hallway/safety)
 "bv" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 1
@@ -837,7 +843,7 @@
 	dir = 1
 	},
 /turf/open/floor/facility/dark,
-/area/department_main/extraction)
+/area/facility_hallway/extraction)
 "cv" = (
 /obj/effect/turf_decal/arrows/red{
 	dir = 8
@@ -987,23 +993,17 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/caution/white,
-/obj/effect/light_emitter{
-	light_power = 4;
-	light_range = 25;
-	set_cap = 3;
-	set_luminosity = 24
-	},
 /turf/open/floor/facility/dark,
-/area/facility_hallway/west)
+/area/facility_hallway/extraction)
 "cY" = (
 /obj/effect/turf_decal/siding{
 	color = "#7D6521";
 	dir = 8
 	},
-/obj/machinery/text_adventure_console,
 /obj/structure/window/reinforced/spawner/east{
 	resistance_flags = 115
 	},
+/obj/machinery/regenerator/safety,
 /turf/open/floor/facility/dark{
 	color = "#ccc8c0"
 	},
@@ -1271,7 +1271,7 @@
 	mouse_opacity = 0;
 	view_range = 3
 	},
-/turf/open/floor/plasteel/dark{
+/turf/open/floor/facility/dark{
 	color = "#ccc8c0"
 	},
 /area/department_main/extraction)
@@ -1860,23 +1860,6 @@
 /turf/open/floor/facility/dark,
 /area/facility_hallway/control)
 "fy" = (
-/obj/effect/turf_decal/box/corners{
-	dir = 4
-	},
-/obj/effect/turf_decal/box/corners{
-	dir = 8
-	},
-/obj/effect/turf_decal/box/red/corners,
-/obj/effect/turf_decal/box/red/corners{
-	dir = 1
-	},
-/obj/effect/turf_decal/arrows/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/arrows/red,
-/obj/effect/turf_decal/siding/thinplating/dark/corner{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -2273,7 +2256,7 @@
 	set_luminosity = 24
 	},
 /turf/open/floor/facility/dark,
-/area/department_main/extraction)
+/area/facility_hallway/extraction)
 "gE" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/hypospray/medipen/salacid,
@@ -2465,9 +2448,6 @@
 	color = "#ccc8c0"
 	},
 /area/department_main/safety)
-"hf" = (
-/turf/closed/indestructible/fakeglass,
-/area/facility_hallway/west)
 "hg" = (
 /obj/effect/turf_decal/siding/thinplating/corner{
 	dir = 8
@@ -3445,7 +3425,7 @@
 /turf/open/floor/facility/dark{
 	color = "#ccc8c0"
 	},
-/area/department_main/extraction)
+/area/facility_hallway/extraction)
 "jG" = (
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 1
@@ -3493,16 +3473,11 @@
 /turf/open/floor/facility/dark,
 /area/facility_hallway/east)
 "jP" = (
-/obj/effect/turf_decal/box/white/corners{
-	dir = 4
+/obj/machinery/door/airlock/highsecurity{
+	name = "Extraction Office Secure Area"
 	},
-/obj/effect/turf_decal/stripes/white/corner{
-	dir = 8
-	},
-/turf/open/floor/facility/dark{
-	color = "#ccc8c0"
-	},
-/area/facility_hallway/west)
+/turf/open/floor/facility/halls,
+/area/facility_hallway/extraction)
 "jQ" = (
 /obj/effect/turf_decal/siding/thinplating/dark/corner,
 /turf/open/floor/plasteel/dark,
@@ -4175,7 +4150,7 @@
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark{
+/turf/open/floor/facility/dark{
 	color = "#ccc8c0"
 	},
 /area/department_main/extraction)
@@ -4552,19 +4527,6 @@
 	},
 /turf/open/floor/facility/dark,
 /area/department_main/training)
-"mS" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 8
-	},
-/obj/machinery/button/door/indestructible{
-	id = "extraction";
-	name = "Extraction Access Shutters";
-	pixel_y = 4;
-	req_one_access_txt = "19";
-	pixel_x = 22
-	},
-/turf/open/floor/plasteel/dark,
-/area/department_main/extraction)
 "mU" = (
 /obj/machinery/door/airlock{
 	name = "restroom"
@@ -5018,7 +4980,7 @@
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark{
+/turf/open/floor/facility/dark{
 	color = "#ccc8c0"
 	},
 /area/department_main/extraction)
@@ -5406,19 +5368,11 @@
 	},
 /area/facility_hallway/control)
 "pv" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 8
+/turf/closed/indestructible/reinforced{
+	name = "facility wall";
+	desc = "A huge chunk of wing-grade metal used in various L corporation facilities. Effectively impervious to conventional methods of destruction."
 	},
-/obj/effect/turf_decal/caution/white{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 4;
-	pixel_x = 9;
-	pixel_y = 4
-	},
-/turf/open/floor/facility/dark,
-/area/facility_hallway/west)
+/area/facility_hallway/extraction)
 "pw" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 8
@@ -5859,14 +5813,8 @@
 	},
 /area/facility_hallway/information)
 "qn" = (
-/obj/effect/turf_decal/box/white/corners{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/white/corner,
-/turf/open/floor/facility/dark{
-	color = "#ccc8c0"
-	},
-/area/facility_hallway/west)
+/turf/closed/indestructible/fakeglass,
+/area/facility_hallway/control)
 "qp" = (
 /obj/effect/turf_decal/siding/green{
 	color = "#006400";
@@ -6187,19 +6135,26 @@
 	},
 /area/facility_hallway/east)
 "qS" = (
-/obj/machinery/light{
-	dir = 8;
-	pixel_x = -9;
-	pixel_y = 4
+/obj/effect/turf_decal/delivery,
+/obj/structure/closet/crate{
+	name = "pe box crate";
+	anchored = 1;
+	opened = 1
 	},
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 4
+/obj/item/rawpe,
+/obj/item/rawpe,
+/obj/item/rawpe,
+/obj/item/rawpe,
+/obj/item/rawpe,
+/obj/item/rawpe,
+/obj/item/rawpe,
+/obj/item/rawpe,
+/obj/item/rawpe,
+/obj/item/rawpe,
+/turf/open/floor/facility/dark{
+	color = "#ccc8c0"
 	},
-/obj/effect/turf_decal/caution/white{
-	dir = 8
-	},
-/turf/open/floor/facility/dark,
-/area/facility_hallway/west)
+/area/department_main/extraction)
 "qX" = (
 /obj/effect/turf_decal/tile/green,
 /obj/effect/turf_decal/tile/brown{
@@ -6623,7 +6578,7 @@
 /turf/open/floor/facility/dark{
 	color = "#ccc8c0"
 	},
-/area/department_main/extraction)
+/area/facility_hallway/extraction)
 "rT" = (
 /obj/effect/turf_decal/siding/red{
 	color = "#440000";
@@ -6975,16 +6930,8 @@
 /turf/open/floor/plasteel/dark,
 /area/department_main/safety)
 "tb" = (
-/obj/effect/turf_decal/box/white/corners{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/white/corner{
-	dir = 4
-	},
-/turf/open/floor/facility/dark{
-	color = "#ccc8c0"
-	},
-/area/facility_hallway/west)
+/turf/closed/indestructible/fakeglass,
+/area/facility_hallway/safety)
 "td" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 8
@@ -7068,8 +7015,19 @@
 	},
 /area/facility_hallway/central)
 "ts" = (
-/turf/closed/indestructible/fakeglass,
-/area/facility_hallway/training)
+/obj/effect/turf_decal/stripes/white/line,
+/obj/effect/turf_decal/caution/white{
+	dir = 1
+	},
+/obj/machinery/camera{
+	alpha = 0;
+	short_range = 3;
+	name = "hidden security camera";
+	mouse_opacity = 0;
+	view_range = 3
+	},
+/turf/open/floor/facility/dark,
+/area/facility_hallway/extraction)
 "tu" = (
 /obj/structure/bodycontainer,
 /obj/machinery/light{
@@ -7132,11 +7090,7 @@
 	},
 /area/department_main/command)
 "tC" = (
-/obj/structure/window/reinforced/fulltile{
-	max_integrity = 500;
-	armor = list("melee" = 30, "bullet" = 30, "laser" = 20, "energy" = 20, "bomb" = 10, "bio" = 100, "rad" = 100, "fire" = 80, "acid" = 70)
-	},
-/turf/open/floor/facility/dark,
+/turf/closed/indestructible/fakeglass,
 /area/facility_hallway/west)
 "tD" = (
 /obj/structure/lattice/lava{
@@ -7376,7 +7330,7 @@
 /turf/open/floor/facility/dark{
 	color = "#ccc8c0"
 	},
-/area/department_main/extraction)
+/area/facility_hallway/extraction)
 "up" = (
 /obj/effect/turf_decal/siding/purple{
 	color = "#8a3080";
@@ -8596,18 +8550,7 @@
 	},
 /area/facility_hallway/south)
 "xD" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 4;
-	pixel_x = 9;
-	pixel_y = 4
-	},
-/obj/machinery/regenerator/safety,
-/turf/open/floor/plasteel/dark{
-	color = "#ccc8c0"
-	},
+/turf/open/floor/plasteel/dark,
 /area/department_main/extraction)
 "xE" = (
 /obj/effect/turf_decal/siding/thinplating/corner,
@@ -9003,7 +8946,7 @@
 	view_range = 3
 	},
 /turf/open/floor/facility/dark,
-/area/department_main/extraction)
+/area/facility_hallway/extraction)
 "za" = (
 /obj/structure/mirror{
 	pixel_y = 27
@@ -9486,14 +9429,8 @@
 	},
 /area/facility_hallway/west)
 "Ad" = (
-/obj/effect/turf_decal/box/white/corners,
-/obj/effect/turf_decal/stripes/white/corner{
-	dir = 1
-	},
-/turf/open/floor/facility/dark{
-	color = "#ccc8c0"
-	},
-/area/facility_hallway/west)
+/turf/closed/indestructible/fakeglass,
+/area/facility_hallway/training)
 "Ae" = (
 /obj/effect/turf_decal/box,
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -10755,10 +10692,7 @@
 	dir = 4
 	},
 /turf/open/floor/facility/dark,
-/area/department_main/extraction)
-"Dv" = (
-/turf/closed/indestructible/fakeglass,
-/area/facility_hallway/east)
+/area/facility_hallway/extraction)
 "Dw" = (
 /obj/machinery/light{
 	dir = 4;
@@ -11526,8 +11460,16 @@
 /turf/open/floor/facility/halls,
 /area/facility_hallway/south)
 "FH" = (
-/turf/closed/indestructible/fakeglass,
-/area/facility_hallway/control)
+/obj/effect/turf_decal/box/red,
+/obj/structure/toolabnormality/wishwell,
+/obj/effect/light_emitter{
+	light_power = 4;
+	light_range = 25;
+	set_cap = 3;
+	set_luminosity = 24
+	},
+/turf/open/floor/facility,
+/area/facility_hallway/extraction)
 "FL" = (
 /obj/effect/turf_decal/siding/green{
 	color = "#006400";
@@ -11857,11 +11799,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/facility_hallway/east)
-"GH" = (
-/obj/effect/turf_decal/box/red,
-/obj/structure/toolabnormality/wishwell,
-/turf/open/floor/facility,
-/area/facility_hallway/west)
 "GK" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 8
@@ -12489,7 +12426,7 @@
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark{
+/turf/open/floor/facility/dark{
 	color = "#ccc8c0"
 	},
 /area/department_main/extraction)
@@ -13621,7 +13558,7 @@
 /area/facility_hallway/training)
 "MF" = (
 /turf/closed/indestructible/fakeglass,
-/area/department_main/extraction)
+/area/facility_hallway/extraction)
 "MH" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 4
@@ -13777,8 +13714,12 @@
 	},
 /area/department_main/safety)
 "Nd" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 8
+/obj/machinery/button/door/indestructible{
+	id = "extraction";
+	name = "Extraction Access Shutters";
+	pixel_y = 4;
+	req_one_access_txt = "19";
+	pixel_x = 22
 	},
 /turf/open/floor/plasteel/dark,
 /area/department_main/extraction)
@@ -13860,7 +13801,7 @@
 /turf/open/floor/facility/dark{
 	color = "#ccc8c0"
 	},
-/area/department_main/extraction)
+/area/facility_hallway/extraction)
 "Np" = (
 /obj/effect/turf_decal/bot_red,
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -15928,21 +15869,8 @@
 /turf/open/floor/plasteel/dark,
 /area/facility_hallway/east)
 "Tz" = (
-/obj/effect/turf_decal/delivery,
-/obj/structure/closet/crate{
-	name = "pe box crate";
-	anchored = 1;
-	opened = 1
-	},
-/obj/item/rawpe,
-/obj/item/rawpe,
-/obj/item/rawpe,
-/obj/item/rawpe,
-/obj/item/rawpe,
-/turf/open/floor/facility/dark{
-	color = "#ccc8c0"
-	},
-/area/department_main/extraction)
+/turf/closed/indestructible/fakeglass,
+/area/facility_hallway/east)
 "TA" = (
 /obj/effect/turf_decal/siding/thinplating/corner{
 	dir = 4
@@ -16586,19 +16514,14 @@
 	},
 /area/facility_hallway/south)
 "Vb" = (
-/obj/effect/turf_decal/stripes/white/line,
-/obj/effect/turf_decal/caution/white{
-	dir = 1
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
 	},
-/obj/machinery/camera{
-	alpha = 0;
-	short_range = 3;
-	name = "hidden security camera";
-	mouse_opacity = 0;
-	view_range = 3
+/obj/effect/turf_decal/caution/white{
+	dir = 8
 	},
 /turf/open/floor/facility/dark,
-/area/facility_hallway/west)
+/area/facility_hallway/extraction)
 "Vd" = (
 /turf/open/floor/plasteel/dark,
 /area/department_main/records)
@@ -17449,23 +17372,6 @@
 	},
 /turf/open/floor/carpet/royalblue,
 /area/department_main/command)
-"XW" = (
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/machinery/vending/hydronutrients{
-	pixel_y = 19;
-	density = 0
-	},
-/turf/open/floor/plasteel/sepia,
-/area/facility_hallway/training)
 "XX" = (
 /obj/effect/turf_decal/box/red,
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -18051,7 +17957,7 @@
 /obj/effect/turf_decal/box/red,
 /obj/structure/toolabnormality/realization,
 /turf/open/floor/facility,
-/area/department_main/extraction)
+/area/facility_hallway/extraction)
 "ZX" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 1
@@ -40799,8 +40705,8 @@ Pr
 Qo
 Qo
 Qo
-ts
-ts
+Ad
+Ad
 Qo
 Qo
 Qo
@@ -40809,9 +40715,9 @@ RY
 RY
 Qo
 Qo
-ts
-ts
-ts
+Ad
+Ad
+Ad
 Qo
 Qo
 RY
@@ -41579,7 +41485,7 @@ KV
 Pt
 LQ
 Qo
-XW
+bm
 Se
 Jj
 Se
@@ -43098,9 +43004,9 @@ fv
 CZ
 fv
 zS
-FH
-FH
-FH
+qn
+qn
+qn
 Qo
 qN
 qN
@@ -43383,7 +43289,7 @@ TZ
 ii
 vZ
 rN
-ts
+Ad
 RY
 RY
 rg
@@ -43640,7 +43546,7 @@ Cg
 we
 vZ
 Qb
-ts
+Ad
 RY
 RY
 rg
@@ -43897,7 +43803,7 @@ TZ
 qb
 vZ
 dC
-ts
+Ad
 RY
 RY
 rg
@@ -45431,10 +45337,10 @@ ED
 mV
 Ea
 tC
-qn
-qS
-tb
-hf
+RY
+RY
+RY
+RY
 RY
 RY
 RY
@@ -45687,11 +45593,11 @@ EE
 Oz
 aP
 fy
-TV
-Vb
-GH
-cX
-hf
+tC
+RY
+RY
+RY
+RY
 RY
 RY
 RY
@@ -45945,9 +45851,9 @@ xu
 uX
 TJ
 tC
-jP
-pv
-Ad
+RY
+RY
+RY
 wK
 wK
 wK
@@ -47751,7 +47657,7 @@ wK
 Oh
 Ac
 Ba
-hf
+tC
 RY
 RY
 RY
@@ -48008,7 +47914,7 @@ Bf
 eI
 Ej
 Rl
-hf
+tC
 RY
 Sb
 Sb
@@ -48265,7 +48171,7 @@ uX
 uX
 Np
 UA
-hf
+tC
 RY
 Sb
 Sb
@@ -52866,7 +52772,7 @@ OJ
 rR
 yZ
 jC
-OJ
+pv
 HY
 CA
 xm
@@ -53119,11 +53025,11 @@ Pc
 uw
 DZ
 Lu
-rj
+jP
 cu
 ZV
 gC
-OJ
+pv
 so
 og
 eq
@@ -53371,16 +53277,16 @@ RY
 BU
 of
 Nd
-Nd
 xD
-mS
+xD
+xD
 Nd
-bm
+aw
 OJ
 No
 Du
 uo
-OJ
+pv
 WE
 WE
 WE
@@ -53618,7 +53524,7 @@ pm
 pm
 pm
 pm
-rg
+pm
 rg
 rg
 rg
@@ -53627,17 +53533,17 @@ RY
 RY
 BU
 Jh
-Tz
 OJ
 OJ
+rj
 OJ
-Tz
-aw
+OJ
+qS
 OJ
 MF
 MF
 MF
-OJ
+pv
 RY
 RY
 RY
@@ -53875,7 +53781,7 @@ pm
 pm
 pm
 pm
-rg
+pm
 rg
 rg
 rg
@@ -53883,13 +53789,13 @@ rg
 RY
 RY
 OJ
-MF
-MF
 OJ
-RY
+pv
+rR
+Vb
+jC
+pv
 OJ
-MF
-MF
 OJ
 RY
 RY
@@ -54132,20 +54038,20 @@ pm
 pm
 pm
 pm
+pm
 rg
 rg
 rg
 rg
-rg
 RY
 RY
 RY
 RY
-RY
-RY
-RY
-RY
-RY
+MF
+ts
+FH
+cX
+MF
 RY
 RY
 RY
@@ -54389,20 +54295,20 @@ pm
 pm
 pm
 pm
+pm
 rg
 rg
 rg
 rg
-rg
 RY
 RY
 RY
 RY
-RY
-RY
-RY
-RY
-RY
+MF
+No
+Du
+uo
+MF
 RY
 RY
 RY
@@ -54646,22 +54552,22 @@ pm
 pm
 pm
 pm
+pm
 rg
 rg
 rg
 rg
 rg
 rg
-rg
-rg
-rg
-rg
-rg
-rg
-rg
-rg
-rg
-rg
+RY
+RY
+MF
+MF
+MF
+MF
+MF
+RY
+RY
 rg
 rg
 rg
@@ -54674,7 +54580,7 @@ rg
 RY
 RY
 RY
-Dv
+Tz
 Ph
 EA
 rA
@@ -54903,22 +54809,7 @@ pm
 pm
 pm
 pm
-rg
-rg
-rg
-rg
-rg
-rg
-rg
-rg
-rg
-rg
-rg
-Ye
-rg
-rg
-rg
-rg
+pm
 rg
 rg
 rg
@@ -54931,7 +54822,22 @@ RY
 RY
 RY
 RY
-Dv
+RY
+RY
+RY
+rg
+rg
+rg
+rg
+rg
+rg
+RY
+RY
+RY
+RY
+RY
+RY
+Tz
 ap
 HX
 bt
@@ -54951,7 +54857,7 @@ IJ
 IJ
 vd
 gc
-Dv
+Tz
 ya
 PZ
 TF
@@ -55160,22 +55066,7 @@ pm
 pm
 pm
 pm
-rg
-rg
-rg
-rg
-rg
-rg
-rg
-rg
-rg
-rg
-rg
-rg
-rg
-rg
-rg
-rg
+pm
 rg
 rg
 rg
@@ -55188,7 +55079,22 @@ RY
 RY
 RY
 RY
-Dv
+RY
+RY
+RY
+rg
+rg
+rg
+rg
+rg
+rg
+RY
+RY
+RY
+RY
+RY
+RY
+Tz
 BH
 UX
 Pk
@@ -55208,7 +55114,7 @@ Zf
 WX
 IJ
 Cf
-Dv
+Tz
 tr
 Er
 Er
@@ -55417,7 +55323,7 @@ pm
 pm
 pm
 pm
-rg
+pm
 rg
 rg
 rg
@@ -55442,8 +55348,8 @@ rg
 RY
 RY
 iL
-bu
-bu
+tb
+tb
 iL
 It
 It
@@ -55465,7 +55371,7 @@ Jn
 Hh
 IJ
 Nt
-Dv
+Tz
 sx
 sx
 sx
@@ -55674,13 +55580,13 @@ pm
 pm
 pm
 pm
+pm
 rg
 rg
 rg
 rg
 rg
-rg
-rg
+Ye
 rg
 rg
 rg
@@ -55698,7 +55604,7 @@ rg
 rg
 RY
 RY
-bu
+tb
 UN
 QD
 yR
@@ -55931,7 +55837,7 @@ pm
 pm
 pm
 pm
-rg
+pm
 rg
 rg
 rg
@@ -55955,7 +55861,7 @@ rg
 rg
 RY
 RY
-bu
+tb
 XM
 Ci
 Kj
@@ -56188,7 +56094,7 @@ pm
 pm
 pm
 pm
-rg
+pm
 rg
 rg
 rg
@@ -56446,21 +56352,21 @@ pm
 pm
 pm
 pm
-pm
-pm
-pm
-pm
-pm
-pm
-pm
-pm
-pm
-pm
-pm
-pm
-pm
-pm
-pm
+rg
+rg
+rg
+rg
+rg
+rg
+rg
+rg
+rg
+rg
+rg
+rg
+rg
+rg
+rg
 rg
 rg
 rg
@@ -56703,21 +56609,21 @@ pm
 pm
 pm
 pm
-pm
-pm
-pm
-pm
-pm
-pm
-pm
-pm
-pm
-pm
-pm
-pm
-pm
-pm
-pm
+rg
+rg
+rg
+rg
+rg
+rg
+rg
+rg
+rg
+rg
+rg
+rg
+rg
+rg
+rg
 rg
 rg
 rg
@@ -57264,7 +57170,7 @@ iL
 gX
 FY
 oW
-bu
+tb
 Er
 nJ
 sx
@@ -57521,7 +57427,7 @@ iL
 bX
 IV
 dc
-bu
+tb
 sx
 sx
 sx
@@ -57778,7 +57684,7 @@ iL
 vS
 ft
 Eh
-bu
+tb
 sx
 sx
 sx
@@ -58011,7 +57917,7 @@ RY
 RY
 RY
 RY
-bu
+tb
 XM
 UJ
 Kj
@@ -58268,7 +58174,7 @@ RY
 RY
 RY
 RY
-bu
+tb
 UN
 Ql
 yR
@@ -58806,7 +58712,7 @@ Ok
 Dr
 ft
 xe
-bu
+tb
 RY
 RY
 RY
@@ -59063,7 +58969,7 @@ qH
 kt
 zW
 xe
-bu
+tb
 RY
 RY
 RY
@@ -59320,7 +59226,7 @@ AA
 Ov
 ft
 xe
-bu
+tb
 RY
 RY
 rg
@@ -59814,8 +59720,8 @@ RY
 iL
 iL
 iL
-bu
-bu
+tb
+tb
 iL
 iL
 iL
@@ -60348,7 +60254,7 @@ iL
 AD
 ft
 xe
-bu
+tb
 RY
 RY
 rg
@@ -60605,7 +60511,7 @@ iL
 Zl
 ft
 dc
-bu
+tb
 RY
 RY
 rg
@@ -60862,7 +60768,7 @@ iL
 wY
 dQ
 Eh
-bu
+tb
 RY
 RY
 rg


### PR DESCRIPTION
Added fake glass and updated the foodstuff industrial dispenser

## About The Pull Request

Added fake glass so that people are less likely to do out of bounds shenanigans, updated foodstuff dispenser so clerks will have easy access to milk and soy milk, and regenerator in extraction main room due to a request from crabby and Kirie allowing me to make that change.

## Why It's Good For The Game

Map bug fixes and tweaks

## Changelog
:cl:
add: Added fake glass on the exterior of the facility, added regenerator on extraction office, added lockdown button in extraction office for the shutters.
tweak: tweaked a foodstuff industrial dispenser to include milk and soymilk.
/:cl: