### PR TITLE
improves ghost possession code, and resolves a very minor bug that was in the code for 1+ month and NOBODY except my friend yesterday noticed it

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -658,7 +658,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		return FALSE
 
 	if(possession_cooldown >= world.time)
-		to_chat(src, span_warning("You are under a cooldown for possessing for [(possession_cooldown - world.time) * 10] more seconds!"))
+		to_chat(src, span_userdanger("You are under a cooldown for possessing for [(possession_cooldown - world.time) * 10] more seconds!"))
 		return FALSE
 
 	if(ismegafauna(target))
@@ -725,6 +725,10 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		to_chat(usr, span_userdanger("This abnormality is blacklisted from being possessed!"))
 		return ..()
 
+	if(possession_cooldown >= world.time)
+		to_chat(src, span_userdanger("You are under a cooldown for possessing for [(possession_cooldown - world.time) * 10] more seconds!"))
+		return ..()
+
 	if(!isobserver(usr)) // safety check
 		to_chat(usr, span_userdanger("you are not an observer despite being an observer, silly. You cant possess abnormalities!"))
 		return ..()
@@ -738,7 +742,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		return ..()
 
 	try_take_abnormality(src, over)
-	return
+	return ..()
 	//LOBOTOMYCORPORATION ADDITION END
 
 //	return ..() LOBOTOMYCORPORATION REMOVAL -- we dont need this anymore since we do safety checks with early returns instead

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -3,8 +3,9 @@ GLOBAL_LIST_EMPTY(ghost_images_simple) //this is a list of all ghost images as t
 
 GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 
-GLOBAL_LIST_INIT(unpossessable_mobs, list(
-	/mob/living/simple_animal/hostile/abnormality/woodsman))
+GLOBAL_LIST_INIT(unpossessable_mobs, list( // LOBOTOMYCORPORATION ADDITION -- abnormality blacklist
+	/mob/living/simple_animal/hostile/abnormality/woodsman,
+))
 
 /mob/dead/observer
 	name = "ghost"
@@ -65,7 +66,7 @@ GLOBAL_LIST_INIT(unpossessable_mobs, list(
 	var/datum/orbit_menu/orbit_menu
 	var/datum/spawners_menu/spawners_menu
 
-	var/possession_cooldown = 0
+	var/possession_cooldown = 0 // LOBOTOMYCORPORATION ADDITION -- Possession cooldown
 
 /mob/dead/observer/Initialize()
 	set_invisibility(GLOB.observer_default_invisibility)
@@ -151,7 +152,8 @@ GLOBAL_LIST_INIT(unpossessable_mobs, list(
 	grant_all_languages()
 	show_data_huds()
 	data_huds_on = 1
-	possession_cooldown = world.time + (10 SECONDS)
+
+	possession_cooldown = world.time + (10 SECONDS) // LOBOTOMYCORPORATION ADDITION -- Possession cooldown
 
 /mob/dead/observer/get_photo_description(obj/item/camera/camera)
 	if(!invisibility || camera.see_ghosts)
@@ -638,14 +640,25 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 	var/list/possessible = list()
 	for(var/mob/living/L in GLOB.alive_mob_list)
-		if(istype(L,/mob/living/carbon/human/dummy) || !get_turf(L) || !SSlobotomy_corp.enable_possession || is_type_in_list(L, GLOB.unpossessable_mobs))
+		if(istype(L,/mob/living/carbon/human/dummy) || !get_turf(L)) //Haha no.
 			continue
+		// LOBOTOMYCORPORATION ADDITION START
+		if(!SSlobotomy_corp.enable_possession)
+			message_admins(span_adminnotice("[src.key] has accessed the mob/dead/observer/verb/possess() whilst abnormality possession is not enabled!"))
+			return
+		if(is_type_in_list(L, GLOB.unpossessable_mobs))
+			continue
+		// LOBOTOMYCORPORATION ADDITION END
 		if(!(L in GLOB.player_list) && !L.mind)
 			possessible += L
 
 	var/mob/living/target = input("Your new life begins today!", "Possess Mob", null, null) as null|anything in sortNames(possessible)
 
-	if(!target || possession_cooldown >= world.time)
+	if(!target)
+		return FALSE
+
+	if(possession_cooldown >= world.time)
+		to_chat(src, span_warning("You are under a cooldown for possessing for [(possession_cooldown - world.time) * 10] more seconds!"))
 		return FALSE
 
 	if(ismegafauna(target))
@@ -660,6 +673,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		return FALSE
 
 	target.key = key
+//	target.faction = list("neutral") LOBOTOMYCORPORATION REMOVAL -- messes with the posessed abnormality's factions
 	return TRUE
 
 //this is a mob verb instead of atom for performance reasons
@@ -700,8 +714,15 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	if(usr != src) // dont give chat feedback, dragging others onto an abnormality is probably just a silly mistake
 		return ..()
 
+	if(!isliving(over)) // you really did just miss your possession target, pathetic. You dont get a satisfactory message for that
+		return ..()
+
 	if(!SSlobotomy_corp.enable_possession) // if admins dont want us to fuck around, lets not fuck around
 		to_chat(usr, span_userdanger("Abnormality possession is not enabled!"))
+		return ..()
+
+	if(is_type_in_list(over, GLOB.unpossessable_mobs))
+		to_chat(usr, span_userdanger("This abnormality is blacklisted from being possessed!"))
 		return ..()
 
 	if(!isobserver(usr)) // safety check


### PR DESCRIPTION
## About The Pull Request

Fixes an old bug that literally never noticed- you being able to drag onto a wall to trigger the "abnormality possession is not enabled!" message
- A harmless bug that annoys me it took SO LONG to find it considering you can do it at ANY shift

Dragging yourself onto an abnormality now respects the possession cooldown
- I have no clue why we even have the cooldown, but whatever. It now respects that 10 seconds short timer

You are now notified if you are on possession cooldown
- Why did we never notify players about it? You literally never encounter the cooldown in normal gameplay, so it literally comes off as input lag on the rare accasion it happens and NOBODY except 1-2 coders know about it

Added modular comments to changes in observer.dm file, and modularized changes done to it
- I just like it that way and it does not hurt :3

Made the abnormality list in observer.dm follow coding standards
- Missed it, shame only i use the modular comments

## Why It's Good For The Game

fix bugs good, bugs bad. I fix bug. Bug now dead

## Changelog
:cl:
fix: you are no longer being yelled at for dragging your ghost onto a wall
fix: dragging yourself onto an abnormality now respects the possession cooldown (does anyone except coders even know about it?)
qol: you are now notified if you are on possession cooldown, instead of being told nothing and left confused for no god damn reason
code: added modular comments to changes in observer.dm file, and modularized changes done to it
code: made the abnormality list in observer.dm follow coding standards
/:cl:
