### PR TITLE
Control Core Suppression now gives 10 LOB as reward

### DIFF
--- a/code/modules/suppressions/control.dm
+++ b/code/modules/suppressions/control.dm
@@ -1,7 +1,7 @@
 /datum/suppression/control
 	name = CONTROL_CORE_SUPPRESSION
 	desc = "Assignments on the abnormality work consoles will be scrambled each meltdown/ordeal."
-	reward_text = "All employees, including those that may join later in the shift will receive a +30 justice attribute buff."
+	reward_text = "The facility is rewarded with extra 10 LOB points."
 	run_text = "The core suppression of Control department has begun. The work assignments will be scrambled each meltdown."
 
 /datum/suppression/control/Run(run_white = FALSE, silent = FALSE)
@@ -14,12 +14,7 @@
 	for(var/obj/machinery/computer/abnormality/C in GLOB.lobotomy_devices)
 		C.scramble_list = list()
 	// Reward!
-	for(var/mob/living/carbon/human/H in GLOB.human_list)
-		if(!H.ckey)
-			continue
-		H.adjust_attribute_buff(JUSTICE_ATTRIBUTE, 30)
-		to_chat(H, "<span class='notice'>You feel much better than ever before!</span>")
-	new /datum/control_reward_tracker() // Gives the reward to late-joiners after it ends
+	SSlobotomy_corp.AddLobPoints(10, "[CONTROL_CORE_SUPPRESSION] completion reward")
 	return ..()
 
 // On lobotomy_corp meltdown event
@@ -33,22 +28,3 @@
 		choose_from -= application_scramble_list[work]
 	for(var/obj/machinery/computer/abnormality/C in GLOB.lobotomy_devices)
 		C.scramble_list = application_scramble_list
-
-// Created when control suppression ends; Used to track new spawns to apply the reward
-
-/datum/control_reward_tracker/New()
-	. = ..()
-	RegisterSignal(SSdcs, COMSIG_GLOB_CREWMEMBER_JOINED, .proc/OnJoin)
-
-/datum/control_reward_tracker/Destroy()
-	UnregisterSignal(SSdcs, COMSIG_GLOB_CREWMEMBER_JOINED)
-	return ..()
-
-// When a new employee spawns in
-/datum/control_reward_tracker/proc/OnJoin(datum/source, mob/living/carbon/human/H, rank)
-	SIGNAL_HANDLER
-	if(!ishuman(H))
-		return FALSE
-	H.adjust_attribute_buff(JUSTICE_ATTRIBUTE, 30)
-	to_chat(H, "<span class='notice'>Control core effects improved your coordination!</span>")
-	return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes Control Core Suppression reward to +10 LOB points instead of +30 justice buff.

## Why It's Good For The Game

A lot of people were complaning about justice buff being either "not worth it" or outright detrimental (clerks going justice-insane).
+10 LOB points might not sound like a very well-thought-out reward, but it *somewhat* fits thematically and is a relatively good reward.
