### PR TITLE
mech damage fixes

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -156,6 +156,18 @@
 	else
 		return ..()
 
+/obj/vehicle/sealed/mecha/attacked_by(obj/item/I, mob/living/user)
+	if(I.force)
+		user.visible_message(span_danger("[user] hits [src] with [I]!"), span_danger("You hit [src] with [I]!"), null, COMBAT_MESSAGE_RANGE)
+		log_combat(user, src, "attacked", I)
+		var/justice_mod = 1 + (get_modified_attribute_level(user, JUSTICE_ATTRIBUTE)/100)
+		var/damage = I.force * justice_mod
+		if(istype(I, /obj/item/ego_weapon))
+			var/obj/item/ego_weapon/theweapon = I
+			damage *= theweapon.force_multiplier
+		take_damage(damage, I.damtype, attack_dir = get_dir(src, user))
+		return TRUE
+
 /**
  * Last proc in the [/obj/item/proc/melee_attack_chain]
  *

--- a/code/modules/vehicles/mecha/combat/combat.dm
+++ b/code/modules/vehicles/mecha/combat/combat.dm
@@ -17,3 +17,18 @@
 		if(istype(I, /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/))
 			var/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/gun = I
 			gun.projectiles_cache = gun.projectiles_cache_max
+
+/obj/vehicle/sealed/mecha/combat/attack_animal(mob/living/simple_animal/user)
+	log_message("Attack by simple animal. Attacker - [user].", LOG_MECHA, color="red")
+	if(!user.melee_damage_upper && !user.obj_damage)
+		user.emote("custom", message = "[user.friendly_verb_continuous] [src].")
+		return 0
+	else
+		var/play_soundeffect = 1
+		if(user.environment_smash)
+			play_soundeffect = 0
+			playsound(src, 'sound/effects/bang.ogg', 50, TRUE)
+		var/animal_damage = rand(user.melee_damage_lower,user.melee_damage_upper)
+		log_combat(user, src, "attacked")
+		attack_generic(user, animal_damage, user.melee_damage_type, MELEE, play_soundeffect)
+		return 1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
All simple animals deal "20 * environment_smash" damage to mechs and environment_smash is 1 for all abnormalities regardless of threat level. This pr makes combat mechs take actual simple mob damage instead.
Additionally added directional armor and justice scaling to weapon attacks from humans.

Since most abnoramality damage is more than 20 this change will require mechs to get more armor and/or integrity to have similar survivability as before.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
All abnormalities no longer deal same damage to mechs regardless of their actual damage stats.
Support for mech vs human combat if that ever happens.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Justice modifier and direction affect weapon damage dealt to mechs
fix: fixed mechs taking 20 damage regardless of abnormality damage stats
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
