### PR TITLE
Surgery Buffs (the lobotomy is real)

### DIFF
--- a/_maps/map_files/Alpha/alphacorp.dmm
+++ b/_maps/map_files/Alpha/alphacorp.dmm
@@ -4026,10 +4026,10 @@
 /area/department_main/information)
 "EI" = (
 /obj/structure/table/glass,
-/obj/item/storage/backpack/duffelbag/med/surgery{
+/obj/item/storage/backpack/duffelbag/med/upgradedsurgery{
 	pixel_y = 10
 	},
-/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/storage/backpack/duffelbag/med/upgradedsurgery,
 /obj/structure/sign/poster/official/cleanliness{
 	pixel_x = -32
 	},

--- a/_maps/map_files/Beta/betacorp.dmm
+++ b/_maps/map_files/Beta/betacorp.dmm
@@ -3436,7 +3436,7 @@
 	pixel_x = 5;
 	pixel_y = 5
 	},
-/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/storage/backpack/duffelbag/med/upgradedsurgery,
 /turf/open/floor/plasteel/white,
 /area/department_main/safety)
 "qR" = (
@@ -9786,7 +9786,7 @@
 /area/department_main/command)
 "WE" = (
 /obj/structure/table/optable,
-/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/storage/backpack/duffelbag/med/upgradedsurgery,
 /turf/open/floor/carpet/purple,
 /area/department_main/information)
 "WF" = (

--- a/_maps/map_files/Delta/deltacorp.dmm
+++ b/_maps/map_files/Delta/deltacorp.dmm
@@ -452,7 +452,7 @@
 	color = "#006400"
 	},
 /obj/structure/table/wood/fancy/green,
-/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/storage/backpack/duffelbag/med/upgradedsurgery,
 /turf/open/floor/plasteel/sepia,
 /area/facility_hallway/safety)
 "bc" = (

--- a/_maps/map_files/Event/skeld.dmm
+++ b/_maps/map_files/Event/skeld.dmm
@@ -6716,10 +6716,10 @@
 /area/ruin/space/has_grav/ancientstation/hydroponics)
 "Gy" = (
 /obj/structure/table/glass,
-/obj/item/storage/backpack/duffelbag/med/surgery{
+/obj/item/storage/backpack/duffelbag/med/upgradedsurgery{
 	pixel_y = 10
 	},
-/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/storage/backpack/duffelbag/med/upgradedsurgery,
 /turf/open/floor/facility/white,
 /area/department_main/safety)
 "GC" = (

--- a/_maps/map_files/Gamma/gammacorp.dmm
+++ b/_maps/map_files/Gamma/gammacorp.dmm
@@ -3927,7 +3927,7 @@
 /turf/open/floor/facility/white,
 /area/department_main/command)
 "zr" = (
-/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/storage/backpack/duffelbag/med/upgradedsurgery,
 /obj/structure/table/reinforced,
 /turf/open/floor/facility/white,
 /area/department_main/safety)

--- a/_maps/map_files/Iota/iotacorp.dmm
+++ b/_maps/map_files/Iota/iotacorp.dmm
@@ -3003,7 +3003,7 @@
 	pixel_y = 4
 	},
 /obj/structure/table/reinforced,
-/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/storage/backpack/duffelbag/med/upgradedsurgery,
 /obj/item/clothing/suit/apron/surgical,
 /obj/effect/turf_decal/stripes/red/full,
 /obj/item/reagent_containers/spray/cleaner,
@@ -13470,7 +13470,7 @@
 /area/space)
 "SA" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/storage/backpack/duffelbag/med/upgradedsurgery,
 /obj/item/clothing/suit/apron/surgical,
 /obj/effect/turf_decal/stripes/red/full,
 /obj/item/reagent_containers/spray/cleaner,

--- a/_maps/map_files/Kappa/kappacorp.dmm
+++ b/_maps/map_files/Kappa/kappacorp.dmm
@@ -7675,8 +7675,8 @@
 /obj/structure/table/reinforced{
 	resistance_flags = 115
 	},
-/obj/item/storage/backpack/duffelbag/med/surgery,
-/obj/item/storage/backpack/duffelbag/med/surgery{
+/obj/item/storage/backpack/duffelbag/med/upgradedsurgery,
+/obj/item/storage/backpack/duffelbag/med/upgradedsurgery{
 	pixel_y = 12
 	},
 /obj/item/clothing/suit/apron/surgical,

--- a/_maps/map_files/Lambda/lambdacorp.dmm
+++ b/_maps/map_files/Lambda/lambdacorp.dmm
@@ -263,7 +263,7 @@
 /area/department_main/control)
 "be" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/backpack/duffelbag/med/surgery{
+/obj/item/storage/backpack/duffelbag/med/upgradedsurgery{
 	pixel_y = 12
 	},
 /obj/item/clothing/suit/apron/surgical,

--- a/_maps/map_files/Psi/psicorp.dmm
+++ b/_maps/map_files/Psi/psicorp.dmm
@@ -5497,7 +5497,7 @@
 	},
 /obj/structure/table/glass,
 /obj/machinery/door/window/southleft,
