### PR TITLE
Kappa and Lambda Map Bug Fixes

### DIFF
--- a/_maps/map_files/Kappa/kappacorp.dmm
+++ b/_maps/map_files/Kappa/kappacorp.dmm
@@ -36,22 +36,14 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
-/obj/item/food/grown/ambrosia/gaia,
-/obj/item/food/grown/ambrosia/gaia,
-/obj/item/food/grown/ambrosia/gaia,
-/obj/item/food/grown/ambrosia/gaia,
-/obj/item/food/grown/ambrosia/gaia,
-/obj/item/food/grown/ambrosia/gaia,
-/obj/item/food/grown/ambrosia/gaia,
-/obj/item/food/grown/ambrosia/gaia,
-/obj/item/food/grown/ambrosia/gaia,
-/obj/item/food/grown/ambrosia/gaia,
 /obj/machinery/light{
 	dir = 4;
 	pixel_x = 9;
 	pixel_y = 4
 	},
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /turf/open/floor/plasteel/sepia,
 /area/facility_hallway/training)
 "as" = (
@@ -65,6 +57,20 @@
 	name = "secure flooring"
 	},
 /area/facility_hallway/training)
+"at" = (
+/obj/effect/turf_decal/siding/purple{
+	color = "#511c4b"
+	},
+/obj/machinery/light{
+	dir = 8;
+	pixel_x = -9;
+	pixel_y = 4
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
+/turf/open/floor/pod/dark,
+/area/department_main/information)
 "au" = (
 /turf/closed/indestructible/reinforced,
 /area/facility_hallway/training)
@@ -216,6 +222,10 @@
 "bd" = (
 /obj/structure/chair/sofa/corp/left{
 	dir = 4
+	},
+/obj/item/toy/plush/yuri,
+/obj/item/food/grown/apple/gold{
+	pixel_y = -6
 	},
 /turf/open/floor/facility/dark{
 	color = "#ccc8c0"
@@ -369,13 +379,19 @@
 /turf/open/floor/pod/dark,
 /area/facility_hallway/control)
 "bY" = (
-/obj/structure/table/reinforced,
-/obj/structure/railing{
-	resistance_flags = 115;
-	name = "wing-grade railing";
-	desc = "Indestructible railing created in a vain attempt of fool-proofing the wing's workplace."
-	},
 /obj/effect/turf_decal/siding/brown,
+/obj/structure/window/reinforced/spawner{
+	resistance_flags = 115
+	},
+/obj/machinery/computer/ego_purchase{
+	dir = 1;
+	pixel_x = -1
+	},
+/obj/structure/window/reinforced/spawner/east{
+	resistance_flags = 115;
+	pixel_y = 64;
+	pixel_x = 4
+	},
 /turf/open/floor/pod/dark,
 /area/department_main/extraction)
 "ca" = (
@@ -393,6 +409,9 @@
 /obj/structure/closet/secure_closet/personal{
 	pixel_x = 6;
 	anchored = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/pod/dark,
 /area/facility_hallway/control)
@@ -414,16 +433,25 @@
 	},
 /area/facility_hallway/central)
 "cd" = (
-/obj/machinery/recharger{
-	pixel_x = -6;
-	pixel_y = 5
+/obj/structure/closet/crate{
+	name = "pe box crate";
+	opened = 1;
+	resistance_flags = 115
 	},
-/obj/machinery/recharger{
-	pixel_x = 6;
-	pixel_y = 5
+/obj/item/refiner_filter/blue{
+	pixel_x = 7;
+	pixel_y = 3
 	},
-/obj/structure/table/reinforced,
-/turf/open/floor/pod,
+/obj/item/refiner_filter/yellow{
+	pixel_x = 1;
+	pixel_y = -4
+	},
+/obj/item/refiner_filter/red,
+/obj/item/refiner_filter/green,
+/obj/item/rawpe,
+/obj/item/rawpe,
+/obj/item/rawpe,
+/turf/open/floor/carpet/purple,
 /area/department_main/information)
 "cg" = (
 /obj/machinery/door/poddoor/preopen{
@@ -460,8 +488,7 @@
 	color = "#422702"
 	},
 /obj/machinery/facility_holomap{
-	dir = 4;
-	forced_zLevel = 2
+	dir = 4
 	},
 /turf/open/floor/pod/dark,
 /area/department_main/training)
@@ -973,8 +1000,7 @@
 /area/facility_hallway/safety)
 "fs" = (
 /obj/machinery/facility_holomap{
-	dir = 1;
-	forced_zLevel = 2
+	dir = 1
 	},
 /obj/effect/turf_decal/siding/red{
 	color = "#440000"
@@ -1024,7 +1050,7 @@
 /turf/open/floor/pod,
 /area/facility_hallway/control)
 "fH" = (
-/obj/effect/turf_decal/arrows{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
 	},
 /turf/open/floor/pod/dark,
@@ -1130,6 +1156,12 @@
 /obj/machinery/door/airlock/glass,
 /turf/open/floor/facility/halls,
 /area/facility_hallway/information)
+"gA" = (
+/obj/machinery/computer/abnormality/training_rabbit{
+	dir = 1
+	},
+/turf/open/floor/pod/dark,
+/area/facility_hallway/information)
 "gE" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "LC33"
@@ -1210,20 +1242,13 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
-/obj/item/food/grown/ambrosia/gaia,
-/obj/item/food/grown/ambrosia/gaia,
-/obj/item/food/grown/ambrosia/gaia,
-/obj/item/food/grown/ambrosia/gaia,
-/obj/item/food/grown/ambrosia/gaia,
-/obj/item/food/grown/ambrosia/gaia,
-/obj/item/food/grown/ambrosia/gaia,
-/obj/item/food/grown/ambrosia/gaia,
-/obj/item/food/grown/ambrosia/gaia,
-/obj/item/food/grown/ambrosia/gaia,
 /obj/machinery/light{
 	dir = 8;
 	pixel_x = -9;
 	pixel_y = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
 /turf/open/floor/plasteel/sepia,
 /area/facility_hallway/training)
@@ -1265,9 +1290,6 @@
 	mouse_opacity = 0;
 	view_range = 3
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
 /turf/open/floor/pod/light,
 /area/facility_hallway/control)
 "gU" = (
@@ -1282,7 +1304,9 @@
 /turf/open/floor/pod/dark,
 /area/facility_hallway/information)
 "gV" = (
-/obj/structure/chair/comfy/black,
+/obj/structure/chair/comfy/black{
+	can_buckle = 0
+	},
 /obj/item/toy/plush/binah,
 /obj/effect/light_emitter{
 	light_power = 4;
@@ -1310,23 +1334,13 @@
 	},
 /area/department_main/command)
 "ha" = (
-/obj/structure/closet/crate{
-	name = "pe box crate";
-	anchored = 1;
-	opened = 1
+/obj/machinery/button/door/indestructible{
+	id = "extraction";
+	name = "Extraction Access Shutters";
+	pixel_y = 5;
+	req_one_access_txt = "19";
+	pixel_x = 22
 	},
-/obj/item/rawpe,
-/obj/item/rawpe,
-/obj/item/rawpe,
-/obj/item/rawpe,
-/obj/item/rawpe,
-/obj/item/rawpe,
-/obj/machinery/light{
-	dir = 4;
-	pixel_x = 9;
-	pixel_y = 4
-	},
-/obj/effect/turf_decal/box/red,
 /turf/open/floor/pod,
 /area/department_main/extraction)
 "hc" = (
@@ -1386,10 +1400,8 @@
 /turf/open/floor/pod/dark,
 /area/facility_hallway/safety)
 "hs" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/arrows,
+/obj/effect/turf_decal/box,
+/obj/structure/refinery,
 /turf/open/floor/pod,
 /area/department_main/information)
 "hy" = (
@@ -1523,11 +1535,7 @@
 	},
 /area/facility_hallway/human)
 "ip" = (
-/obj/structure/window/reinforced/fulltile/indestructable,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/facility/dark{
-	color = "#ccc8c0"
-	},
+/turf/closed/indestructible/fakeglass,
 /area/facility_hallway/training)
 "ir" = (
 /turf/open/floor/facility/dark,
@@ -1761,6 +1769,24 @@
 /obj/effect/turf_decal/trimline/green/filled/warning,
 /turf/open/floor/pod/dark,
 /area/facility_hallway/safety)
+"jE" = (
+/obj/structure/closet/crate{
+	name = "pe box crate";
+	anchored = 1;
+	opened = 1
+	},
+/obj/item/rawpe,
+/obj/item/rawpe,
+/obj/item/rawpe,
+/obj/item/rawpe,
+/obj/item/rawpe,
+/obj/item/rawpe,
+/obj/effect/turf_decal/box/red,
+/obj/effect/turf_decal/siding{
+	color = "#7D6521"
+	},
+/turf/open/floor/pod/dark,
+/area/department_main/extraction)
 "jL" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 6
@@ -2090,10 +2116,7 @@
 	},
 /area/facility_hallway/records)
 "lm" = (
-/obj/structure/window/reinforced/fulltile/indestructable,
-/turf/open/floor/facility/dark{
-	color = "#ccc8c0"
-	},
+/turf/closed/indestructible/fakeglass,
 /area/facility_hallway/control)
 "ls" = (
 /obj/machinery/disposal/bin{
@@ -2627,19 +2650,17 @@
 	slowdown = -0.3
 	},
 /area/department_main/command)
+"mL" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 9
+	},
+/turf/open/floor/pod,
+/area/department_main/information)
 "mN" = (
-/obj/structure/chair/sofa/corp/right{
-	dir = 8;
-	can_buckle = 0
-	},
-/obj/item/toy/plush/yuri,
-/obj/item/food/grown/apple/gold{
-	pixel_y = -6
-	},
-/turf/open/floor/facility/dark{
-	color = "#ccc8c0"
-	},
-/area/facility_hallway/human)
+/obj/structure/disposalpipe/segment,
+/obj/machinery/regenerator/safety,
+/turf/open/floor/pod/dark,
+/area/department_main/extraction)
 "nh" = (
 /obj/effect/turf_decal/siding/purple{
 	color = "#511c4b";
@@ -2935,10 +2956,12 @@
 /turf/open/floor/carpet/orange,
 /area/department_main/training)
 "ot" = (
-/obj/structure/refinery,
-/obj/effect/turf_decal/box,
-/turf/open/floor/pod/dark,
-/area/department_main/information)
+/obj/machinery/vending/cola,
+/obj/effect/turf_decal/delivery/white,
+/turf/open/floor/facility/dark{
+	color = "#ccc8c0"
+	},
+/area/facility_hallway/human)
 "ov" = (
 /obj/structure/rack{
 	pixel_x = -1
@@ -2996,15 +3019,14 @@
 	},
 /area/facility_hallway/training)
 "oA" = (
-/obj/machinery/button/door/indestructible{
-	id = "extraction";
-	name = "Extraction Access Shutters";
-	pixel_y = 5;
-	req_one_access_txt = "19";
-	pixel_x = 22
+/obj/effect/turf_decal/siding/purple{
+	color = "#511c4b"
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
 	},
 /turf/open/floor/pod/dark,
-/area/department_main/extraction)
+/area/department_main/information)
 "oB" = (
 /obj/effect/turf_decal/sand/plating,
 /turf/open/floor/plasteel,
@@ -3505,8 +3527,7 @@
 /obj/effect/turf_decal/trimline/red/filled,
 /obj/structure/fans/tiny,
 /obj/machinery/facility_holomap{
-	dir = 1;
-	forced_zLevel = 2
+	dir = 1
 	},
 /turf/open/floor/plasteel/bluespace{
 	name = "secure flooring"
@@ -3651,10 +3672,6 @@
 	},
 /area/department_main/information)
 "rO" = (
-/obj/structure/bookcase/random{
-	pixel_y = 15;
-	density = 0
-	},
 /obj/effect/turf_decal/siding/brown{
 	dir = 8;
 	color = "#422702"
@@ -3662,6 +3679,10 @@
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /obj/structure/disposalpipe/segment{
 	dir = 9
+	},
+/obj/structure/bookcase/random{
+	pixel_y = 15;
+	density = 0
 	},
 /turf/open/floor/pod,
 /area/department_main/training)
@@ -3825,14 +3846,10 @@
 /turf/open/floor/facility/halls,
 /area/facility_hallway/records)
 "sx" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/caution{
-	dir = 8
-	},
-/turf/open/floor/pod/dark,
-/area/facility_hallway/information)
+/obj/structure/refinery,
+/obj/effect/turf_decal/box,
+/turf/open/floor/pod,
+/area/department_main/information)
 "sB" = (
 /obj/effect/turf_decal/sand/plating,
 /turf/open/floor/plasteel,
@@ -4005,18 +4022,15 @@
 /turf/open/floor/pod/dark,
 /area/department_main/control)
 "tr" = (
-/obj/effect/turf_decal/siding/red{
-	color = "#440000";
-	dir = 4
-	},
-/obj/machinery/cryopod{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/pod/dark,
-/area/facility_hallway/control)
+/turf/open/floor/plating/ironsand{
+	color = "#c3bab0";
+	name = "Outskirt";
+	density = 1
+	},
+/area/facility_hallway/central)
 "tw" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
