### PR TITLE
hammer rhino improvements

### DIFF
--- a/code/modules/vehicles/mecha/equipment/weapons/mecha_melee.dm
+++ b/code/modules/vehicles/mecha/equipment/weapons/mecha_melee.dm
@@ -1,7 +1,9 @@
 /obj/item/mecha_parts/mecha_equipment/hammer
 	name = "Rhino Hammer (Red)"
 	desc = "Equipment for smashing and bashing. Does Red Damage"
-	icon_state = "mecha_drill"
+	icon = 'ModularTegustation/Teguicons/workshop.dmi'
+	icon_state = "hammertemplate"
+	color = "#db2121"
 	equip_cooldown = 15
 	energy_drain = 10
 	force = 200
@@ -14,7 +16,9 @@
 /obj/item/mecha_parts/mecha_equipment/hammer/rhinoblade
 	name = "Rhino Hammer (Black)"
 	desc = "Equipment for cutting and slicing. Does Black damage"
-	icon_state = "mecha_drill"
+	icon = 'ModularTegustation/Teguicons/workshop.dmi'
+	icon_state = "hammertemplate"
+	color = "#210f3d"
 	equip_cooldown = 15
 	energy_drain = 10
 	force = 200
@@ -31,10 +35,36 @@
 
 	if(isliving(target))
 		var/mob/living/L = target
-		L.apply_damage(force, damtype, null, L.run_armor_check(null, damtype), spread_damage = TRUE)
-		playsound(src,'sound/weapons/fixer/generic/club2.ogg',40,TRUE)
+		//for the immunity/healing visual effects
+		if(ishostile(target))
+			var/mob/living/simple_animal/hostile/H = target
+			H.attack_threshold_check(force, damtype)
+		else
+			L.apply_damage(force, damtype, null, L.run_armor_check(null, damtype), spread_damage = TRUE)
+		if(prob(50))
+			L.add_splatter_floor(get_turf(L))
+		chassis.do_attack_animation(L)
+		playsound(src, 'sound/weapons/fixer/generic/club2.ogg', 40, TRUE)
+		chassis.visible_message(span_danger("[chassis.name] smashes [L] with [src]!"), ignored_mobs = list(source, L))
+		to_chat(source, span_danger("You smash [L] with your [src]!"))
+		to_chat(L, span_danger("[chassis.name] smashes you with [src]!"))
+		log_combat(source, L, "attacked", src)
+	else if(ismecha(target))
+		var/obj/vehicle/sealed/mecha/M = target
+		M.take_damage(force, damtype, attack_dir = get_dir(M, src))
+		chassis.do_attack_animation(M)
+		playsound(src, 'sound/weapons/fixer/generic/club2.ogg', 40, TRUE)
+		chassis.visible_message(span_danger("[chassis.name] smashes [M.name] with [src]!"), ignored_mobs = M.occupants + source)
+		to_chat(source, span_danger("You smash [M.name] with [src]!"))
+		to_chat(M.occupants, span_danger("[chassis.name] smashes you with [src]!"))
+		log_combat(source, M, "attacked", src)
+	else if(isstructure(target) || ismachinery(target))
+		var/obj/O = target
+		O.take_damage(force / 2, damtype)
+		chassis.do_attack_animation(O)
+		playsound(src, 'sound/weapons/fixer/generic/club2.ogg', 40, TRUE)
+	else
+		playsound(src, 'sound/weapons/fwoosh.ogg', 70, TRUE)
 
 	new /obj/effect/temp_visual/smash_effect(get_turf(target))
-
 	return ..()
-


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds more visual feedback to the rhino hammer attacks.
Hammer attacks can now destroy objects and attack other rhinos.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Unlike before now you can tell whether your attacks hit or missed entirely.
Can finally smash all the annoying doors and windows with your hammer.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added attack animation, chat messages, and visual effects for hammer rhinos.
tweak: Hammer rhinos can now hit and break structures, machinery, and other rhinos.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