-/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/storage/backpack/duffelbag/med/upgradedsurgery,
 /obj/item/reagent_containers/medigel/sterilizine{
 	pixel_x = -5;
 	pixel_y = 6

--- a/_maps/map_files/Theta/thetacorp.dmm
+++ b/_maps/map_files/Theta/thetacorp.dmm
@@ -4598,7 +4598,7 @@
 	dir = 1
 	},
 /obj/structure/table/wood/fancy/green,
-/obj/item/storage/backpack/duffelbag/med/surgery{
+/obj/item/storage/backpack/duffelbag/med/upgradedsurgery{
 	pixel_y = 4
 	},
 /turf/open/floor/plasteel/sepia,
@@ -5268,7 +5268,7 @@
 	dir = 8
 	},
 /obj/structure/table/wood/fancy/green,
-/obj/item/storage/backpack/duffelbag/med/surgery{
+/obj/item/storage/backpack/duffelbag/med/upgradedsurgery{
 	pixel_y = 4
 	},
 /turf/open/floor/plasteel/sepia,

--- a/_maps/map_files/Xi/xicommand.dmm
+++ b/_maps/map_files/Xi/xicommand.dmm
@@ -8147,7 +8147,7 @@
 /turf/open/floor/wood,
 /area/city/shop)
 "uC" = (
-/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/storage/backpack/duffelbag/med/upgradedsurgery,
 /obj/structure/window/reinforced/spawner{
 	max_integrity = 25
 	},
@@ -17460,7 +17460,7 @@
 /turf/open/floor/plating/ashplanet/rocky,
 /area/city/backstreets_alley)
 "Sf" = (
-/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/storage/backpack/duffelbag/med/upgradedsurgery,
 /obj/structure/window/reinforced/spawner/north{
 	max_integrity = 25;
 	opacity = 1
@@ -17705,7 +17705,7 @@
 /area/city/house)
 "SI" = (
 /obj/machinery/vending/medical,
-/obj/item/storage/backpack/duffelbag/med/surgery{
+/obj/item/storage/backpack/duffelbag/med/upgradedsurgery{
 	pixel_y = 18
 	},
 /turf/open/floor/plasteel/showroomfloor,

--- a/_maps/map_files/Xi/xicorp.dmm
+++ b/_maps/map_files/Xi/xicorp.dmm
@@ -4138,7 +4138,7 @@
 /area/facility_hallway/control)
 "EJ" = (
 /obj/structure/table/glass,
-/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/storage/backpack/duffelbag/med/upgradedsurgery,
 /obj/item/reagent_containers/spray/cleaner{
 	pixel_x = 5;
 	pixel_y = 5
@@ -4273,7 +4273,7 @@
 /area/facility_hallway/command)
 "FE" = (
 /obj/structure/table/glass,
-/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/storage/backpack/duffelbag/med/upgradedsurgery,
 /obj/item/reagent_containers/spray/cleaner{
 	pixel_x = 5;
 	pixel_y = 5

--- a/_maps/map_files/Zeta/zetacorp.dmm
+++ b/_maps/map_files/Zeta/zetacorp.dmm
@@ -8868,7 +8868,7 @@
 /area/facility_hallway/safety)
 "yR" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/storage/backpack/duffelbag/med/upgradedsurgery,
 /obj/effect/turf_decal/stripes/red/full,
 /turf/open/floor/facility/white,
 /area/facility_hallway/safety)

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -430,6 +430,36 @@
 	name = "surgical duffel bag"
 	desc = "A large duffel bag for holding extra medical supplies - this one seems to be designed for holding surgical tools."
 
+/obj/item/storage/backpack/duffelbag/med/surgery/PopulateContents()
+	new /obj/item/scalpel(src)
+	new /obj/item/hemostat(src)
+	new /obj/item/retractor(src)
+	new /obj/item/circular_saw(src)
+	new /obj/item/surgicaldrill(src)
+	new /obj/item/cautery(src)
+	new /obj/item/bonesetter(src)
+	new /obj/item/surgical_drapes(src)
+	new /obj/item/clothing/mask/surgical(src)
+	new /obj/item/razor(src)
+	new /obj/item/blood_filter(src)
+
+/obj/item/storage/backpack/duffelbag/med/upgradedsurgery
+	name = "surgical duffel bag"
+	desc = "A large duffel bag for holding extra medical supplies - this one seems to hold upgraded surgical tools."
+	icon_state = "duffel-syndiemed"
+	inhand_icon_state = "duffel-syndiemed"
+
+/obj/item/storage/backpack/duffelbag/med/upgradedsurgery/PopulateContents()
+	new /obj/item/scalpel/advanced(src)
+	new /obj/item/retractor/advanced(src)
+	new /obj/item/cautery/advanced(src)
+	new /obj/item/bonesetter(src)
+	new /obj/item/surgical_drapes(src)
+	new /obj/item/clothing/mask/surgical(src)
+	new /obj/item/razor(src)
+	new /obj/item/blood_filter(src)
+	new /obj/item/reagent_containers/medigel/sterilizine(src)
+
 /obj/item/storage/backpack/duffelbag/explorer
 	name = "explorator's duffel bag"
 	desc = "A large duffel bag for holding extra exotic treasures."
@@ -465,21 +495,6 @@
 	desc = "A large duffel bag for holding extra viral bottles."
 	icon_state = "duffel-virology"
 	inhand_icon_state = "duffel-virology"
-
-
-
-/obj/item/storage/backpack/duffelbag/med/surgery/PopulateContents()
-	new /obj/item/scalpel(src)
-	new /obj/item/hemostat(src)
-	new /obj/item/retractor(src)
-	new /obj/item/circular_saw(src)
-	new /obj/item/surgicaldrill(src)
-	new /obj/item/cautery(src)
-	new /obj/item/bonesetter(src)
-	new /obj/item/surgical_drapes(src)
-	new /obj/item/clothing/mask/surgical(src)
-	new /obj/item/razor(src)
-	new /obj/item/blood_filter(src)
 
 /obj/item/storage/backpack/duffelbag/sec
 	name = "security duffel bag"

--- a/code/modules/surgery/advanced/bioware/cortex_imprint.dm
+++ b/code/modules/surgery/advanced/bioware/cortex_imprint.dm
@@ -11,6 +11,7 @@
 	possible_locs = list(BODY_ZONE_HEAD)
 	target_mobtypes = list(/mob/living/carbon/human)
 	bioware_target = BIOWARE_CORTEX
+	requires_tech = FALSE
 
 /datum/surgery/advanced/bioware/cortex_imprint/can_start(mob/user, mob/living/carbon/target)
 	var/obj/item/organ/brain/B = target.getorganslot(ORGAN_SLOT_BRAIN)

--- a/code/modules/surgery/advanced/bioware/ligament_hook.dm
+++ b/code/modules/surgery/advanced/bioware/ligament_hook.dm
@@ -11,6 +11,7 @@
 				/datum/surgery_step/close)
 	possible_locs = list(BODY_ZONE_CHEST)
 	bioware_target = BIOWARE_LIGAMENTS
+	requires_tech = FALSE
 
 /datum/surgery_step/reshape_ligaments
 	name = "reshape ligaments"

--- a/code/modules/surgery/advanced/bioware/vein_threading.dm
+++ b/code/modules/surgery/advanced/bioware/vein_threading.dm
@@ -10,6 +10,7 @@
 				/datum/surgery_step/close)
 	possible_locs = list(BODY_ZONE_CHEST)
 	bioware_target = BIOWARE_CIRCULATION
+	requires_tech = FALSE
 
 /datum/surgery_step/thread_veins
 	name = "thread veins"

--- a/code/modules/surgery/advanced/lobotomy.dm
+++ b/code/modules/surgery/advanced/lobotomy.dm
@@ -12,6 +12,7 @@
 	target_mobtypes = list(/mob/living/carbon/human)
 	possible_locs = list(BODY_ZONE_HEAD)
 	requires_bodypart_type = 0
+	requires_tech = FALSE
 
 /datum/surgery/advanced/lobotomy/can_start(mob/user, mob/living/carbon/target)
 	if(!..())
@@ -48,12 +49,7 @@
 		if(1)
 			target.gain_trauma_type(BRAIN_TRAUMA_MILD, TRAUMA_RESILIENCE_MAGIC)
 		if(2)
-			if(HAS_TRAIT(target, TRAIT_SPECIAL_TRAUMA_BOOST) && prob(50))
-				target.gain_trauma_type(BRAIN_TRAUMA_SPECIAL, TRAUMA_RESILIENCE_MAGIC)
-			else
-				target.gain_trauma_type(BRAIN_TRAUMA_SEVERE, TRAUMA_RESILIENCE_MAGIC)
-		if(3)
-			target.gain_trauma_type(BRAIN_TRAUMA_SPECIAL, TRAUMA_RESILIENCE_MAGIC)
+			target.gain_trauma_type(BRAIN_TRAUMA_SEVERE, TRAUMA_RESILIENCE_MAGIC)
 		else
 			// do nothing
 	return ..()
@@ -65,16 +61,11 @@
 			"<span class='notice'>[user] successfully lobotomizes [target]!</span>",
 			"<span class='notice'>[user] completes the surgery on [target]'s brain.</span>")
 		B.applyOrganDamage(80)
