### PR TITLE
Liu gloves on City are no longer combo focused

### DIFF
--- a/ModularTegustation/tegu_items/associations/association_beacon.dm
+++ b/ModularTegustation/tegu_items/associations/association_beacon.dm
@@ -42,11 +42,11 @@
 	desc = "A kit from Section 1 containing Liu association gear."
 
 /obj/item/storage/box/association/liu/PopulateContents()
-	new /obj/item/ego_weapon/city/liu/fist(src)
-	new /obj/item/ego_weapon/city/liu/fist(src)
-	new /obj/item/ego_weapon/city/liu/fist(src)
-	new /obj/item/ego_weapon/city/liu/fist/vet(src)
-	new /obj/item/ego_weapon/city/liu/fist/vet(src)
+	new /obj/item/ego_weapon/city/liu/fire/section5(src)
+	new /obj/item/ego_weapon/city/liu/fire/section5(src)
+	new /obj/item/ego_weapon/city/liu/fire/section5(src)
+	new /obj/item/ego_weapon/city/liu/fire/section5/vet(src)
+	new /obj/item/ego_weapon/city/liu/fire/section5/vet(src)
 	new /obj/item/clothing/suit/armor/ego_gear/city/liu/section5(src)
 	new /obj/item/clothing/suit/armor/ego_gear/city/liu/section5(src)
 	new /obj/item/clothing/suit/armor/ego_gear/city/liu/section5(src)

--- a/code/game/objects/items/ego_weapons/non_abnormality/weak_edits/city.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/weak_edits/city.dm
@@ -213,6 +213,3 @@
 							TEMPERANCE_ATTRIBUTE = 60,
 							JUSTICE_ATTRIBUTE = 80
 							)
-	hitsound = 'sound/weapons/fixer/generic/fist1.ogg'
-
-

--- a/code/game/objects/items/ego_weapons/non_abnormality/weak_edits/city.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/weak_edits/city.dm
@@ -185,3 +185,34 @@
 
 /obj/item/clothing/suit/armor/ego_gear/city/kcorp_l1/weak
 	attribute_requirements = list()
+
+
+//People bitched a lot
+/obj/item/ego_weapon/city/liu/fire/section5
+	name = "liu combat gloves"
+	icon_state = "liufist"
+	desc = "A gauntlet used by Liu Sections 4,5 and 6. Requires martial arts training to make use of."
+	force = 20
+	attack_speed = 0.7
+	attribute_requirements = list(
+							FORTITUDE_ATTRIBUTE = 60,
+							PRUDENCE_ATTRIBUTE = 40,
+							TEMPERANCE_ATTRIBUTE = 40,
+							JUSTICE_ATTRIBUTE = 40
+							)
+	hitsound = 'sound/weapons/fixer/generic/fist1.ogg'
+
+
+/obj/item/ego_weapon/city/liu/fire/section5/vet
+	name = "liu veteran combat gloves"
+	icon_state = "liufist_vet"
+	force = 32
+	attribute_requirements = list(
+							FORTITUDE_ATTRIBUTE = 100,
+							PRUDENCE_ATTRIBUTE = 80,
+							TEMPERANCE_ATTRIBUTE = 60,
+							JUSTICE_ATTRIBUTE = 80
+							)
+	hitsound = 'sound/weapons/fixer/generic/fist1.ogg'
+
+


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Liu gloves on the city are replaced with a similar looking one that instead is just the other Liu fist.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
People didn't use them because they had a skill issue, this lessens their skill issue immensely.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Liu association on the city now is just the other liu gloves
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
