### PR TITLE
Clerks can no longer obtain E.G.O. gifts

### DIFF
--- a/ModularTegustation/tegu_items/gadgets/powered.dm
+++ b/ModularTegustation/tegu_items/gadgets/powered.dm
@@ -410,9 +410,6 @@
 		if(H.target != user)
 			hit_message = span_warning("[user] injected some enkephalin into [T].")
 			H.GiveTarget(user)
-			if(isabnormalitymob(H)) // RISK. REWARD.
-				var/mob/living/simple_animal/hostile/abnormality/abno = H
-				abno.GiftUser(user, 1, 100)
 			user.visible_message(hit_message)
 			cell.charge -= batterycost
 			update_icon()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes clerk ego gifts from #1590 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Gifts are a cool and rare thing for agents to sometimes get. Clerks running around with 8 gifts displayed how this feature was a mistake.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Removed free ego gifts obtained when using the enkephalin injector
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
