### PR TITLE
Fixes CoL13 crate chances

### DIFF
--- a/ModularTegustation/tegu_items/associations/cityspawners.dm
+++ b/ModularTegustation/tegu_items/associations/cityspawners.dm
@@ -46,7 +46,6 @@
 		/obj/structure/lootcrate/workshoprosespanner,
 		/obj/structure/lootcrate/backstreets,
 		/obj/structure/lootcrate/jcorp,
-		/obj/structure/lootcrate/limbus,
 		)
 
 /obj/effect/landmark/cratespawn/Initialize()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Crate spawns were coded in a way limbus crates were listed twice increasing their chances of being spawned within ruins
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The game was rigged from the start, this fixes that
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixed limbus crates having double the normal chance of rolling when spawned within ruins
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
