### PR TITLE
Fixes N-Corp hideout having no recruit armor, removes the last pale seal

### DIFF
--- a/_maps/RandomRooms/backstreets/large_north/robot_lna.dmm
+++ b/_maps/RandomRooms/backstreets/large_north/robot_lna.dmm
@@ -223,9 +223,7 @@
 /obj/structure/closet/crate/large,
 /obj/item/ego_weapon/city/ncorp_mark,
 /obj/item/ego_weapon/city/ncorp_mark/black,
-/obj/item/ego_weapon/city/ncorp_mark/pale,
 /obj/item/ego_weapon/city/ncorp_mark/white,
-/obj/item/soap/ncorporation,
 /turf/open/floor/engine,
 /area/city/backstreets_room)
 "S" = (

--- a/_maps/templates/syndicate_office/nagelcorp.dmm
+++ b/_maps/templates/syndicate_office/nagelcorp.dmm
@@ -457,6 +457,12 @@
 	name = "ncorp recruit equipment crate";
 	opened = 1
 	},
+/obj/item/clothing/suit/armor/ego_gear/city/ncorp/weak,
+/obj/item/clothing/suit/armor/ego_gear/city/ncorp/weak,
+/obj/item/clothing/suit/armor/ego_gear/city/ncorp/weak,
+/obj/item/clothing/suit/armor/ego_gear/city/ncorp/weak,
+/obj/item/clothing/suit/armor/ego_gear/city/ncorp/weak,
+/obj/item/clothing/suit/armor/ego_gear/city/ncorp/weak,
 /turf/open/floor/stone,
 /area/city/backstreets_room)
 "wu" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes the pale seal and soap from the robot ruin, adds 6 N-Corp Klein armors to N-Corp hideout of the weak variant
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
N-Corp needs their recruiting gimmick so that was fixed and the pale seal in that ruin was uneeded, only N-Corp could use it and the pale seal was already removed completely from N-Corp
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added 6 weak Klein armor sets to N-Corp hideout
del: Removed pale seal and soap from robot lna ruin
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