@@ -4041,13 +4055,14 @@
 /turf/open/floor/pod/dark,
 /area/department_main/control)
 "tC" = (
-/obj/machinery/text_adventure_console,
-/obj/machinery/light{
-	dir = 8;
-	pixel_x = -9;
-	pixel_y = 4
-	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/button/door/indestructible{
+	id = "extraction";
+	name = "Extraction Access Shutters";
+	pixel_y = 5;
+	req_one_access_txt = "19";
+	pixel_x = -22
+	},
 /turf/open/floor/pod,
 /area/department_main/extraction)
 "tF" = (
@@ -4077,12 +4092,31 @@
 /turf/open/floor/plasteel,
 /area/facility_hallway/human)
 "tP" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/arrows{
+	dir = 4
+	},
+/obj/effect/light_emitter{
+	light_power = 4;
+	light_range = 25;
+	set_cap = 3;
+	set_luminosity = 24
+	},
+/obj/machinery/camera{
+	alpha = 0;
+	short_range = 13;
+	name = "hidden security camera";
+	mouse_opacity = 0;
+	view_range = 13
+	},
 /obj/machinery/light{
 	dir = 8;
 	pixel_x = -9;
 	pixel_y = 4
 	},
-/turf/open/floor/pod/light,
+/turf/open/floor/pod,
 /area/facility_hallway/information)
 "tR" = (
 /obj/structure/disposalpipe/segment{
@@ -4400,8 +4434,11 @@
 /turf/open/floor/pod,
 /area/department_main/control)
 "vw" = (
-/obj/effect/turf_decal/arrows{
-	dir = 1
+/obj/effect/turf_decal/siding/purple{
+	color = "#511c4b"
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 5
 	},
 /turf/open/floor/pod/dark,
 /area/department_main/information)
@@ -4465,6 +4502,9 @@
 	pixel_x = -7;
 	resistance_flags = 115
 	},
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
 /turf/open/floor/facility/dark{
 	color = "#ccc8c0"
 	},
@@ -4511,18 +4551,12 @@
 	},
 /area/department_main/extraction)
 "wc" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/arrows{
-	dir = 8
-	},
 /obj/machinery/light{
 	dir = 4;
 	pixel_x = 9;
 	pixel_y = 4
 	},
-/turf/open/floor/pod,
+/turf/open/floor/pod/light,
 /area/facility_hallway/information)
 "wd" = (
 /obj/effect/turf_decal/sand/plating,
@@ -4572,12 +4606,11 @@
 /turf/open/floor/pod,
 /area/department_main/control)
 "wr" = (
-/obj/machinery/computer/ego_purchase{
-	pixel_x = -5
-	},
+/obj/effect/turf_decal/box/red,
 /obj/effect/turf_decal/siding{
 	color = "#7D6521"
 	},
+/obj/structure/toolabnormality/wishwell,
 /turf/open/floor/facility/dark{
 	color = "#ccc8c0"
 	},
@@ -4876,8 +4909,7 @@
 	dir = 4
 	},
 /obj/machinery/facility_holomap{
-	dir = 4;
-	forced_zLevel = 2
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -4908,6 +4940,10 @@
 /obj/item/reagent_containers/hypospray/emais,
 /turf/open/floor/pod,
 /area/department_main/safety)
+"xI" = (
+/obj/structure/flora/rock/pile/largejungle,
+/turf/open/water/deep/saltwater/safe,
+/area/facility_hallway/central)
 "xM" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/hypospray/medipen/salacid,
@@ -5114,8 +5150,7 @@
 	dir = 8
 	},
 /obj/machinery/facility_holomap{
-	dir = 1;
-	forced_zLevel = 2
+	dir = 1
 	},
 /obj/machinery/light{
 	dir = 4;
@@ -5508,8 +5543,7 @@
 	desc = "Indestructible railing created in a vain attempt of fool-proofing the wing's workplace."
 	},
 /obj/structure/window/reinforced/spawner/east{
-	resistance_flags = 115;
-	density = 0
+	resistance_flags = 115
 	},
 /turf/open/floor/pod/dark,
 /area/facility_hallway/records)
@@ -5533,8 +5567,7 @@
 /area/facility_hallway/information)
 "AH" = (
 /obj/machinery/facility_holomap{
-	dir = 1;
-	forced_zLevel = 2
+	dir = 1
 	},
 /obj/machinery/light{
 	dir = 8;
@@ -5556,13 +5589,15 @@
 /turf/open/floor/carpet/purple,
 /area/department_main/information)
 "AK" = (
-/obj/machinery/computer/abnormality_logs,
 /obj/effect/turf_decal/siding{
 	color = "#7D6521"
 	},
 /obj/machinery/light{
 	dir = 1;
 	pixel_y = 19
+	},
+/obj/machinery/text_adventure_console{
+	pixel_y = 3
 	},
 /turf/open/floor/facility/dark{
 	color = "#ccc8c0"
@@ -5623,9 +5658,6 @@
 	dir = 9
 	},
 /obj/effect/landmark/latejoin,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/pod/light,
 /area/facility_hallway/control)
 "Bf" = (
@@ -5914,10 +5946,11 @@
 	},
 /area/facility_hallway/human)
 "Dp" = (
-/obj/effect/turf_decal/arrows{
-	dir = 4
+/obj/structure/fans/tiny,
+/obj/effect/turf_decal/trimline/purple/filled,
+/turf/open/floor/plasteel/bluespace{
+	name = "secure flooring"
 	},
-/turf/open/floor/pod/dark,
 /area/department_main/information)
 "Dw" = (
 /obj/machinery/door/airlock/external/glass,
@@ -5970,8 +6003,7 @@
 /area/department_main/information)
 "DE" = (
 /obj/machinery/facility_holomap{
-	dir = 4;
-	forced_zLevel = 2
+	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 8
@@ -6201,10 +6233,7 @@
 /turf/open/floor/pod/dark,
 /area/department_main/training)
 "EN" = (
-/obj/structure/window/reinforced/fulltile/indestructable,
-/turf/open/floor/facility/dark{
-	color = "#ccc8c0"
-	},
+/turf/closed/indestructible/fakeglass,
 /area/facility_hallway/information)
 "EO" = (
 /obj/effect/turf_decal/plaque{
@@ -6270,7 +6299,9 @@
 /obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /turf/open/floor/pod,
 /area/facility_hallway/control)
 "Fi" = (
@@ -6434,6 +6465,9 @@
 	anchored = 1
 	},
 /obj/item/toy/plush/nihil,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/pod/dark,
 /area/facility_hallway/control)
 "FE" = (
@@ -6571,7 +6605,7 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 1
+	dir = 5
 	},
 /turf/open/floor/pod,
 /area/facility_hallway/control)
@@ -6848,6 +6882,21 @@
 	},
 /turf/open/floor/pod/light,
 /area/facility_hallway/information)
+"HL" = (
+/obj/effect/turf_decal/siding/brown,
+/obj/structure/window/reinforced/spawner{
+	dir = 8;
+	pixel_x = -4;
+	resistance_flags = 115
+	},
+/obj/structure/railing{
+	resistance_flags = 115;
+	name = "wing-grade railing";
+	desc = "Indestructible railing created in a vain attempt of fool-proofing the wing's workplace."
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/pod/dark,
+/area/department_main/extraction)
 "HO" = (
 /obj/effect/turf_decal/caution/white{
 	pixel_y = -1
@@ -6949,7 +6998,7 @@
 	dir = 1
 	},
 /obj/machinery/chem_dispenser/fullupgrade{
-	dispensable_reagents = list(/datum/reagent/consumable/enzyme,/datum/reagent/consumable/eggyolk,/datum/reagent/consumable/flour,/datum/reagent/consumable/rice,/datum/reagent/consumable/sugar,/datum/reagent/consumable/caramel,/datum/reagent/consumable/honey,/datum/reagent/consumable/salt,/datum/reagent/consumable/blackpepper,/datum/reagent/consumable/soysauce,/datum/reagent/consumable/bbqsauce,/datum/reagent/consumable/ketchup,/datum/reagent/consumable/capsaicin,/datum/reagent/consumable/frostoil,/datum/reagent/consumable/garlic,/datum/reagent/consumable/cherryjelly,/datum/reagent/consumable/bluecherryjelly,/datum/reagent/consumable/vanilla,/datum/reagent/consumable/coco,/datum/reagent/consumable/cornoil,/datum/reagent/consumable/corn_syrup,/datum/reagent/consumable/corn_starch,/datum/reagent/consumable/dry_ramen,/datum/reagent/consumable/clownstears,/datum/reagent/consumable/astrotame,/datum/reagent/consumable/secretsauce,/datum/reagent/consumable/laughsyrup,/datum/reagent/consumable/pancakebatter,/datum/reagent/water/holywater,/datum/reagent/fuel);
+	dispensable_reagents = list(/datum/reagent/consumable/enzyme,/datum/reagent/consumable/eggyolk,/datum/reagent/consumable/flour,/datum/reagent/consumable/rice,/datum/reagent/consumable/sugar,/datum/reagent/consumable/caramel,/datum/reagent/consumable/honey,/datum/reagent/consumable/salt,/datum/reagent/consumable/blackpepper,/datum/reagent/consumable/soysauce,/datum/reagent/consumable/bbqsauce,/datum/reagent/consumable/ketchup,/datum/reagent/consumable/capsaicin,/datum/reagent/consumable/frostoil,/datum/reagent/consumable/garlic,/datum/reagent/consumable/cherryjelly,/datum/reagent/consumable/bluecherryjelly,/datum/reagent/consumable/vanilla,/datum/reagent/consumable/coco,/datum/reagent/consumable/cornoil,/datum/reagent/consumable/corn_syrup,/datum/reagent/consumable/corn_starch,/datum/reagent/consumable/dry_ramen,/datum/reagent/consumable/clownstears,/datum/reagent/consumable/astrotame,/datum/reagent/consumable/secretsauce,/datum/reagent/consumable/laughsyrup,/datum/reagent/consumable/pancakebatter,/datum/reagent/water/holywater,/datum/reagent/fuel,/datum/reagent/consumable/soymilk,/datum/reagent/consumable/milk);
 	name = "Industrial Foodstuff Dispenser";
 	desc = "Creates and dispenses a variety of kitchen ingredients.";
 	emagged_reagents = null
@@ -7111,6 +7160,11 @@
 /obj/machinery/telecomms/processor/preset_three,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/facility_hallway/training)
+"IU" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/purple/filled/end,
+/turf/open/floor/pod/light,
+/area/department_main/information)
 "Jb" = (
 /obj/effect/turf_decal/siding/purple{
 	dir = 8;
@@ -7223,8 +7277,7 @@
 /area/facility_hallway/central)
 "JI" = (
 /obj/machinery/facility_holomap{
-	dir = 4;
-	forced_zLevel = 2
+	dir = 4
 	},
 /turf/open/floor/pod/dark,
 /area/department_main/information)
@@ -7277,23 +7330,10 @@
 /area/department_main/command)
 "Kh" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/arrows{
 	dir = 4
 	},
-/obj/effect/light_emitter{
-	light_power = 4;
-	light_range = 25;
-	set_cap = 3;
-	set_luminosity = 24
-	},
-/obj/machinery/camera{
-	alpha = 0;
-	short_range = 13;
-	name = "hidden security camera";
-	mouse_opacity = 0;
-	view_range = 13
+/obj/effect/turf_decal/arrows{
+	dir = 8
 	},
 /turf/open/floor/pod,
 /area/facility_hallway/information)
@@ -7544,11 +7584,11 @@
 	},
 /area/department_main/command)
 "LG" = (
-/obj/machinery/computer/extraction_cargo{
-	pixel_x = 5
-	},
 /obj/effect/turf_decal/siding{
 	color = "#7D6521"
+	},
+/obj/machinery/computer/abnormality_logs{
+	pixel_x = 4
 	},
 /turf/open/floor/facility/dark{
 	color = "#ccc8c0"
@@ -7669,9 +7709,12 @@
 /turf/open/floor/pod/dark,
 /area/department_main/training)
 "Mh" = (
-/obj/structure/window/reinforced/fulltile/indestructable,
-/turf/open/floor/facility/dark{
-	color = "#ccc8c0"
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
+/turf/closed/indestructible/reinforced{
+	name = "facility wall";
+	desc = "A huge chunk of wing-grade metal used in various L corporation facilities. Effectively impervious to conventional methods of destruction."
 	},
 /area/facility_hallway/training)
 "Mj" = (
@@ -7725,6 +7768,27 @@
 	color = "#ccc8c0"
 	},
 /area/facility_hallway/records)
+"Mt" = (
+/obj/item/refiner_filter/blue{
+	pixel_x = 7;
+	pixel_y = 3
+	},
+/obj/item/refiner_filter/yellow{
+	pixel_x = 1;
+	pixel_y = -4
+	},
+/obj/item/refiner_filter/red,
+/obj/item/refiner_filter/green,
+/obj/item/rawpe,
+/obj/item/rawpe,
+/obj/item/rawpe,
+/obj/structure/closet/crate{
+	name = "pe box crate";
+	opened = 1;
+	resistance_flags = 115
+	},
+/turf/open/floor/carpet/purple,
+/area/department_main/information)
 "Mu" = (
 /turf/open/floor/pod/dark,
 /area/department_main/training)
@@ -7899,10 +7963,10 @@
 /turf/open/floor/pod/dark,
 /area/facility_hallway/information)
 "Nt" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 9
