### PR TITLE
Me when i waste an hour of my life on improving the code of status effects

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/aleph/army_in_black.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/army_in_black.dm
@@ -343,7 +343,7 @@ GLOBAL_LIST_EMPTY(army)
 /datum/status_effect/protection
 	id = "protection"
 	status_type = STATUS_EFFECT_UNIQUE
-	duration = 120 SECONDS
+	duration = 2 MINUTES
 	alert_type = null
 	tick_interval = 30
 	var/boom = TRUE

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/nihil.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/nihil.dm
@@ -120,7 +120,7 @@
 /datum/status_effect/stacking/void
 	id = "stacking_void"
 	status_type = STATUS_EFFECT_UNIQUE
-	duration = 200 //20 seconds
+	duration = 20 SECONDS
 	alert_type = null
 	stack_decay = 0
 	stacks = 1

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/seasons.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/seasons.dm
@@ -642,7 +642,7 @@
 /datum/status_effect/freezing
 	id = "freezing"
 	status_type = STATUS_EFFECT_UNIQUE
-	duration = 300
+	duration = 30 SECONDS
 	alert_type = /atom/movable/screen/alert/status_effect/freezing
 
 /atom/movable/screen/alert/status_effect/freezing
@@ -654,7 +654,7 @@
 /datum/status_effect/fogbound
 	id = "fogbound"
 	status_type = STATUS_EFFECT_UNIQUE
-	duration = 300
+	duration = 30 SECONDS
 	alert_type = /atom/movable/screen/alert/status_effect/fogbound
 
 /datum/status_effect/fogbound/on_apply()

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/staining_rose.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/staining_rose.dm
@@ -140,7 +140,7 @@
 /datum/status_effect/wilting
 	id = "wilting"
 	status_type = STATUS_EFFECT_UNIQUE
-	duration = 3000		//Lasts 5 minutes, or when the weather ends
+	duration = 5 MINUTES	// Can end early when the weather ends
 	alert_type = null
 
 /datum/status_effect/wilting/on_apply()

--- a/code/modules/mob/living/simple_animal/abnormality/he/drifting_fox.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/drifting_fox.dm
@@ -103,19 +103,19 @@
 
 /datum/status_effect/false_kindness/on_apply() //" Borrowed " from Ptear blade, courtesy of gong.
 	. = ..()
-	if(ishuman(owner))
-		var/mob/living/carbon/human/L = owner //Stolen from Ptear Blade, MAYBE works on people?
-		to_chat(L, span_userdanger("You feel the foxes gaze upon you!"))
-		L.physiology.black_mod *= 1.3
+	if(!ishuman(owner))
 		return
+	var/mob/living/carbon/human/status_holder = owner //Stolen from Ptear Blade, MAYBE works on people?
+	to_chat(status_holder, span_userdanger("You feel the foxes gaze upon you!"))
+	status_holder.physiology.black_mod *= 1.3
 
 /datum/status_effect/false_kindness/on_remove()
 	. = ..()
 	if(ishuman(owner))
-		var/mob/living/carbon/human/L = owner
-		to_chat(L, span_userdanger("You feel as though its gaze has lifted.")) //stolen from PT wep, but I asked so this 100% ok.
-		L.physiology.black_mod /= 1.3
 		return
+	var/mob/living/carbon/human/status_holder = owner
+	to_chat(status_holder, span_userdanger("You feel as though its gaze has lifted.")) //stolen from PT wep, but I asked so this 100% ok.
+	status_holder.physiology.black_mod /= 1.3
 
 //mob/living/simple_animal/hostile/abnormality/drifting_fox/Life()
 	//. = ..()

--- a/code/modules/mob/living/simple_animal/abnormality/he/fan.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/fan.dm
@@ -132,7 +132,7 @@
 /datum/status_effect/stacking/fanhot
 	id = "stacking_fanhot"
 	status_type = STATUS_EFFECT_UNIQUE
-	duration = 200 //20 seconds
+	duration = 20 SECONDS
 	alert_type = null
 	stack_decay = 0
 	tick_interval = 10
@@ -159,21 +159,24 @@
 	. = ..()
 	if(!stacks_added)
 		return
-	if(stacks > 10)
-		owner.apply_damage((stacks / 5), RED_DAMAGE, null, owner.run_armor_check(null, RED_DAMAGE), spread_damage = TRUE)
-		owner.playsound_local(owner, 'sound/effects/book_burn.ogg', 25, TRUE)
+	if(stacks <= 10)
+		return
+	owner.apply_damage((stacks / 5), RED_DAMAGE, null, owner.run_armor_check(null, RED_DAMAGE), spread_damage = TRUE)
+	owner.playsound_local(owner, 'sound/effects/book_burn.ogg', 25, TRUE)
 
 /datum/status_effect/stacking/fanhot/on_remove()
 	. = ..()
-	if(ishuman(owner))
-		to_chat(owner, span_nicegreen("Someone turned on the AC! Rejoice!"))
-		if(owner.client)
-			owner.remove_client_colour(/datum/client_colour/glass_colour/orange)
+	if(!ishuman(owner))
+		return
+	to_chat(owner, span_nicegreen("Someone turned on the AC! Rejoice!"))
+	if(owner.client)
+		owner.remove_client_colour(/datum/client_colour/glass_colour/orange)
 
 /datum/status_effect/stacking/fanhot/threshold_cross_effect()
-	if(ishuman(owner))
-		var/mob/living/carbon/human/H = owner
-		to_chat(owner, span_warning("IT'S TOO HOT!"))
-		H.adjust_fire_stacks(15)
-		H.IgniteMob()
-		stacks -= 5
+	if(!ishuman(owner))
+		return
+	var/mob/living/carbon/human/status_holder = owner
+	to_chat(status_holder, span_warning("IT'S TOO HOT!"))
+	status_holder.adjust_fire_stacks(15)
+	status_holder.IgniteMob()
+	stacks -= 5

--- a/code/modules/mob/living/simple_animal/abnormality/he/golden_false_apple.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/golden_false_apple.dm
@@ -483,21 +483,22 @@
 	return ..()
 
 /datum/status_effect/stacking/maggots/tick()//change this to golden apple's life tick for less lag
-	var/mob/living/carbon/human/H = owner
-	H.apply_damage(stacks * 1, BLACK_DAMAGE, null, H.run_armor_check(null, BLACK_DAMAGE))
-	if(H.stat >= HARD_CRIT)
-		var/obj/structure/spider/cocoon/casing = new(H.loc)
-		H.forceMove(casing)
-		casing.name = "pile of maggots"
-		casing.desc = "They're wriggling and writhing over something."
-		casing.icon_state = pick(
-			"cocoon_large1",
-			"cocoon_large2",
-			"cocoon_large3",
-		)
-		casing.density = FALSE
-		casing.color = "#01F9C6"
-		qdel(src)
+	var/mob/living/carbon/human/status_holder = owner
+	status_holder.apply_damage(stacks * 1, BLACK_DAMAGE, null, H.run_armor_check(null, BLACK_DAMAGE))
+	if(status_holder.stat < HARD_CRIT)
+		return
+	var/obj/structure/spider/cocoon/casing = new(H.loc)
+	status_holder.forceMove(casing)
+	casing.name = "pile of maggots"
+	casing.desc = "They're wriggling and writhing over something."
+	casing.icon_state = pick(
+		"cocoon_large1",
+		"cocoon_large2",
+		"cocoon_large3",
+	)
+	casing.density = FALSE
+	casing.color = "#01F9C6"
+	qdel(src)
 
 /obj/item/food/grown/apple/gold/abnormality
 	food_reagents = list(/datum/reagent/abnormality/ambrosia = 10)

--- a/code/modules/mob/living/simple_animal/abnormality/he/laetitia.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/laetitia.dm
@@ -105,39 +105,44 @@
 	return ..()
 
 /datum/status_effect/pranked/tick()
