### PR TITLE
Training Dummy Rabbit no longer breach Red Hood

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/waw/red_riding_mercenary.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/red_riding_mercenary.dm
@@ -439,6 +439,8 @@ It has now been over four months. Now we get her for real. -Coxswain
 		else
 			manual_emote("perks up for a moment, then settles back down, looking annoyed.")
 		return
+	if(istype(abno, /mob/living/simple_animal/hostile/abnormality/training_rabbit))
+		return
 	if(datum_reference.qliphoth_meter > 1)
 		if(client)
 			to_chat(src, span_notice("You hear something..."))


### PR DESCRIPTION
## About The Pull Request
Little Red Riding Hooded Mercenary now ignore Training Dummy Bunny breach, which won't lower her Qliphoth Counter
## Why It's Good For The Game
Clerks can grief by breaching the bunny to get Red Hood to leave her cell and start whaling on people. This is clearly an oversight.