-	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/purple/filled/end{
+	dir = 1
+	},
 /turf/open/floor/pod/light,
 /area/department_main/information)
 "Nw" = (
@@ -8059,9 +8123,6 @@
 	dir = 5
 	},
 /obj/effect/landmark/latejoin,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/pod/light,
 /area/facility_hallway/control)
 "Og" = (
@@ -8442,19 +8503,14 @@
 	},
 /area/department_main/command)
 "PX" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/window/reinforced/spawner/west{
-	max_integrity = 25;
-	resistance_flags = 115;
-	pixel_y = -128;
-	density = 0;
-	pixel_x = 96
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/turf/open/floor/plating/ironsand{
-	density = 1;
-	name = "Outskirt"
+/obj/effect/turf_decal/caution{
+	dir = 4
 	},
-/area/facility_hallway/central)
+/turf/open/floor/pod/dark,
+/area/facility_hallway/information)
 "PY" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
@@ -8475,15 +8531,14 @@
 /turf/open/floor/pod/dark,
 /area/facility_hallway/information)
 "Qe" = (
+/obj/effect/turf_decal/trimline/brown/filled/line,
 /obj/structure/bookcase/random{
 	pixel_y = 15;
 	density = 0
 	},
 /obj/effect/turf_decal/siding/brown{
-	dir = 4;
-	color = "#422702"
+	dir = 4
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/pod,
 /area/department_main/training)
 "Qi" = (
@@ -8637,9 +8692,6 @@
 	mouse_opacity = 0;
 	view_range = 3
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
 /turf/open/floor/pod/light,
 /area/facility_hallway/control)
 "QH" = (
@@ -8729,6 +8781,15 @@
 	},
 /turf/open/floor/pod/light,
 /area/facility_hallway/safety)
+"Rm" = (
+/obj/structure/chair/comfy/black{
+	dir = 1;
+	pixel_y = 7;
+	pixel_x = 3;
+	can_buckle = 0
+	},
+/turf/open/floor/carpet/royalblack,
+/area/department_main/extraction)
 "Rp" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "LC30"
@@ -9085,16 +9146,9 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
-/obj/item/food/grown/ambrosia/gaia,
-/obj/item/food/grown/ambrosia/gaia,
-/obj/item/food/grown/ambrosia/gaia,
-/obj/item/food/grown/ambrosia/gaia,
-/obj/item/food/grown/ambrosia/gaia,
-/obj/item/food/grown/ambrosia/gaia,
-/obj/item/food/grown/ambrosia/gaia,
-/obj/item/food/grown/ambrosia/gaia,
-/obj/item/food/grown/ambrosia/gaia,
-/obj/item/food/grown/ambrosia/gaia,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/sepia,
 /area/facility_hallway/training)
 "Tr" = (
@@ -9123,18 +9177,15 @@
 /turf/open/floor/plasteel,
 /area/facility_hallway/human)
 "Tv" = (
-/obj/effect/turf_decal/siding/red{
-	color = "#440000";
-	dir = 8
-	},
-/obj/machinery/cryopod{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 10
 	},
-/turf/open/floor/pod/dark,
-/area/facility_hallway/control)
+/turf/open/floor/plating/ironsand{
+	color = "#c3bab0";
+	name = "Outskirt";
+	density = 1
+	},
+/area/facility_hallway/central)
 "Ty" = (
 /obj/effect/turf_decal/sand,
 /obj/effect/turf_decal/trimline/brown/filled/warning{
@@ -9226,6 +9277,12 @@
 /area/facility_hallway/information)
 "Ua" = (
 /obj/structure/table/wood/fancy/purple,
+/obj/item/deepscanner{
+	pixel_y = 6
+	},
+/obj/item/deepscanner{
+	pixel_y = 6
+	},
 /obj/item/deepscanner{
 	pixel_y = 6
 	},
@@ -9441,26 +9498,21 @@
 /area/department_main/command)
 "UV" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/window/reinforced/spawner/east{
-	resistance_flags = 115;
-	pixel_y = -160;
-	density = 0;
-	pixel_x = 159
+/turf/closed/indestructible/reinforced{
+	name = "facility wall";
+	desc = "A huge chunk of wing-grade metal used in various L corporation facilities. Effectively impervious to conventional methods of destruction."
+	},
+/area/department_main/extraction)
+"UW" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
 /turf/open/floor/plating/ironsand{
-	density = 1;
-	name = "Outskirt"
+	color = "#c3bab0";
+	name = "Outskirt";
+	density = 1
 	},
 /area/facility_hallway/central)
-"UW" = (
-/obj/structure/window/reinforced/fulltile/indestructable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/facility/dark{
-	color = "#ccc8c0"
-	},
-/area/facility_hallway/control)
 "Vc" = (
 /obj/effect/turf_decal/box,
 /obj/structure/toolabnormality/shelter/entrance,
@@ -9756,14 +9808,6 @@
 	color = "#c3bab0"
 	},
 /area/facility_hallway/manager)
-"Xb" = (
-/obj/structure/flora/rock/pile/largejungle,
-/turf/open/water/deep/freshwater{
-	environment = list(/obj/item/food/fish/fresh_water = 1000, /obj/item/food/fish/fresh_water/angelfish = 1000, /obj/item/food/fish/fresh_water/guppy = 1000, /obj/item/food/fish/fresh_water/plasmatetra = 1000, /obj/item/food/fish/fresh_water/catfish = 400, /obj/item/food/fish/fresh_water/ratfish = 200, /obj/item/food/fish/fresh_water/waterflea = 200, /obj/item/food/fish/fresh_water/yin = 200, /obj/item/food/fish/fresh_water/yang = 200, /obj/item/stack/spacecash/c1 = 700, /obj/item/stack/fish_points = 600, /obj/item/food/dough = 500, /obj/item/food/canned/peaches = 300, /obj/item/food/breadslice/moldy = 300, /obj/item/clothing/head/beret/fishing_hat = 200, /obj/item/food/grown/harebell = 200, /obj/item/reagent_containers/food/drinks/bottle/wine/unlabeled = 200, /obj/item/fishing_component/hook/bone = 100);
-	icon_state = "red1";
-	color = "#c3bab0"
-	},
-/area/facility_hallway/central)
 "Xj" = (
 /obj/structure/closet/crate/freezer/surplus_limbs{
 	anchored = 1
@@ -9934,9 +9978,8 @@
 /turf/open/floor/pod/dark,
 /area/facility_hallway/training)
 "XM" = (
-/obj/structure/chair/sofa/corp/left{
-	dir = 8;
-	can_buckle = 0
+/obj/effect/turf_decal/loading_area/white{
+	dir = 8
 	},
 /turf/open/floor/facility/dark{
 	color = "#ccc8c0"
@@ -9956,11 +9999,24 @@
 	},
 /area/department_main/safety)
 "XT" = (
-/obj/machinery/computer/abnormality/training_rabbit{
-	dir = 4
+/obj/effect/turf_decal/siding/brown,
+/obj/machinery/computer/extraction_cargo{
+	pixel_x = 4;
+	dir = 1
 	},
-/turf/open/floor/pod/light,
-/area/facility_hallway/information)
+/obj/structure/window/reinforced/spawner/west{
+	resistance_flags = 115
+	},
+/obj/structure/window/reinforced/spawner{
+	resistance_flags = 115
+	},
+/obj/structure/window/reinforced/spawner/west{
+	resistance_flags = 115;
+	pixel_y = 65;
+	pixel_x = -1
+	},
+/turf/open/floor/pod/dark,
+/area/department_main/extraction)
 "XW" = (
 /obj/effect/turf_decal/sand/plating{
 	color = "#c3bab0"
@@ -10232,16 +10288,15 @@
 /turf/open/floor/pod/light,
 /area/facility_hallway/human)
 "Zo" = (
-/obj/effect/turf_decal/siding/purple{
-	color = "#511c4b"
+/obj/effect/turf_decal/siding/brown,
+/obj/structure/railing{
+	resistance_flags = 115;
+	name = "wing-grade railing";
+	desc = "Indestructible railing created in a vain attempt of fool-proofing the wing's workplace."
 	},
-/obj/machinery/light{
-	dir = 8;
-	pixel_x = -9;
-	pixel_y = 4
-	},
+/obj/structure/table/reinforced,
 /turf/open/floor/pod/dark,
-/area/department_main/information)
+/area/department_main/extraction)
 "Zu" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
@@ -10363,12 +10418,12 @@
 /turf/open/floor/facility/dark,
 /area/facility_hallway/control)
 "ZP" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 8
-	},
 /obj/effect/turf_decal/trimline/purple/filled/warning,
 /obj/structure/disposalpipe/junction/flip{
 	dir = 1
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 9
 	},
 /turf/open/floor/pod/light,
 /area/department_main/information)