-	if((duration - world.time) <= 100) //at most a 10 second warning
-		if(!prank_overlay && (get_attribute_level(owner, PRUDENCE_ATTRIBUTE) >= 60))
-			if(ishuman(owner))
-				var/mob/living/carbon/human/L = owner
-				//i swear this is all necessary
-				prank_overlay = new
-				prank_overlay.icon = 'ModularTegustation/Teguicons/tegu_effects.dmi'
-				prank_overlay.icon_state = "prank_gift"
-				prank_overlay.layer = -BODY_FRONT_LAYER
-				prank_overlay.plane = FLOAT_PLANE
-				prank_overlay.mouse_opacity = 0
-				prank_overlay.vis_flags = VIS_INHERIT_ID
-				prank_overlay.alpha = 0
-				to_chat(L, span_danger("Your heart-shaped present begins to crack..."))
-				animate(prank_overlay, alpha = 255, time = (duration - world.time))
-				L.vis_contents += prank_overlay
+	if(!(duration - world.time) <= 100) //at most a 10 second warning
+		return
+	if(prank_overlay && (get_attribute_level(owner, PRUDENCE_ATTRIBUTE) < 60))
+		return
+	if(!ishuman(owner))
+		return
+	var/mob/living/carbon/human/status_holder = owner
+	//i swear this is all necessary
+	prank_overlay = new
+	prank_overlay.icon = 'ModularTegustation/Teguicons/tegu_effects.dmi'
+	prank_overlay.icon_state = "prank_gift"
+	prank_overlay.layer = -BODY_FRONT_LAYER
+	prank_overlay.plane = FLOAT_PLANE
+	prank_overlay.mouse_opacity = 0
+	prank_overlay.vis_flags = VIS_INHERIT_ID
+	prank_overlay.alpha = 0
+	to_chat(status_holder, span_danger("Your heart-shaped present begins to crack..."))
+	animate(prank_overlay, alpha = 255, time = (duration - world.time))
+	status_holder.vis_contents += prank_overlay
 
 /datum/status_effect/pranked/on_remove()
 	UnregisterSignal(owner, COMSIG_WORK_STARTED)
 	if(prank_overlay in owner.vis_contents)
 		owner.vis_contents -= prank_overlay
-	if(duration < world.time) //if prank removed due to it expiring
-		if(ishuman(owner))
-			var/mob/living/carbon/human/L = owner
-			to_chat(L, span_userdanger("You feel something deep in your body explode!"))
-			L.vis_contents -= prank_overlay
-			var/location = get_turf(L)
-			new /mob/living/simple_animal/hostile/gift(location)
-			var/rand_dir = pick(NORTH, SOUTH, EAST, WEST)
-			var/atom/throw_target = get_edge_target_turf(L, rand_dir)
-			if(!L.anchored)
-				L.throw_at(throw_target, rand(1, 3), 7, L)
-			L.apply_damage(200, RED_DAMAGE, null, L.run_armor_check(null, RED_DAMAGE), spread_damage = TRUE)//Usually a kill, you can block it if you're good
+	if(!duration < world.time) //if prank removed due to it expiring
+		return
+	if(!ishuman(owner))
+		return
+	var/mob/living/carbon/human/status_holder = owner
+	to_chat(status_holder, span_userdanger("You feel something deep in your body explode!"))
+	status_holder.vis_contents -= prank_overlay
+	var/location = get_turf(status_holder)
+	new /mob/living/simple_animal/hostile/gift(location)
+	var/rand_dir = pick(NORTH, SOUTH, EAST, WEST)
+	var/atom/throw_target = get_edge_target_turf(status_holder, rand_dir)
+	if(!status_holder.anchored)
+		status_holder.throw_at(throw_target, rand(1, 3), 7, status_holder)
+	status_holder.apply_damage(200, RED_DAMAGE, null, status_holder.run_armor_check(null, RED_DAMAGE), spread_damage = TRUE)//Usually a kill, you can block it if you're good
 
 /datum/status_effect/pranked/proc/TriggerPrank()
 	//immediately set to 10 seconds, don't shorten if less than 10 seconds remaining
@@ -148,10 +153,11 @@
 //Half prank duration once if you work with another abnorm
 /datum/status_effect/pranked/proc/WorkCheck(datum/source, datum/abnormality/datum_sent, mob/living/carbon/human/user, work_type)
 	SIGNAL_HANDLER
-	if(datum_sent != laetitia_datum_reference)
-		var/newduration = duration
-		newduration = (newduration - world.time)/2
-		duration = newduration + world.time
-		UnregisterSignal(owner, COMSIG_WORK_STARTED)
+	if(datum_sent == laetitia_datum_reference)
+		return
+	var/newduration = duration
+	newduration = (newduration - world.time)/2
+	duration = newduration + world.time
+	UnregisterSignal(owner, COMSIG_WORK_STARTED)
 
 #undef STATUS_EFFECT_PRANKED

--- a/code/modules/mob/living/simple_animal/abnormality/he/puss_in_boots.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/puss_in_boots.dm
@@ -83,13 +83,14 @@
 		say("At last, someone worthy!")
 
 /mob/living/simple_animal/hostile/abnormality/puss_in_boots/proc/Blessing(mob/living/carbon/human/user)
-	var/datum/status_effect/chosen/C = blessed_human.has_status_effect(/datum/status_effect/chosen)
-	if(!C)
-		user.apply_status_effect(STATUS_EFFECT_CHOSEN)
-		RegisterSignal(user, COMSIG_LIVING_DEATH, .proc/BlessedDeath)
-		RegisterSignal(user, COMSIG_HUMAN_INSANE, .proc/BlessedDeath)
-		RegisterSignal(user, COMSIG_WORK_STARTED, .proc/OnWorkStart)
-		RegisterSignal(SSdcs, COMSIG_GLOB_ABNORMALITY_BREACH, .proc/OnAbnoBreach)
+	var/datum/status_effect/chosen/Chosen = blessed_human.has_status_effect(/datum/status_effect/chosen)
+	if(Chosen)
+		return
+	user.apply_status_effect(STATUS_EFFECT_CHOSEN)
+	RegisterSignal(user, COMSIG_LIVING_DEATH, .proc/BlessedDeath)
+	RegisterSignal(user, COMSIG_HUMAN_INSANE, .proc/BlessedDeath)
+	RegisterSignal(user, COMSIG_WORK_STARTED, .proc/OnWorkStart)
+	RegisterSignal(SSdcs, COMSIG_GLOB_ABNORMALITY_BREACH, .proc/OnAbnoBreach)
 
 /mob/living/simple_animal/hostile/abnormality/puss_in_boots/proc/BlessedDeath(datum/source, gibbed)
 	SIGNAL_HANDLER

--- a/code/modules/mob/living/simple_animal/abnormality/he/red_shoes.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/red_shoes.dm
@@ -230,7 +230,7 @@
 /datum/status_effect/red_possess//This status will cause you to special panic if your sanity reaches 0 while you have it. If red shoes isn't present or already breached, it will swap to murder panic.
 	id = "redpossess"
 	status_type = STATUS_EFFECT_UNIQUE
-	duration = 120 SECONDS
+	duration = 2 MINUTES
 	alert_type = /atom/movable/screen/alert/status_effect/red_possess
 
 /atom/movable/screen/alert/status_effect/red_possess
@@ -243,12 +243,12 @@
 	if(!ishuman(owner))
 		qdel(src)
 		return
-	var/mob/living/carbon/human/H = owner
-	var/usertemp = (get_attribute_level(H, TEMPERANCE_ATTRIBUTE))
+	var/mob/living/carbon/human/status_holder = owner
+	var/usertemp = (get_attribute_level(status_holder, TEMPERANCE_ATTRIBUTE))
 	var/desire_damage = clamp((80 - (usertemp / 2)),80, 10)//deals between 80 and 10 white damage depending on your temperance attribute when applied.
-	H.apply_damage(desire_damage, WHITE_DAMAGE, null, H.run_armor_check(null, WHITE_DAMAGE), spread_damage = TRUE)//DIE!
-	H.adjust_attribute_bonus(PRUDENCE_ATTRIBUTE, -50)//By using bonuses, this lowers your maximum prudence
-	if(H.sanity_lost)
+	status_holder.apply_damage(desire_damage, WHITE_DAMAGE, null, status_holder.run_armor_check(null, WHITE_DAMAGE), spread_damage = TRUE)//DIE!
+	status_holder.adjust_attribute_bonus(PRUDENCE_ATTRIBUTE, -50)//By using bonuses, this lowers your maximum prudence
+	if(status_holder.sanity_lost)
 		qdel(src)
 		return
 	return ..()
@@ -256,20 +256,20 @@
 /datum/status_effect/red_possess/on_remove()
 	if(!ishuman(owner))
 		return
-	var/mob/living/carbon/human/H = owner
+	var/mob/living/carbon/human/status_holder = owner
 	H.adjust_attribute_bonus(PRUDENCE_ATTRIBUTE, 50)//Return prudence back to normal
-	if(H.sanity_lost)
+	if(status_holder.sanity_lost)
 		QDEL_NULL(owner.ai_controller)
-		H.ai_controller = /datum/ai_controller/insane/red_possess
-		H.InitializeAIController()
+		status_holder.ai_controller = /datum/ai_controller/insane/red_possess
+		status_holder.InitializeAIController()
 	return ..()
 
 /datum/status_effect/red_possess/tick()//delete the status if sanity is restored or a panic occurs
 	..()
-	var/mob/living/carbon/human/H = owner
-	if(H.sanityhealth == H.maxSanity)
+	var/mob/living/carbon/human/status_holder = owner
+	if(status_holder.sanityhealth == H.maxSanity)
 		qdel(src)
