### PR TITLE
Possible fix to dead followers following

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/ordeal/steel.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/steel.dm
@@ -51,7 +51,7 @@
 /mob/living/simple_animal/hostile/ordeal/steel_dawn/LoseAggro()
 	. = ..()
 	a_intent_change(INTENT_HELP)
-	if(leader)
+	if(leader && stat != DEAD)
 		Goto(leader,move_to_delay,1)
 
 //More Mutated Subtype of Dawns, they are fast and hit faster.


### PR DESCRIPTION

## About The Pull Request
When a steel loses aggro it auto returns to its leader without checking if the steel is already dead. Now it checks the stat of the steel losing aggro.

## Changelog
:cl:
fix: dead steels following commanders.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