@@ -33913,7 +33968,7 @@ oz
 PH
 aL
 pQ
-Xb
+xI
 KF
 pQ
 pQ
@@ -34688,7 +34743,7 @@ pQ
 pQ
 pQ
 uJ
-Xb
+xI
 pQ
 pQ
 pQ
@@ -34938,8 +34993,8 @@ bA
 WT
 Ze
 oz
-Mh
-Mh
+ip
+ip
 oz
 oz
 aL
@@ -35198,8 +35253,8 @@ oz
 JB
 QU
 gM
-oz
-aL
+Mh
+UW
 aL
 pQ
 pQ
@@ -35455,8 +35510,8 @@ zv
 aO
 ml
 Tq
-Mh
-aL
+ip
+tr
 aL
 pQ
 pQ
@@ -35713,7 +35768,7 @@ sR
 oX
 ao
 ip
-HA
+Tv
 HA
 rD
 rD
@@ -35938,7 +35993,7 @@ pQ
 pQ
 pQ
 pQ
-Xb
+xI
 uJ
 pQ
 pQ
@@ -36246,7 +36301,7 @@ gl
 nO
 aL
 xT
-Xb
+xI
 dr
 pQ
 pQ
@@ -36458,7 +36513,7 @@ pQ
 pQ
 pQ
 KF
-Xb
+xI
 Fy
 pQ
 pQ
@@ -36722,8 +36777,8 @@ dS
 dS
 oC
 dS
-dS
-dS
+UV
+mN
 vx
 rO
 zQ
@@ -36969,18 +37024,18 @@ XG
 wP
 dS
 dS
-dS
 vh
 dS
 dS
 dS
 dS
-UV
-PX
+dS
+dS
+dS
 dS
 lW
-VL
-VL
+yy
+wQ
 VL
 VL
 Gx
@@ -37226,8 +37281,8 @@ WV
 WV
 PH
 PH
-aL
-aH
+tr
+pQ
 pQ
 pQ
 pQ
@@ -37282,7 +37337,7 @@ aL
 aL
 pQ
 dr
-Xb
+xI
 uJ
 pQ
 pQ
@@ -37483,8 +37538,8 @@ cB
 cB
 hE
 hE
-hE
-UW
+cB
+lm
 lm
 hE
 hE
@@ -37493,10 +37548,10 @@ hE
 hE
 aL
 aL
-yy
-wQ
-Cc
-tF
+VL
+jE
+cH
+Zo
 Sg
 eu
 wy
@@ -37741,7 +37796,7 @@ ig
 px
 hE
 FD
-Tv
+bc
 bc
 Pc
 hE
@@ -37752,8 +37807,8 @@ aL
 aL
 VL
 LG
-cH
-bY
+Rm
+XT
 Dx
 Dx
 zi
@@ -37997,7 +38052,7 @@ wL
 Yx
 DS
 ZN
-Dj
+RI
 Bb
 QA
 rf
@@ -38267,7 +38322,7 @@ aL
 VL
 wr
 cH
-bY
+HL
 Sg
 Sg
 Mu
@@ -38524,7 +38579,7 @@ aL
 yy
 wQ
 Cc
-tF
+NK
 Sg
 Dx
 zi
@@ -38779,9 +38834,9 @@ hE
 aL
 aL
 yy
-oA
+wQ
 ha
-NK
+tF
 bu
 LT
 Ah
@@ -39592,7 +39647,7 @@ nO
 aL
 aL
 aL
-Xb
+xI
 KF
 pQ
 pQ
@@ -41061,7 +41116,7 @@ pQ
 pQ
 pQ
 pQ
-Xb
+xI
 dr
 pQ
 pQ
@@ -41857,7 +41912,7 @@ Wk
 Zc
 wS
 JP
-ZA
+hh
 hh
 hh
 bG
@@ -42114,7 +42169,7 @@ cv
 rk
 fs
 JP
-Jt
+hh
 hh
 hh
 bG
@@ -42371,7 +42426,7 @@ cv
 rk
 fs
 JP
-KB
+hh
 hh
 hh
 bG
@@ -42408,7 +42463,7 @@ AY
 iU
 MM
 Nt
-ax
+IU
 ZP
 DR
 Yi
@@ -42666,7 +42721,7 @@ QW
 QW
 YV
 Vz
-hk
+oA
 cA
 lz
 ia
@@ -42923,9 +42978,9 @@ QW
 QW
 Ud
 kj
-hk
+oA
 cA
-mN
+XM
 XM
 uh
 Vg
@@ -43178,12 +43233,12 @@ ax
 Pl
 IM
 HY
-Tf
+sx
 Dp
-hk
+oA
 cA
-uh
-uh
+ot
+ot
 uh
 Vg
 Vg
@@ -43436,11 +43491,11 @@ AY
 DZ
 AY
 hs
-ot
+Dp
 vw
-Zo
 cA
-XT
+cA
+nO
 nO
 nO
 nO
@@ -43692,14 +43747,14 @@ iI
 AY
 DZ
 AY
-Tf
+mL
 fH
-iI
-hk
-bj
-bq
+fH
+at
+ay
+do
 tP
-bq
+Lj
 nO
 Vg
 Vg
@@ -43913,7 +43968,7 @@ FR
 HD
 qW
 JP
-hh
+ZA
 hh
 hh
 bG
@@ -43949,14 +44004,14 @@ iI
 AY
 DZ
 AY
-DD
-jc
+Tf
+Mt
 cd
 hk
 ay
-sx
-sx
-sx
+dX
+ok
+ch
 nO
 zA
 zA
@@ -44170,7 +44225,7 @@ mo
 cv
 Qv
 JP
-hh
+Jt
 hh
 hh
 bG
@@ -44211,9 +44266,9 @@ AJ
 NF
 hk
 ay
-do
+Iw
 Kh
-Lj
+RU
 nO
 aL
 aL
@@ -44427,7 +44482,7 @@ Uv
 CX
 tz
 JP
-hh
+KB
 hh
 hh
 bG
@@ -44468,9 +44523,9 @@ jc
 Qo
 hk
 ay
-dX
-ok
-ch
+PX
+PX
+PX
 nO
 aL
 aL
@@ -44660,7 +44715,7 @@ pQ
 pQ
 pQ
 Fy
-Xb
+xI
 Fy
 pQ
 pQ
@@ -44724,10 +44779,10 @@ On
 iI
 iI
 RE
-Vu
-Iw
+bj
+bq
 wc
-RU
+gA
 nO
 aL
 aL
@@ -44981,7 +45036,7 @@ cA
 cA
 cA
 cA
-dO
+Cx
 nO
 nO
 nO
@@ -47304,7 +47359,7 @@ aL
 aL
 pQ
 Fy
-Xb
+xI
 Fy
 pQ
 pQ
@@ -48019,7 +48074,7 @@ hE
 Ya
 Yx
 Cq
-VK
+TR
 Gt
 gS
 QA
@@ -48277,7 +48332,7 @@ CJ
 Yx
 MK
 ZN
-Dj
+RI
 Of
 ES
 rf
@@ -48535,7 +48590,7 @@ jy
 oq
 hE
 ca
-tr
+hc
 hc
 br
 hE
@@ -48791,8 +48846,8 @@ hE
 cB
 cB
 hE
-hE
-UW
+cB
+lm
 lm
 hE
 hE
@@ -49048,8 +49103,8 @@ PH
 WV
 cc
 dS
-dS
 KQ
+dS
 dS
 dS
 dS
@@ -50077,7 +50132,7 @@ pQ
 pQ
 pQ
 bC
-Xb
+xI
 dr
 pQ
 pQ
@@ -50130,7 +50185,7 @@ pQ
 pQ
 pQ
 dr
-Xb
+xI
 pQ
 pQ
 pQ
@@ -50840,7 +50895,7 @@ pQ
 pQ
 pQ
 uJ
-Xb
+xI
 KF
 pQ
 pQ
@@ -51623,7 +51678,7 @@ pQ
 pQ
 pQ
 dr
-Xb
+xI
 uJ
 pQ
 Ec

--- a/_maps/map_files/Lambda/lambdacorp.dmm
+++ b/_maps/map_files/Lambda/lambdacorp.dmm
@@ -1,4 +1,26 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aa" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/obj/machinery/camera{
+	alpha = 0;
+	short_range = 5;
+	name = "hidden security camera";
+	mouse_opacity = 0;
+	view_range = 5
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/light_emitter{
+	light_power = 4;
+	light_range = 25;
+	set_cap = 3;
+	set_luminosity = 24
+	},
+/turf/open/floor/pod/dark,
+/area/facility_hallway/information)
 "ad" = (
 /obj/structure/disposaloutlet,
 /obj/structure/disposalpipe/trunk,
@@ -97,12 +119,6 @@
 	},
 /turf/open/floor/pod,
 /area/department_main/information)
-"aD" = (
-/obj/effect/turf_decal/trimline/purple/filled/warning{
-	dir = 9
-	},
-/turf/open/floor/pod/dark,
-/area/facility_hallway/information)
 "aF" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/telecomms/receiver/preset_right,
@@ -285,7 +301,9 @@
 /area/facility_hallway/training)
 "bw" = (
 /turf/open/floor/plating/ironsand{
-	color = "#c3bab0"
+	color = "#c3bab0";
+	name = "Outskirt";
+	density = 1
 	},
 /area/space)
 "bz" = (
@@ -299,6 +317,12 @@
 /obj/effect/turf_decal/siding{
 	color = "#7D6521";
 	dir = 1
+	},
+/obj/machinery/button/door/indestructible{
+	id = "extraction1";
+	name = "Observation Deck Shutters";
+	pixel_y = 5;
+	pixel_x = 22
 	},
 /turf/open/floor/pod/light,
 /area/department_main/extraction)
@@ -464,19 +488,6 @@
 	desc = "A huge chunk of wing-grade metal used in various L corporation facilities. Effectively impervious to conventional methods of destruction."
 	},
 /area/facility_hallway/east)
-"cN" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
-/obj/structure/transit_tube/station/reverse{
-	dir = 1;
-	resistance_flags = 115
-	},
-/obj/structure/transit_tube_pod{
-	dir = 4
-	},
-/turf/open/floor/pod/dark,
-/area/facility_hallway/control)
 "cU" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/pod,
@@ -540,15 +551,26 @@
 	desc = "A huge chunk of wing-grade metal used in various L corporation facilities. Effectively impervious to conventional methods of destruction."
 	},
 /area/facility_hallway/east)
+"dr" = (
+/obj/effect/turf_decal/box,
+/obj/structure/toolabnormality/wishwell,
+/turf/open/floor/pod/dark,
+/area/facility_hallway/command)
 "dt" = (
-/turf/open/floor/fakespace{
-	desc = "it is impossible to cross now, this land is no more.";
-	name = "broken reality";
-	density = 1;
-	CanAtmosPass = 0;
-	CanAtmosPassVertical = 0
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
 	},
-/area/space)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/light_emitter{
+	light_power = 4;
+	light_range = 25;
+	set_cap = 3;
+	set_luminosity = 24
+	},
+/turf/open/floor/pod/dark,
+/area/facility_hallway/information)
 "dv" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
@@ -629,6 +651,17 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/carpet/royalblue,
 /area/department_main/command)
+"dG" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/arrows,
+/obj/machinery/light{
+	dir = 1;
+	pixel_y = 19
+	},
+/turf/open/floor/pod,
+/area/facility_hallway/command)
 "dI" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
@@ -712,6 +745,9 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 6
 	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
+	},
 /turf/open/floor/pod/light,
 /area/department_main/command)
 "dW" = (
@@ -744,6 +780,26 @@
 	name = "secure flooring"
 	},
 /area/facility_hallway/control)
+"ef" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/red{
+	color = "#440000";
+	dir = 4
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/disposal/bin{
+	pixel_x = 15;
+	density = 0;
+	resistance_flags = 115
+	},
+/turf/open/floor/plasteel/bluespace{
+	name = "secure flooring"
+	},
+/area/facility_hallway/control)
 "eg" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
@@ -758,22 +814,24 @@
 /obj/item/toy/plush/gebura,
 /turf/open/floor/pod/dark,
 /area/department_main/control)
+"eh" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/obj/effect/light_emitter{
+	light_power = 4;
+	light_range = 25;
+	set_cap = 3;
+	set_luminosity = 24
+	},
+/turf/open/floor/pod/dark,
+/area/facility_hallway/information)
 "ei" = (
 /obj/machinery/telecomms/relay/preset/telecomms,
 /obj/structure/emergency_shield,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/facility_hallway/training)
-"ek" = (
-/obj/effect/turf_decal/trimline/purple/filled,
-/obj/structure/fans/tiny,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/plasteel/bluespace{
-	name = "secure flooring"
-	},
-/area/facility_hallway/information)
 "el" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
@@ -971,6 +1029,21 @@
 	name = "secure flooring"
 	},
 /area/facility_hallway/training)
+"fn" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/light_emitter{
+	light_power = 4;
+	light_range = 25;
+	set_cap = 3;
+	set_luminosity = 24
+	},
+/turf/open/floor/pod/dark,
+/area/facility_hallway/safety)
 "fq" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
@@ -1109,6 +1182,13 @@
 	name = "secure flooring"
 	},
 /area/facility_hallway/safety)
+"fU" = (
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 9
+	},
+/turf/open/floor/pod/light,
+/area/department_main/command)
 "fX" = (
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -1131,11 +1211,11 @@
 /turf/open/floor/pod,
 /area/department_main/safety)
 "ge" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
 	},
 /turf/open/floor/pod/light,
-/area/department_main/command)
+/area/facility_hallway/command)
 "gf" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 9
@@ -1248,21 +1328,6 @@
 	opacity = 0
 	},
 /area/department_main/command)
-"gA" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/light_emitter{
-	light_power = 4;
-	light_range = 25;
-	set_cap = 3;
-	set_luminosity = 24
-	},
-/turf/open/floor/pod/dark,
-/area/facility_hallway/information)
 "gC" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
@@ -1479,13 +1544,15 @@
 /turf/open/floor/pod/light,
 /area/department_main/training)
 "hL" = (
-/turf/open/floor/plating/ironsand{
-	density = 1;
-	name = "Outskirt";
-	CanAtmosPass = 0;
-	CanAtmosPassVertical = 0
+/obj/effect/turf_decal/trimline/purple/filled,
+/obj/structure/fans/tiny,
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
-/area/space)
+/turf/open/floor/plasteel/bluespace{
+	name = "secure flooring"
+	},
+/area/facility_hallway/information)
 "hM" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 5
@@ -1596,21 +1663,6 @@
 	},
 /turf/open/floor/pod/light,
 /area/facility_hallway/information)
-"ij" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/light_emitter{
-	light_power = 4;
-	light_range = 25;
-	set_cap = 3;
-	set_luminosity = 24
-	},
-/turf/open/floor/pod/dark,
-/area/facility_hallway/safety)
 "il" = (
 /obj/structure/refinery,
 /turf/open/floor/carpet/purple,
@@ -1826,23 +1878,10 @@
 	},
 /turf/open/floor/pod/light,
 /area/facility_hallway/training)
-"jl" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
-/turf/open/floor/pod/dark,
-/area/facility_hallway/control)
 "js" = (
 /obj/machinery/door/airlock/glass,
 /turf/open/floor/facility/halls,
 /area/facility_hallway/west)
-"jv" = (
-/obj/effect/turf_decal/trimline/purple/filled,
-/obj/structure/fans/tiny,
-/turf/open/floor/plasteel/bluespace{
-	name = "secure flooring"
-	},
-/area/facility_hallway/information)
 "jw" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
@@ -1872,25 +1911,17 @@
 	opacity = 0
 	},
 /area/department_main/extraction)
-"jD" = (
-/obj/machinery/light{
-	dir = 8;
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/turf/open/floor/pod/light,
-/area/facility_hallway/information)
 "jF" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
 /obj/machinery/chem_dispenser/fullupgrade{
-	dispensable_reagents = list(/datum/reagent/consumable/enzyme,/datum/reagent/consumable/eggyolk,/datum/reagent/consumable/flour,/datum/reagent/consumable/rice,/datum/reagent/consumable/sugar,/datum/reagent/consumable/caramel,/datum/reagent/consumable/honey,/datum/reagent/consumable/salt,/datum/reagent/consumable/blackpepper,/datum/reagent/consumable/soysauce,/datum/reagent/consumable/bbqsauce,/datum/reagent/consumable/ketchup,/datum/reagent/consumable/capsaicin,/datum/reagent/consumable/frostoil,/datum/reagent/consumable/garlic,/datum/reagent/consumable/cherryjelly,/datum/reagent/consumable/bluecherryjelly,/datum/reagent/consumable/vanilla,/datum/reagent/consumable/coco,/datum/reagent/consumable/cornoil,/datum/reagent/consumable/corn_syrup,/datum/reagent/consumable/corn_starch,/datum/reagent/consumable/dry_ramen,/datum/reagent/consumable/clownstears,/datum/reagent/consumable/astrotame,/datum/reagent/consumable/secretsauce,/datum/reagent/consumable/laughsyrup,/datum/reagent/consumable/pancakebatter,/datum/reagent/water/holywater,/datum/reagent/fuel);
+	dispensable_reagents = list(/datum/reagent/consumable/enzyme,/datum/reagent/consumable/eggyolk,/datum/reagent/consumable/flour,/datum/reagent/consumable/rice,/datum/reagent/consumable/sugar,/datum/reagent/consumable/caramel,/datum/reagent/consumable/honey,/datum/reagent/consumable/salt,/datum/reagent/consumable/blackpepper,/datum/reagent/consumable/soysauce,/datum/reagent/consumable/bbqsauce,/datum/reagent/consumable/ketchup,/datum/reagent/consumable/capsaicin,/datum/reagent/consumable/frostoil,/datum/reagent/consumable/garlic,/datum/reagent/consumable/cherryjelly,/datum/reagent/consumable/bluecherryjelly,/datum/reagent/consumable/vanilla,/datum/reagent/consumable/coco,/datum/reagent/consumable/cornoil,/datum/reagent/consumable/corn_syrup,/datum/reagent/consumable/corn_starch,/datum/reagent/consumable/dry_ramen,/datum/reagent/consumable/clownstears,/datum/reagent/consumable/astrotame,/datum/reagent/consumable/secretsauce,/datum/reagent/consumable/laughsyrup,/datum/reagent/consumable/pancakebatter,/datum/reagent/water/holywater,/datum/reagent/fuel,/datum/reagent/consumable/soymilk,/datum/reagent/consumable/milk);
 	name = "Industrial Foodstuff Dispenser";
 	desc = "Creates and dispenses a variety of kitchen ingredients.";
 	emagged_reagents = null;
-	pixel_y = 16;
+	pixel_y = 15;
 	density = 0
 	},
 /turf/open/floor/plasteel/white,
@@ -1903,6 +1934,13 @@
 	name = "secure flooring"
 	},
 /area/facility_hallway/control)
+"jI" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/pod/light,
+/area/department_main/command)
 "jM" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/telecomms/processor/preset_four,
@@ -2223,18 +2261,6 @@
 "lh" = (
 /turf/open/floor/pod/light,
 /area/facility_hallway/information)
-"ll" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
-/obj/effect/light_emitter{
-	light_power = 4;
-	light_range = 25;
-	set_cap = 3;
-	set_luminosity = 24
-	},
-/turf/open/floor/pod/dark,
-/area/facility_hallway/control)
 "ln" = (
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -2360,6 +2386,26 @@
 	opacity = 0
 	},
 /area/department_main/training)
+"mg" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/purple{
+	dir = 8;
+	color = "#511c4b"
+	},
+/obj/machinery/disposal/bin{
+	pixel_x = -15;
+	density = 0;
+	resistance_flags = 115
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/open/floor/plasteel/bluespace{
+	name = "secure flooring"
+	},
+/area/facility_hallway/information)
 "mi" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
@@ -2486,6 +2532,13 @@
 	},
 /turf/open/floor/pod/dark,
 /area/facility_hallway/information)
+"mL" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/pod/dark,
+/area/department_main/command)
 "mM" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -2738,6 +2791,14 @@
 	desc = "A huge chunk of wing-grade metal used in various L corporation facilities. Effectively impervious to conventional methods of destruction."
 	},
 /area/department_main/safety)
+"nS" = (
+/obj/machinery/light{
+	dir = 4;
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/turf/open/floor/pod/light,
+/area/facility_hallway/control)
 "nT" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 5
@@ -2763,6 +2824,12 @@
 /obj/machinery/vending/lobotomyarmband,
 /turf/open/floor/carpet/royalblue,
 /area/department_main/command)
+"oa" = (
+/obj/effect/turf_decal/trimline/red/filled/warning{
+	dir = 5
+	},
+/turf/open/floor/pod/dark,
+/area/facility_hallway/control)
 "oc" = (
 /obj/structure/window/reinforced/fulltile{
 	max_integrity = 500;
@@ -2924,6 +2991,12 @@
 	desc = "A huge chunk of wing-grade metal used in various L corporation facilities. Effectively impervious to conventional methods of destruction."
 	},
 /area/department_main/information)
+"pu" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/turf/open/floor/pod/dark,
+/area/facility_hallway/information)
 "pv" = (
 /obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 9
@@ -3115,19 +3188,15 @@
 	},
 /area/facility_hallway/west)
 "qp" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/arrows{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 4;
-	pixel_x = 9;
-	pixel_y = 4
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 4
 	},
-/turf/open/floor/pod,
-/area/facility_hallway/control)
+/turf/open/floor/pod/light,
+/area/department_main/command)
 "qt" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
@@ -3360,6 +3429,14 @@
 	name = "Outskirt"
 	},
 /area/space)
+"rd" = (
+/obj/machinery/light{
+	dir = 8;
+	pixel_x = -4;
+	pixel_y = 4
+	},
+/turf/open/floor/pod/light,
+/area/facility_hallway/information)
 "rm" = (
 /obj/effect/turf_decal/trimline/green/filled/warning{
 	dir = 9
@@ -3400,6 +3477,21 @@
 	},
 /turf/open/floor/pod/dark,
 /area/facility_hallway/east)
+"rB" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/light_emitter{
+	light_power = 4;
+	light_range = 25;
+	set_cap = 3;
+	set_luminosity = 24
+	},
+/turf/open/floor/pod/dark,
+/area/facility_hallway/training)
 "rE" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/effect/turf_decal/siding/purple{
@@ -3460,16 +3552,6 @@
 /area/facility_hallway/safety)
 "rV" = (
 /obj/machinery/hydroponics/constructable,
-/obj/item/food/grown/ambrosia/gaia,
-/obj/item/food/grown/ambrosia/gaia,
-/obj/item/food/grown/ambrosia/gaia,
-/obj/item/food/grown/ambrosia/gaia,
-/obj/item/food/grown/ambrosia/gaia,
-/obj/item/food/grown/ambrosia/gaia,
-/obj/item/food/grown/ambrosia/gaia,
-/obj/item/food/grown/ambrosia/gaia,
-/obj/item/food/grown/ambrosia/gaia,
-/obj/item/food/grown/ambrosia/gaia,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
@@ -3559,10 +3641,25 @@
 /turf/open/floor/pod/light,
 /area/department_main/control)
 "sm" = (
-/obj/machinery/door/airlock/glass{
-	icon = 'icons/obj/doors/airlocks/station/atmos.dmi'
+/obj/structure/closet/crate{
+	name = "pe box crate";
+	anchored = 1;
+	opened = 1
 	},
-/turf/open/floor/facility/halls,
+/obj/item/rawpe,
+/obj/item/rawpe,
+/obj/item/rawpe,
+/obj/item/rawpe,
+/obj/item/rawpe,
+/obj/item/rawpe,
+/obj/effect/turf_decal/box/red,
+/obj/item/rawpe,
+/obj/item/rawpe,
+/obj/item/rawpe,
+/obj/item/rawpe,
+/obj/item/rawpe,
+/obj/item/rawpe,
+/turf/open/floor/pod,
 /area/department_main/extraction)
 "sn" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -3694,19 +3791,18 @@
 /turf/closed/indestructible/rock,
 /area/space)
 "sS" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/effect/turf_decal/siding{
+	color = "#7D6521";
+	dir = 1
 	},
