### PR TITLE
Jeong Weapon Fix

### DIFF
--- a/code/game/objects/items/ego_weapons/non_abnormality/jeong.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/jeong.dm
@@ -31,7 +31,7 @@
 	ready = FALSE
 	to_chat(user, "<span class='userdanger'>Low at Night.</span>")
 	force*=3
-	user.adjustBruteLoss(user.maxHealth*0.4)
+	user.adjustBruteLoss(user.maxHealth*0.2)
 	addtimer(CALLBACK(src, .proc/Return, user), 5 SECONDS)
 
 /obj/item/ego_weapon/city/jeong/attack(mob/living/target, mob/living/carbon/human/user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Jeong weapons are supposed to sacrifice 20% hp for 3x damage. They currently sacrifice double this.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes weapon more accurate in the better of the two ways.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Jeong office weaponry now takes 20% hp instead of 40%
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