-		switch(rand(1,3))
+		switch(rand(1,2))
 			if(1)
 				target.gain_trauma_type(BRAIN_TRAUMA_MILD, TRAUMA_RESILIENCE_MAGIC)
 			if(2)
-				if(HAS_TRAIT(target, TRAIT_SPECIAL_TRAUMA_BOOST) && prob(50))
-					target.gain_trauma_type(BRAIN_TRAUMA_SPECIAL, TRAUMA_RESILIENCE_MAGIC)
-				else
-					target.gain_trauma_type(BRAIN_TRAUMA_SEVERE, TRAUMA_RESILIENCE_MAGIC)
-			if(3)
-				target.gain_trauma_type(BRAIN_TRAUMA_SPECIAL, TRAUMA_RESILIENCE_MAGIC)
+				target.gain_trauma_type(BRAIN_TRAUMA_SEVERE, TRAUMA_RESILIENCE_MAGIC)
 	else
 		user.visible_message("<span class='warning'>[user] suddenly notices that the brain [user.p_they()] [user.p_were()] working on is not there anymore.</span>", "<span class='warning'>You suddenly notice that the brain you were working on is not there anymore.</span>")
 	return FALSE

--- a/code/modules/surgery/healing.dm
+++ b/code/modules/surgery/healing.dm
@@ -112,7 +112,6 @@
 /datum/surgery/healing/brute/upgraded
 	name = "Tend Wounds (Bruises, Adv.)"
 	replaced_by = /datum/surgery/healing/brute/upgraded/femto
-	requires_tech = TRUE
 	healing_step_type = /datum/surgery_step/heal/brute/upgraded
 	desc = "A surgical procedure that provides advanced treatment for a patient's brute traumas. Heals more when the patient is severely injured."
 
@@ -150,7 +149,6 @@
 /datum/surgery/healing/burn/upgraded
 	name = "Tend Wounds (Burn, Adv.)"
 	replaced_by = /datum/surgery/healing/burn/upgraded/femto
-	requires_tech = TRUE
 	healing_step_type = /datum/surgery_step/heal/burn/upgraded
 	desc = "A surgical procedure that provides advanced treatment for a patient's burns. Heals more when the patient is severely injured."
 
@@ -182,7 +180,6 @@
 /datum/surgery/healing/combo
 	name = "Tend Wounds (Mixture, Basic)"
 	replaced_by = /datum/surgery/healing/combo/upgraded
-	requires_tech = TRUE
 	healing_step_type = /datum/surgery_step/heal/combo
 	desc = "A surgical procedure that provides basic treatment for a patient's burns and brute traumas. Heals slightly more when the patient is severely injured."
 
@@ -192,9 +189,9 @@
 	healing_step_type = /datum/surgery_step/heal/combo/upgraded
 	desc = "A surgical procedure that provides advanced treatment for a patient's burns and brute traumas. Heals more when the patient is severely injured."
 
-
 /datum/surgery/healing/combo/upgraded/femto //no real reason to type it like this except consistency, don't worry you're not missing anything
 	name = "Tend Wounds (Mixture, Exp.)"
+	requires_tech = TRUE
 	replaced_by = null
 	healing_step_type = /datum/surgery_step/heal/combo/upgraded/femto
 	desc = "A surgical procedure that provides experimental treatment for a patient's burns and brute traumas. Heals considerably more when the patient is severely injured."

--- a/code/modules/surgery/stomachpump.dm
+++ b/code/modules/surgery/stomachpump.dm
@@ -1,5 +1,5 @@
 /datum/surgery/stomach_pump
-	name = "Stomach Pump"
+	name = "Stomach pump"
 	steps = list(/datum/surgery_step/incise,
 				/datum/surgery_step/retract_skin,
 				/datum/surgery_step/incise,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
- Tend wounds brute, burn, and mix advanced are available roundstart
- Lobotomy, ligament hook, vein threading, cortex imprint researched surgeries are available roundstart 
- Lobotomies can no longer give special traumas
- New surgical bag with advanced tools added to LC13 facility maps

## Why It's Good For The Game
- Tend wounds advanced: Because the base version sucks and takes too long
- Advanced tools: See above
- Lobotomy: How can we call ours Lobotomy Corporation without lobotomies?
- Ligament hook: Thought it would be funny for people to reattach their lost body parts
- Vein threading: For the people who keep running anemia trait for some reason
- Cortex imprint: Would also be nice to have a beneficial surgery that prevented brain traumas

Other surgeries excluded because I felt they would be too game-changing/break abnorm gimmicks. Hopefully these changes make surgery faster and more practical.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: surgeries previously behind research can be used roundstart, advanced surgery tools provided to facilities
/:cl:
