### PR TITLE
Small edit to the special text of hypocrisy

### DIFF
--- a/code/modules/projectiles/guns/ego_gun/waw.dm
+++ b/code/modules/projectiles/guns/ego_gun/waw.dm
@@ -499,7 +499,8 @@
 	icon_state = "hypocrisy"
 	inhand_icon_state = "hypocrisy"
 	worn_icon_state = "hypocrisy"
-	special = "Use this weapon in hand to place a trap."
+	special = "Use this weapon in hand to place a trap that inflicts \
+		50 RED damage and alerts the user of the area it was triggered."
 	ammo_type = /obj/item/ammo_casing/caseless/ego_hypocrisy
 	weapon_weight = WEAPON_HEAVY
 	fire_delay = 25


### PR DESCRIPTION
## About The Pull Request
I thought about it and i should let the person know that the trap does 50 red damage to hostiles.

"Use this weapon in hand to place a trap that inflicts \
50 RED damage and alerts the user of the area it was triggered."

## Why It's Good For The Game
Informs the user of what damage type the trap is and how lethal it is to monsters.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Hypocrisy
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
