### PR TITLE
Improved work economy with Piscine Mermaid

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/he/pisc_mermaid.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/pisc_mermaid.dm
@@ -70,7 +70,7 @@
 	if(crown?.loved == user)
 		if(crown.loved)
 			datum_reference.qliphoth_change(2)
-			(crown.love_cooldown) = world.time + (crown.love_cooldown_time)
+			crown.love_cooldown = world.time + (crown.love_cooldown_time)
 		return
 
 /mob/living/simple_animal/hostile/abnormality/pisc_mermaid/AttemptWork(mob/living/carbon/human/user, work_type)

--- a/code/modules/mob/living/simple_animal/abnormality/he/pisc_mermaid.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/pisc_mermaid.dm
@@ -69,7 +69,8 @@
 		return
 	if(crown?.loved == user)
 		if(crown.loved)
-			datum_reference.qliphoth_change(1)
+			datum_reference.qliphoth_change(2)
+			(crown.love_cooldown) = world.time + (crown.love_cooldown_time)
 		return
 
 /mob/living/simple_animal/hostile/abnormality/pisc_mermaid/AttemptWork(mob/living/carbon/human/user, work_type)
@@ -263,7 +264,7 @@
 	worn_icon = 'icons/mob/clothing/ego_gear/head.dmi'
 	var/success_mod = 1.15
 	var/love_cooldown
-	var/love_cooldown_time = 3 MINUTES //It takes around 9 minutes for mermaid to breach if left unchecked
+	var/love_cooldown_time = 3.3 MINUTES //It takes around 10 minutes for mermaid to breach if left unchecked
 	var/mob/living/simple_animal/hostile/abnormality/pisc_mermaid/mermaid
 	var/mob/living/carbon/human/loved //What's wrong anon? Unconditional love is what you wanted right?
 

--- a/code/modules/mob/living/simple_animal/abnormality/he/pisc_mermaid.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/pisc_mermaid.dm
@@ -70,7 +70,7 @@
 	if(crown?.loved == user)
 		if(crown.loved)
 			datum_reference.qliphoth_change(2)
-			crown.love_cooldown = world.time + (crown.love_cooldown_time)
+			crown.love_cooldown = (world.time + crown.love_cooldown_time)
 		return
 
 /mob/living/simple_animal/hostile/abnormality/pisc_mermaid/AttemptWork(mob/living/carbon/human/user, work_type)

--- a/code/modules/paperwork/records/info/he.dm
+++ b/code/modules/paperwork/records/info/he.dm
@@ -191,7 +191,7 @@
 		"When the work result was Normal or Bad, the Qliphoth Counter lowered.",
 		"When the work result was Good, Piscine Mermaid offered a crown if no other copies were present in the facility. (From then on, the employee wearing the crown will be referred to as O-01-129-1).",
 		"O-01-129-1 had greatly increased work success rates with any Abnormality, but the Qliphoth Counter would periodically decrease as long as the crown was worn.",
-		"When O-01-129-1 completed their work on Piscine Mermaid with a Good result, the Qliphoth Counter increased.",
+		"When O-01-129-1 completed their work on Piscine Mermaid with a Good result, the Qliphoth Counter increased by 2. This would also delay the reduction of the Qlipoth Counter",
 		"The Qliphoth Counter dropped to 0 when O-01-129-1 removed their crown.",
 		"When the Qliphoth Counter reached 0, the crown was destroyed. O-01-129-1 was greatly slowed before Piscine Mermaid teleported to them.",
 		"Piscine Mermaid slowly suffocated everyone within sight. O-01-129-1 could not breath as long as Piscine Mermaid was alive.",


### PR DESCRIPTION
## About The Pull Request

Piscine Mermaid now gain 2 Qlipoth Counter when her lover get a good result with her.
Good work result as a lover now also reset the timer for the Qlipoth reduction.
Also added an extra 20 seconds on the timer to make total breach time 10 minutes (up from 9).
Small tweak to her documentation to point out the qlipoth gain along with the timer reset.

## Why It's Good For The Game

With these changes, being the lover of the Mermaid will hog less of your time and make her far more manageable while reducing her impact on the amount of work per meltdowns.
Simply put, if the lover get a good work result, her Qlipoth Counter maxes out AND the Qlipoth Reduction timer of the crown is resetted, meaning you get the maximum possible duration of not working Piscine Mermaid. With the extra 20 seconds added on the timer, you have 3 minute and 20 seconds before a lose of counter and a whole 10 minute before she breaches.
Reducing the amount of time needed to work mermaid over a given amount of time also mean there's more works available as a whole, as you are not dedicating as much works toward mermaid.