### PR TITLE
Removes plasma from Plasteel grinding, removes naturally respawning plasma replaces it with drugged oceanic soda, removes cigar explosives

### DIFF
--- a/code/_globalvars/lists/maintenance_loot.dm
+++ b/code/_globalvars/lists/maintenance_loot.dm
@@ -106,7 +106,6 @@ GLOBAL_LIST_INIT(common_loot, list( //common: basic items
 		/obj/item/stock_parts/cell = 1,
 		/obj/item/stack/rods/twentyfive = 1,
 		/obj/item/stack/sheet/metal/twenty = 1,
-		/obj/item/stack/sheet/mineral/plasma = 1,
 		/obj/item/sign = 1,
 
 		//assemblies
@@ -129,6 +128,7 @@ GLOBAL_LIST_INIT(common_loot, list( //common: basic items
 		/obj/item/reagent_containers/glass/beaker = 1,
 		/obj/item/reagent_containers/glass/rag = 1,
 		/obj/item/reagent_containers/hypospray/medipen/pumpup = 2,
+		/obj/item/reagent_containers/food/drinks/soda_cans/oceanwave = 1,
 		) = 1,
 
 	list(//food

--- a/code/_globalvars/lists/maintenance_loot.dm
+++ b/code/_globalvars/lists/maintenance_loot.dm
@@ -106,6 +106,7 @@ GLOBAL_LIST_INIT(common_loot, list( //common: basic items
 		/obj/item/stock_parts/cell = 1,
 		/obj/item/stack/rods/twentyfive = 1,
 		/obj/item/stack/sheet/metal/twenty = 1,
+//      /obj/item/stack/sheet/mineral/plasma = 1, LOBOTOMYCORPORATION REMOVAL -- This was used to blatantly grief
 		/obj/item/sign = 1,
 
 		//assemblies

--- a/code/_globalvars/lists/maintenance_loot.dm
+++ b/code/_globalvars/lists/maintenance_loot.dm
@@ -128,7 +128,7 @@ GLOBAL_LIST_INIT(common_loot, list( //common: basic items
 		/obj/item/reagent_containers/glass/beaker = 1,
 		/obj/item/reagent_containers/glass/rag = 1,
 		/obj/item/reagent_containers/hypospray/medipen/pumpup = 2,
-		/obj/item/reagent_containers/food/drinks/soda_cans/oceanwave = 1,
+		/obj/item/reagent_containers/food/drinks/soda_cans/oceanwave = 1, // LOBOTOMYCORPORATION ADDITION
 		) = 1,
 
 	list(//food

--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -943,28 +943,6 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		reagents.flags |= NO_REACT
 		STOP_PROCESSING(SSobj, src)
 
-/obj/item/clothing/mask/vape/proc/hand_reagents()//had to rename to avoid duplicate error
-	if(reagents.total_volume)
-		if(iscarbon(loc))
-			var/mob/living/carbon/C = loc
-			if (src == C.wear_mask) // if it's in the human/monkey mouth, transfer reagents to the mob
-				var/fraction = min(REAGENTS_METABOLISM/reagents.total_volume, 1) //this will react instantly, making them a little more dangerous than cigarettes
-				reagents.expose(C, INGEST, fraction)
-				if(!reagents.trans_to(C, REAGENTS_METABOLISM))
-					reagents.remove_any(REAGENTS_METABOLISM)
-				if(reagents.get_reagent_amount(/datum/reagent/fuel))
-					//HOT STUFF
-					C.adjust_fire_stacks(2)
-					C.IgniteMob()
-
-				if(reagents.get_reagent_amount(/datum/reagent/toxin/plasma)) // the plasma explodes when exposed to fire
-					var/datum/effect_system/reagents_explosion/e = new()
-					e.set_up(round(reagents.get_reagent_amount(/datum/reagent/toxin/plasma) / 2.5, 1), get_turf(src), 0, 0)
-					e.start()
-					qdel(src)
-				return
-		reagents.remove_any(REAGENTS_METABOLISM)
-
 /obj/item/clothing/mask/vape/process(delta_time)
 	var/mob/living/M = loc
 
@@ -987,21 +965,4 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		s.start()
 		vapetime -= vapedelay
 
-	if((obj_flags & EMAGGED) && vapetime >= vapedelay)
-		var/datum/effect_system/smoke_spread/chem/smoke_machine/s = new
-		s.set_up(reagents, 4, 24, loc)
-		s.start()
-		vapetime -= vapedelay
-		if(prob(5))//small chance for the vape to break and deal damage if it's emagged
-			playsound(get_turf(src), 'sound/effects/pop_expl.ogg', 50, FALSE)
-			M.apply_damage(20, BURN, BODY_ZONE_HEAD)
-			M.Paralyze(300)
-			var/datum/effect_system/spark_spread/sp = new /datum/effect_system/spark_spread
-			sp.set_up(5, 1, src)
-			sp.start()
-			to_chat(M, "<span class='userdanger'>[src] suddenly explodes in your mouth!</span>")
-			qdel(src)
-			return
 
-	if(reagents?.total_volume)
-		hand_reagents()

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -1,4 +1,4 @@
-/* Diffrent misc types of sheets
+GG/* Diffrent misc types of sheets
  * Contains:
  * Metal
  * Plasteel
@@ -187,7 +187,7 @@ GLOBAL_LIST_INIT(plasteel_recipes, list ( \
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 100, ACID = 80)
 	resistance_flags = FIRE_PROOF
 	merge_type = /obj/item/stack/sheet/plasteel
-	grind_results = list(/datum/reagent/iron = 20, /datum/reagent/toxin/plasma = 20)
+	grind_results = list(/datum/reagent/iron = 20)
 	point_value = 23
 	tableVariant = /obj/structure/table/reinforced
 	material_flags = MATERIAL_NO_EFFECTS

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -187,7 +187,8 @@ GLOBAL_LIST_INIT(plasteel_recipes, list ( \
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 100, ACID = 80)
 	resistance_flags = FIRE_PROOF
 	merge_type = /obj/item/stack/sheet/plasteel
-	grind_results = list(/datum/reagent/iron = 20)
+//	grind_results = list(/datum/reagent/iron = 20, /datum/reagent/toxin/plasma = 20) LOBOTOMYCORPORATION EDIT CHANGE OLD
+	grind_results = list(/datum/reagent/iron = 20) // LOBOTOMYCORPORATION EDIT CHANGE NEW -- Removes plasma
 	point_value = 23
 	tableVariant = /obj/structure/table/reinforced
 	material_flags = MATERIAL_NO_EFFECTS


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Ided pr. Removes the main grief sources used by one specific person who was publically discussing how to further abuse it in CoL IC with other players and using these mechanics to instantly gib abnormalities.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Plasma is a grief tool theres no other way of putting it, removing its sources and uses improves the game. (also Randal Im disappointed in you)
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Removed plasma from plasteel grinding
del: Removed explosive smokes
del: Removed naturally spawning CoL plasma due to old SS13 station maints code
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