-/obj/effect/turf_decal/arrows{
-	dir = 4
+/obj/machinery/button/door/indestructible{
+	id = "extraction1";
+	name = "Observation Deck Shutters";
+	pixel_y = 5;
+	pixel_x = -22
 	},
-/obj/machinery/light{
-	dir = 8;
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/turf/open/floor/pod,
-/area/facility_hallway/information)
+/turf/open/floor/pod/light,
+/area/department_main/extraction)
 "sU" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
@@ -3807,6 +3903,9 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
 /turf/open/floor/pod/light,
 /area/department_main/command)
 "tI" = (
@@ -3830,20 +3929,18 @@
 	},
 /turf/open/floor/pod,
 /area/department_main/information)
-"tS" = (
-/obj/machinery/light{
-	dir = 4;
-	pixel_x = 4;
-	pixel_y = 4
+"tT" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
 	},
 /turf/open/floor/pod/light,
-/area/facility_hallway/control)
-"tT" = (
-/turf/closed/indestructible/reinforced{
-	name = "facility wall";
-	desc = "A huge chunk of wing-grade metal used in various L corporation facilities. Effectively impervious to conventional methods of destruction."
+/area/facility_hallway/command)
+"tU" = (
+/obj/machinery/door/airlock/highsecurity{
+	name = "Extraction Office Secure Area"
 	},
-/area/department_main/extraction)
+/turf/open/floor/facility/halls,
+/area/facility_hallway/command)
 "tW" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 5
@@ -4153,6 +4250,16 @@
 	density = 1
 	},
 /area/facility_hallway/human)
+"vJ" = (
+/obj/machinery/button/door/indestructible{
+	id = "extraction";
+	name = "Extraction Access Shutters";
+	pixel_y = 5;
+	req_one_access_txt = "19";
+	pixel_x = 22
+	},
+/turf/open/floor/pod/light,
+/area/department_main/extraction)
 "vM" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
@@ -4315,33 +4422,6 @@
 	},
 /turf/open/floor/pod/dark,
 /area/facility_hallway/command)
-"wp" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/purple{
-	dir = 8;
-	color = "#511c4b"
-	},
-/obj/machinery/disposal/bin{
-	pixel_x = -15;
-	density = 0;
-	resistance_flags = 115
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/turf/open/floor/plasteel/bluespace{
-	name = "secure flooring"
-	},
-/area/facility_hallway/information)
-"wq" = (
-/obj/effect/turf_decal/trimline/red/filled,
-/obj/structure/fans/tiny,
-/turf/open/floor/plasteel/bluespace{
-	name = "secure flooring"
-	},
-/area/facility_hallway/control)
 "wt" = (
 /obj/machinery/light{
 	dir = 4;
@@ -4589,7 +4669,10 @@
 	},
 /area/facility_hallway/control)
 "xF" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
 /turf/open/floor/pod/light,
@@ -4662,18 +4745,8 @@
 	},
 /area/facility_hallway/command)
 "ye" = (
-/obj/structure/closet/crate{
-	name = "pe box crate";
-	anchored = 1;
-	opened = 1
-	},
-/obj/item/rawpe,
-/obj/item/rawpe,
-/obj/item/rawpe,
-/obj/item/rawpe,
-/obj/item/rawpe,
-/obj/item/rawpe,
 /obj/effect/turf_decal/box/red,
+/obj/machinery/regenerator/safety,
 /turf/open/floor/pod,
 /area/department_main/extraction)
 "yg" = (
@@ -4704,12 +4777,6 @@
 	color = "#ccc8c0"
 	},
 /area/department_main/extraction)
-"yo" = (
-/obj/effect/turf_decal/trimline/red/filled/warning{
-	dir = 5
-	},
-/turf/open/floor/pod/dark,
-/area/facility_hallway/control)
 "ys" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 5
@@ -4754,16 +4821,6 @@
 /area/department_main/safety)
 "yJ" = (
 /obj/machinery/hydroponics/constructable,
-/obj/item/food/grown/ambrosia/gaia,
-/obj/item/food/grown/ambrosia/gaia,
-/obj/item/food/grown/ambrosia/gaia,
-/obj/item/food/grown/ambrosia/gaia,
-/obj/item/food/grown/ambrosia/gaia,
-/obj/item/food/grown/ambrosia/gaia,
-/obj/item/food/grown/ambrosia/gaia,
-/obj/item/food/grown/ambrosia/gaia,
-/obj/item/food/grown/ambrosia/gaia,
-/obj/item/food/grown/ambrosia/gaia,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
@@ -4966,26 +5023,6 @@
 	dir = 6
 	},
 /turf/open/floor/pod/dark,
-/area/facility_hallway/control)
-"Ac" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/red{
-	color = "#440000";
-	dir = 4
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/machinery/disposal/bin{
-	pixel_x = 15;
-	density = 0;
-	resistance_flags = 115
-	},
-/turf/open/floor/plasteel/bluespace{
-	name = "secure flooring"
-	},
 /area/facility_hallway/control)
 "Af" = (
 /obj/effect/spawner/abnormality_room,
@@ -5331,10 +5368,16 @@
 /turf/open/floor/carpet/green,
 /area/department_main/safety)
 "Ci" = (
-/obj/effect/turf_decal/box,
-/obj/structure/toolabnormality/realization,
-/turf/open/floor/pod/dark,
-/area/facility_hallway/control)
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/arrows,
+/obj/machinery/light{
+	dir = 1;
+	pixel_y = 15
+	},
+/turf/open/floor/pod,
+/area/facility_hallway/command)
 "Cj" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/pod/dark,
@@ -5591,18 +5634,6 @@
 	desc = "A huge chunk of wing-grade metal used in various L corporation facilities. Effectively impervious to conventional methods of destruction."
 	},
 /area/facility_hallway/training)
-"DE" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/obj/effect/light_emitter{
-	light_power = 4;
-	light_range = 25;
-	set_cap = 3;
-	set_luminosity = 24
-	},
-/turf/open/floor/pod/dark,
-/area/facility_hallway/information)
 "DK" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 5
@@ -5723,6 +5754,13 @@
 	name = "secure flooring"
 	},
 /area/facility_hallway/safety)
+"Ez" = (
+/obj/effect/turf_decal/trimline/purple/filled,
+/obj/structure/fans/tiny,
+/turf/open/floor/plasteel/bluespace{
+	name = "secure flooring"
+	},
+/area/facility_hallway/information)
 "EC" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
@@ -5784,7 +5822,11 @@
 	},
 /area/facility_hallway/control)
 "EQ" = (
-/turf/closed/indestructible/fakeglass,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/turf/open/floor/pod/dark,
 /area/department_main/command)
 "EX" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
@@ -5827,10 +5869,11 @@
 /turf/open/floor/facility/halls,
 /area/facility_hallway/command)
 "Fh" = (
-/obj/effect/turf_decal/box,
-/obj/structure/toolabnormality/clock,
-/turf/open/floor/pod/dark,
-/area/facility_hallway/information)
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "extraction1"
+	},
+/turf/closed/indestructible/fakeglass,
+/area/department_main/command)
 "Fi" = (
 /obj/effect/turf_decal/siding/brown{
 	dir = 8;
@@ -6105,6 +6148,20 @@
 	},
 /turf/open/floor/pod/dark,
 /area/facility_hallway/information)
+"GC" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/arrows{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8;
+	pixel_x = -9;
+	pixel_y = 4
+	},
+/turf/open/floor/pod,
+/area/facility_hallway/command)
 "GE" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -6185,6 +6242,22 @@
 	},
 /turf/open/floor/noslip,
 /area/facility_hallway/command)
+"Hf" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/obj/effect/landmark/xeno_spawn,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/light_emitter{
+	light_power = 4;
+	light_range = 25;
+	set_cap = 3;
+	set_luminosity = 24
+	},
+/turf/open/floor/pod/dark,
+/area/facility_hallway/information)
 "Hh" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
@@ -6202,6 +6275,19 @@
 	},
 /turf/open/floor/pod/light,
 /area/facility_hallway/human)
+"Hm" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/structure/transit_tube/station/reverse{
+	dir = 1;
+	resistance_flags = 115
+	},
+/obj/structure/transit_tube_pod{
+	dir = 4
+	},
+/turf/open/floor/pod/dark,
+/area/facility_hallway/control)
 "Hn" = (
 /obj/effect/turf_decal/siding/red{
 	color = "#440000";
@@ -6251,12 +6337,6 @@
 /turf/open/floor/pod/dark,
 /area/facility_hallway/command)
 "HA" = (
-/obj/structure/closet/crate{
-	name = "pe box crate";
-	anchored = 1;
-	opened = 1;
-	resistance_flags = 115
-	},
 /obj/item/refiner_filter/yellow{
 	pixel_x = 1;
 	pixel_y = -4
@@ -6265,12 +6345,15 @@
 	pixel_x = 7;
 	pixel_y = 3
 	},
-/obj/item/rawpe,
-/obj/item/rawpe,
-/obj/item/rawpe,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/refiner_filter/red,
+/obj/item/refiner_filter/green,
+/obj/item/rawpe,
+/obj/item/rawpe,
+/obj/item/rawpe,
+/obj/structure/rack,
 /turf/open/floor/carpet/purple,
 /area/department_main/information)
 "HC" = (
@@ -6343,6 +6426,18 @@
 	},
 /turf/open/floor/pod/dark,
 /area/department_main/command)
+"HT" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/pod/light,
+/area/department_main/command)
 "HU" = (
 /obj/effect/turf_decal/trimline/green/filled/line,
 /turf/open/floor/pod,
@@ -6385,12 +6480,10 @@
 /turf/open/floor/carpet/green,
 /area/department_main/safety)
 "If" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/arrows,
-/turf/open/floor/pod,
-/area/facility_hallway/control)
+/obj/effect/turf_decal/box,
+/obj/structure/toolabnormality/realization,
+/turf/open/floor/pod/dark,
+/area/facility_hallway/command)
 "Ih" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
@@ -6485,6 +6578,9 @@
 "Is" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 10
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 4
 	},
 /turf/open/floor/pod/light,
 /area/department_main/command)
@@ -6642,6 +6738,11 @@
 "IV" = (
 /obj/effect/turf_decal/trimline/yellow/filled,
 /obj/structure/sign/ordealmonitor,
+/obj/machinery/light{
+	dir = 8;
+	pixel_x = -9;
+	pixel_y = 4
+	},
 /turf/open/floor/pod/dark,
 /area/department_main/command)
 "IZ" = (
@@ -6661,6 +6762,12 @@
 	},
 /turf/open/floor/pod/dark,
 /area/facility_hallway/east)
