### PR TITLE
Fixes negative fort and prud bonuses

### DIFF
--- a/code/datums/attributes/_attribute.dm
+++ b/code/datums/attributes/_attribute.dm
@@ -134,6 +134,14 @@ GLOBAL_LIST_INIT(attribute_types, list(
 		return 1
 	return max(1, atr.get_level_bonus())
 
+/proc/get_level_bonus_raw(mob/living/carbon/human/user, attribute)
+	if(!istype(user) || !attribute)
+		return 0
+	var/datum/attribute/atr = user.attributes[attribute]
+	if(!istype(atr))
+		return 0
+	return atr.get_level_bonus()
+
 // Attribute buffs
 /mob/living/carbon/human/proc/adjust_attribute_buff(attribute, addition)
 	if(!attribute)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1287,8 +1287,8 @@
 
 /mob/living/carbon/human/updatehealth()
 	if(LAZYLEN(attributes))
-		maxHealth = DEFAULT_HUMAN_MAX_HEALTH + round(get_attribute_level(src, FORTITUDE_ATTRIBUTE) * FORTITUDE_MOD + get_level_bonus(src, FORTITUDE_ATTRIBUTE))
-		maxSanity = DEFAULT_HUMAN_MAX_SANITY + round(get_attribute_level(src, PRUDENCE_ATTRIBUTE) * PRUDENCE_MOD + get_level_bonus(src, PRUDENCE_ATTRIBUTE))
+		maxHealth = max(1, DEFAULT_HUMAN_MAX_HEALTH + round(get_attribute_level(src, FORTITUDE_ATTRIBUTE) * FORTITUDE_MOD + get_level_bonus_raw(src, FORTITUDE_ATTRIBUTE)))
+		maxSanity = max(1, DEFAULT_HUMAN_MAX_SANITY + round(get_attribute_level(src, PRUDENCE_ATTRIBUTE) * PRUDENCE_MOD + get_level_bonus_raw(src, PRUDENCE_ATTRIBUTE)))
 	. = ..()
 	dna?.species.spec_updatehealth(src)
 	sanityhealth = maxSanity - sanityloss


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes negative fortitude and prudence bonuses not reducing health at all.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Poor screenwriters note and you must be happy bonuses will work properly.
No more extra 1 hp from the getbonus proc returning 1 when bonus is at 0.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixed all negative health and sanity bonuses such as Poor screenwriters note and You must be happy not doing anything.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