-	if(H.sanity_lost)
+	if(status_holder.sanity_lost)
 		qdel(src)
 
 //***Custom Panic Definiton***

--- a/code/modules/mob/living/simple_animal/abnormality/he/silent_girl.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/silent_girl.dm
@@ -111,25 +111,27 @@
 
 /datum/status_effect/sg_guilty/on_apply()
 	. = ..()
-	if(ishuman(owner))
-		var/mob/living/carbon/human/H = owner
-		to_chat(H, span_userdanger("You feel a heavy weight upon your shoulders."))
-		playsound(get_turf(H), 'sound/abnormalities/silentgirl/Guilt_Apply.ogg', 50, 0, 2)
-		H.add_overlay(guilt_icon)
-		H.physiology.work_success_mod *= 0.70
-		RegisterSignal(H, COMSIG_WORK_COMPLETED, .proc/OnWorkComplete)
+	if(!ishuman(owner))
+		return
+	var/mob/living/carbon/human/status_holder = owner
+	to_chat(status_holder, span_userdanger("You feel a heavy weight upon your shoulders."))
+	playsound(get_turf(status_holder), 'sound/abnormalities/silentgirl/Guilt_Apply.ogg', 50, 0, 2)
+	status_holder.add_overlay(guilt_icon)
+	status_holder.physiology.work_success_mod *= 0.70
+	RegisterSignal(status_holder, COMSIG_WORK_COMPLETED, .proc/OnWorkComplete)
 
 /datum/status_effect/sg_guilty/on_remove()
 	. = ..()
-	if(ishuman(owner))
-		var/mob/living/carbon/human/H = owner
-		to_chat(H, span_nicegreen("You feel a weight lift from your shoulders."))
-		playsound(get_turf(H), 'sound/abnormalities/silentgirl/Guilt_Remove.ogg', 50, 0, 2)
-		H.cut_overlay(guilt_icon)
-		H.physiology.work_success_mod /= 0.70
-		UnregisterSignal(H, COMSIG_WORK_COMPLETED)
-		if(!isnull(datum_reference))
-			INVOKE_ASYNC(datum_reference, /datum/abnormality/proc/qliphoth_change, 1, owner)
+	if(!ishuman(owner))
+		return
+	var/mob/living/carbon/human/status_holder = owner
+	to_chat(status_holder, span_nicegreen("You feel a weight lift from your shoulders."))
+	playsound(get_turf(status_holder), 'sound/abnormalities/silentgirl/Guilt_Remove.ogg', 50, 0, 2)
+	status_holder.cut_overlay(guilt_icon)
+	status_holder.physiology.work_success_mod /= 0.70
+	UnregisterSignal(status_holder, COMSIG_WORK_COMPLETED)
+	if(!isnull(datum_reference))
+		INVOKE_ASYNC(datum_reference, /datum/abnormality/proc/qliphoth_change, 1, owner)
 
 /datum/status_effect/sg_guilty/refresh()
 	playsound(get_turf(owner), 'sound/abnormalities/silentgirl/Guilt_Apply.ogg', 50, 0, 2)

--- a/code/modules/mob/living/simple_animal/abnormality/he/singing_machine.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/singing_machine.dm
@@ -207,12 +207,13 @@ Finally, an abnormality that DOESN'T have to do any fancy movement shit. It's a 
 
 /datum/status_effect/display/singing_machine/on_apply()
 	. = ..()
-	if(ishuman(owner))
-		var/mob/living/carbon/human/H = owner
-		H.adjust_attribute_bonus(FORTITUDE_ATTRIBUTE, -5)
-		H.adjust_attribute_bonus(PRUDENCE_ATTRIBUTE, -5)
-		H.adjust_attribute_bonus(JUSTICE_ATTRIBUTE, 10)
-		H.physiology.white_mod *= 1.1
+	if(!ishuman(owner))
+		return
+	var/mob/living/carbon/human/status_holder = owner
+	status_holder.adjust_attribute_bonus(FORTITUDE_ATTRIBUTE, -5)
+	status_holder.adjust_attribute_bonus(PRUDENCE_ATTRIBUTE, -5)
+	status_holder.adjust_attribute_bonus(JUSTICE_ATTRIBUTE, 10)
+	status_holder.physiology.white_mod *= 1.1
 
 /datum/status_effect/display/singing_machine/tick()
 	if(world.time % addictionTick == 0 && ishuman(owner)) // Give or take one, this will fire off as many times as if I set up a proper timer variable.
@@ -221,11 +222,12 @@ Finally, an abnormality that DOESN'T have to do any fancy movement shit. It's a 
 
 /datum/status_effect/display/singing_machine/on_remove()
 	. = ..()
-	if(ishuman(owner))
-		var/mob/living/carbon/human/H = owner
-		H.adjust_attribute_bonus(FORTITUDE_ATTRIBUTE, 5)
-		H.adjust_attribute_bonus(PRUDENCE_ATTRIBUTE, 5)
-		H.adjust_attribute_bonus(JUSTICE_ATTRIBUTE, -10)
-		H.physiology.white_mod /= 1.1
+	if(!ishuman(owner))
+		return
+	var/mob/living/carbon/human/status_holder = owner
+	status_holder.adjust_attribute_bonus(FORTITUDE_ATTRIBUTE, 5)
+	status_holder.adjust_attribute_bonus(PRUDENCE_ATTRIBUTE, 5)
+	status_holder.adjust_attribute_bonus(JUSTICE_ATTRIBUTE, -10)
+	status_holder.physiology.white_mod /= 1.1
 
 #undef STATUS_EFFECT_MUSIC

--- a/code/modules/mob/living/simple_animal/abnormality/teth/cherry_blossoms.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/cherry_blossoms.dm
@@ -77,7 +77,7 @@
 /datum/status_effect/markedfordeath
 	id = "markedfordeath"
 	status_type = STATUS_EFFECT_UNIQUE
-	duration = 100		//Lasts 10 seconds
+	duration = 10 SECONDS
 	alert_type = /atom/movable/screen/alert/status_effect/marked
 
 /atom/movable/screen/alert/status_effect/marked
@@ -88,31 +88,35 @@
 
 /datum/status_effect/markedfordeath/on_apply()
 	. = ..()
-	if(ishuman(owner))
-		var/mob/living/carbon/human/L = owner
-		L.physiology.red_mod *= 4
-		L.physiology.white_mod *= 4
-		L.physiology.black_mod *= 4
-		L.physiology.pale_mod *= 4
+	if(!ishuman(owner))
+		return
+	var/mob/living/carbon/human/status_holder = owner
+	status_holder.physiology.red_mod *= 4
+	status_holder.physiology.white_mod *= 4
+	status_holder.physiology.black_mod *= 4
+	status_holder.physiology.pale_mod *= 4
 
 /datum/status_effect/markedfordeath/tick()
-	var/mob/living/carbon/human/Y = owner
-	if(Y.sanity_lost)
-		Y.death()
-	if(owner.stat == DEAD)
-		for(var/mob/living/carbon/human/H in GLOB.player_list)
-			if(H.stat != DEAD)
-				H.adjustBruteLoss(-500) // It heals everyone to full
-				H.adjustSanityLoss(-500) // It heals everyone to full
-				H.remove_status_effect(STATUS_EFFECT_MARKEDFORDEATH)
+	var/mob/living/carbon/human/status_holder = owner
+	if(status_holder.sanity_lost)
+		status_holder.death()
+	if(owner.stat != DEAD)
+		return
+	for(var/mob/living/carbon/human/affected_human in GLOB.player_list)
+		if(affected_human.stat == DEAD)
+			continue
+		affected_human.adjustBruteLoss(-500) // It heals everyone to full
+		affected_human.adjustSanityLoss(-500) // It heals everyone to full
+		affected_human.remove_status_effect(STATUS_EFFECT_MARKEDFORDEATH)
 
 /datum/status_effect/markedfordeath/on_remove()
 	. = ..()
-	if(ishuman(owner))
-		var/mob/living/carbon/human/L = owner
-		L.physiology.red_mod /= 4
-		L.physiology.white_mod /= 4
-		L.physiology.black_mod /= 4
-		L.physiology.pale_mod /= 4
+	if(!ishuman(owner))
+		return
+	var/mob/living/carbon/human/status_holder = owner
+	status_holder.physiology.red_mod /= 4
+	status_holder.physiology.white_mod /= 4
+	status_holder.physiology.black_mod /= 4
+	status_holder.physiology.pale_mod /= 4
 
 #undef STATUS_EFFECT_MARKEDFORDEATH

--- a/code/modules/mob/living/simple_animal/abnormality/teth/crumbling_armor.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/crumbling_armor.dm
@@ -176,7 +176,7 @@
 /datum/status_effect/cowardice
 	id = "cowardice"
 	status_type = STATUS_EFFECT_UNIQUE
-	duration = 10		//Lasts 1 second
+	duration = 1 SECONDS
 	alert_type = /atom/movable/screen/alert/status_effect/cowardice
 	var/punishment_damage = 25
 
@@ -196,16 +196,16 @@
 
 /datum/status_effect/cowardice/proc/Punishment()
 	SIGNAL_HANDLER
-	var/mob/living/carbon/human/H = owner
-	if(!istype(H))
+	var/mob/living/carbon/human/status_holder = owner
+	if(!istype(status_holder))
 		return
-	var/obj/item/bodypart/head/head = owner.get_bodypart("head")
-	if(!istype(head))
+	var/obj/item/bodypart/head/holders_head = owner.get_bodypart("head")
+	if(!istype(holders_head))
 		return FALSE
-	playsound(get_turf(H), 'sound/abnormalities/crumbling/attack.ogg', 50, FALSE)
-	H.apply_damage(punishment_damage, PALE_DAMAGE, null, H.run_armor_check(null, PALE_DAMAGE), spread_damage = TRUE)
+	playsound(get_turf(status_holder), 'sound/abnormalities/crumbling/attack.ogg', 50, FALSE)
+	status_holder.apply_damage(punishment_damage, PALE_DAMAGE, null, H.run_armor_check(null, PALE_DAMAGE), spread_damage = TRUE)
 	if(H.health < 0)
-		head.dismember()
+		holders_head.dismember()
 	new /obj/effect/temp_visual/slice(get_turf(H))
 	qdel(src)
 

--- a/code/modules/mob/living/simple_animal/abnormality/teth/dingle_dangle.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/dingle_dangle.dm
@@ -67,17 +67,19 @@
 /datum/status_effect/dangle
 	id = "dangle"
 	status_type = STATUS_EFFECT_UNIQUE
-	duration = 3000		//Lasts 5 minutes
+	duration = 5 MINUTES
 	alert_type = /atom/movable/screen/alert/status_effect/dangle
 
 /datum/status_effect/dangle/on_apply()
 	. = ..()
-	if(ishuman(owner))
-		var/mob/living/carbon/human/L = owner
-		L.adjust_attribute_bonus(JUSTICE_ATTRIBUTE, 15)
+	if(!ishuman(owner))
+		return
+	var/mob/living/carbon/human/status_holder = owner
+	status_holder.adjust_attribute_bonus(JUSTICE_ATTRIBUTE, 15)
 
 /datum/status_effect/dangle/on_remove()
 	. = ..()
-	if(ishuman(owner))
-		var/mob/living/carbon/human/L = owner
-		L.adjust_attribute_bonus(JUSTICE_ATTRIBUTE, -15)
+	if(!ishuman(owner))
+		return
+	var/mob/living/carbon/human/status_holder = owner
+	status_holder.adjust_attribute_bonus(JUSTICE_ATTRIBUTE, -15)

--- a/code/modules/mob/living/simple_animal/abnormality/teth/faelantern.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/faelantern.dm
@@ -354,14 +354,16 @@
 
 /datum/status_effect/fairy_lure/on_apply()
 	. = ..()
-	if(ishuman(owner))
-		var/mob/living/carbon/human/H = owner
-		H.physiology.red_mod *= 5
+	if(!ishuman(owner))
+		return
+	var/mob/living/carbon/human/status_holder = owner
+	status_holder.physiology.red_mod *= 5
 
 /datum/status_effect/fairy_lure/on_remove()
 	. = ..()
-	if(ishuman(owner))
-		var/mob/living/carbon/human/H = owner
-		H.physiology.red_mod /= 5
+	if(!ishuman(owner))
+		return
+	var/mob/living/carbon/human/status_holder = owner
+	status_holder.physiology.red_mod /= 5
 
 #undef STATUS_EFFECT_FAIRYLURE

--- a/code/modules/mob/living/simple_animal/abnormality/teth/pale_horse.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/pale_horse.dm
@@ -284,16 +284,18 @@
 
 /datum/status_effect/mortis/on_apply()
 	. = ..()
-	if(ishuman(owner))
-		to_chat(owner, span_warning("You feel weak..."))
-		var/mob/living/carbon/human/M = owner
-		M.physiology.pale_mod *= 2
+	if(!ishuman(owner))
+		return
+	to_chat(owner, span_warning("You feel weak..."))
+	var/mob/living/carbon/human/status_holder = owner
+	status_holder.physiology.pale_mod *= 2
 
 /datum/status_effect/mortis/on_remove()
 	. = ..()
-	if(ishuman(owner))
-		to_chat(owner, span_warning("You regain your vigor."))
-		var/mob/living/carbon/human/M = owner
-		M.physiology.pale_mod /= 2
+	if(!ishuman(owner))
+		return
+	to_chat(owner, span_warning("You regain your vigor."))
+	var/mob/living/carbon/human/status_holder = owner
+	status_holder.physiology.pale_mod /= 2
 
 #undef STATUS_EFFECT_MORTIS

--- a/code/modules/mob/living/simple_animal/abnormality/teth/penitent_girl.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/penitent_girl.dm
@@ -53,7 +53,7 @@
 /datum/status_effect/penitence
 	id = "penitence"
 	status_type = STATUS_EFFECT_UNIQUE
-	duration = 600		//Cut off your own legs after 60 seconds if you are still insane
+	duration = 1 MINUTES
 	alert_type = null
 
 /datum/status_effect/penitence/on_apply()
@@ -65,29 +65,30 @@
 /datum/status_effect/penitence/on_remove()
 	. = ..()
 	owner.cut_overlay(mutable_appearance('icons/mob/clothing/feet.dmi', "red_shoes", -ABOVE_MOB_LAYER))
-	if(ishuman(owner))
-		var/mob/living/carbon/human/user = owner
-		if(!user.sanity_lost) //Are we still insane? If not, we get to keep our legs.
-			return
-		if(HAS_TRAIT(user, TRAIT_NODISMEMBER))
-			return
-		var/obj/item/bodypart/l_leg = user.get_bodypart(BODY_ZONE_L_LEG)
-		var/obj/item/bodypart/r_leg = user.get_bodypart(BODY_ZONE_R_LEG)
-		var/did_the_thing = (l_leg?.dismember() && r_leg?.dismember()) //not all limbs can be removed, so important to check that we did. the. thing.
-		if(!did_the_thing)
-			return
-		if(user.stat < UNCONSCIOUS) //Not unconscious/dead
-			user.say("Please forgive me... I'll just cut off my feet.")
-		user.adjustBruteLoss(300)//DIE! For real, this time.
+	if(!ishuman(owner))
+		return
+	var/mob/living/carbon/human/status_holder = owner
+	if(!status_holder.sanity_lost) //Are we still insane? If not, we get to keep our legs.
+		return
+	if(HAS_TRAIT(status_holder, TRAIT_NODISMEMBER))
+		return
+	var/obj/item/bodypart/left_leg = status_holder.get_bodypart(BODY_ZONE_L_LEG)
+	var/obj/item/bodypart/right_leg = status_holder.get_bodypart(BODY_ZONE_R_LEG)
+	var/did_the_thing = (left_leg?.dismember() && right_leg?.dismember()) //not all limbs can be removed, so important to check that we did. the. thing.
+	if(!did_the_thing)
+		return
+	if(status_holder.stat < UNCONSCIOUS) //Not unconscious/dead
+		status_holder.say("Please forgive me... I'll just cut off my feet.")
+	status_holder.adjustBruteLoss(300)//DIE! For real, this time.
 
 /datum/status_effect/penitence/tick()
 	if(!ishuman(owner))
 		return
-	var/mob/living/carbon/human/user = owner
-	if(!user.sanity_lost && !QDELETED(user))
+	var/mob/living/carbon/human/status_holder = owner
+	if(!status_holder.sanity_lost && !QDELETED(status_holder))
 		qdel(src)
 	else
-		user.emote("spin")
+		status_holder.emote("spin")
 
 #undef STATUS_EFFECT_PENITENCE
 

--- a/code/modules/mob/living/simple_animal/abnormality/teth/so_that_no_cry.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/so_that_no_cry.dm
@@ -228,7 +228,7 @@
 /datum/status_effect/stacking/talisman //Justice increasing talismans
 	id = "talisman"
 	status_type = STATUS_EFFECT_MULTIPLE
-	duration = 240 SECONDS //Lasts for 4 minutes
+	duration = 4 MINUTES
 	stack_decay = 0 //Without this the stacks were decaying after 1 sec
 	max_stacks = 6 //actual max is 5 for +25 Justice, 6 instantly curses you
 	stacks = 1
@@ -238,38 +238,41 @@
 	var/safe_removal = FALSE
 
 /datum/status_effect/stacking/talisman/on_apply()
-	if(ishuman(owner))
-		var/mob/living/carbon/human/H = owner
-		H.adjust_attribute_bonus(JUSTICE_ATTRIBUTE, 5)
+	if(!ishuman(owner))
+		return ..()
+	var/mob/living/carbon/human/status_holder = owner
+	status_holder.adjust_attribute_bonus(JUSTICE_ATTRIBUTE, 5)
 	return ..()
 
 /datum/status_effect/stacking/talisman/add_stacks(stacks_added)
-	if(ishuman(owner))
-		var/mob/living/carbon/human/H = owner
-		H.adjust_attribute_bonus(JUSTICE_ATTRIBUTE, 5 * stacks_added)//max of 25
+	if(!ishuman(owner))
+		return ..()
+	var/mob/living/carbon/human/status_holder = owner
+	status_holder.adjust_attribute_bonus(JUSTICE_ATTRIBUTE, 5 * stacks_added) //max of 25
 	return ..()
 
 /datum/status_effect/stacking/talisman/threshold_cross_effect()
-	var/mob/living/carbon/human/H = owner
+	var/mob/living/carbon/human/status_holder = owner
 	safe_removal = TRUE
-	H.apply_status_effect(STATUS_EFFECT_CURSETALISMAN)
-	new /obj/effect/temp_visual/talisman/curse(get_turf(H))
-	var/datum/status_effect/stacking/curse_talisman/G = H.has_status_effect(/datum/status_effect/stacking/curse_talisman)
-	G.add_stacks(5)
+	status_holder.apply_status_effect(STATUS_EFFECT_CURSETALISMAN)
+	new /obj/effect/temp_visual/talisman/curse(get_turf(status_holder))
+	var/datum/status_effect/stacking/curse_talisman/talismans = status_holder.has_status_effect(/datum/status_effect/stacking/curse_talisman)
+	talismans.add_stacks(5)
 	return ..()
 
 /datum/status_effect/stacking/talisman/on_remove()
-	if(ishuman(owner))
-		var/mob/living/carbon/human/H = owner
-		H.adjust_attribute_bonus(JUSTICE_ATTRIBUTE, -5 * stacks)
-		if(safe_removal == TRUE)
-			safe_removal = FALSE
-			return ..()
-		if (stacks > 0)
-			safe_removal = FALSE
-			H.apply_status_effect(STATUS_EFFECT_CURSETALISMAN)
-			var/datum/status_effect/stacking/curse_talisman/G = H.has_status_effect(/datum/status_effect/stacking/curse_talisman)
-			G.add_stacks(stacks-1)
+	if(!ishuman(owner))
+		return ..()
+	var/mob/living/carbon/human/status_holder = owner
+	status_holder.adjust_attribute_bonus(JUSTICE_ATTRIBUTE, -5 * stacks)
+	if(safe_removal == TRUE)
+		safe_removal = FALSE
+		return ..()
+	if(stacks > 0)
+		safe_removal = FALSE
+		status_holder.apply_status_effect(STATUS_EFFECT_CURSETALISMAN)
+		var/datum/status_effect/stacking/curse_talisman/talismans = status_holder.has_status_effect(/datum/status_effect/stacking/curse_talisman)
+		talismans.add_stacks(stacks-1)
 	return ..()
 
 /atom/movable/screen/alert/status_effect/talisman
@@ -282,7 +285,7 @@
 /datum/status_effect/stacking/curse_talisman //Justice DECREASING talismans
 	id = "curse_talisman"
 	status_type = STATUS_EFFECT_MULTIPLE
-	duration = 360 SECONDS //Lasts for 6 minutes
+	duration = 6 MINUTES
 	stack_decay = 0 //Without this the stacks were decaying after 1 sec
 	max_stacks = 6 // -7 per stack, up to -42 Justice
 	stacks = 1
@@ -290,21 +293,24 @@
 	consumed_on_threshold = FALSE
 
 /datum/status_effect/stacking/curse_talisman/on_apply()
-	if(ishuman(owner))
-		var/mob/living/carbon/human/H = owner
-		H.adjust_attribute_bonus(JUSTICE_ATTRIBUTE, -7 * stacks)
+	if(!ishuman(owner))
+		return ..()
+	var/mob/living/carbon/human/status_holder = owner
+	status_holder.adjust_attribute_bonus(JUSTICE_ATTRIBUTE, -7 * stacks)
 	return ..()
 
 /datum/status_effect/stacking/curse_talisman/add_stacks(stacks_added)
-	if(ishuman(owner))
-		var/mob/living/carbon/human/H = owner
-		H.adjust_attribute_bonus(JUSTICE_ATTRIBUTE, -7 * stacks_added)//max of -42
+	if(!ishuman(owner))
+		return ..()
+	var/mob/living/carbon/human/status_holder = owner
+	status_holder.adjust_attribute_bonus(JUSTICE_ATTRIBUTE, -7 * stacks_added) //max of -42
 	return ..()
 
 /datum/status_effect/stacking/curse_talisman/on_remove()
-	if(ishuman(owner))
-		var/mob/living/carbon/human/H = owner
-		H.adjust_attribute_bonus(JUSTICE_ATTRIBUTE, 7 * stacks)
+	if(!ishuman(owner))
+		return ..()
+	var/mob/living/carbon/human/status_holder = owner
+	status_holder.adjust_attribute_bonus(JUSTICE_ATTRIBUTE, 7 * stacks)
 	return ..()
 
 /atom/movable/screen/alert/status_effect/curse_talisman

--- a/code/modules/mob/living/simple_animal/abnormality/waw/babayaga.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/babayaga.dm
@@ -253,7 +253,7 @@
 /datum/status_effect/babayaga
 	id = "babayaga"
 	status_type = STATUS_EFFECT_UNIQUE
-	duration = 50		//Lasts 5 seconds
+	duration = 5 SECONDS
 	alert_type = /atom/movable/screen/alert/status_effect/babayaga
 
 /atom/movable/screen/alert/status_effect/babayaga

--- a/code/modules/mob/living/simple_animal/abnormality/waw/fire_bird.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/fire_bird.dm
@@ -222,7 +222,7 @@
 /datum/status_effect/blazing
 	id = "blazing"
 	status_type = STATUS_EFFECT_UNIQUE
-	duration = 600
+	duration = 60 SECONDS
 	alert_type = /atom/movable/screen/alert/status_effect/FireRegen
 	var/b_tick = 10
 	tick_interval = 5 SECONDS
@@ -235,11 +235,12 @@
 
 /datum/status_effect/blazing/tick()
 	..()
-	if(ishuman(owner))
-		var/mob/living/carbon/human/L = owner
-		L.adjustBruteLoss(-b_tick)
-		L.adjustFireLoss(-b_tick)
-		L.adjustSanityLoss(-b_tick)
+	if(!ishuman(owner))
+		return
+	var/mob/living/carbon/human/status_holder = owner
+	status_holder.adjustBruteLoss(-b_tick)
+	status_holder.adjustFireLoss(-b_tick)
+	status_holder.adjustSanityLoss(-b_tick)
 
 #undef STATUS_EFFECT_BLAZING
 
@@ -257,22 +258,24 @@
 
 /datum/status_effect/blinded/on_apply()
 	. = ..()
-	if(ishuman(owner))
-		var/mob/living/carbon/human/L = owner
-		cantsee += L
-		cantsee[L] = get_attribute_level(L, TEMPERANCE_ATTRIBUTE)/2
-		L.adjust_attribute_bonus(TEMPERANCE_ATTRIBUTE, -cantsee[L])
-		to_chat(L, span_userdanger("The light of the bird burns your eyes!"))
-		RegisterSignal(L, COMSIG_WORK_COMPLETED, .proc/BlindedWork)
+	if(!ishuman(owner))
+		return
+	var/mob/living/carbon/human/status_holder = owner
+	cantsee += status_holder
+	cantsee[status_holder] = get_attribute_level(status_holder, TEMPERANCE_ATTRIBUTE)/2
+	status_holder.adjust_attribute_bonus(TEMPERANCE_ATTRIBUTE, -cantsee[status_holder])
+	to_chat(status_holder, span_userdanger("The light of the bird burns your eyes!"))
+	RegisterSignal(status_holder, COMSIG_WORK_COMPLETED, .proc/BlindedWork)
 
 /datum/status_effect/blinded/on_remove()
 	. = ..()