+"Je" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/pod/light,
+/area/facility_hallway/command)
 "Ji" = (
 /obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 10
@@ -6778,6 +6885,18 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/facility_hallway/training)
+"JA" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/effect/light_emitter{
+	light_power = 4;
+	light_range = 25;
+	set_cap = 3;
+	set_luminosity = 24
+	},
+/turf/open/floor/pod/dark,
+/area/facility_hallway/control)
 "JB" = (
 /obj/machinery/door/poddoor/shutters/window/preopen,
 /obj/effect/turf_decal/trimline/red/filled/warning,
@@ -6866,6 +6985,16 @@
 	name = "secure flooring"
 	},
 /area/facility_hallway/east)
+"JQ" = (
+/obj/effect/turf_decal/trimline/yellow/filled,
+/obj/structure/sign/ordealmonitor,
+/obj/machinery/light{
+	dir = 4;
+	pixel_x = 9;
+	pixel_y = 4
+	},
+/turf/open/floor/pod/dark,
+/area/department_main/command)
 "JS" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
@@ -7311,6 +7440,12 @@
 	},
 /turf/open/floor/pod,
 /area/department_main/command)
+"Mf" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/pod/light,
+/area/facility_hallway/command)
 "Mg" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 10
@@ -7377,6 +7512,18 @@
 /obj/item/deepscanner{
 	pixel_y = 6
 	},
+/obj/item/deepscanner{
+	pixel_y = 6
+	},
+/obj/item/deepscanner{
+	pixel_y = 6
+	},
+/obj/item/deepscanner{
+	pixel_y = 6
+	},
+/obj/item/deepscanner{
+	pixel_y = 6
+	},
 /turf/open/floor/carpet/purple,
 /area/department_main/information)
 "MA" = (
@@ -7405,6 +7552,15 @@
 	color = "#ccc8c0"
 	},
 /area/facility_hallway/human)
+"MC" = (
+/obj/machinery/door/airlock/glass{
+	icon = 'icons/obj/doors/airlocks/station/atmos.dmi'
+	},
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "extraction"
+	},
+/turf/open/floor/facility/halls,
+/area/department_main/extraction)
 "MF" = (
 /obj/structure/window/reinforced/fulltile{
 	opacity = 1;
@@ -7537,6 +7693,15 @@
 	},
 /turf/open/floor/pod/dark,
 /area/facility_hallway/west)
+"Nj" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/arrows{
+	dir = 8
+	},
+/turf/open/floor/pod,
+/area/facility_hallway/command)
 "No" = (
 /obj/effect/turf_decal/siding/brown{
 	dir = 1;
@@ -7557,6 +7722,13 @@
 	},
 /turf/open/floor/pod/light,
 /area/facility_hallway/safety)
+"Nx" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/pod/light,
+/area/department_main/command)
 "Nz" = (
 /obj/effect/turf_decal/delivery/red,
 /obj/machinery/light{
@@ -7638,6 +7810,20 @@
 	},
 /turf/open/floor/pod/light,
 /area/facility_hallway/information)
+"NM" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/arrows{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4;
+	pixel_x = 9;
+	pixel_y = 4
+	},
+/turf/open/floor/pod,
+/area/facility_hallway/command)
 "NN" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
@@ -7655,6 +7841,15 @@
 	},
 /turf/open/floor/pod/light,
 /area/facility_hallway/training)
+"NS" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/arrows{
+	dir = 4
+	},
+/turf/open/floor/pod,
+/area/facility_hallway/command)
 "NT" = (
 /obj/machinery/cryopod{
 	dir = 8
@@ -7828,6 +8023,12 @@
 /area/department_main/training)
 "Ph" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
 /turf/open/floor/pod/light,
 /area/department_main/command)
 "Pi" = (
@@ -7871,28 +8072,6 @@
 	},
 /turf/open/floor/carpet/red,
 /area/department_main/control)
-"Ps" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/obj/machinery/camera{
-	alpha = 0;
-	short_range = 5;
-	name = "hidden security camera";
-	mouse_opacity = 0;
-	view_range = 5
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/light_emitter{
-	light_power = 4;
-	light_range = 25;
-	set_cap = 3;
-	set_luminosity = 24
-	},
-/turf/open/floor/pod/dark,
-/area/facility_hallway/information)
 "Pu" = (
 /obj/machinery/sleeper/syndie{
 	dir = 8
@@ -7932,6 +8111,26 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/pod/dark,
 /area/facility_hallway/east)
+"PE" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/arrows{
+	dir = 1
+	},
+/obj/effect/light_emitter{
+	light_power = 4;
+	light_range = 25;
+	set_cap = 3;
+	set_luminosity = 24
+	},
+/obj/machinery/camera{
+	alpha = 0;
+	short_range = 13;
+	name = "hidden security camera";
+	mouse_opacity = 0;
+	view_range = 13
+	},
+/turf/open/floor/pod,
+/area/facility_hallway/command)
 "PH" = (
 /obj/machinery/computer/camera_advanced{
 	resistance_flags = 115;
@@ -7985,6 +8184,13 @@
 	},
 /turf/open/floor/pod/light,
 /area/facility_hallway/east)
+"PQ" = (
+/obj/effect/turf_decal/trimline/red/filled,
+/obj/structure/fans/tiny,
+/turf/open/floor/plasteel/bluespace{
+	name = "secure flooring"
+	},
+/area/facility_hallway/control)
 "PS" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 9
@@ -8136,6 +8342,9 @@
 /turf/open/floor/pod/dark,
 /area/facility_hallway/information)
 "QF" = (
+/obj/machinery/door/poddoor/shutters/window/preopen{
+	id = "extraction1"
+	},
 /turf/closed/indestructible/fakeglass,
 /area/department_main/extraction)
 "QG" = (
@@ -8214,6 +8423,13 @@
 	},
 /turf/open/floor/pod/dark,
 /area/facility_hallway/command)
+"Rl" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/pod/light,
+/area/department_main/command)
 "Ro" = (
 /obj/machinery/computer/cryopod{
 	pixel_y = 28
@@ -8307,6 +8523,12 @@
 	},
 /turf/open/floor/pod/dark,
 /area/facility_hallway/east)
+"RK" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/turf/open/floor/pod/dark,
+/area/facility_hallway/control)
 "RL" = (
 /obj/machinery/telecomms/server/presets/command{
 	name = "Command Server"
@@ -8615,6 +8837,15 @@
 	},
 /turf/open/floor/pod/dark,
 /area/facility_hallway/control)
+"Tj" = (
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 5
+	},
+/turf/open/floor/pod/light,
+/area/department_main/command)
 "Tk" = (
 /obj/structure/table/wood/fancy/orange{
 	resistance_flags = 115
@@ -8725,7 +8956,7 @@
 /area/facility_hallway/human)
 "TK" = (
 /obj/effect/turf_decal/box,
-/obj/structure/toolabnormality/wishwell,
+/obj/structure/toolabnormality/clock,
 /turf/open/floor/pod/dark,
 /area/facility_hallway/control)
 "TL" = (
@@ -8871,22 +9102,6 @@
 	},
 /turf/open/floor/pod,
 /area/department_main/control)
-"Ur" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/obj/effect/landmark/xeno_spawn,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/light_emitter{
-	light_power = 4;
-	light_range = 25;
-	set_cap = 3;
-	set_luminosity = 24
-	},
-/turf/open/floor/pod/dark,
-/area/facility_hallway/information)
 "Ut" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
@@ -8956,6 +9171,12 @@
 	name = "secure flooring"
 	},
 /area/facility_hallway/training)
+"UJ" = (
+/obj/effect/turf_decal/trimline/purple/filled/warning{
+	dir = 9
+	},
+/turf/open/floor/pod/dark,
+/area/facility_hallway/information)
 "UP" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
@@ -9203,21 +9424,6 @@
 	},
 /turf/open/floor/carpet/green,
 /area/department_main/safety)
-"Vd" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/light_emitter{
-	light_power = 4;
-	light_range = 25;
-	set_cap = 3;
-	set_luminosity = 24
-	},
-/turf/open/floor/pod/dark,
-/area/facility_hallway/training)
 "Ve" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
@@ -9297,6 +9503,23 @@
 	name = "secure flooring"
 	},
 /area/facility_hallway/information)
+"Vq" = (
+/obj/item/refiner_filter/blue{
+	pixel_x = 7;
+	pixel_y = 3
+	},
+/obj/item/refiner_filter/yellow{
+	pixel_x = 1;
+	pixel_y = -4
+	},
+/obj/item/refiner_filter/red,
+/obj/item/refiner_filter/green,
+/obj/item/rawpe,
+/obj/item/rawpe,
+/obj/item/rawpe,
+/obj/structure/rack,
+/turf/open/floor/carpet/purple,
+/area/department_main/information)
 "Vt" = (
 /obj/structure/window/reinforced/fulltile{
 	max_integrity = 500;
@@ -9504,28 +9727,18 @@
 /area/facility_hallway/control)
 "Ws" = (
 /obj/machinery/hydroponics/constructable,
-/obj/item/food/grown/ambrosia/gaia,
-/obj/item/food/grown/ambrosia/gaia,
-/obj/item/food/grown/ambrosia/gaia,
-/obj/item/food/grown/ambrosia/gaia,
-/obj/item/food/grown/ambrosia/gaia,
-/obj/item/food/grown/ambrosia/gaia,
-/obj/item/food/grown/ambrosia/gaia,
-/obj/item/food/grown/ambrosia/gaia,
-/obj/item/food/grown/ambrosia/gaia,
-/obj/item/food/grown/ambrosia/gaia,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/bar,
 /obj/machinery/light{
-	dir = 1;
-	pixel_y = 19
-	},
-/obj/machinery/light{
 	dir = 8;
 	pixel_x = -9;
 	pixel_y = 4
+	},
+/obj/machinery/light{
+	dir = 1;
+	pixel_y = 19
 	},
 /turf/open/floor/plasteel/sepia,
 /area/facility_hallway/training)
@@ -9741,6 +9954,16 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/pod/dark,
 /area/department_main/extraction)
+"XH" = (
+/obj/machinery/button/door/indestructible{
+	id = "extraction";
+	name = "Extraction Access Shutters";
+	pixel_y = 5;
+	req_one_access_txt = "19";
+	pixel_x = -22
+	},
+/turf/open/floor/pod/light,
+/area/department_main/extraction)
 "XJ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -9794,6 +10017,14 @@
 	},
 /turf/open/floor/pod,
 /area/department_main/command)
+"XV" = (
+/turf/open/floor/plating/ironsand{
+	density = 1;
+	name = "Outskirt";
+	CanAtmosPass = 0;
+	CanAtmosPassVertical = 0
+	},
+/area/space)
 "XY" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
@@ -9821,16 +10052,6 @@
 /obj/machinery/telecomms/bus/preset_four,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/facility_hallway/training)
-"Yf" = (
-/obj/effect/turf_decal/trimline/red/filled,
-/obj/structure/fans/tiny,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/plasteel/bluespace{
-	name = "secure flooring"
-	},
-/area/facility_hallway/control)
 "Yg" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/effect/landmark/latejoin,
@@ -9956,12 +10177,6 @@
 	},
 /turf/open/floor/pod/dark,
 /area/facility_hallway/control)
-"YV" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/turf/open/floor/pod/dark,
-/area/facility_hallway/information)
 "YW" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
@@ -9985,6 +10200,16 @@
 	},
 /turf/open/floor/pod/light,
 /area/department_main/training)
+"Zc" = (
+/obj/effect/turf_decal/trimline/red/filled,
+/obj/structure/fans/tiny,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plasteel/bluespace{
+	name = "secure flooring"
+	},
+/area/facility_hallway/control)
 "Zg" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
@@ -9998,6 +10223,15 @@
 	},
 /turf/open/floor/pod,
 /area/department_main/training)
+"Zo" = (
+/turf/open/floor/fakespace{
+	desc = "it is impossible to cross now, this land is no more.";
+	name = "broken reality";
+	density = 1;
+	CanAtmosPass = 0;
+	CanAtmosPassVertical = 0
+	},
+/area/space)
 "Zp" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
@@ -31593,7 +31827,7 @@ ZN
 ZN
 DD
 if
-Vd
+rB
 og
 DD
 sR
@@ -31828,10 +32062,10 @@ EP
 ML
 iW
 Wo
-Wo
-Wo
-Wo
-Wo
+sR
+sR
+sR
+sR
 sR
 sR
 sR
@@ -32084,11 +32318,11 @@ Bz
 JF
 SZ
 YU
-Vt
-Ma
-Qz
-lw
 Wo
+sR
+sR
+sR
+sR
 sR
 sR
 sR
@@ -32341,11 +32575,11 @@ jH
 jH
 Tx
 oN
-PM
-If
-Ci
-FZ
 Wo
+sR
+sR
+sR
+sR
 sR
 sR
 sR
@@ -32598,10 +32832,10 @@ gf
 Sz
 Sz
 kB
-Vt
-XJ
-qp
-Ej
+Wo
+sR
+sR
+sR
 Wo
 Wo
 Wo
@@ -32615,7 +32849,7 @@ DD
 DD
 DD
 DD
-DD
+iv
 DD
 DD
 DD
@@ -39529,8 +39763,8 @@ Wo
 EP
 bQ
 YU
-wq
-Yf
+PQ
+Zc
 dT
 AF
 jH
@@ -39784,10 +40018,10 @@ Qj
 Qj
 Wo
 xE
-yo
+oa
 oN
 gf
-Ac
+ef
 Sz
 Sz
 kB
@@ -39803,10 +40037,10 @@ Ia
 Ia
 Ia
 Ia
-Ia
-wV
-Ia
-Ia
+PZ
+PZ
+PZ
+PZ
 PZ
 ZU
 ZU
@@ -40060,10 +40294,10 @@ Ia
 Ia
 Ia
 wV
-Ia
-Ia
-Ia
-Ia
+PZ
+ge
+GC
+Je
 PZ
 ZU
 ZU
@@ -40298,7 +40532,7 @@ Qj
 Qj
 Wo
 jf
-jl
+RK
 mv
 Wo
 Qj
@@ -40317,10 +40551,10 @@ Ia
 wV
 wV
 Ia
-Ia
-Ia
-rc
-Ia
+PZ
+Ci
+If
+PE
 PZ
 ZU
 ZU
@@ -40555,7 +40789,7 @@ Wo
 Wo
 Wo
 ec
-ll
+JA
 mv
 Wo
 Qj
@@ -40574,10 +40808,10 @@ wV
 Ia
 wV
 wV
-Ia
-Ia
-Ia
-Ia
+PZ
+Mf
+Nj
+tT
 PZ
 ZU
 ZU
@@ -40812,7 +41046,7 @@ Ia
 Ia
 Wo
 ZR
-jl
+RK
 mv
 Wo
 Qj
@@ -40831,9 +41065,9 @@ wV
 Ia
 Ia
 Ia
-Ia
-Ia
 uO
+uO
+tU
 uO
 uO
 uO
@@ -41069,8 +41303,8 @@ Ia
 Ia
 Wo
 Hn
-cN
-tS
+Hm
+nS
 Wo
 Qj
 Qj
@@ -41088,10 +41322,10 @@ wV
 Ia
 Ia
 wV
-Ia
-Ia
-EQ
+Fh
 we
+mL
+VF
 Zv
 IV
 Zv
@@ -41342,13 +41576,13 @@ Ia
 Ia
 Ia
 wV
-Ia
+xZ
 wV
 Ia
-xZ
-Ia
-EQ
+Fh
 pk
+mL
+VF
 us
 Iq
 tz
@@ -41602,10 +41836,10 @@ wV
 Ia
 wV
 Ia
-Ia
-Ia
-EQ
+Fh
 hP
+Tj
+qp
 xF
 tD
 Is
@@ -41859,13 +42093,13 @@ wV
 wV
 wV
 wV
-Ia
-tT
 uO
 uO
-sm
+uO
+MC
+uO
 gx
-fM
+Rl
 KH
 AI
 sk
@@ -42109,20 +42343,20 @@ Ia
 Ia
 Ia
 Ia
-Ia
-Ia
-wV
-wV
-wV
-wV
-Ia
+XV
+XV
+Zo
+Zo
+Zo
+Zo
+XV
 Ia
 gM
-bJ
+sS
 fE
-fE
+XH
 jC
-fM
+Nx
 Eg
 vE
 zQ
@@ -42366,17 +42600,17 @@ Ia
 Ia
 Ia
 wV
-Ia
-dt
-dt
-dt
-dt
-dt
-Ia
+XV
+bO
+bO
+bO
+bO
+bO
+XV
 Ia
 gM
 MQ
-ye
+sm
 Ox
 XG
 fM
@@ -42623,13 +42857,13 @@ wV
 wV
 Ia
 wV
-Ia
-dt
+XV
 bO
 bO
 bO
-dt
-wV
+bO
+bO
+Zo
 Ia
 QF
 So
@@ -42872,21 +43106,21 @@ qI
 bw
 Ia
 rc
-Ia
-Ia
-wV
-wV
+xZ
 Ia
 wV
-Ia
+wV
 Ia
 wV
-dt
+Ia
+Ia
+Zo
+bO
 bO
 ZW
 bO
-hL
-Ia
+bO
+XV
 Ia
 QF
 Ox
@@ -43137,13 +43371,13 @@ Ia
 wV
 wV
 wV
-wV
-dt
+Zo
 bO
 bO
 bO
-dt
-Ia
+bO
+bO
+XV
 Ia
 QF
 vR
@@ -43394,13 +43628,13 @@ wV
 wV
 Ia
 Ia
-wV
-dt
-dt
-dt
-dt
-dt
-wV
+Zo
+bO
+bO
+bO
+bO
+bO
+Zo
 Ia
 gM
 MQ
@@ -43651,20 +43885,20 @@ Ia
 Ia
 Ia
 Ia
-wV
-wV
-Ia
-wV
-Ia
-wV
-Ia
+Zo
+Zo
+XV
+Zo
+XV
+Zo
+XV
 Ia
 gM
 bJ
 fE
-fE
+vJ
 SY
-fM
+jI
 lt
 ni
 XT
@@ -43915,13 +44149,13 @@ wV
 Ia
 wV
 Ia
-Ia
-tT
 uO
 uO
-sm
+uO
+MC
+uO
 gx
-fM
+Rl
 KH
 gr
 sk
@@ -44172,12 +44406,12 @@ wV
 Ia
 wV
 Ia
-Ia
-Ia
-EQ
+Fh
 dR
+fU
+HT
 Ph
-ge
+xF
 dV
 KH
 Vj
@@ -44426,13 +44660,13 @@ Ia
 wV
 Ia
 Ia
-Ia
+xZ
 wV
 Ia
-xZ
-Ia
-EQ
+Fh
 pk
+EQ
+VF
 CB
 uv
 Py
@@ -44668,14 +44902,14 @@ Ia
 Vi
 YN
 Kc
-jD
+rd
 Vi
 QJ
 QJ
 QJ
 Vi
 Qa
-Ur
+Hf
 lh
 Vi
 Ia
@@ -44686,12 +44920,12 @@ wV
 Ia
 Ia
 wV
-Ia
-Ia
-EQ
+Fh
 nn
+EQ
+VF
 pQ
-IV
+JQ
 pQ
 cF
 Pi
@@ -44924,7 +45158,7 @@ Ia
 Ia
 Vi
 yK
-YV
+pu
 lh
 Vi
 QJ
@@ -44943,9 +45177,9 @@ wV
 wV
 Ia
 Ia
-Ia
-Ia
 uO
+uO
+tU
 uO
 uO
 uO
@@ -45181,7 +45415,7 @@ Vi
 Vi
 Af
 lR
-DE
+eh
 lh
 Vi
 QJ
@@ -45200,10 +45434,10 @@ wV
 bO
 Ia
 Ia
-rc
-Ia
-Ia
-Ia
+PZ
+ge
+NS
+Je
 PZ
 ZU
 ZU
@@ -45438,7 +45672,7 @@ QJ
 QJ
 Vi
 Qa
-YV
+pu
 lh
 Vi
 QJ
@@ -45457,10 +45691,10 @@ wV
 Ia
 Ia
 Ia
-Ia
-Ia
-Ia
-Ia
+PZ
+dG
+dr
+PE
 PZ
 ZU
 ZU
@@ -45714,10 +45948,10 @@ Ia
 Ia
 Ia
 Ia
-wV
-Ia
-Ia
-Ia
+PZ
+Mf
+NM
+tT
 PZ
 ZU
 ZU
@@ -45952,10 +46186,10 @@ QJ
 QJ
 Vi
 lR
-aD
+UJ
 Gt
 DK
-wp
+mg
 XY
 XY
 Wa
@@ -45971,10 +46205,10 @@ Ia
 Ia
 wV
 Ia
-Ia
-Ia
-Ia
-Ia
+PZ
+PZ
+PZ
+PZ
 PZ
 ZU
 ZU
@@ -46211,8 +46445,8 @@ Vi
 Qa
 Gp
 AS
-jv
-ek
+Ez
+hL
 VW
 IM
 Yy
@@ -49031,7 +49265,7 @@ sR
 sR
 sR
 QV
-wc
+Oi
 Sv
 cW
 vN
@@ -49041,7 +49275,7 @@ CV
 CV
 sB
 aC
-il
+Vq
 HC
 ep
 Zt
@@ -49288,7 +49522,7 @@ sR
 sR
 sR
 QV
-Oi
+OH
 mq
 sp
 vN
@@ -49545,13 +49779,13 @@ sR
 sR
 sR
 QV
-OH
+wc
 di
 EY
 vN
 kn
 ZH
-EF
+il
 EF
 KE
 eq
@@ -50065,7 +50299,7 @@ hs
 Kn
 Kh
 ZH
-EF
+il
 EF
 KE
 BK
@@ -53158,10 +53392,10 @@ DK
 XY
 XY
 Wa
-hv
-pd
-sS
-hs
+Vi
+sR
+sR
+sR
 Vi
 Vi
 Vi
@@ -53415,11 +53649,11 @@ Vo
 Vo
 ae
 Gt
-AU
-yZ
-Fh
-iT
 Vi
+sR
+sR
+sR
+sR
 sR
 sR
 sR
@@ -53672,11 +53906,11 @@ aq
 Mg
 Ya
 AS
-hv
-ia
-IC
-gH
 Vi
+sR
+sR
+sR
+sR
 sR
 sR
 sR
@@ -53930,10 +54164,10 @@ lR
 Pn
 Xd
 Vi
-Vi
-Vi
-Vi
-Vi
+sR
+sR
+sR
+sR
 sR
 sR
 sR
@@ -54176,7 +54410,7 @@ QJ
 QJ
 Vi
 tI
-Ps
+aa
 lh
 Vi
 QJ
@@ -54209,7 +54443,7 @@ Bi
 Bi
 VM
 Gc
-ij
+fn
 BZ
 VM
 sR
@@ -55212,7 +55446,7 @@ QJ
 QJ
 Vi
 tI
-gA
+dt
 lh
 Vi
 sR


### PR DESCRIPTION
Fixed issues regarding the map

## About The Pull Request

A couple of minor map fixes, such as including milk and soy milk in industrial foodstuff dispenser, adding more fake glass to prevent out of bounds shenanigans, added regenerator to extraction, changes to refinery, and lastly adding missing abnormality cell spawner. 

## Why It's Good For The Game

a lot of QoL map changes

## Changelog
:cl:
add: Added QoL Changes to map Lambda and Kappa
tweak: tweaked industrial foodstuff dispenser
/:cl: