### PR TITLE
KQE Damage Coeff Fix

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/he/KQE.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/KQE.dm
@@ -94,7 +94,7 @@
 		if(!LAZYLEN(GLOB.department_centers))
 			heart = TRUE
 		else
-			damage_coeff = list(RED_DAMAGE = 0.3, WHITE_DAMAGE = 0.2, BLACK_DAMAGE = 0.2, PALE_DAMAGE = 0.2)//In regular gamemodes you are now esentially forced to suppress the heart
+			ChangeResistances(list(RED_DAMAGE = 0.3, WHITE_DAMAGE = 0.2, BLACK_DAMAGE = 0.2, PALE_DAMAGE = 0.2)) //In regular gamemodes you are now esentially forced to suppress the heart
 			var/X = pick(GLOB.department_centers)
 			var/mob/living/simple_animal/hostile/kqe_heart/H = new(get_turf(X))
 			heart = H

--- a/code/modules/mob/living/simple_animal/animal_defense.dm
+++ b/code/modules/mob/living/simple_animal/animal_defense.dm
@@ -131,6 +131,13 @@
 	if(islist(damage_coeff))
 		ChangeResistances(damage_coeff)
 		stack_trace("[src] has a damage_coeff list and was hurt!")
+	else if(!type(damage_coeff))
+		stack_trace("[src] has an invalid damage coeff entirely!? Resetting to default.")
+		if(!istype(unmodified_damage_coeff_datum))
+			stack_trace("[src] has an invalid unmodified damage coeff!? Resetting to 1s")
+			unmodified_damage_coeff_datum = makeDamCoeff()
+		damage_coeff = unmodified_damage_coeff_datum
+		UpdateResistances()
 	temp_damage *= damage_coeff.getCoeff(damagetype)
 
 	if(temp_damage >= 0 && temp_damage <= force_threshold)

--- a/code/modules/mob/living/simple_animal/animal_defense.dm
+++ b/code/modules/mob/living/simple_animal/animal_defense.dm
@@ -131,7 +131,7 @@
 	if(islist(damage_coeff))
 		ChangeResistances(damage_coeff)
 		stack_trace("[src] has a damage_coeff list and was hurt!")
-	else if(!type(damage_coeff))
+	else if(!istype(damage_coeff))
 		stack_trace("[src] has an invalid damage coeff entirely!? Resetting to default.")
 		if(!istype(unmodified_damage_coeff_datum))
 			stack_trace("[src] has an invalid unmodified damage coeff!? Resetting to 1s")

--- a/code/modules/mob/living/simple_animal/animal_defense.dm
+++ b/code/modules/mob/living/simple_animal/animal_defense.dm
@@ -129,10 +129,9 @@
 	var/temp_damage = damage
 
 	if(islist(damage_coeff))
-		temp_damage *= damage_coeff[damagetype]
+		ChangeResistances(damage_coeff)
 		stack_trace("[src] has a damage_coeff list and was hurt!")
-	else
-		temp_damage *= damage_coeff.getCoeff(damagetype)
+	temp_damage *= damage_coeff.getCoeff(damagetype)
 
 	if(temp_damage >= 0 && temp_damage <= force_threshold)
 		visible_message(span_warning("[src] looks unharmed!"))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
KQE was setting it's resists to a list which is deprecated. This resolves that.
Also sets it so that an abno who is hurt with an invalid damage_coeff _should_ fix itself and report on more severe bugs.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes KQE being WRONG.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: KQE not taking damage properly while hearting.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