-	if(ishuman(owner))
-		var/mob/living/carbon/human/L = owner
-		L.adjust_attribute_bonus(TEMPERANCE_ATTRIBUTE, cantsee[L])
-		cantsee -= L
-		to_chat(L, span_nicegreen("The blinding light fades..."))
-		UnregisterSignal(L, COMSIG_WORK_COMPLETED, .proc/BlindedWork)
+	if(!ishuman(owner))
+		return
+	var/mob/living/carbon/human/status_holder = owner
+	status_holder.adjust_attribute_bonus(TEMPERANCE_ATTRIBUTE, cantsee[status_holder])
+	cantsee -= status_holder
+	to_chat(status_holder, span_nicegreen("The blinding light fades..."))
+	UnregisterSignal(status_holder, COMSIG_WORK_COMPLETED, .proc/BlindedWork)
 
 /datum/status_effect/blinded/proc/BlindedWork(datum/source, datum/abnormality/datum_sent, mob/living/carbon/human/user)
 	SIGNAL_HANDLER

--- a/code/modules/mob/living/simple_animal/abnormality/waw/luna.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/luna.dm
@@ -181,7 +181,7 @@
 /datum/status_effect/lunar
 	id = "lunar"
 	status_type = STATUS_EFFECT_UNIQUE
-	duration = 600		//Lasts 60 seconds
+	duration = 60 SECONDS
 	alert_type = /atom/movable/screen/alert/status_effect/lunar
 
 /atom/movable/screen/alert/status_effect/lunar
@@ -192,16 +192,18 @@
 
 /datum/status_effect/lunar/on_apply()
 	. = ..()
-	if(ishuman(owner))
-		var/mob/living/carbon/human/L = owner
-		L.adjust_attribute_buff(JUSTICE_ATTRIBUTE, 10)
-		L.adjust_attribute_buff(TEMPERANCE_ATTRIBUTE, 10)
+	if(!ishuman(owner))
+		return
+	var/mob/living/carbon/human/status_holder = owner
+	status_holder.adjust_attribute_buff(JUSTICE_ATTRIBUTE, 10)
+	status_holder.adjust_attribute_buff(TEMPERANCE_ATTRIBUTE, 10)
 
 /datum/status_effect/lunar/on_remove()
 	. = ..()
-	if(ishuman(owner))
-		var/mob/living/carbon/human/L = owner
-		L.adjust_attribute_buff(JUSTICE_ATTRIBUTE, -10)
-		L.adjust_attribute_buff(TEMPERANCE_ATTRIBUTE, -10)
+	if(!ishuman(owner))
+		return
+	var/mob/living/carbon/human/status_holder = owner
+	status_holder.adjust_attribute_buff(JUSTICE_ATTRIBUTE, -10)
+	status_holder.adjust_attribute_buff(TEMPERANCE_ATTRIBUTE, -10)
 
 #undef STATUS_EFFECT_LUNAR

--- a/code/modules/mob/living/simple_animal/abnormality/waw/parasite_tree.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/parasite_tree.dm
@@ -262,34 +262,38 @@
 
 /datum/status_effect/display/parasite_tree_blessing/on_apply()
 	. = ..()
-	if(ishuman(owner))
-		var/mob/living/carbon/human/H = owner
-		H.adjust_attribute_buff(TEMPERANCE_ATTRIBUTE, 10)
-		H.adjust_attribute_buff(PRUDENCE_ATTRIBUTE, 10)
-		connected_abno = locate(/mob/living/simple_animal/hostile/abnormality/parasite_tree) in GLOB.abnormality_mob_list
-		if(connected_abno)
-			connected_abno.blessed += src
-			connected_abno.datum_reference.qliphoth_change(-1)
+	if(!ishuman(owner))
+		return
+	var/mob/living/carbon/human/status_holder = owner
+	status_holder.adjust_attribute_buff(TEMPERANCE_ATTRIBUTE, 10)
+	status_holder.adjust_attribute_buff(PRUDENCE_ATTRIBUTE, 10)
+	connected_abno = locate(/mob/living/simple_animal/hostile/abnormality/parasite_tree) in GLOB.abnormality_mob_list
+	if(!connected_abno)
+		return
+	connected_abno.blessed += src
+	connected_abno.datum_reference.qliphoth_change(-1)
 
 /datum/status_effect/display/parasite_tree_blessing/tick()
 	. = ..()
-	if(ishuman(owner))
-		var/mob/living/carbon/human/H = owner
-		H.adjustSanityLoss(-3)
-		if(H.stat == DEAD)
-			qdel(src)
-	else
+	if(!ishuman(owner))
 		QDEL_IN(src, 5)
+		return
+	var/mob/living/carbon/human/status_holder = owner
+	status_holder.adjustSanityLoss(-3)
+	if(status_holder.stat == DEAD)
+		qdel(src)
 
 /datum/status_effect/display/parasite_tree_blessing/on_remove()
-	if(ishuman(owner))
-		var/mob/living/carbon/human/H = owner
-		if(connected_abno)
-			connected_abno.blessed -= src
-			if(H.stat == DEAD)
-				connected_abno.datum_reference.qliphoth_change(1)
-		H.adjust_attribute_buff(TEMPERANCE_ATTRIBUTE, -10)
-		H.adjust_attribute_buff(PRUDENCE_ATTRIBUTE, -10)
+	if(!ishuman(owner))
+		return ..()
+	var/mob/living/carbon/human/status_holder = owner
+	status_holder.adjust_attribute_buff(TEMPERANCE_ATTRIBUTE, -10)
+	status_holder.adjust_attribute_buff(PRUDENCE_ATTRIBUTE, -10)
+	if(!connected_abno)
+		return ..()
+	connected_abno.blessed -= src
+	if(status_holder.stat == DEAD)
+		connected_abno.datum_reference.qliphoth_change(1)
 	return ..()
 
 /datum/status_effect/display/parasite_tree_blessing/proc/facadeFalls()
@@ -310,31 +314,32 @@
 /datum/status_effect/display/parasite_tree_curse/on_apply()
 	. = ..()
 	connected_abno = locate(/mob/living/simple_animal/hostile/abnormality/parasite_tree) in GLOB.abnormality_mob_list
+	to_chat(owner, span_warning("You feel something sprouting under your skin! Its time to be reborn with the tree."))
 	if(connected_abno)
 		connected_abno.blessed += src
-	to_chat(owner, span_warning("You feel something sprouting under your skin! Its time to be reborn with the tree."))
 
 /datum/status_effect/display/parasite_tree_curse/tick()
 	. = ..()
-	if(ishuman(owner))
-		var/mob/living/carbon/human/L = owner
-		if(L.sanity_lost || L.stat == DEAD)
-			qdel(src)
-		var/tree_toxin = L.maxSanity * 0.20
-		L.apply_damage(tree_toxin, WHITE_DAMAGE, null, L.run_armor_check(null, WHITE_DAMAGE), spread_damage = FALSE)
+	if(!ishuman(owner))
+		return
+	var/mob/living/carbon/human/status_holder = owner
+	if(status_holder.sanity_lost || status_holder.stat == DEAD)
+		qdel(src)
+	var/tree_toxin = status_holder.maxSanity * 0.20
+	status_holder.apply_damage(tree_toxin, WHITE_DAMAGE, null, status_holder.run_armor_check(null, WHITE_DAMAGE), spread_damage = FALSE)
 
 /datum/status_effect/display/parasite_tree_curse/on_remove()
-	var/mob/living/carbon/human/host = owner
+	var/mob/living/carbon/human/status_holder = owner
 	if(connected_abno)
 		connected_abno.blessed -= src
-		if(!owner || host.stat == DEAD)
+		if(!owner || status_holder.stat == DEAD)
 			connected_abno.endBreach()
-	if(host.sanity_lost && host.stat != DEAD)
-		var/mob/living/simple_animal/hostile/parasite_tree_sapling/N = new(owner.loc)
-		nested_items(N, host.get_item_by_slot(ITEM_SLOT_SUITSTORE))
-		nested_items(N, host.get_item_by_slot(ITEM_SLOT_BELT))
-		nested_items(N, host.get_item_by_slot(ITEM_SLOT_BACK))
-		nested_items(N, host.get_item_by_slot(ITEM_SLOT_OCLOTHING))
+	if(status_holder.sanity_lost && status_holder.stat != DEAD)
+		var/mob/living/simple_animal/hostile/parasite_tree_sapling/new_mob = new(owner.loc)
+		nested_items(new_mob, host.get_item_by_slot(ITEM_SLOT_SUITSTORE))
+		nested_items(new_mob, host.get_item_by_slot(ITEM_SLOT_BELT))
+		nested_items(new_mob, host.get_item_by_slot(ITEM_SLOT_BACK))
+		nested_items(new_mob, host.get_item_by_slot(ITEM_SLOT_OCLOTHING))
 		QDEL_IN(owner, 5) //rabbit sanity implant explodes at 5
 	return ..()
 

--- a/code/modules/mob/living/simple_animal/abnormality/waw/rose_sign.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/rose_sign.dm
@@ -460,10 +460,10 @@
 /datum/status_effect/stacking/crownthorns
 	id = "thorns"
 	status_type = STATUS_EFFECT_MULTIPLE
