### PR TITLE
CENSORED and ??? no longer do enhanced obj damage

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/aleph/censored.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/censored.dm
@@ -17,7 +17,6 @@
 	fear_level = ALEPH_LEVEL + 3
 	health = 4000
 	maxHealth = 4000
-	obj_damage = 600
 	damage_coeff = list(RED_DAMAGE = 0.6, WHITE_DAMAGE = 0.8, BLACK_DAMAGE = 0.4, PALE_DAMAGE = 1)
 	melee_damage_type = BLACK_DAMAGE
 	melee_damage_lower = 75
@@ -240,7 +239,6 @@
 	/* Stats */
 	health = 600
 	maxHealth = 600
-	obj_damage = 300
 	damage_coeff = list(RED_DAMAGE = 0.8, WHITE_DAMAGE = 1.2, BLACK_DAMAGE = 0.5, PALE_DAMAGE = 1)
 	melee_damage_type = BLACK_DAMAGE
 	melee_damage_lower = 25


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
CENSORED no longer deals 15x the obj damage of all other abnos and ??? no longer deals 7.5x the obj damage of abnos as well
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
We don't need this anymore, door bolting is gone, reduced to atoms, and CENSORED and its minions can't oneshot doors or the R-Corp comms thingamajig
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: CENSORED and its minions no longer do massively higher object damage
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
