### PR TITLE
Radio only job title abbreviations

### DIFF
--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -223,12 +223,16 @@
 	if(H.mind && (H.mind.assigned_role != H.mind.special_role))
 		var/assignment
 		var/trueassignment //tegu edit - alt job titles
+		var/jobabbreviation
 		if(H.mind.assigned_role)
 			assignment = H.mind.assigned_role
 		else if(H.job)
 			assignment = H.job
 		else
 			assignment = "Unassigned"
+
+		var/datum/job/J = SSjob.GetJob(H.job)
+		jobabbreviation = J ? "[J.job_abbreviation]" : "" //can't be null
 
 		//Tegu edit - Alt job titles
 		trueassignment = assignment
@@ -259,6 +263,7 @@
 		G.fields["name"]		= H.real_name
 		G.fields["rank"]		= assignment
 		G.fields["truerank"] = trueassignment //tegu edit - alt job titles
+		G.fields["jobabbrev"] = jobabbreviation
 		G.fields["age"]			= H.age
 		G.fields["species"]	= H.dna.species.name
 		G.fields["fingerprint"]	= md5(H.dna.uni_identity)

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -176,6 +176,8 @@ GLOBAL_LIST_INIT(freqtospan, list(
 
 /atom/movable/proc/GetJob() //Get a job, you lazy butte
 
+/atom/movable/proc/GetJobAbbrev()
+
 /atom/movable/proc/GetSource()
 
 /atom/movable/proc/GetRadio()
@@ -183,6 +185,7 @@ GLOBAL_LIST_INIT(freqtospan, list(
 //VIRTUALSPEAKERS
 /atom/movable/virtualspeaker
 	var/job
+	var/jobabbrev
 	var/atom/movable/source
 	var/obj/item/radio/radio
 
@@ -202,9 +205,12 @@ INITIALIZE_IMMEDIATE(/atom/movable/virtualspeaker)
 	if(ishuman(M))
 		// Humans use their job as seen on the crew manifest. This is so the AI
 		// can know their job even if they don't carry an ID.
-		var/datum/data/record/findjob = find_record("name", name, GLOB.data_core.general)
+		// LCorp13 Changes: Due to having respawn, we have to search by assignment instead of name
+		var/mob/living/carbon/human/H = M
+		var/datum/data/record/findjob = find_record("truerank", H.mind.assigned_role, GLOB.data_core.general)
 		if(findjob)
 			job = findjob.fields["rank"]
+			jobabbrev = findjob.fields["jobabbrev"]
 		else
 			job = "Unknown"
 	else if(iscarbon(M))  // Carbon nonhuman
@@ -220,6 +226,9 @@ INITIALIZE_IMMEDIATE(/atom/movable/virtualspeaker)
 		job = "Machine"
 	else  // Unidentifiable mob
 		job = "Unknown"
+
+/atom/movable/virtualspeaker/GetJobAbbrev()
+	return jobabbrev
 
 /atom/movable/virtualspeaker/GetJob()
 	return job

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -101,6 +101,9 @@
 	var/rank_title
 	var/trusted_rank
 
+	///Job abbreviation used when humans talk on radio. If null should not add anything to radio messages
+	var/job_abbreviation
+
 /datum/job/New()
 	. = ..()
 	var/list/jobs_changes = GetMapChanges()

--- a/code/modules/jobs/job_types/agent.dm
+++ b/code/modules/jobs/job_types/agent.dm
@@ -4,7 +4,7 @@
 	faction = "Station"
 	total_positions = -1
 	spawn_positions = -1
-	supervisors = "the manager"
+	supervisors = "the Manager"
 	selection_color = "#ccaaaa"
 	exp_requirements = 60
 	exp_type = EXP_TYPE_CREW
@@ -25,7 +25,9 @@
 								JUSTICE_ATTRIBUTE = 20
 								)
 
-	job_important = "You are an L-Corp agent. Your job is to work on, and suppress abnormalities. Use :h to talk on your departmental radio."
+	job_important = "You are a L-Corp Agent. Your job is to work on and suppress Abnormalities. Use :h to talk on your departmental radio."
+
+	job_abbreviation = "AGT"
 
 	var/normal_attribute_level = 20 // Scales with round time & facility upgrades
 
@@ -134,7 +136,9 @@
 	exp_type = EXP_TYPE_CREW
 	exp_type_department = EXP_TYPE_SECURITY
 	mapexclude = list("wonderlabs", "mini")
-	job_important = "You are an Agent Captain. You're an experienced agent, that is expected to disseminate your information and experience as well as help lead the agents."
+	job_important = "You are an Agent Captain. As an experienced Agent, you are expected to disseminate important information and use your experience lead other Agents."
+
+	job_abbreviation = "CPT"
 
 /datum/outfit/job/agent/captain
 	name = "Agent Captain"
@@ -157,8 +161,10 @@
 	display_order = JOB_DISPLAY_ORDER_INTERN
 	normal_attribute_level = 20
 	exp_requirements = 0
-	job_important = "You are an Agent Intern. Your main goal is to learn how to work on abnormalities, and assist in suppression. Other agents should be more understanding to your mistakes. \
-	If there is a Records Officer, seek them for assistance."
+	job_important = "You are an Agent Intern. Your main goal is to learn how to work on Abnormalities and assist in suppressions. Other Agents will be more aware of your inexperience. \
+	If there is a Records Officer, seek them out for assistance."
+
+	job_abbreviation = "INRN"
 
 /datum/outfit/job/agent/intern
 	name = "Agent Intern"

--- a/code/modules/jobs/job_types/assistant.dm
+++ b/code/modules/jobs/job_types/assistant.dm
@@ -23,8 +23,9 @@ GLOBAL_LIST_EMPTY(spawned_clerks)
 
 	allow_bureaucratic_error = FALSE
 //	loadalways = TRUE
-	job_important = "You are a Clerk. You're the jack of all trades in LCorp. You are to assist with cleanup, cooking, medical and other miscellaneous tasks. You are fragile, but important."
+	job_important = "You are a Clerk. Since you are unable to work with Abnormalities, you are expected to do cleanup, cooking, medical and other miscellaneous tasks. You are fragile but have access to a variety of support tools."
 
+	job_abbreviation = "CLK"
 
 //Cannot Gain stats.
 /datum/job/assistant/after_spawn(mob/living/carbon/human/H, mob/M, latejoin = FALSE)

--- a/code/modules/jobs/job_types/command.dm
+++ b/code/modules/jobs/job_types/command.dm
@@ -62,7 +62,7 @@
 	outfit = /datum/outfit/job/command/records
 	exp_requirements = 600
 	job_important = "You are the Records Officer. Your job is to manage Records. You have filing cabinets in the back of your office filled with information about Abnormalities; ensure Agents are well-informed about any in the facility. \
-	You have access to powerful handheld watches with various beneficial effects."
+	You also have access to powerful handheld watches with various beneficial effects."
 	job_notice = "Being in charge of handling Abnormality documentation, you should also assist new Interns and Clerks in learning how to work at L-Corp."
 
 	job_abbreviation = "RO"

--- a/code/modules/jobs/job_types/command.dm
+++ b/code/modules/jobs/job_types/command.dm
@@ -31,7 +31,9 @@
 	access = list(ACCESS_COMMAND) // LC13:To-Do
 	minimal_access = list(ACCESS_COMMAND)
 	mapexclude = list("mini")
-	job_important = "You are the Extraction Officer. Your job is to manage the EGO console, Extraction purchase console, and power generation system. Your main goal is to make sure the agents are well-equipped."
+	job_important = "You are the Extraction Officer. Your job is to manage the EGO console, Extraction purchase console, and power generation system. Your main goal is to ensure Agents are well-equipped with EGO."
+
+	job_abbreviation = "EO"
 
 	job_attribute_limit = 60
 	roundstart_attributes = list(
@@ -59,9 +61,11 @@
 	title = "Records Officer"
 	outfit = /datum/outfit/job/command/records
 	exp_requirements = 600
-	job_important = "You are the Records Officer. Your job is to manage Records. You have filing cabinets in the back of your office filled with all sorts of information; make sure the agents know this information. \
-	Make sure that you assist Interns and new clerks in learning how to work at Lcorp. Help agents use tool abnormalities with proper warnings. \
-	As well as this, you have access to powerful handheld watches with various effects."
+	job_important = "You are the Records Officer. Your job is to manage Records. You have filing cabinets in the back of your office filled with information about Abnormalities; ensure Agents are well-informed about any in the facility. \
+	You have access to powerful handheld watches with various beneficial effects."
+	job_notice = "Being in charge of handling Abnormality documentation, you should also assist new Interns and Clerks in learning how to work at L-Corp."
+
+	job_abbreviation = "RO"
 
 /datum/job/command/records/after_spawn(mob/living/H, mob/M)
 	. = ..()

--- a/code/modules/jobs/job_types/manager.dm
+++ b/code/modules/jobs/job_types/manager.dm
@@ -23,7 +23,9 @@
 								TEMPERANCE_ATTRIBUTE = 0,
 								JUSTICE_ATTRIBUTE = 0
 								)
-	job_important = "You are the Manager. Your goal is to provide overwatch to all agents and clerks and direct works. You can also choose abnormalities and apply buffs to agents."
+	job_important = "You are the Manager. Your goal is to provide overwatch to Agents and Clerks while guiding the facility's progress. You are able to choose arriving Abnormalities, buy facility upgrades, and apply buffs through your camera console."
+
+	job_abbreviation = "MGR"
 
 /datum/job/manager/announce(mob/living/carbon/human/H)
 	..()

--- a/code/modules/jobs/job_types/trusted_players/representative.dm
+++ b/code/modules/jobs/job_types/trusted_players/representative.dm
@@ -22,6 +22,8 @@
 								JUSTICE_ATTRIBUTE = 0
 								)
 
+	job_abbreviation = "REP"
+
 /datum/job/representative/after_spawn(mob/living/carbon/human/H, mob/M)
 	ADD_TRAIT(H, TRAIT_COMBATFEAR_IMMUNE, JOB_TRAIT)
 	ADD_TRAIT(H, TRAIT_WORK_FORBIDDEN, JOB_TRAIT)	//My guy you aren't even from this corporation

--- a/code/modules/jobs/job_types/trusted_players/sephirah.dm
+++ b/code/modules/jobs/job_types/trusted_players/sephirah.dm
@@ -9,11 +9,13 @@
 	access = list(ACCESS_NETWORK, ACCESS_COMMAND, ACCESS_MANAGER) // Network is the trusted chat gamer access
 	minimal_access = list(ACCESS_NETWORK, ACCESS_COMMAND, ACCESS_MANAGER)
 	mapexclude = list("wonderlabs", "mini")
-	job_important = "You are a roleplay role, and may not partake in combat. Assist the manager and roleplay with the agents and clerks"
-	job_notice = "In the OOC tab you have a verb called 'randomize current abnormality'. \
-		It is to be used to spice up boring rounds, and punish manager players you think are playing too safe. \
-		This is an OOC tool. Do not bring alert to the fact that you can do this IC. Alert any administrators if any IC action is taken against you. \
+	job_important = "You are a strictly roleplay role and are forbidden from partaking in combat. Assist the Manager and improve IC roleplay during the round."
+	job_notice = "In the OOC tab you have a verb called 'Randomize Current Abnormality'. \
+		It should be used to spice up boring rounds and discourage Managers you think are playing too safe. \
+		This is an OOC-only tool. Do not allow anyone IC to learn of this ability. Alert administrators if any IC action is taken against you. \
 		Abusing this will result in a loss of whitelist."
+
+	job_abbreviation = "SEPH"
 
 /datum/job/command/sephirah/after_spawn(mob/living/carbon/human/H, mob/M)
 	. = ..()

--- a/code/modules/mob/living/carbon/human/human_say.dm
+++ b/code/modules/mob/living/carbon/human/human_say.dm
@@ -38,16 +38,6 @@
 /mob/living/carbon/human/compose_job(atom/movable/speaker, message_langs, raw_message, radio_freq)
 	var/job_abbreviation = speaker.GetJobAbbrev()
 	return job_abbreviation ? (radio_freq ? " ([job_abbreviation])" : "") : ""
-	// if(job_abbreviation)
-	// 	return radio_freq ? " ([job_abbreviation])" : ""
-	// else
-	// 	return ""
-	// if(job_abbreviation)
-	// 	return "[radio_freq ? " \[[job_abbreviation]\]" : ""]"
-	// else
-	// 	return ""
-//	return job_abbreviation ? "[(radio_freq ? " \[[job_abbreviation]\]" : " NORADIO"]" : " NOABBREV"
-//	return "[radio_freq ? " (" + speaker.GetJobAbbrev() + ")"]": ""
 
 /mob/living/carbon/human/IsVocal()
 	// how do species that don't breathe talk? magic, that's what.

--- a/code/modules/mob/living/carbon/human/human_say.dm
+++ b/code/modules/mob/living/carbon/human/human_say.dm
@@ -35,6 +35,20 @@
 		return GetSpecialVoice()
 	return real_name
 
+/mob/living/carbon/human/compose_job(atom/movable/speaker, message_langs, raw_message, radio_freq)
+	var/job_abbreviation = speaker.GetJobAbbrev()
+	return job_abbreviation ? (radio_freq ? " ([job_abbreviation])" : "") : ""
+	// if(job_abbreviation)
+	// 	return radio_freq ? " ([job_abbreviation])" : ""
+	// else
+	// 	return ""
+	// if(job_abbreviation)
+	// 	return "[radio_freq ? " \[[job_abbreviation]\]" : ""]"
+	// else
+	// 	return ""
+//	return job_abbreviation ? "[(radio_freq ? " \[[job_abbreviation]\]" : " NORADIO"]" : " NOABBREV"
+//	return "[radio_freq ? " (" + speaker.GetJobAbbrev() + ")"]": ""
+
 /mob/living/carbon/human/IsVocal()
 	// how do species that don't breathe talk? magic, that's what.
 	if(!HAS_TRAIT_FROM(src, TRAIT_NOBREATH, SPECIES_TRAIT) && !getorganslot(ORGAN_SLOT_LUNGS))

--- a/code/modules/mob/say_readme.md
+++ b/code/modules/mob/say_readme.md
@@ -87,7 +87,7 @@ global procs
 		Composes the href tags used by the AI for tracking. Returns "" for all mobs except AIs.
 
 	compose_job(message, atom/movable/speaker, message_langs, raw_message, radio_freq)
-		Composes the job and the end tag for tracking hrefs. Returns "" for all mobs except AIs.
+		Composes the job and the end tag for tracking hrefs. Returns "" for all mobs except AIs and humans with job abbreviations.
 
 	hivecheck()
 		Returns TRUE if the mob can hear and talk in the alien hivemind.
@@ -174,6 +174,8 @@ If radio_freq is not null, the code will rely on the fact that the speaker is vi
 	(all of these procs are defined at the atom/movable level and return "" at that level.)
 	GetJob()
 		Returns the job string variable of the virtual speaker.
+	GetJobAbbrev()
+		Returns the job abbreviation string variable of the virtual speaker.
 	GetTrack()
 		Returns wether the tracking href should be fake or not.
 	GetSource()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
- General record of datacore now includes job abbreviations
- Virtual speakers grab job abbreviations which show up in radio only
- Virtual speakers use human assigned roles instead of name (no more ling impersonation)
- Job descriptions rewritten with slightly better grammar

## Why It's Good For The Game
Hijacked AI code to add job title abbreviations only for humans receiving radio messages from other humans. No other feature such as human name is affected. Since we have respawn that can create two job manifests with the same name, virtual speakers have to search by actual role instead of name. Any jobs without ```job_abbrevation``` set will not modify radio messages. Admins can varedit the general records for custom abbreviations.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: job abbreviations for radio messages only
tweak: virtual speakers use assigned role instead of name when searching manifest
:cl:

