### PR TITLE
adds fetus, philip and child of the galaxy to flesh idol blacklist

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/waw/flesh_idol.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/flesh_idol.dm
@@ -36,7 +36,7 @@
 	var/list/blacklist = list(/mob/living/simple_animal/hostile/abnormality/melting_love, /mob/living/simple_animal/hostile/abnormality/distortedform,
 				/mob/living/simple_animal/hostile/abnormality/white_night, /mob/living/simple_animal/hostile/abnormality/nihil,
 				/mob/living/simple_animal/hostile/abnormality/galaxy_child, /mob/living/simple_animal/hostile/abnormality/fetus,
-				)
+				/mob/living/simple_animal/hostile/abnormality/crying_children, )
 
 /mob/living/simple_animal/hostile/abnormality/flesh_idol/WorkComplete(mob/living/carbon/human/user, work_type, pe)
 	..()

--- a/code/modules/mob/living/simple_animal/abnormality/waw/flesh_idol.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/flesh_idol.dm
@@ -34,7 +34,9 @@
 	var/run_num = 2		//How many things you breach
 
 	var/list/blacklist = list(/mob/living/simple_animal/hostile/abnormality/melting_love, /mob/living/simple_animal/hostile/abnormality/distortedform,
-				/mob/living/simple_animal/hostile/abnormality/white_night, /mob/living/simple_animal/hostile/abnormality/nihil)
+				/mob/living/simple_animal/hostile/abnormality/white_night, /mob/living/simple_animal/hostile/abnormality/nihil,
+				/mob/living/simple_animal/hostile/abnormality/galaxy_child, /mob/living/simple_animal/hostile/abnormality/fetus,
+				)
 
 /mob/living/simple_animal/hostile/abnormality/flesh_idol/WorkComplete(mob/living/carbon/human/user, work_type, pe)
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
These three were added each for their respective reasons
Galaxy is a instant unavoidable fuck you, arguments may be made about abnos like prince however their effects are minor and can be easily undone unlike death.
Philip was added due to the same reason as DF and Nihil, being a major boss.
Fetus may sound out of place in this blacklist however he is also a unavoidable middle finger as there is no way of stopping his crying without death, if he were to instantly kill the agent there would be no difference.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
We should not have a abnormality instantly kill agents with no counterplay, the excuse of "Don't work Flesh Idol" also does not work as meltdown works count towards his breach counter this will hopefully make the game healthier.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Adds Phillip, Child of the galaxy and nameless fetus to Flesh Idol blacklist
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
