### PR TITLE
KK replace their cardboard swords with steel and kill off a Ronin.

### DIFF
--- a/_maps/templates/syndicate_office/kurokumosake.dmm
+++ b/_maps/templates/syndicate_office/kurokumosake.dmm
@@ -129,9 +129,6 @@
 	dir = 4
 	},
 /obj/item/clothing/suit/armor/ego_gear/city/kurokumo/captain,
-/obj/item/ego_weapon/city/kurokumo{
-	name = "captain kurokumo blade"
-	},
 /obj/item/shears,
 /obj/structure/closet/cabinet{
 	anchored = 1
@@ -139,6 +136,10 @@
 /obj/machinery/light/floor,
 /obj/item/storage/firstaid/regular,
 /obj/item/storage/firstaid/revival,
+/obj/item/ego_weapon/city/kurokumo{
+	name = "captain kurokumo blade";
+	force = 60
+	},
 /turf/open/floor/carpet/royalblack,
 /area/city/backstreets_room)
 "gh" = (
@@ -736,13 +737,13 @@
 /turf/open/floor/wood,
 /area/city/backstreets_room)
 "GO" = (
-/obj/item/ego_weapon/city/kurokumo/weak,
-/obj/item/ego_weapon/city/kurokumo/weak,
 /obj/item/clothing/suit/armor/ego_gear/city/kurokumo,
 /obj/item/clothing/suit/armor/ego_gear/city/kurokumo,
 /obj/structure/closet/cabinet{
 	anchored = 1
 	},
+/obj/item/ego_weapon/city/kurokumo,
+/obj/item/ego_weapon/city/kurokumo,
 /turf/open/floor/carpet/black,
 /area/city/backstreets_room)
 "Hf" = (
@@ -778,10 +779,10 @@
 /obj/structure/closet/cabinet{
 	anchored = 1
 	},
-/obj/item/ego_weapon/city/kurokumo/weak,
-/obj/item/ego_weapon/city/kurokumo/weak,
 /obj/item/clothing/suit/armor/ego_gear/city/kurokumo,
 /obj/item/clothing/suit/armor/ego_gear/city/kurokumo,
+/obj/item/ego_weapon/city/kurokumo,
+/obj/item/ego_weapon/city/kurokumo,
 /turf/open/floor/carpet/black,
 /area/city/backstreets_room)
 "Jz" = (
@@ -890,13 +891,13 @@
 	},
 /area/city/backstreets_room)
 "PK" = (
-/obj/item/ego_weapon/city/kurokumo/weak,
-/obj/item/ego_weapon/city/kurokumo/weak,
 /obj/structure/closet/cabinet{
 	anchored = 1
 	},
 /obj/item/clothing/suit/armor/ego_gear/city/kurokumo/jacket,
 /obj/item/clothing/suit/armor/ego_gear/city/kurokumo/jacket,
+/obj/item/ego_weapon/city/kurokumo,
+/obj/item/ego_weapon/city/kurokumo,
 /turf/open/floor/carpet/black,
 /area/city/backstreets_room)
 "Qo" = (

--- a/code/modules/jobs/job_types/city/syndicate/kurokumo/captain.dm
+++ b/code/modules/jobs/job_types/city/syndicate/kurokumo/captain.dm
@@ -41,7 +41,7 @@
 			processing.total_positions = 4
 
 		if(istype(processing, /datum/job/ronin))
-			processing.total_positions = 2
+			processing.total_positions = 1
 	. = ..()
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I may have made a minor mistake by buffing BL but keeping the crit reliant syndicate with only 30 red damage on the dust, which is why Im reducing ronins and buffing KK.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
KK should be a threat but their reliance on storing Poise before PvP holds them back too hard especially when theyre a syndicate forced to deal with Ronins
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added base KK blades to base
del: Removed 1 Ronin
tweak: tweaked KK blade to 60 red
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
