### PR TITLE
Fixes a single character issue in Drifting Foxes attribute check.

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/he/drifting_fox.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/drifting_fox.dm
@@ -63,7 +63,7 @@
 /mob/living/simple_animal/hostile/abnormality/drifting_fox/PostWorkEffect(mob/living/carbon/human/user, work_type, pe, work_time)
 	if(user in pet)
 		pet -= user
-	if(get_attribute_level(user, TEMPERANCE_ATTRIBUTE) <= 40)
+	if(get_attribute_level(user, TEMPERANCE_ATTRIBUTE) < 40)
 		datum_reference.qliphoth_change(-1)
 	return
 

--- a/code/modules/paperwork/records/info/he.dm
+++ b/code/modules/paperwork/records/info/he.dm
@@ -494,7 +494,7 @@
 	abno_type = /mob/living/simple_animal/hostile/abnormality/drifting_fox
 	abno_code = "T-02-173"
 	abno_info = list(
-		"It was noted that working on T-02-11-03 with a Temperance level of 2 or less lowered the Qliphoth counter.",
+		"It was noted that working on T-02-11-03 with a Temperance level of less than 2 lowered the Qliphoth counter.",
 		"Employees who pet T-02-11-03 before a work were noted to have remarkably increased success rates with the Abnormality when completing Attachment work.",
 		"When the work result was Bad, the Qliphoth counter lowered.")
 

--- a/code/modules/paperwork/records/info/he.dm
+++ b/code/modules/paperwork/records/info/he.dm
@@ -494,7 +494,7 @@
 	abno_type = /mob/living/simple_animal/hostile/abnormality/drifting_fox
 	abno_code = "T-02-173"
 	abno_info = list(
-		"It was noted that working on T-02-11-03 with a Temperance level of less than 2 lowered the Qliphoth counter.",
+		"It was noted that working on T-02-11-03 with a Temperance level of 2 or less lowered the Qliphoth counter.",
 		"Employees who pet T-02-11-03 before a work were noted to have remarkably increased success rates with the Abnormality when completing Attachment work.",
 		"When the work result was Bad, the Qliphoth counter lowered.")
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Drifting Fox checked your temperance through <= this meant that if you had level 2 youd pass the check however if you had exactly 40 you'd fail the check misleading players into believing it was a Temperance 3 check.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This is just mean to the player, there shouldn't be secret rug pulls unintentional or not towards the players.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: tweaked the attribute check by making it <40 over <=
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