-	duration = -1//INFINITE POWER!!!
+	duration = -1 //INFINITE POWER!!!
 	max_stacks = 5
 	stacks = 1
-	tick_interval = 25 SECONDS//you get about a minute and a half
+	tick_interval = 25 SECONDS //you get about a minute and a half
 	on_remove_on_mob_delete = TRUE
 	alert_type = /atom/movable/screen/alert/status_effect/crownthorns
 	consumed_on_threshold = FALSE
@@ -478,36 +478,37 @@
 	icon_state = "rose_sign"
 
 /datum/status_effect/stacking/crownthorns/on_apply()
-	var/mob/living/carbon/human/H = owner
-	H.adjust_attribute_bonus(FORTITUDE_ATTRIBUTE, -attribute_penalty)
+	var/mob/living/carbon/human/status_holder = owner
+	status_holder.adjust_attribute_bonus(FORTITUDE_ATTRIBUTE, -attribute_penalty)
 	return ..()
 
 /datum/status_effect/stacking/crownthorns/tick()
 	to_chat(owner, span_warning("Thorns painfully dig into your skin!"))
 	owner.emote("scream")
 	stacks += 1
-	var/mob/living/carbon/human/H = owner
-	H.adjust_attribute_bonus(FORTITUDE_ATTRIBUTE, -25)//By using bonuses, this lowers your maximum health
+	var/mob/living/carbon/human/status_holder = owner
+	status_holder.adjust_attribute_bonus(FORTITUDE_ATTRIBUTE, -25)//By using bonuses, this lowers your maximum health
 	attribute_penalty += 25
 	if(master)
 		master.adjustBruteLoss(-100)
-	if(H.stat >= HARD_CRIT || stacks == max_stacks)
-		status_applicant.killed = FALSE
-		status_applicant.death()
-		H.death()
-		var/turf/T = get_turf(owner)
-		if(locate(/obj/structure/rose_crucifix) in T)
-			T = pick_n_take(T.reachableAdjacentTurfs())//if a crucifix is on this tile, it'll still create another one. You probably shouldn't be letting this many people die to begin with
-			owner.forceMove(T)
-		var/obj/structure/rose_crucifix/N = new(get_turf(T))
-		N.buckle_mob(owner)
-		qdel(src)
+	if(!status_holder.stat >= HARD_CRIT || stacks != max_stacks)
+		return
+	status_applicant.killed = FALSE
+	status_applicant.death()
+	status_holder.death()
+	var/turf/T = get_turf(owner)
+	if(locate(/obj/structure/rose_crucifix) in T)
+		T = pick_n_take(T.reachableAdjacentTurfs())//if a crucifix is on this tile, it'll still create another one. You probably shouldn't be letting this many people die to begin with
+		owner.forceMove(T)
+	var/obj/structure/rose_crucifix/N = new(get_turf(T))
+	N.buckle_mob(owner)
+	qdel(src)
 
 /datum/status_effect/stacking/crownthorns/on_remove()
 	to_chat(owner, span_nicegreen("The prickly feeling stops."))
-	var/mob/living/carbon/human/H = owner
-	H.adjust_attribute_bonus(FORTITUDE_ATTRIBUTE, attribute_penalty)
-	owner.adjustBruteLoss(-attribute_penalty)
+	var/mob/living/carbon/human/status_holder = owner
+	status_holder.adjust_attribute_bonus(FORTITUDE_ATTRIBUTE, attribute_penalty)
+	status_holder.adjustBruteLoss(-attribute_penalty)
 	return ..()
 
 //On-kill visual effect

--- a/code/modules/mob/living/simple_animal/abnormality/waw/screenwriter.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/screenwriter.dm
@@ -200,13 +200,13 @@ Defeating the murderer also surpresses the abnormality.
 /datum/status_effect/actor/proc/ChangeToVictim() // So you have chosen death
 	if(role == "victim")
 		return
-	var/mob/living/carbon/human/H = owner
+	var/mob/living/carbon/human/status_holder = owner
 	if(stat)
-		H.adjust_attribute_bonus(stat, -stat_modifier)
+		status_holder.adjust_attribute_bonus(stat, -stat_modifier)
 	else
 		return
 	stat_modifier = -100
-	H.adjust_all_attribute_bonuses(stat_modifier)
+	status_holder.adjust_all_attribute_bonuses(stat_modifier)
 	owner.cut_overlay(mutable_appearance('icons/effects/32x64.dmi', role, -ABOVE_MOB_LAYER))
 	role = "victim"
 	owner.add_overlay(mutable_appearance('icons/effects/32x64.dmi', role, -ABOVE_MOB_LAYER))
@@ -214,7 +214,7 @@ Defeating the murderer also surpresses the abnormality.
 	to_chat(owner, span_userdanger("You will now play the role of the victim!"))
 
 /datum/status_effect/actor/proc/AssignRole()
-	var/mob/living/carbon/human/H = owner
+	var/mob/living/carbon/human/status_holder = owner
 	owner.add_overlay(mutable_appearance('icons/effects/32x64.dmi', role, -ABOVE_MOB_LAYER))
 	switch(role)
 		if("coward")
@@ -228,9 +228,9 @@ Defeating the murderer also surpresses the abnormality.
 			stat = PRUDENCE_ATTRIBUTE
 		if("victim")
 			stat_modifier = -100
-			H.adjust_all_attribute_bonuses(stat_modifier)
+			status_holder.adjust_all_attribute_bonuses(stat_modifier)
 			return
-	H.adjust_attribute_bonus(stat, stat_modifier)
+	status_holder.adjust_attribute_bonus(stat, stat_modifier)
 
 //Mob
 /mob/living/simple_animal/hostile/actor

--- a/code/modules/mob/living/simple_animal/abnormality/waw/wrath_servant.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/wrath_servant.dm
@@ -857,14 +857,14 @@
 	. = ..()
 	if(!isliving(owner))
 		return
-	var/mob/living/L = owner
-	L.apply_damage(5, BLACK_DAMAGE, null, L.run_armor_check(null, BLACK_DAMAGE), spread_damage = TRUE)
-	if(!ishuman(L))
+	var/mob/living/status_holder = owner
+	status_holder.apply_damage(5, BLACK_DAMAGE, null, L.run_armor_check(null, BLACK_DAMAGE), spread_damage = TRUE)
+	if(!ishuman(status_holder))
 		return
-	if((L.sanityhealth <= 0) || (L.health <= 0))
-		var/turf/T = get_turf(L)
-		L.gib(TRUE, TRUE, TRUE)
-		new /mob/living/simple_animal/hostile/azure_stave(T)
+	if((status_holder.sanityhealth <= 0) || (status_holder.health <= 0))
+		var/turf/spawner_turf = get_turf(status_holder)
+		status_holder.gib(TRUE, TRUE, TRUE)
+		new /mob/living/simple_animal/hostile/azure_stave(spawner_turf)
 
 #undef STATUS_EFFECT_ACIDIC_GOO
 #undef SERVANT_SMASH_COOLDOWN

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/blubbering_toad.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/blubbering_toad.dm
@@ -277,7 +277,7 @@
 /datum/status_effect/blue_resin
 	id = "blue resin"
 	status_type = STATUS_EFFECT_UNIQUE
-	duration = 3000 //Lasts 5 mins
+	duration = 5 MINUTES
 	alert_type = /atom/movable/screen/alert/status_effect/blue_resin
 
 /atom/movable/screen/alert/status_effect/blue_resin
@@ -289,13 +289,15 @@
 /datum/status_effect/blue_resin/on_apply()
 	. = ..()
 	if(ishuman(owner))
-		var/mob/living/carbon/human/L = owner
-		L.physiology.black_mod *= 0.9
+		return
+	var/mob/living/carbon/human/status_holder = owner
+	status_holder.physiology.black_mod *= 0.9
 
 /datum/status_effect/blue_resin/on_remove()
 	. = ..()
 	if(ishuman(owner))
-		var/mob/living/carbon/human/L = owner
-		L.physiology.black_mod /= 0.9
+		return
+	var/mob/living/carbon/human/status_holder = owner
+	status_holder.physiology.black_mod /= 0.9
 
 #undef STATUS_EFFECT_BLUERESIN

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/bottle.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/bottle.dm
@@ -204,7 +204,7 @@
 /datum/status_effect/tears
 	id = "tears"
 	status_type = STATUS_EFFECT_MULTIPLE	//You should be able to stack this, I hope
-	duration = 3000 //Lasts 5 minutes.
+	duration = 5 MINUTES
 	alert_type = /atom/movable/screen/alert/status_effect/tears
 	var/scaling = 20
 
@@ -216,23 +216,25 @@
 
 /datum/status_effect/tears/on_apply()
 	. = ..()
-	if(ishuman(owner))
-		var/mob/living/carbon/human/L = owner
-		to_chat(owner, span_danger("Something once important to you is gone now. You feel like crying."))
-		L.adjust_attribute_buff(FORTITUDE_ATTRIBUTE, -scaling)
-		L.adjust_attribute_buff(PRUDENCE_ATTRIBUTE, -scaling)
-		L.adjust_attribute_buff(TEMPERANCE_ATTRIBUTE, -scaling)
-		L.adjust_attribute_buff(JUSTICE_ATTRIBUTE, -scaling)
+	if(!ishuman(owner))
+		return
+	var/mob/living/carbon/human/status_holder = owner
+	to_chat(owner, span_danger("Something once important to you is gone now. You feel like crying."))
+	status_holder.adjust_attribute_buff(FORTITUDE_ATTRIBUTE, -scaling)
+	status_holder.adjust_attribute_buff(PRUDENCE_ATTRIBUTE, -scaling)
+	status_holder.adjust_attribute_buff(TEMPERANCE_ATTRIBUTE, -scaling)
+	status_holder.adjust_attribute_buff(JUSTICE_ATTRIBUTE, -scaling)
 
 /datum/status_effect/tears/on_remove()
 	. = ..()
-	if(ishuman(owner))
-		var/mob/living/carbon/human/L = owner
-		to_chat(owner, span_nicegreen("You feel your strength return to you."))
-		L.adjust_attribute_buff(FORTITUDE_ATTRIBUTE, scaling)
-		L.adjust_attribute_buff(PRUDENCE_ATTRIBUTE, scaling)
-		L.adjust_attribute_buff(TEMPERANCE_ATTRIBUTE, scaling)
-		L.adjust_attribute_buff(JUSTICE_ATTRIBUTE, scaling)
+	if(!ishuman(owner))
+		return
+	var/mob/living/carbon/human/status_holder = owner
+	to_chat(owner, span_nicegreen("You feel your strength return to you."))
+	status_holder.adjust_attribute_buff(FORTITUDE_ATTRIBUTE, scaling)
+	status_holder.adjust_attribute_buff(PRUDENCE_ATTRIBUTE, scaling)
+	status_holder.adjust_attribute_buff(TEMPERANCE_ATTRIBUTE, scaling)
+	status_holder.adjust_attribute_buff(JUSTICE_ATTRIBUTE, scaling)
 
 /datum/status_effect/tears/less
 	duration = 2 MINUTES

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/hammer_light.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/hammer_light.dm
@@ -339,32 +339,28 @@
 /datum/status_effect/evening_twilight
 	id = "evening_twilight"
 	status_type = STATUS_EFFECT_UNIQUE
-	duration = 3000 // max duration
+	duration = 5 MINUTES // max duration
 	alert_type = null
 	var/attribute_bonus = 0
 
 /datum/status_effect/evening_twilight/on_apply()
 	if(!ishuman(owner))
 		return
-	var/mob/living/carbon/human/user = owner
-	to_chat(user, span_nicegreen("You feel powerful."))
-	user.add_overlay(mutable_appearance('ModularTegustation/Teguicons/32x32.dmi', "hammer_overlay", -ABOVE_MOB_LAYER))
-	user.physiology.red_mod *= 0.3
-	user.physiology.white_mod *= 0.3
-	user.physiology.black_mod *= 0.3
-	user.physiology.pale_mod *= 0.3
-	duration = min(get_user_level(user) * 300, initial(duration)) //30 seconds per level, so a max of about 3.5 minutes at 130/all.
+	var/mob/living/carbon/human/status_holder = owner
+	to_chat(status_holder, span_nicegreen("You feel powerful."))
+	status_holder.add_overlay(mutable_appearance('ModularTegustation/Teguicons/32x32.dmi', "hammer_overlay", -ABOVE_MOB_LAYER))
+	status_holder.physiology.red_mod *= 0.3
+	status_holder.physiology.white_mod *= 0.3
+	status_holder.physiology.black_mod *= 0.3
+	status_holder.physiology.pale_mod *= 0.3
+	duration = min(get_user_level(status_holder) * 300, initial(duration)) //30 seconds per level, so a max of about 3.5 minutes at 130/all.
 	return ..()
 
 /datum/status_effect/evening_twilight/on_remove()
 	if(!ishuman(owner))
 		return
-	var/mob/living/carbon/human/user = owner
-	user.physiology.red_mod /= 0.3
-	user.physiology.white_mod /= 0.3
-	user.physiology.black_mod /= 0.3
-	user.physiology.pale_mod /= 0.3
-	user.dust()
+	var/mob/living/status_holder = owner
+	status_holder.dust()
 	return ..()
 
 //Simple mob

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/quiet_day.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/quiet_day.dm
@@ -228,21 +228,23 @@
 /datum/status_effect/quiet
 	id = "quiet_day"
 	status_type = STATUS_EFFECT_UNIQUE
-	duration = 3000		//Lasts 5 minutes
+	duration = 5 MINUTES
 	alert_type = /atom/movable/screen/alert/status_effect/quiet
 	var/attribute_buff = FORTITUDE_ATTRIBUTE
 
 /datum/status_effect/quiet/on_apply()
 	. = ..()
-	if(ishuman(owner))
-		var/mob/living/carbon/human/L = owner
-		L.adjust_attribute_buff(attribute_buff, 15)
+	if(!ishuman(owner))
+		return
+	var/mob/living/carbon/human/status_holder = owner
+	status_holder.adjust_attribute_buff(attribute_buff, 15)
 
 /datum/status_effect/quiet/on_remove()
 	. = ..()
-	if(ishuman(owner))
-		var/mob/living/carbon/human/L = owner
-		L.adjust_attribute_buff(attribute_buff, -15)
+	if(!ishuman(owner))
+		return
+	var/mob/living/carbon/human/status_holder = owner
+	status_holder.adjust_attribute_buff(attribute_buff, -15)
 
 
 //Here so that the defines work

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/sleeping_beauty.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/sleeping_beauty.dm
@@ -121,7 +121,7 @@
 /datum/status_effect/rested
 	id = "rested"
 	status_type = STATUS_EFFECT_UNIQUE
-	duration = 600		//Lasts 60 seconds
+	duration = 60 SECONDS
 	alert_type = /atom/movable/screen/alert/status_effect/rested
 
 /atom/movable/screen/alert/status_effect/rested
@@ -132,10 +132,11 @@
 
 /datum/status_effect/rested/tick()
 	. = ..()
-	var/mob/living/carbon/human/H = owner
+	var/mob/living/carbon/human/status_holder = owner
 	if(prob(50))
-		H.adjustBruteLoss(-1)
-		H.adjustSanityLoss(-1)
+		return
+	status_holder.adjustBruteLoss(-1)
+	status_holder.adjustSanityLoss(-1)
 
 //pink midnight code
 

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/we_can_change_anything.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/we_can_change_anything.dm
@@ -215,7 +215,7 @@
 /datum/status_effect/we_can_change_anything
 	id = "change"
 	status_type = STATUS_EFFECT_UNIQUE
-	duration = 3000 //Lasts 5 mins
+	duration = 5 MINUTES
 	alert_type = /atom/movable/screen/alert/status_effect/we_can_change_anything
 
 /atom/movable/screen/alert/status_effect/we_can_change_anything
@@ -226,15 +226,17 @@
 
 /datum/status_effect/we_can_change_anything/on_apply()
 	. = ..()
-	if(ishuman(owner))
-		var/mob/living/carbon/human/L = owner
-		L.physiology.red_mod *= 0.9
+	if(!ishuman(owner))
+		return
+	var/mob/living/carbon/human/status_holder = owner
+	status_holder.physiology.red_mod *= 0.9
 
 /datum/status_effect/we_can_change_anything/on_remove()
 	. = ..()
-	if(ishuman(owner))
-		var/mob/living/carbon/human/L = owner
-		L.physiology.red_mod /= 0.9
+	if(!ishuman(owner))
+		return
+	var/mob/living/carbon/human/status_holder = owner
+	status_holder.physiology.red_mod /= 0.9
 
 #undef STATUS_EFFECT_CHANGE
 


### PR DESCRIPTION

## About The Pull Request

- Makes all status effect's durations use the SECONDS and MINUTES defines, for more clear code
- Removes a lot of indentation, a lotta lot by utilizing early returns
- Removes a good portion of single-letter variables on status effects

## Why It's Good For The Game

STOP TELLING GIVING ME `duration = 3000 // lasts 5 minutes` JUST FUCKING SAY `duration = 5 MINUTES` FOR GODS SAKES

## Changelog
:cl:
code: status effects are now more clear
/:cl:
