### PR TITLE
L Corp Crate scams you less and include injectors now

### DIFF
--- a/ModularTegustation/tegu_items/refinery/crates/corporation.dm
+++ b/ModularTegustation/tegu_items/refinery/crates/corporation.dm
@@ -3,17 +3,14 @@
 	name = "Lobotomy Corporation Gear Crate"
 	desc = "A crate recieved from headquarters. Contains standard gear for lobotomy corporation employees. Open with a Crowbar."
 	icon_state = "crate_lc"
-	rarechance = 10
+	rarechance = 25
+	veryrarechance = 10
 	lootlist =	list(
 		/obj/item/powered_gadget/detector_gadget/abnormality,
 		/obj/item/powered_gadget/slowingtrapmk1,
 		/obj/item/clerkbot_gadget,
 		/obj/item/powered_gadget/handheld_taser,
-		/obj/item/storage/box/minertracker,
 		/obj/item/forcefield_projector,
-		/obj/item/flashlight/seclite,
-		/obj/item/storage/belt/ego,
-		/obj/item/safety_kit,
 		/obj/item/reagent_containers/hypospray/emais,
 		/obj/item/clothing/glasses/meson,
 		/obj/item/powered_gadget/vitals_projector,
@@ -27,6 +24,13 @@
 		/obj/item/managerbullet,
 		/obj/item/powered_gadget/teleporter,
 		/obj/item/tool_extractor,
+	)
+
+	//Injectors, quite desireable as they are quite expensive.
+	veryrareloot =	list(
+		/obj/item/trait_injector/agent_workchance_trait_injector,
+		/obj/item/trait_injector/clerk_fear_immunity_injector,
+		/obj/item/trait_injector/officer_upgrade_injector,
 	)
 
 //K Corporation


### PR DESCRIPTION
## About The Pull Request

Removed some of the cheaper extraction items from the L Corp Crate (those that you can buy for less than a PE box worth of PE).
Removed some of the more common/easily findable items from the L Corp Crate.
Made the Rare pool of the L Corp Crate more common (10% --> 25%)
Added a very rare loot pool (10%) which include Officer Upgrade Injector, Work Chance Injector and Clerk Fear Immunity Injector.

## Why It's Good For The Game

The L Corp power output is often avoided due to the L Corp Crate having some subpar items, as beside the Enkephalin Resonance Unit and maybe the occasional bullet that might come in handy, there really wasnt that much interesting items to get. Sure you could get some items for cheaper but it was pretty RNG.
By clearing the pool of scams/very common items, we add more value to the crate.
We make the rare loot pool more common to make the items worth using more.
We add a very rare pool of items that include the work chance injector for agent, which is quite expensive, the officer stat upgrade which is also expensive AND the fear immunity injector for clerks to, every now and then, allow a combat clerk or very supportive clerk to assist in fighting the abnormalities, granted he knows what he is doing.

All in all, you now have a good reason to run the L Corp Gacha.