### PR TITLE
Making shepherd abnormality friendly on r corp map

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/he/blue_shepherd.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/blue_shepherd.dm
@@ -66,6 +66,7 @@
 	var/list/people_list = list() //list of people shepperd can mention
 	var/buddy_hit = FALSE
 	var/red_hit = FALSE // Controls Little Red Riding Hooded Mercenary's ability to be "hit" by slash attacks
+	var/combat_map = FALSE
 	//lines said during combat
 	var/list/combat_lines = list(
 		"Have at you!",
@@ -126,6 +127,9 @@
 
 /mob/living/simple_animal/hostile/abnormality/blue_shepherd/Initialize()
 	. = ..()
+	if(IsCombatMap())
+		combat_map = TRUE
+		faction |= "hostile"
 	RegisterSignal(SSdcs, COMSIG_GLOB_MOB_DEATH, .proc/OnMobDeath) // Alright, here we go again
 	RegisterSignal(SSdcs, COMSIG_GLOB_CREWMEMBER_JOINED, .proc/OnNewCrew)
 	//makes a list of people and abno to shit talk
@@ -290,7 +294,7 @@
 	if(stat == DEAD)
 		return
 	new /obj/effect/temp_visual/smash_effect(T)
-	for(var/mob/living/L in HurtInTurf(T, list(), slash_damage, BLACK_DAMAGE, hurt_mechs = TRUE, hurt_structure = TRUE, break_not_destroy = TRUE))
+	for(var/mob/living/L in HurtInTurf(T, list(), slash_damage, BLACK_DAMAGE, check_faction = combat_map, hurt_mechs = TRUE, hurt_structure = TRUE, break_not_destroy = TRUE))
 		if(L == awakened_buddy && !buddy_hit)
 			buddy_hit = TRUE //sometimes buddy get hit twice so we check if it got hit in this slash
 			awakened_buddy.adjustHealth(700) //it would take approximatively 9 slashes to take buddy down

--- a/code/modules/mob/living/simple_animal/abnormality/he/red_buddy.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/red_buddy.dm
@@ -72,6 +72,8 @@
 
 /mob/living/simple_animal/hostile/abnormality/red_buddy/Initialize()
 	. = ..()
+	if(IsCombatMap())
+		faction |= "hostile"
 	if(LAZYLEN(SSlobotomy_corp.all_abnormality_datums))
 		for(var/datum/abnormality/A in SSlobotomy_corp.all_abnormality_datums)
 			if(A.name == "Blue Smocked Shepherd")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes shepherd and red buddy aoes not hit allies on R corp map.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Less friendly fire
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Blue shepherd and red buddy aoe attacks wont hit allies on R corp map
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
