### PR TITLE
more 515 porting

### DIFF
--- a/ModularTegustation/tegu_drinks/twistedtea.dm
+++ b/ModularTegustation/tegu_drinks/twistedtea.dm
@@ -110,7 +110,7 @@
 		W.reagents.add_reagent(chem, 1)
 
 	//Make em move dat ass, hun
-	addtimer(CALLBACK(src, /obj/item/melee/twistedtea/proc/move_particles, reagent_particles), 2)
+	addtimer(CALLBACK(src, TYPE_PROC_REF(/obj/item/melee/twistedtea, move_particles), reagent_particles), 2)
 
 	if(!unlimiteduse)
 		broken = TRUE
@@ -143,7 +143,7 @@
 			particles -= W
 	if(repetition < power)
 		repetition++
-		addtimer(CALLBACK(src, /obj/item/melee/twistedtea/proc/move_particles, particles, repetition), 2)
+		addtimer(CALLBACK(src, TYPE_PROC_REF(/obj/item/melee/twistedtea, move_particles), particles, repetition), 2)
 
 
 

--- a/ModularTegustation/tegu_mobs/apocalypse_bird.dm
+++ b/ModularTegustation/tegu_mobs/apocalypse_bird.dm
@@ -367,7 +367,7 @@
 		P.xo = PT.x - T.x
 		P.original = PT
 		P.preparePixelProjectile(PT, T)
-		addtimer(CALLBACK (P, .obj/projectile/proc/fire), 6.5 SECONDS)
+		addtimer(CALLBACK (P, TYPE_PROC_REF(/obj/projectile, fire)), 6.5 SECONDS)
 
 	SLEEP_CHECK_DEATH(6.5 SECONDS)
 	playsound(src, 'sound/abnormalities/apocalypse/fire.ogg', 75, FALSE, 12)
@@ -690,7 +690,7 @@
 		return
 
 	if(!LAZYLEN(controller.current_path))
-		controller.current_path = get_path_to(living_pawn, target, /turf/proc/Distance_cardinal, 0, 80)
+		controller.current_path = get_path_to(living_pawn, target, TYPE_PROC_REF(/turf, Distance_cardinal), 0, 80)
 		if(!controller.current_path.len) // Returned FALSE or null.
 			finish_action(controller, FALSE)
 			return

--- a/code/controllers/subsystem/blackmarket.dm
+++ b/code/controllers/subsystem/blackmarket.dm
@@ -79,7 +79,7 @@ SUBSYSTEM_DEF(blackmarket)
 				to_chat(recursive_loc_check(purchase.uplink.loc, /mob), span_notice("[purchase.uplink] flashes a message noting that the order is being teleported to [get_area(targetturf)] in 60 seconds."))
 
 				// do_teleport does not want to teleport items from nullspace, so it just forceMoves and does sparks.
-				addtimer(CALLBACK(src, /datum/controller/subsystem/blackmarket/proc/fake_teleport, purchase.entry.spawn_item(), targetturf), 60 SECONDS)
+				addtimer(CALLBACK(src, TYPE_PROC_REF(/datum/controller/subsystem/blackmarket, fake_teleport), purchase.entry.spawn_item(), targetturf), 60 SECONDS)
 				queued_purchases -= purchase
 				qdel(purchase)
 			// Get the current location of the uplink if it exists, then throws the item from space at the station from a random direction.

--- a/code/controllers/subsystem/explosions.dm
+++ b/code/controllers/subsystem/explosions.dm
@@ -283,7 +283,7 @@ SUBSYSTEM_DEF(explosions)
 					M.playsound_local(epicenter, null, echo_volume, 1, frequency, S = explosion_echo_sound, distance_multiplier = 0)
 
 				if(creaking_explosion) // 5 seconds after the bang, the station begins to creak
-					addtimer(CALLBACK(M, /mob/proc/playsound_local, epicenter, null, rand(FREQ_LOWER, FREQ_UPPER), 1, frequency, null, null, FALSE, hull_creaking_sound, 0), CREAK_DELAY)
+					addtimer(CALLBACK(M, TYPE_PROC_REF(/mob, playsound_local), epicenter, null, rand(FREQ_LOWER, FREQ_UPPER), 1, frequency, null, null, FALSE, hull_creaking_sound, 0), CREAK_DELAY)
 
 	if(heavy_impact_range > 1)
 		var/datum/effect_system/explosion/E

--- a/code/controllers/subsystem/lobotomy_events.dm
+++ b/code/controllers/subsystem/lobotomy_events.dm
@@ -84,7 +84,7 @@ SUBSYSTEM_DEF(lobotomy_events)
 				continue
 			if(!A.IsContained())
 				continue
-			INVOKE_ASYNC(A.datum_reference, /datum/abnormality/proc/qliphoth_change, -999)
+			INVOKE_ASYNC(A.datum_reference, TYPE_PROC_REF(/datum/abnormality, qliphoth_change), -999)
 			break
 	return
 	//Further checks for event abnos can go here.
@@ -140,7 +140,7 @@ SUBSYSTEM_DEF(lobotomy_events)
 		if(YINYANG)
 			if(YY_breached.len < 2)
 				return FALSE
-			var/list/meet_path = get_path_to(YY_breached[1], YY_breached[2], /turf/proc/Distance, 0, 200)
+			var/list/meet_path = get_path_to(YY_breached[1], YY_breached[2], TYPE_PROC_REF(/turf, Distance), 0, 200)
 			YY_middle = meet_path[round(meet_path.len/2)]
 			for(var/mob/living/simple_animal/hostile/abnormality/A in YY_breached)
 				A.patrol_to(YY_middle)

--- a/code/datums/ai/sanity/sanityloss_behaviors.dm
+++ b/code/datums/ai/sanity/sanityloss_behaviors.dm
@@ -189,7 +189,7 @@
 			return
 
 	// If we can't move towards the item
-	if(!get_path_to(living_pawn, get_turf(target), /turf/proc/Distance_cardinal, 0, 10))
+	if(!get_path_to(living_pawn, get_turf(target), TYPE_PROC_REF(/turf, Distance_cardinal), 0, 10))
 		finish_action(controller, FALSE)
 		return
 
@@ -260,7 +260,7 @@
 
 	var/turf/target = controller.blackboard[BB_INSANE_CURRENT_ATTACK_TARGET]
 	if(!LAZYLEN(controller.current_path) && !living_pawn.Adjacent(target))
-		controller.current_path = get_path_to(living_pawn, target, /turf/proc/Distance_cardinal, 0, 120)
+		controller.current_path = get_path_to(living_pawn, target, TYPE_PROC_REF(/turf, Distance_cardinal), 0, 120)
 		if(!LAZYLEN(controller.current_path)) // Returned FALSE or null.
 			finish_action(controller, FALSE)
 			return
@@ -370,7 +370,7 @@
 
 	var/obj/machinery/computer/abnormality/target = controller.blackboard[BB_INSANE_CURRENT_ATTACK_TARGET]
 	if(!LAZYLEN(controller.current_path) && !living_pawn.Adjacent(target))
-		controller.current_path = get_path_to(living_pawn, get_step(target, SOUTH), /turf/proc/Distance_cardinal, 0, 50)
+		controller.current_path = get_path_to(living_pawn, get_step(target, SOUTH), TYPE_PROC_REF(/turf, Distance_cardinal), 0, 50)
 		if(!LAZYLEN(controller.current_path)) // Returned FALSE or null.
 			finish_action(controller, FALSE)
 			return
@@ -401,7 +401,7 @@
 	if(succeeded)
 		var/turf/T = get_closest_atom(/turf/open, GLOB.xeno_spawn, controller.pawn)
 		if(T)
-			controller.current_path = get_path_to(controller.pawn, T, /turf/proc/Distance_cardinal, 0, 50)
+			controller.current_path = get_path_to(controller.pawn, T, TYPE_PROC_REF(/turf, Distance_cardinal), 0, 50)
 			if(!LAZYLEN(controller.current_path))
 				finish_action(controller, FALSE)
 				return

--- a/code/datums/components/tackle.dm
+++ b/code/datums/components/tackle.dm
@@ -179,7 +179,7 @@
 			user.Knockdown(30)
 			if(ishuman(target) && !T.has_movespeed_modifier(/datum/movespeed_modifier/shove))
 				T.add_movespeed_modifier(/datum/movespeed_modifier/shove) // maybe define a slightly more severe/longer slowdown for this
-				addtimer(CALLBACK(T, /mob/living/carbon/proc/clear_shove_slowdown), SHOVE_SLOWDOWN_LENGTH * 2)
+				addtimer(CALLBACK(T, TYPE_PROC_REF(/mob/living/carbon, clear_shove_slowdown)), SHOVE_SLOWDOWN_LENGTH * 2)
 
 		if(-1 to 0) // decent hit, both parties are about equally inconvenienced
 			user.visible_message("<span class='warning'>[user] lands a passable [tackle_word] on [target], sending them both tumbling!</span>", "<span class='userdanger'>You land a passable [tackle_word] on [target], sending you both tumbling!</span>", ignored_mobs = target)

--- a/code/datums/ductnet.dm
+++ b/code/datums/ductnet.dm
@@ -15,8 +15,8 @@
 /datum/ductnet/proc/remove_duct(obj/machinery/duct/ducting)
 	destroy_network(FALSE)
 	for(var/obj/machinery/duct/D in ducting.neighbours)
-		addtimer(CALLBACK(D, /obj/machinery/duct/proc/reconnect), 0) //all needs to happen after the original duct that was destroyed finishes destroying itself
-		addtimer(CALLBACK(D, /obj/machinery/duct/proc/generate_connects), 0)
+		addtimer(CALLBACK(D, TYPE_PROC_REF(/obj/machinery/duct, reconnect)), 0) //all needs to happen after the original duct that was destroyed finishes destroying itself
+		addtimer(CALLBACK(D, TYPE_PROC_REF(/obj/machinery/duct, generate_connects)), 0)
 	qdel(src)
 ///add a plumbing object to either demanders or suppliers
 /datum/ductnet/proc/add_plumber(datum/component/plumbing/P, dir)

--- a/code/datums/elements/atmos_sensitive.dm
+++ b/code/datums/elements/atmos_sensitive.dm
@@ -10,7 +10,7 @@
 		return ELEMENT_INCOMPATIBLE
 	var/atom/to_track = target
 	if(isopenturf(to_track.loc))
-		to_track.RegisterSignal(to_track.loc, COMSIG_TURF_EXPOSE, /atom/proc/check_atmos_process)
+		to_track.RegisterSignal(to_track.loc, COMSIG_TURF_EXPOSE, TYPE_PROC_REF(/atom, check_atmos_process))
 	RegisterSignal(to_track, COMSIG_MOVABLE_MOVED, PROC_REF(handle_move))
 	return ..()
 
@@ -28,7 +28,7 @@
 	microchipped_lad.UnregisterSignal(oldloc, COMSIG_TURF_EXPOSE)
 	if(isopenturf(microchipped_lad.loc))
 		var/turf/open/new_spot = microchipped_lad.loc
-		microchipped_lad.RegisterSignal(new_spot, COMSIG_TURF_EXPOSE, /atom/proc/check_atmos_process)
+		microchipped_lad.RegisterSignal(new_spot, COMSIG_TURF_EXPOSE, TYPE_PROC_REF(/atom, check_atmos_process))
 		microchipped_lad.check_atmos_process(null, new_spot.air, new_spot.temperature) //Make sure you're properly registered
 
 /atom/proc/check_atmos_process(datum/source, datum/gas_mixture/air, exposed_temperature)

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -155,7 +155,7 @@
 	owner.add_stun_absorption("bloody bastard sword", duration, 2, "doesn't even flinch as the sword's power courses through them!", "You shrug off the stun!", " glowing with a blazing red aura!")
 	owner.spin(duration,1)
 	animate(owner, color = oldcolor, time = duration, easing = EASE_IN)
-	addtimer(CALLBACK(owner, /atom/proc/update_atom_colour), duration)
+	addtimer(CALLBACK(owner, TYPE_PROC_REF(/atom, update_atom_colour)), duration)
 	playsound(owner, 'sound/weapons/fwoosh.ogg', 75, FALSE)
 	return ..()
 

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -596,7 +596,7 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 		if(!L.client.played)
 			SEND_SOUND(L, sound(sound, repeat = 0, wait = 0, volume = 25, channel = CHANNEL_AMBIENCE))
 			L.client.played = TRUE
-			addtimer(CALLBACK(L.client, /client/proc/ResetAmbiencePlayed), 600)
+			addtimer(CALLBACK(L.client, TYPE_PROC_REF(/client, ResetAmbiencePlayed)), 600)
 
 ///Divides total beauty in the room by roomsize to allow us to get an average beauty per tile.
 /area/proc/update_beauty()

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -116,7 +116,7 @@
 		addtimer(CALLBACK(src, PROC_REF(send_intercept), 0), rand(waittime_l, waittime_h))
 	generate_station_goals()
 
-	addtimer(CALLBACK(SSabnormality_queue, /datum/controller/subsystem/abnormality_queue/proc/HandleStartingAbnormalities), ABNORMALITY_DELAY)
+	addtimer(CALLBACK(SSabnormality_queue, TYPE_PROC_REF(/datum/controller/subsystem/abnormality_queue, HandleStartingAbnormalities)), ABNORMALITY_DELAY)
 
 	gamemode_ready = TRUE
 	return TRUE

--- a/code/game/machinery/computer/abnormality_auxiliary.dm
+++ b/code/game/machinery/computer/abnormality_auxiliary.dm
@@ -119,7 +119,7 @@
 			to_chat(usr, span_userdanger("Good luck, Manager."))
 			playsound(get_turf(src), 'sound/machines/terminal_prompt_confirm.ogg', 50, TRUE)
 			updateUsrDialog()
-			addtimer(CALLBACK(SSlobotomy_corp.core_suppression, /datum/suppression/proc/Run), 2 SECONDS)
+			addtimer(CALLBACK(SSlobotomy_corp.core_suppression, TYPE_PROC_REF(/datum/suppression, Run)), 2 SECONDS)
 			return TRUE
 
 		// Facility upgrade topics

--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -1012,7 +1012,7 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 						var/mob/living/L = usr
 						L.Stun(200, ignore_canstun = TRUE) //you can't run :^)
 					var/S = new /obj/singularity/academy(usr.loc)
-					addtimer(CALLBACK(src, /atom/movable/proc/say, "[S] winks out, just as suddenly as it appeared."), 50)
+					addtimer(CALLBACK(src, TYPE_PROC_REF(/atom/movable, say), "[S] winks out, just as suddenly as it appeared."), 50)
 					QDEL_IN(S, 50)
 			else
 				event = null

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -624,7 +624,7 @@
 			if(!machine_stat)
 				update_icon(AIRLOCK_DENY)
 				playsound(src,doorDeni,50,FALSE,3)
-				addtimer(CALLBACK(src, /atom/proc/update_icon, AIRLOCK_CLOSED), AIRLOCK_DENY_ANIMATION_TIME)
+				addtimer(CALLBACK(src, TYPE_PROC_REF(/atom, update_icon), AIRLOCK_CLOSED), AIRLOCK_DENY_ANIMATION_TIME)
 
 /obj/machinery/door/airlock/examine(mob/user)
 	. = ..()

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -653,7 +653,7 @@ GENE SCANNER
 			else
 				to_chat(user, "<span class='warning'>[src]'s barometer function says a storm will land in approximately [butchertime(fixed)].</span>")
 		cooldown = TRUE
-		addtimer(CALLBACK(src,/obj/item/analyzer/proc/ping), cooldown_time)
+		addtimer(CALLBACK(src, TYPE_PROC_REF(/obj/item/analyzer, ping)), cooldown_time)
 
 /obj/item/analyzer/proc/ping()
 	if(isliving(loc))

--- a/code/game/objects/items/ego_weapons/aleph.dm
+++ b/code/game/objects/items/ego_weapons/aleph.dm
@@ -1103,7 +1103,7 @@
 			break
 		for(var/obj/machinery/door/D in T.contents)
 			if(D.density)
-				addtimer(CALLBACK (D, .obj/machinery/door/proc/open))
+				addtimer(CALLBACK (D, TYPE_PROC_REF(/obj/machinery/door, open)))
 		target_turf = T
 		line_turfs += T
 	user.dir = get_dir(user, A)

--- a/code/game/objects/items/ego_weapons/he.dm
+++ b/code/game/objects/items/ego_weapons/he.dm
@@ -1095,7 +1095,7 @@
 		return
 	if(!activated)
 		return
-	if(!LAZYLEN(get_path_to(src,target, /turf/proc/Distance, 0, 20)))
+	if(!LAZYLEN(get_path_to(src,target, TYPE_PROC_REF(/turf, Distance), 0, 20)))
 		to_chat(user, span_notice("Invalid target."))
 		activated = FALSE
 		return

--- a/code/game/objects/items/ego_weapons/ordeal.dm
+++ b/code/game/objects/items/ego_weapons/ordeal.dm
@@ -170,7 +170,7 @@
 				playsound(user, 'ModularTegustation/Tegusounds/claw/move.ogg', 50, 1)
 				for(var/obj/machinery/door/MD in T.contents) // Hiding behind a door mortal?
 					if(MD.density)
-						addtimer(CALLBACK (MD, .obj/machinery/door/proc/open))
+						addtimer(CALLBACK (MD, TYPE_PROC_REF(/obj/machinery/door, open)))
 			// Damage
 			for(var/mob/living/L in mobs_to_hit)
 				if(user.faction_check_mob(L))

--- a/code/game/objects/items/extinguisher.dm
+++ b/code/game/objects/items/extinguisher.dm
@@ -160,7 +160,7 @@
 		if(user.buckled && isobj(user.buckled) && !user.buckled.anchored)
 			var/obj/B = user.buckled
 			var/movementdirection = turn(direction,180)
-			addtimer(CALLBACK(src, /obj/item/extinguisher/proc/move_chair, B, movementdirection), 1)
+			addtimer(CALLBACK(src, TYPE_PROC_REF(/obj/item/extinguisher, move_chair), B, movementdirection), 1)
 
 		else user.newtonian_move(turn(direction, 180))
 
@@ -188,7 +188,7 @@
 			reagents.trans_to(W,1, transfered_by = user)
 
 		//Make em move dat ass, hun
-		addtimer(CALLBACK(src, /obj/item/extinguisher/proc/move_particles, water_particles), 2)
+		addtimer(CALLBACK(src, TYPE_PROC_REF(/obj/item/extinguisher, move_particles), water_particles), 2)
 
 //Particle movement loop
 /obj/item/extinguisher/proc/move_particles(list/particles, repetition=0)
@@ -210,7 +210,7 @@
 			particles -= W
 	if(repetition < power)
 		repetition++
-		addtimer(CALLBACK(src, /obj/item/extinguisher/proc/move_particles, particles, repetition), 2)
+		addtimer(CALLBACK(src, TYPE_PROC_REF(/obj/item/extinguisher, move_particles), particles, repetition), 2)
 
 //Chair movement loop
 /obj/item/extinguisher/proc/move_chair(obj/B, movementdirection, repetition=0)
@@ -228,7 +228,7 @@
 			return
 
 	repetition++
-	addtimer(CALLBACK(src, /obj/item/extinguisher/proc/move_chair, B, movementdirection, repetition), timer_seconds)
+	addtimer(CALLBACK(src, TYPE_PROC_REF(/obj/item/extinguisher, move_chair), B, movementdirection, repetition), timer_seconds)
 
 /obj/item/extinguisher/AltClick(mob/user)
 	if(!user.canUseTopic(src, BE_CLOSE, NO_DEXTERITY, FALSE, TRUE))

--- a/code/game/objects/items/fixerskills/level1/defensive.dm
+++ b/code/game/objects/items/fixerskills/level1/defensive.dm
@@ -19,7 +19,7 @@
 	if (ishuman(owner))
 		var/mob/living/carbon/human/human = owner
 		human.add_movespeed_modifier(/datum/movespeed_modifier/hunkerdown)
-		addtimer(CALLBACK(human, .mob/proc/remove_movespeed_modifier, /datum/movespeed_modifier/hunkerdown), 10 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
+		addtimer(CALLBACK(human, TYPE_PROC_REF(/mob, remove_movespeed_modifier), /datum/movespeed_modifier/hunkerdown), 10 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
 		human.physiology.red_mod *= 0.6
 		human.physiology.white_mod *= 0.6
 		human.physiology.black_mod *= 0.6

--- a/code/game/objects/items/fixerskills/level1/movement.dm
+++ b/code/game/objects/items/fixerskills/level1/movement.dm
@@ -71,7 +71,7 @@
 	if (ishuman(owner))
 		var/mob/living/carbon/human/human = owner
 		human.add_movespeed_modifier(/datum/movespeed_modifier/assault)
-		addtimer(CALLBACK(human, .mob/proc/remove_movespeed_modifier, /datum/movespeed_modifier/assault), 5 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
+		addtimer(CALLBACK(human, TYPE_PROC_REF(/mob, remove_movespeed_modifier), /datum/movespeed_modifier/assault), 5 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
 		StartCooldown()
 
 /datum/movespeed_modifier/assault
@@ -99,7 +99,7 @@
 	if (ishuman(owner))
 		var/mob/living/carbon/human/human = owner
 		human.add_movespeed_modifier(/datum/movespeed_modifier/retreat)
-		addtimer(CALLBACK(human, .mob/proc/remove_movespeed_modifier, /datum/movespeed_modifier/retreat), 5 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
+		addtimer(CALLBACK(human, TYPE_PROC_REF(/mob, remove_movespeed_modifier), /datum/movespeed_modifier/retreat), 5 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
 		human.physiology.red_mod *= 1.3
 		human.physiology.white_mod *= 1.3
 		human.physiology.black_mod *= 1.3

--- a/code/game/objects/items/grenades/clusterbuster.dm
+++ b/code/game/objects/items/grenades/clusterbuster.dm
@@ -78,7 +78,7 @@
 		var/obj/item/grenade/P = new type(loc)
 		if(istype(P))
 			P.active = TRUE
-			addtimer(CALLBACK(P, /obj/item/grenade/proc/detonate), rand(15,60))
+			addtimer(CALLBACK(P, TYPE_PROC_REF(/obj/item/grenade, detonate)), rand(15,60))
 		var/steps = rand(1,4)
 		for(var/i in 1 to steps)
 			step_away(src,loc)
@@ -107,7 +107,7 @@
 		var/chosen = pick(subtypesof(/obj/item/slime_extract))
 		var/obj/item/slime_extract/P = new chosen(loc)
 		if(volatile)
-			addtimer(CALLBACK(P, /obj/item/slime_extract/proc/activate_slime), rand(15,60))
+			addtimer(CALLBACK(P, TYPE_PROC_REF(/obj/item/slime_extract, activate_slime)), rand(15,60))
 		var/steps = rand(1,4)
 		for(var/i in 1 to steps)
 			step_away(src,loc)

--- a/code/game/objects/items/miscellaneous.dm
+++ b/code/game/objects/items/miscellaneous.dm
@@ -378,7 +378,7 @@
 	user.visible_message("<span class='suicide'>[user] starts saying their Hail Mary's at a terrifying pace! It looks like [user.p_theyre()] trying to enter the afterlife!</span>")
 	user.say("Hail Mary, full of grace, the Lord is with thee. Blessed are thou amongst women, and blessed is the fruit of thy womb, Jesus. Holy Mary, mother of God, pray for us sinners, now and at the hour of our death. Amen. ", forced = /obj/item/virgin_mary)
 	addtimer(CALLBACK(src, PROC_REF(manual_suicide), user), 75)
-	addtimer(CALLBACK(user, /atom/movable/proc/say, "O my Mother, preserve me this day from mortal sin..."), 50)
+	addtimer(CALLBACK(user, TYPE_PROC_REF(/atom/movable, say), "O my Mother, preserve me this day from mortal sin..."), 50)
 	return MANUAL_SUICIDE
 
 /obj/item/virgin_mary/proc/manual_suicide(mob/living/user)

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -43,12 +43,12 @@
 	if(patient == user)
 		if(!silent)
 			user.visible_message("<span class='notice'>[user] starts to apply [src] on [user.p_them()]self...</span>", "<span class='notice'>You begin applying [src] on yourself...</span>")
-		if(!do_mob(user, patient, self_delay, extra_checks=CALLBACK(patient, /mob/living/proc/can_inject, user, TRUE)))
+		if(!do_mob(user, patient, self_delay, extra_checks=CALLBACK(patient, TYPE_PROC_REF(/mob/living, can_inject), user, TRUE)))
 			return
 	else if(other_delay)
 		if(!silent)
 			user.visible_message("<span class='notice'>[user] starts to apply [src] on [patient].</span>", "<span class='notice'>You begin applying [src] on [patient]...</span>")
-		if(!do_mob(user, patient, other_delay, extra_checks=CALLBACK(patient, /mob/living/proc/can_inject, user, TRUE)))
+		if(!do_mob(user, patient, other_delay, extra_checks=CALLBACK(patient, TYPE_PROC_REF(/mob/living, can_inject), user, TRUE)))
 			return
 
 	if(heal(patient, user))

--- a/code/game/objects/structures/false_walls.dm
+++ b/code/game/objects/structures/false_walls.dm
@@ -44,7 +44,7 @@
 		for(var/mob/living/obstacle in srcturf) //Stop people from using this as a shield
 			opening = FALSE
 			return
-	addtimer(CALLBACK(src, /obj/structure/falsewall/proc/toggle_open), 5)
+	addtimer(CALLBACK(src, TYPE_PROC_REF(/obj/structure/falsewall, toggle_open)), 5)
 
 /obj/structure/falsewall/proc/toggle_open()
 	if(!QDELETED(src))

--- a/code/game/objects/structures/tutorial.dm
+++ b/code/game/objects/structures/tutorial.dm
@@ -21,7 +21,7 @@
 		var/turf/shove_turf = get_step(loc, shove_dir)
 		if(Move(shove_turf, shove_dir))
 			to_chat(user, "<span class='notice'>You push \the [src] out of the way.</span>")
-			addtimer(CALLBACK(src, /atom/movable/proc/forceMove, oldturf), 20 SECONDS)
+			addtimer(CALLBACK(src, TYPE_PROC_REF(/atom/movable, forceMove), oldturf), 20 SECONDS)
 
 /obj/machinery/power/emitter/energycannon/tutorialemitter
 

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -230,7 +230,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 //Removes the ahelp verb and returns it after 2 minutes
 /datum/admin_help/proc/TimeoutVerb()
 	remove_verb(initiator, /client/verb/adminhelp)
-	initiator.adminhelptimerid = addtimer(CALLBACK(initiator, /client/proc/giveadminhelpverb), 1200, TIMER_STOPPABLE) //2 minute cooldown of admin helps
+	initiator.adminhelptimerid = addtimer(CALLBACK(initiator, TYPE_PROC_REF(/client, giveadminhelpverb)), 1200, TIMER_STOPPABLE) //2 minute cooldown of admin helps
 
 //private
 /datum/admin_help/proc/FullMonty(ref_src)
@@ -354,7 +354,7 @@ GLOBAL_DATUM_INIT(ahelp_tickets, /datum/admin_help_tickets, new)
 	state = AHELP_RESOLVED
 	GLOB.ahelp_tickets.ListInsert(src)
 
-	addtimer(CALLBACK(initiator, /client/proc/giveadminhelpverb), 50)
+	addtimer(CALLBACK(initiator, TYPE_PROC_REF(/client, giveadminhelpverb)), 50)
 
 	AddInteraction("<font color='green'>Resolved by [key_name].</font>")
 	to_chat(initiator, "<span class='adminhelp'>Your ticket has been resolved by an admin. The Adminhelp verb will be returned to you shortly.</span>", confidential = TRUE)

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -128,7 +128,7 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 		alert("Wait until the game starts")
 		return
 	if(ishuman(M))
-		INVOKE_ASYNC(M, /mob/living/carbon/human/proc/Alienize)
+		INVOKE_ASYNC(M, TYPE_PROC_REF(/mob/living/carbon/human, Alienize))
 		SSblackbox.record_feedback("tally", "admin_verb", 1, "Make Alien") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 		log_admin("[key_name(usr)] made [key_name(M)] into an alien at [AREACOORD(M)].")
 		message_admins(span_adminnotice("[key_name_admin(usr)] made [ADMIN_LOOKUPFLW(M)] into an alien."))
@@ -143,7 +143,7 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 		alert("Wait until the game starts")
 		return
 	if(ishuman(M))
-		INVOKE_ASYNC(M, /mob/living/carbon/human/proc/slimeize)
+		INVOKE_ASYNC(M, TYPE_PROC_REF(/mob/living/carbon/human, slimeize))
 		SSblackbox.record_feedback("tally", "admin_verb", 1, "Make Slime") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 		log_admin("[key_name(usr)] made [key_name(M)] into a slime at [AREACOORD(M)].")
 		message_admins(span_adminnotice("[key_name_admin(usr)] made [ADMIN_LOOKUPFLW(M)] into a slime."))

--- a/code/modules/antagonists/changeling/powers/tiny_prick.dm
+++ b/code/modules/antagonists/changeling/powers/tiny_prick.dm
@@ -47,7 +47,7 @@
 		return
 	if(!isturf(user.loc))
 		return
-	if(!AStar(user, target.loc, /turf/proc/Distance, changeling.sting_range, simulated_only = FALSE))
+	if(!AStar(user, target.loc, TYPE_PROC_REF(/turf, Distance), changeling.sting_range, simulated_only = FALSE))
 		return
 	if(target.mind && target.mind.has_antag_datum(/datum/antagonist/changeling))
 		sting_feedback(user, target)

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -430,7 +430,7 @@
 			L.mob_light(_range = 2, _color = LIGHT_COLOR_HOLY_MAGIC, _duration = 10 SECONDS)
 			var/mutable_appearance/forbearance = mutable_appearance('icons/effects/genetics.dmi', "servitude", -MUTATIONS_LAYER)
 			L.add_overlay(forbearance)
-			addtimer(CALLBACK(L, /atom/proc/cut_overlay, forbearance), 100)
+			addtimer(CALLBACK(L, TYPE_PROC_REF(/atom, cut_overlay), forbearance), 100)
 
 			if(istype(anti_magic_source, /obj/item))
 				var/obj/item/ams_object = anti_magic_source

--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -172,7 +172,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 	var/oldcolor = color
 	color = rgb(255, 0, 0)
 	animate(src, color = oldcolor, time = 5)
-	addtimer(CALLBACK(src, /atom/proc/update_atom_colour), 5)
+	addtimer(CALLBACK(src, TYPE_PROC_REF(/atom, update_atom_colour)), 5)
 
 //Malformed Rune: This forms if a rune is not drawn correctly. Invoking it does nothing but hurt the user.
 /obj/effect/rune/malformed
@@ -236,7 +236,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 		..()
 		do_sacrifice(L, invokers)
 	animate(src, color = oldcolor, time = 5)
-	addtimer(CALLBACK(src, /atom/proc/update_atom_colour), 5)
+	addtimer(CALLBACK(src, TYPE_PROC_REF(/atom, update_atom_colour)), 5)
 	Cult_team.check_size() // Triggers the eye glow or aura effects if the cult has grown large enough relative to the crew
 	rune_in_use = FALSE
 

--- a/code/modules/antagonists/disease/disease_event.dm
+++ b/code/modules/antagonists/disease/disease_event.dm
@@ -19,7 +19,7 @@
 
 	var/mob/camera/disease/virus = new /mob/camera/disease(SSmapping.get_station_center())
 	virus.key = selected.key
-	INVOKE_ASYNC(virus, /mob/camera/disease/proc/pick_name)
+	INVOKE_ASYNC(virus, TYPE_PROC_REF(/mob/camera/disease, pick_name))
 	message_admins("[ADMIN_LOOKUPFLW(virus)] has been made into a sentient disease by an event.")
 	log_game("[key_name(virus)] was spawned as a sentient disease by an event.")
 	spawned_mobs += virus

--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -497,7 +497,7 @@
 	SSticker.roundend_check_paused = FALSE
 
 /obj/machinery/nuclearbomb/proc/really_actually_explode(off_station)
-	Cinematic(get_cinematic_type(off_station),world,CALLBACK(SSticker,/datum/controller/subsystem/ticker/proc/station_explosion_detonation,src))
+	Cinematic(get_cinematic_type(off_station),world,CALLBACK(SSticker, TYPE_PROC_REF(/datum/controller/subsystem/ticker, station_explosion_detonation),src))
 	INVOKE_ASYNC(GLOBAL_PROC, GLOBAL_PROC_REF(KillEveryoneOnZLevel), z)
 
 /obj/machinery/nuclearbomb/proc/get_cinematic_type(off_station)
@@ -723,7 +723,7 @@ This is here to make the tiles around the station mininuke change when it's arme
 	user.visible_message("<span class='suicide'>[user] is going delta! It looks like [user.p_theyre()] trying to commit suicide!</span>")
 	playsound(src, 'sound/machines/alarm.ogg', 50, -1, TRUE)
 	for(var/i in 1 to 100)
-		addtimer(CALLBACK(user, /atom/proc/add_atom_colour, (i % 2)? "#00FF00" : "#FF0000", ADMIN_COLOUR_PRIORITY), i)
+		addtimer(CALLBACK(user, TYPE_PROC_REF(/atom, add_atom_colour), (i % 2)? "#00FF00" : "#FF0000", ADMIN_COLOUR_PRIORITY), i)
 	addtimer(CALLBACK(src, PROC_REF(manual_suicide), user), 101)
 	return MANUAL_SUICIDE
 

--- a/code/modules/asset_cache/transports/asset_transport.dm
+++ b/code/modules/asset_cache/transports/asset_transport.dm
@@ -131,7 +131,7 @@
 
 			client.sent_assets[new_asset_name] = ACI.hash
 
-		addtimer(CALLBACK(client, /client/proc/asset_cache_update_json), 1 SECONDS, TIMER_UNIQUE|TIMER_OVERRIDE)
+		addtimer(CALLBACK(client, TYPE_PROC_REF(/client, asset_cache_update_json)), 1 SECONDS, TIMER_UNIQUE|TIMER_OVERRIDE)
 		return TRUE
 	return FALSE
 

--- a/code/modules/clothing/masks/hailer.dm
+++ b/code/modules/clothing/masks/hailer.dm
@@ -132,7 +132,7 @@ GLOBAL_LIST_INIT(hailer_phrases, list(
 	if(!overuse_cooldown) // check if we can reset recent uses
 		recent_uses = 0
 		overuse_cooldown = TRUE
-		addtimer(CALLBACK(src, /obj/item/clothing/mask/gas/sechailer/proc/reset_overuse_cooldown), OVERUSE_COOLDOWN)
+		addtimer(CALLBACK(src, TYPE_PROC_REF(/obj/item/clothing/mask/gas/sechailer, reset_overuse_cooldown)), OVERUSE_COOLDOWN)
 
 	switch(recent_uses)
 		if(3)
@@ -168,7 +168,7 @@ GLOBAL_LIST_INIT(hailer_phrases, list(
 		usr.audible_message("[usr]'s Compli-o-Nator: <font color='red' size='4'><b>[initial(phrase.phrase_text)]</b></font>")
 		playsound(src, "sound/runtime/complionator/[initial(phrase.phrase_sound)].ogg", 100, FALSE, 4)
 		cooldown = TRUE
-		addtimer(CALLBACK(src, /obj/item/clothing/mask/gas/sechailer/proc/reset_cooldown), PHRASE_COOLDOWN)
+		addtimer(CALLBACK(src, TYPE_PROC_REF(/obj/item/clothing/mask/gas/sechailer, reset_cooldown)), PHRASE_COOLDOWN)
 		. = TRUE
 
 /obj/item/clothing/mask/gas/sechailer/proc/reset_cooldown()

--- a/code/modules/clothing/shoes/_shoes.dm
+++ b/code/modules/clothing/shoes/_shoes.dm
@@ -228,7 +228,7 @@
 				to_chat(our_guy, "<span class='danger'>You stumble a bit on your untied shoelaces!</span>")
 				if(!our_guy.has_movespeed_modifier(/datum/movespeed_modifier/shove))
 					our_guy.add_movespeed_modifier(/datum/movespeed_modifier/shove)
-					addtimer(CALLBACK(our_guy, /mob/living/carbon/proc/clear_shove_slowdown), SHOVE_SLOWDOWN_LENGTH)
+					addtimer(CALLBACK(our_guy, TYPE_PROC_REF(/mob/living/carbon, clear_shove_slowdown)), SHOVE_SLOWDOWN_LENGTH)
 
 			if(26 to 1000)
 				wiser = FALSE

--- a/code/modules/events/fake_virus.dm
+++ b/code/modules/events/fake_virus.dm
@@ -27,5 +27,5 @@
 			if(prob(25))//1/4 odds to get a spooky message instead of coughing out loud
 				addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(to_chat), onecoughman, span_warning("[pick("Your head hurts.", "Your head pounds.")]")), rand(30,150))
 			else
-				addtimer(CALLBACK(onecoughman, .mob/proc/emote, pick("cough", "sniff", "sneeze")), rand(30,150))//deliver the message with a slightly randomized time interval so there arent multiple people coughing at the exact same time
+				addtimer(CALLBACK(onecoughman, TYPE_PROC_REF(/mob, emote), pick("cough", "sniff", "sneeze")), rand(30,150))//deliver the message with a slightly randomized time interval so there arent multiple people coughing at the exact same time
 			fake_virus_victims -= onecoughman

--- a/code/modules/jobs/job_exp.dm
+++ b/code/modules/jobs/job_exp.dm
@@ -200,7 +200,7 @@ GLOBAL_PROTECT(exp_to_update)
 			"ckey" = ckey,
 			"minutes" = jvalue)))
 		prefs.exp[jtype] += jvalue
-	addtimer(CALLBACK(SSblackbox,/datum/controller/subsystem/blackbox/proc/update_exp_db),20,TIMER_OVERRIDE|TIMER_UNIQUE)
+	addtimer(CALLBACK(SSblackbox, TYPE_PROC_REF(/datum/controller/subsystem/blackbox, update_exp_db)),20,TIMER_OVERRIDE|TIMER_UNIQUE)
 
 
 //ALWAYS call this at beginning to any proc touching player flags, or your database admin will probably be mad

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -234,7 +234,7 @@
 /datum/job/proc/announce_head(mob/living/carbon/human/H, channels) //tells the given channel that the given mob is the new department head. See communications.dm for valid channels.
 	if(H && GLOB.announcement_systems.len)
 		//timer because these should come after the captain announcement
-		SSticker.OnRoundstart(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(_addtimer), CALLBACK(pick(GLOB.announcement_systems), /obj/machinery/announcement_system/proc/announce, "NEWHEAD", H.real_name, H.job, channels), 1))
+		SSticker.OnRoundstart(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(_addtimer), CALLBACK(pick(GLOB.announcement_systems), TYPE_PROC_REF(/obj/machinery/announcement_system, announce), "NEWHEAD", H.real_name, H.job, channels), 1))
 
 //If the configuration option is set to require players to be logged as old enough to play certain jobs, then this proc checks that they are, otherwise it just returns 1
 /datum/job/proc/player_old_enough(client/C)

--- a/code/modules/mining/equipment/resonator.dm
+++ b/code/modules/mining/equipment/resonator.dm
@@ -111,7 +111,7 @@
 		to_chat(L, span_userdanger("[src] ruptured with you in it!"))
 		L.apply_damage(resonance_damage, BRUTE)
 		L.add_movespeed_modifier(/datum/movespeed_modifier/resonance)
-		addtimer(CALLBACK(L, /mob/proc/remove_movespeed_modifier, /datum/movespeed_modifier/resonance), 10 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
+		addtimer(CALLBACK(L, TYPE_PROC_REF(/mob, remove_movespeed_modifier), /datum/movespeed_modifier/resonance), 10 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
 	for(var/obj/effect/temp_visual/resonance/field in range(1, src))
 		if(field != src && !field.rupturing)
 			field.burst()

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -163,7 +163,7 @@ GLOBAL_LIST_INIT(unpossessable_mobs, list( // LOBOTOMYCORPORATION ADDITION -- ab
 	var/old_color = color
 	color = "#960000"
 	animate(src, color = old_color, time = 10, flags = ANIMATION_PARALLEL)
-	addtimer(CALLBACK(src, /atom/proc/update_atom_colour), 10)
+	addtimer(CALLBACK(src, TYPE_PROC_REF(/atom, update_atom_colour)), 10)
 
 /mob/dead/observer/Destroy()
 	if(data_huds_on)

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -290,7 +290,7 @@
 		target.visible_message(span_danger("[name] kicks [target.name] onto [target.p_their()] side!"),
 						span_userdanger("You're kicked onto your side by [name]!"), span_hear("You hear aggressive shuffling followed by a loud thud!"), COMBAT_MESSAGE_RANGE, src)
 		to_chat(src, span_danger("You kick [target.name] onto [target.p_their()] side!"))
-		addtimer(CALLBACK(target, /mob/living/proc/SetKnockdown, 0), SHOVE_CHAIN_PARALYZE)
+		addtimer(CALLBACK(target, TYPE_PROC_REF(/mob/living, SetKnockdown), 0), SHOVE_CHAIN_PARALYZE)
 		log_combat(src, target, "kicks", "onto their side (paralyzing)")
 
 	if(shove_blocked && !target.is_shove_knockdown_blocked() && !target.buckled)
@@ -349,7 +349,7 @@
 			if(target_held_item)
 				target.visible_message(span_danger("[target.name]'s grip on \the [target_held_item] loosens!"),
 					span_warning("Your grip on \the [target_held_item] loosens!"), null, COMBAT_MESSAGE_RANGE)
-			addtimer(CALLBACK(target, /mob/living/carbon/proc/clear_shove_slowdown), SHOVE_SLOWDOWN_LENGTH)
+			addtimer(CALLBACK(target, TYPE_PROC_REF(/mob/living/carbon, clear_shove_slowdown)), SHOVE_SLOWDOWN_LENGTH)
 		else if(target_held_item)
 			target.dropItemToGround(target_held_item)
 			knocked_item = TRUE

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -524,7 +524,7 @@
 
 /mob/living/proc/get_up(instant = FALSE)
 	set waitfor = FALSE
-	if(!instant && !do_mob(src, src, 1 SECONDS, timed_action_flags = (IGNORE_USER_LOC_CHANGE|IGNORE_TARGET_LOC_CHANGE|IGNORE_HELD_ITEM), extra_checks = CALLBACK(src, /mob/living/proc/rest_checks_callback), interaction_key = DOAFTER_SOURCE_GETTING_UP))
+	if(!instant && !do_mob(src, src, 1 SECONDS, timed_action_flags = (IGNORE_USER_LOC_CHANGE|IGNORE_TARGET_LOC_CHANGE|IGNORE_HELD_ITEM), extra_checks = CALLBACK(src, TYPE_PROC_REF(/mob/living, rest_checks_callback)), interaction_key = DOAFTER_SOURCE_GETTING_UP))
 		return
 	if(resting || body_position == STANDING_UP || HAS_TRAIT(src, TRAIT_FLOORED))
 		return

--- a/code/modules/mob/living/simple_animal/abnormality/_abnormality.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_abnormality.dm
@@ -129,7 +129,7 @@
 	SHOULD_CALL_PARENT(TRUE)
 	if(istype(datum_reference)) // Respawn the mob on death
 		datum_reference.current = null
-		addtimer(CALLBACK (datum_reference, .datum/abnormality/proc/RespawnAbno), 30 SECONDS)
+		addtimer(CALLBACK (datum_reference, TYPE_PROC_REF(/datum/abnormality, RespawnAbno)), 30 SECONDS)
 	..()
 	if(loc)
 		if(isarea(loc))

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/distortedform.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/distortedform.dm
@@ -639,7 +639,7 @@
 		if(Y.stat == DEAD) //they chose to die instead of facing the fear
 			continue
 		Y.add_overlay(icon('icons/effects/effects.dmi', "spreadwarning"))
-		addtimer(CALLBACK(Y, .atom/proc/cut_overlay, \
+		addtimer(CALLBACK(Y, TYPE_PROC_REF(/atom, cut_overlay), \
 								icon('icons/effects/effects.dmi', "spreadwarning")), 45)
 		chosen_targets += Y
 
@@ -694,7 +694,7 @@
 	if(target.sanity_lost)
 		target.Stun(55) //Immobilize does not stop AI controllers from moving, for some reason.
 	target.add_overlay(icon('icons/effects/effects.dmi', "distortedgrab"))
-	addtimer(CALLBACK(target, .atom/proc/cut_overlay, \
+	addtimer(CALLBACK(target, TYPE_PROC_REF(/atom, cut_overlay), \
 							icon('icons/effects/effects.dmi', "distortedgrab")), 50)
 	if(get_dist(src, target) > 3)
 		var/list/all_turfs = RANGE_TURFS(1, src) //We need to grab the player, but also have them be visible.
@@ -873,7 +873,7 @@
 		if(Y.stat == DEAD) //they chose to die instead of facing the fear
 			continue
 		Y.add_overlay(icon('icons/effects/effects.dmi', "zorowarning"))
-		addtimer(CALLBACK(Y, .atom/proc/cut_overlay, \
+		addtimer(CALLBACK(Y, TYPE_PROC_REF(/atom, cut_overlay), \
 								icon('icons/effects/effects.dmi', "zorowarning")), 40)
 		chosen_targets += Y
 	SLEEP_CHECK_DEATH(35)
@@ -890,7 +890,7 @@
 		if(jump_turf.is_blocked_turf(exclude_mobs = TRUE))
 			jump_turf = get_turf(Y)
 		Y.add_overlay(icon('icons/effects/effects.dmi', "zoro"))
-		addtimer(CALLBACK(Y, .atom/proc/cut_overlay, \
+		addtimer(CALLBACK(Y, TYPE_PROC_REF(/atom, cut_overlay), \
 								icon('icons/effects/effects.dmi', "zoro")), 14)
 		playsound(Y, 'sound/abnormalities/pussinboots/slash.ogg', 50, FALSE, 2)
 		forceMove(jump_turf)
@@ -1105,7 +1105,7 @@
 		W.obj_destruction("holy spear")
 	for(var/obj/machinery/door/D in T.contents)
 		if(D.density)
-			addtimer(CALLBACK (D, .obj/machinery/door/proc/open))
+			addtimer(CALLBACK (D, TYPE_PROC_REF(/obj/machinery/door, open)))
 	if(stop_charge)
 		transform_cooldown += 1 SECONDS
 		can_act = TRUE
@@ -1407,7 +1407,7 @@
 		return
 	playsound(target, 'sound/weapons/ego/price_of_silence.ogg', 25, FALSE, 9)
 	target.add_overlay(icon('icons/effects/effects.dmi', "chronofield"))
-	addtimer(CALLBACK(target, .atom/proc/cut_overlay, \
+	addtimer(CALLBACK(target, TYPE_PROC_REF(/atom, cut_overlay), \
 							icon('icons/effects/effects.dmi', "chronofield")), 40)
 	addtimer(CALLBACK(src, PROC_REF(FreezeMob), target), 40)
 
@@ -1582,7 +1582,7 @@
 			var/obj/effect/magic_bullet/B = new(T)
 			playsound(get_turf(src), 'sound/abnormalities/freischutz/shoot.ogg', 100, FALSE, 20)
 			B.dir = freidir
-			addtimer(CALLBACK(B, .obj/effect/magic_bullet/proc/moveBullet), 0.1)
+			addtimer(CALLBACK(B, TYPE_PROC_REF(/obj/effect/magic_bullet, moveBullet)), 0.1)
 			src.icon = 'ModularTegustation/Teguicons/32x64.dmi'
 			src.update_icon()
 			for(var/obj/effect/frei_magic/Port in portals)

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/mountain.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/mountain.dm
@@ -350,7 +350,7 @@
 		target_turf = get_closest_atom(/turf/open, low_priority_turfs, src)
 
 	if(istype(target_turf))
-		patrol_path = get_path_to(src, target_turf, /turf/proc/Distance_cardinal, 0, 200)
+		patrol_path = get_path_to(src, target_turf, TYPE_PROC_REF(/turf, Distance_cardinal), 0, 200)
 		return
 	return ..()
 

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/white_night.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/white_night.dm
@@ -358,7 +358,7 @@ GLOBAL_LIST_EMPTY(apostles)
 	if(!istype(WN))
 		return
 	var/turf/target_turf = pick(RANGE_TURFS(2, WN))
-	patrol_path = get_path_to(src, target_turf, /turf/proc/Distance_cardinal, 0, 200)
+	patrol_path = get_path_to(src, target_turf, TYPE_PROC_REF(/turf, Distance_cardinal), 0, 200)
 	playsound(get_turf(src), 'sound/abnormalities/whitenight/apostle_growl.ogg', 75, FALSE)
 	TemporarySpeedChange(-4, 5 SECONDS) // OUT OF MY WAY
 
@@ -452,7 +452,7 @@ GLOBAL_LIST_EMPTY(apostles)
 		W.obj_destruction("holy spear")
 	for(var/obj/machinery/door/D in T.contents)
 		if(D.density)
-			addtimer(CALLBACK (D, .obj/machinery/door/proc/open))
+			addtimer(CALLBACK (D, TYPE_PROC_REF(/obj/machinery/door, open)))
 	if(stop_charge)
 		can_act = TRUE
 		return

--- a/code/modules/mob/living/simple_animal/abnormality/he/blue_shepherd.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/blue_shepherd.dm
@@ -335,7 +335,7 @@
 	if(prob(lie_chance))
 		lie = TRUE
 		if(buddy_abno)
-			buddy_abno.lying_timer = addtimer(CALLBACK(buddy_abno, /mob/living/simple_animal/hostile/abnormality/red_buddy/proc/ShepherdLying), 90 SECONDS)
+			buddy_abno.lying_timer = addtimer(CALLBACK(buddy_abno, TYPE_PROC_REF(/mob/living/simple_animal/hostile/abnormality/red_buddy, ShepherdLying)), 90 SECONDS)
 			buddy_abno.lying = TRUE
 	else
 		lie = FALSE

--- a/code/modules/mob/living/simple_animal/abnormality/he/der_freischutz.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/der_freischutz.dm
@@ -127,7 +127,7 @@
 			var/obj/effect/magic_bullet/B = new(T)
 			playsound(get_turf(src), 'sound/abnormalities/freischutz/shoot.ogg', 100, 0, 20)
 			B.dir = freidir
-			addtimer(CALLBACK(B, .obj/effect/magic_bullet/proc/moveBullet), 0.1)
+			addtimer(CALLBACK(B, TYPE_PROC_REF(/obj/effect/magic_bullet, moveBullet)), 0.1)
 			src.icon = 'ModularTegustation/Teguicons/32x64.dmi'
 			src.update_icon()
 			for(var/obj/effect/frei_magic/Port in portals)

--- a/code/modules/mob/living/simple_animal/abnormality/he/eris.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/eris.dm
@@ -82,7 +82,7 @@
 
 	var/turf/target_turf = get_closest_atom(/turf/open, target_turfs, src)
 	if(istype(target_turf))
-		patrol_path = get_path_to(src, target_turf, /turf/proc/Distance_cardinal, 0, 200)
+		patrol_path = get_path_to(src, target_turf, TYPE_PROC_REF(/turf, Distance_cardinal), 0, 200)
 		return
 	return ..()
 

--- a/code/modules/mob/living/simple_animal/abnormality/he/helper.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/helper.dm
@@ -141,7 +141,7 @@
 			stop_charge = TRUE
 			break
 		if(D.density)
-			INVOKE_ASYNC(D, /obj/machinery/door/proc/open, 2)
+			INVOKE_ASYNC(D, TYPE_PROC_REF(/obj/machinery/door, open), 2)
 	if(stop_charge)
 		playsound(src, 'sound/abnormalities/helper/disable.ogg', 75, 1)
 		SLEEP_CHECK_DEATH(5 SECONDS)

--- a/code/modules/mob/living/simple_animal/abnormality/he/puss_in_boots.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/puss_in_boots.dm
@@ -230,7 +230,7 @@
 	finishing = TRUE
 	face_atom(target)
 	T.add_overlay(icon('icons/effects/effects.dmi', "zorowarning"))
-	addtimer(CALLBACK(T, .atom/proc/cut_overlay, \
+	addtimer(CALLBACK(T, TYPE_PROC_REF(/atom, cut_overlay), \
 							icon('icons/effects/effects.dmi', "zorowarning")), 40)
 	say("En garde!")
 	SLEEP_CHECK_DEATH(40)
@@ -240,7 +240,7 @@
 		if(jump_turf.is_blocked_turf(exclude_mobs = TRUE))
 			jump_turf = get_turf(target)
 		T.add_overlay(icon('icons/effects/effects.dmi', "zoro"))
-		addtimer(CALLBACK(T, .atom/proc/cut_overlay, \
+		addtimer(CALLBACK(T, TYPE_PROC_REF(/atom, cut_overlay), \
 								icon('icons/effects/effects.dmi', "zoro")), 14)
 		playsound(target, 'sound/abnormalities/pussinboots/slash.ogg', 50, 0, 2)
 		forceMove(jump_turf)

--- a/code/modules/mob/living/simple_animal/abnormality/he/red_shoes.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/red_shoes.dm
@@ -313,7 +313,7 @@
 		finish_action(controller, FALSE)
 		return
 	if(!LAZYLEN(current_path))
-		current_path = get_path_to(living_pawn, target, /turf/proc/Distance_cardinal, 0, 80)
+		current_path = get_path_to(living_pawn, target, TYPE_PROC_REF(/turf, Distance_cardinal), 0, 80)
 		if(!current_path) // Returned FALSE or null.
 			finish_action(controller, FALSE)
 			return

--- a/code/modules/mob/living/simple_animal/abnormality/he/road_home.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/road_home.dm
@@ -242,7 +242,7 @@
 		NewHouse()
 		return
 	var/house_turf = pick(potential_centers)
-	house_path = get_path_to(road_home_turf, house_turf, /turf/proc/Distance_cardinal, 0, 400)
+	house_path = get_path_to(road_home_turf, house_turf, TYPE_PROC_REF(/turf, Distance_cardinal), 0, 400)
 	if(!house_path.len)
 		spawn_tried++
 		NewHouse()
@@ -256,7 +256,7 @@
 	house.alpha = 0
 	house.road_home_mob = src
 
-	addtimer(CALLBACK(house, .obj/road_house/proc/FallDown), 3 SECONDS)
+	addtimer(CALLBACK(house, TYPE_PROC_REF(/obj/road_house, FallDown)), 3 SECONDS)
 	road_finished = FALSE
 	road_segment_finished = FALSE
 	if(move_timer_id)

--- a/code/modules/mob/living/simple_animal/abnormality/he/silent_girl.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/silent_girl.dm
@@ -129,7 +129,7 @@
 		H.physiology.work_success_mod /= 0.70
 		UnregisterSignal(H, COMSIG_WORK_COMPLETED)
 		if(!isnull(datum_reference))
-			INVOKE_ASYNC(datum_reference, /datum/abnormality/proc/qliphoth_change, 1, owner)
+			INVOKE_ASYNC(datum_reference, TYPE_PROC_REF(/datum/abnormality, qliphoth_change), 1, owner)
 
 /datum/status_effect/sg_guilty/refresh()
 	playsound(get_turf(owner), 'sound/abnormalities/silentgirl/Guilt_Apply.ogg', 50, 0, 2)

--- a/code/modules/mob/living/simple_animal/abnormality/he/wayward_passenger.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/wayward_passenger.dm
@@ -106,7 +106,7 @@
 	if(client)
 		switch(chosen_attack)
 			if(1)
-				if(!LAZYLEN(get_path_to(src,target, /turf/proc/Distance, 0, 30)))
+				if(!LAZYLEN(get_path_to(src,target, TYPE_PROC_REF(/turf, Distance), 0, 30)))
 					to_chat(src, span_notice("Invalid target."))
 					return
 				TryTeleport(get_turf(target))

--- a/code/modules/mob/living/simple_animal/abnormality/teth/MHz.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/MHz.dm
@@ -71,7 +71,7 @@
 		rose_available = TRUE
 		break
 
-	addtimer(CALLBACK (datum_reference, /datum/abnormality/proc/qliphoth_change, 4), reset_time)
+	addtimer(CALLBACK (datum_reference, TYPE_PROC_REF(/datum/abnormality, qliphoth_change), 4), reset_time)
 
 	if(!rose_available)
 		SSweather.run_weather(/datum/weather/mhz)

--- a/code/modules/mob/living/simple_animal/abnormality/teth/faelantern.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/faelantern.dm
@@ -290,7 +290,7 @@
 		return
 
 	if(!LAZYLEN(controller.current_path))
-		controller.current_path = get_path_to(living_pawn, target, /turf/proc/Distance_cardinal, 0, 80)
+		controller.current_path = get_path_to(living_pawn, target, TYPE_PROC_REF(/turf, Distance_cardinal), 0, 80)
 		if(!controller.current_path.len) // Returned FALSE or null.
 			finish_action(controller, FALSE)
 			return

--- a/code/modules/mob/living/simple_animal/abnormality/teth/pale_horse.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/pale_horse.dm
@@ -205,7 +205,7 @@
 		target_turf = get_closest_atom(/turf/open, low_priority_turfs, src)
 
 	if(istype(target_turf))
-		patrol_path = get_path_to(src, target_turf, /turf/proc/Distance_cardinal, 0, 200)
+		patrol_path = get_path_to(src, target_turf, TYPE_PROC_REF(/turf, Distance_cardinal), 0, 200)
 		return
 	return ..()
 

--- a/code/modules/mob/living/simple_animal/abnormality/teth/punishing_bird.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/punishing_bird.dm
@@ -312,7 +312,7 @@
 
 	var/turf/target_turf = get_closest_atom(/turf/open, target_turfs, src)
 	if(istype(target_turf))
-		patrol_path = get_path_to(src, target_turf, /turf/proc/Distance_cardinal, 0, 200)
+		patrol_path = get_path_to(src, target_turf, TYPE_PROC_REF(/turf, Distance_cardinal), 0, 200)
 		return
 	return ..()
 

--- a/code/modules/mob/living/simple_animal/abnormality/teth/scorched_girl.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/scorched_girl.dm
@@ -54,7 +54,7 @@
 	if(!target_center)
 		..()
 	else
-		patrol_path = get_path_to(src, target_center, /turf/proc/Distance_cardinal, 0, 200)
+		patrol_path = get_path_to(src, target_center, TYPE_PROC_REF(/turf, Distance_cardinal), 0, 200)
 
 /mob/living/simple_animal/hostile/abnormality/scorched_girl/MeleeAction()
 	return OpenFire()

--- a/code/modules/mob/living/simple_animal/abnormality/waw/alriune.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/alriune.dm
@@ -87,7 +87,7 @@
 					var/mob/living/carbon/human/H = L
 					if(H.sanity_lost)
 						new /obj/effect/temp_visual/alriune_curtain(get_turf(H))
-						addtimer(CALLBACK(H, .atom/proc/add_overlay, \
+						addtimer(CALLBACK(H, TYPE_PROC_REF(/atom, add_overlay), \
 							icon('ModularTegustation/Teguicons/tegu_effects.dmi', "alriune_kill")), 5)
 						playsound(H, 'sound/abnormalities/alriune/kill.ogg', 75, TRUE)
 						H.death()

--- a/code/modules/mob/living/simple_animal/abnormality/waw/big_bird.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/big_bird.dm
@@ -149,11 +149,11 @@
 		if(prob(66))
 			to_chat(C, span_warning("You feel tired..."))
 			C.blur_eyes(5)
-			addtimer(CALLBACK (C, .mob/proc/blind_eyes, 2), 2 SECONDS)
-			addtimer(CALLBACK (C, .mob/living/proc/Stun, 2 SECONDS), 2 SECONDS)
+			addtimer(CALLBACK (C, TYPE_PROC_REF(/mob, blind_eyes), 2), 2 SECONDS)
+			addtimer(CALLBACK (C, TYPE_PROC_REF(/mob/living, Stun), 2 SECONDS), 2 SECONDS)
 			var/new_overlay = mutable_appearance('ModularTegustation/Teguicons/tegu_effects.dmi', "enchanted", -HALO_LAYER)
 			C.add_overlay(new_overlay)
-			addtimer(CALLBACK (C, .atom/proc/cut_overlay, new_overlay), 4 SECONDS)
+			addtimer(CALLBACK (C, TYPE_PROC_REF(/atom, cut_overlay), new_overlay), 4 SECONDS)
 
 /mob/living/simple_animal/hostile/abnormality/big_bird/proc/on_mob_death(datum/source, mob/living/died, gibbed)
 	SIGNAL_HANDLER

--- a/code/modules/mob/living/simple_animal/abnormality/waw/clouded_monk.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/clouded_monk.dm
@@ -189,7 +189,7 @@
 			stop_charge = TRUE
 			break
 		if(D.density)
-			INVOKE_ASYNC(D, /obj/machinery/door/proc/open, 2)
+			INVOKE_ASYNC(D, TYPE_PROC_REF(/obj/machinery/door, open), 2)
 	if(stop_charge)
 		charging = FALSE
 		icon_state = icon_aggro

--- a/code/modules/mob/living/simple_animal/abnormality/waw/clown_smiling.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/clown_smiling.dm
@@ -143,7 +143,7 @@
 
 	var/turf/target_turf = get_closest_atom(/turf/open, target_turfs, src)
 	if(istype(target_turf))
-		patrol_path = get_path_to(src, target_turf, /turf/proc/Distance_cardinal, 0, 200)
+		patrol_path = get_path_to(src, target_turf, TYPE_PROC_REF(/turf, Distance_cardinal), 0, 200)
 		return
 	return ..()
 

--- a/code/modules/mob/living/simple_animal/abnormality/waw/despair_knight.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/despair_knight.dm
@@ -91,7 +91,7 @@
 		P.xo = target.x - T.x
 		P.original = target
 		P.preparePixelProjectile(target, T)
-		addtimer(CALLBACK (P, .obj/projectile/proc/fire), 3)
+		addtimer(CALLBACK (P, TYPE_PROC_REF(/obj/projectile, fire)), 3)
 	SLEEP_CHECK_DEATH(3)
 	playsound(get_turf(src), 'sound/abnormalities/despairknight/attack.ogg', 50, 0, 4)
 	return

--- a/code/modules/mob/living/simple_animal/abnormality/waw/dreaming_current.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/dreaming_current.dm
@@ -131,7 +131,7 @@
 			break
 		var/list/our_path = list()
 		for(var/o = 1 to 3) // Grand total of 3 retries
-			our_path = get_path_to(path_start, T, /turf/proc/Distance_cardinal, dash_max_distance)
+			our_path = get_path_to(path_start, T, TYPE_PROC_REF(/turf, Distance_cardinal), dash_max_distance)
 			if(islist(our_path) && LAZYLEN(our_path))
 				break
 			potential_turfs -= T // Couldn't find path to it, don't try again
@@ -172,7 +172,7 @@
 		W.obj_destruction("teeth")
 	for(var/obj/machinery/door/D in T.contents)
 		if(D.density)
-			addtimer(CALLBACK (D, .obj/machinery/door/proc/open))
+			addtimer(CALLBACK (D, TYPE_PROC_REF(/obj/machinery/door, open)))
 	forceMove(T)
 	if(prob(33))
 		playsound(T, "sound/abnormalities/dreamingcurrent/move.ogg", 10, TRUE, 3)

--- a/code/modules/mob/living/simple_animal/abnormality/waw/fire_bird.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/fire_bird.dm
@@ -169,7 +169,7 @@
 		W.obj_destruction("flames")
 	for(var/obj/machinery/door/D in T.contents)
 		if(D.density)
-			addtimer(CALLBACK (D, .obj/machinery/door/proc/open))
+			addtimer(CALLBACK (D, TYPE_PROC_REF(/obj/machinery/door, open)))
 	if(stop_charge)
 		can_act = TRUE
 		return

--- a/code/modules/mob/living/simple_animal/abnormality/waw/flesh_idol.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/flesh_idol.dm
@@ -75,7 +75,7 @@
 
 //Meltdown
 /mob/living/simple_animal/hostile/abnormality/flesh_idol/ZeroQliphoth(mob/living/carbon/human/user)
-	addtimer(CALLBACK (datum_reference, /datum/abnormality/proc/qliphoth_change, 4), reset_time)
+	addtimer(CALLBACK (datum_reference, TYPE_PROC_REF(/datum/abnormality, qliphoth_change), 4), reset_time)
 	var/list/total_abnormalities = list()
 
 	for(var/mob/living/simple_animal/hostile/abnormality/A in GLOB.abnormality_mob_list)

--- a/code/modules/mob/living/simple_animal/abnormality/waw/greed_king.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/greed_king.dm
@@ -72,7 +72,7 @@
 	chosen_attack_num = 2
 
 /datum/action/innate/abnormality_attack/kog_teleport/Activate()
-	addtimer(CALLBACK(A, .mob/living/simple_animal/hostile/abnormality/greed_king/proc/startTeleport), 1)
+	addtimer(CALLBACK(A, TYPE_PROC_REF(/mob/living/simple_animal/hostile/abnormality/greed_king, startTeleport)), 1)
 	to_chat(A, chosen_message)
 
 /mob/living/simple_animal/hostile/abnormality/greed_king/Life()

--- a/code/modules/mob/living/simple_animal/abnormality/waw/hatred_queen.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/hatred_queen.dm
@@ -134,7 +134,7 @@
 	alpha = initial(alpha)
 	var/obj/effect/qoh_sygil/S = new(get_turf(src))
 	S.icon_state = "qoh2"
-	addtimer(CALLBACK(S, .obj/effect/qoh_sygil/proc/fade_out), 5 SECONDS)
+	addtimer(CALLBACK(S, TYPE_PROC_REF(/obj/effect/qoh_sygil, fade_out)), 5 SECONDS)
 	for(var/obj/effect/qoh_sygil/QS in spawned_effects)
 		QS.fade_out()
 	spawned_effects.Cut()
@@ -185,7 +185,7 @@
 		return
 
 	if(prob(4))
-		addtimer(CALLBACK(src, .atom/movable/proc/say, "With love!"))
+		addtimer(CALLBACK(src, TYPE_PROC_REF(/atom/movable, say), "With love!"))
 	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/hatred_queen/Life()
@@ -254,7 +254,7 @@
 	var/obj/effect/qoh_sygil/S = new(get_turf(src))
 	S.icon_state = "qoh1"
 	spawned_effects += S
-	addtimer(CALLBACK(src, .atom/movable/proc/say, "Go! Arcana Beats~!"))
+	addtimer(CALLBACK(src, TYPE_PROC_REF(/atom/movable, say), "Go! Arcana Beats~!"))
 	switch(dir)
 		if(EAST)
 			S.pixel_x += 16
@@ -341,8 +341,8 @@
 					S.layer += i*0.1
 				if(NORTH)
 					S.layer -= i*0.1 // So they appear below each other
-			addtimer(CALLBACK(src, .atom/movable/proc/say, beamtalk[i*2 - 1]))
-			addtimer(CALLBACK(src, .atom/movable/proc/say, beamtalk[i*2]), beam_startup/2)
+			addtimer(CALLBACK(src, TYPE_PROC_REF(/atom/movable, say), beamtalk[i*2 - 1]))
+			addtimer(CALLBACK(src, TYPE_PROC_REF(/atom/movable, say), beamtalk[i*2]), beam_startup/2)
 		else //hostile sigil spawning
 			switch(i)
 				if(1)
@@ -370,7 +370,7 @@
 	var/beam_stage = 1
 	var/beam_damage_final = beam_damage
 	if(friendly)
-		addtimer(CALLBACK(src, .atom/movable/proc/say, "ARCANA SLAVE!"))
+		addtimer(CALLBACK(src, TYPE_PROC_REF(/atom/movable, say), "ARCANA SLAVE!"))
 	else
 		accumulated_beam_damage = 150
 	for(var/h = 1 to beam_maximum_ticks)
@@ -480,7 +480,7 @@
 	forceMove(teleport_target)
 	var/obj/effect/qoh_sygil/S = new(teleport_target)
 	S.icon_state = "qoh2"
-	addtimer(CALLBACK(S, .obj/effect/qoh_sygil/proc/fade_out), 2 SECONDS)
+	addtimer(CALLBACK(S, TYPE_PROC_REF(/obj/effect/qoh_sygil, fade_out)), 2 SECONDS)
 	SLEEP_CHECK_DEATH(2 SECONDS) //2 seconds to teleport
 	invisibility = 0
 	density = TRUE
@@ -548,7 +548,7 @@
 	breach_max_death = 0
 	icon_state = icon_crazy
 	visible_message(span_danger("[src] falls to her knees, muttering something under her breath."))
-	addtimer(CALLBACK(src, .atom/movable/proc/say, "I wasn’t able to protect anyone like she did…"))
+	addtimer(CALLBACK(src, TYPE_PROC_REF(/atom/movable, say), "I wasn’t able to protect anyone like she did…"))
 	addtimer(CALLBACK(src, PROC_REF(HostileTransform)), 10 SECONDS)
 
 /mob/living/simple_animal/hostile/abnormality/hatred_queen/SuccessEffect(mob/living/carbon/human/user, work_type, pe)
@@ -603,7 +603,7 @@
 			if((saving_humans.stat != DEAD) && saving_humans.z == z)
 				breach_max_death++
 		breach_max_death = max(breach_max_death/2, 1) //make it 1 if it's somehow zero
-		addtimer(CALLBACK(src, .atom/movable/proc/say, "In the name of Love and Justice~ Here comes Magical Girl!"))
+		addtimer(CALLBACK(src, TYPE_PROC_REF(/atom/movable, say), "In the name of Love and Justice~ Here comes Magical Girl!"))
 		return ..()
 	HostileTransform()
 	return ..()

--- a/code/modules/mob/living/simple_animal/abnormality/waw/judgement_bird.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/judgement_bird.dm
@@ -196,7 +196,7 @@
 
 	var/turf/target_turf = pick(target_turfs)
 	if(istype(target_turf))
-		patrol_path = get_path_to(src, target_turf, /turf/proc/Distance_cardinal, 0, 200)
+		patrol_path = get_path_to(src, target_turf, TYPE_PROC_REF(/turf, Distance_cardinal), 0, 200)
 		return
 	return ..()
 

--- a/code/modules/mob/living/simple_animal/abnormality/waw/little_prince.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/little_prince.dm
@@ -259,7 +259,7 @@
 		return
 
 	if(!LAZYLEN(current_path))
-		current_path = get_path_to(living_pawn, target, /turf/proc/Distance_cardinal, 0, 80)
+		current_path = get_path_to(living_pawn, target, TYPE_PROC_REF(/turf, Distance_cardinal), 0, 80)
 		if(!current_path) // Returned FALSE or null.
 			finish_action(controller, FALSE)
 			return

--- a/code/modules/mob/living/simple_animal/abnormality/waw/pygmalion.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/pygmalion.dm
@@ -83,7 +83,7 @@
 		P.xo = target.x - T.x
 		P.original = target
 		P.preparePixelProjectile(target, T)
-		addtimer(CALLBACK (P, .obj/projectile/proc/fire), 3)
+		addtimer(CALLBACK (P, TYPE_PROC_REF(/obj/projectile, fire)), 3)
 	return
 
 

--- a/code/modules/mob/living/simple_animal/abnormality/waw/red_riding_mercenary.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/red_riding_mercenary.dm
@@ -164,7 +164,7 @@ It has now been over four months. Now we get her for real. -Coxswain
 	chosen_attack_num = 1
 
 /datum/action/innate/abnormality_attack/find_target/Activate()
-	addtimer(CALLBACK(A, .mob/living/simple_animal/hostile/abnormality/red_hood/proc/PlayerTargetFind), 1)
+	addtimer(CALLBACK(A, TYPE_PROC_REF(/mob/living/simple_animal/hostile/abnormality/red_hood, PlayerTargetFind)), 1)
 	to_chat(A, chosen_message)
 
 /mob/living/simple_animal/hostile/abnormality/red_hood/proc/PlayerTargetFind()
@@ -178,7 +178,7 @@ It has now been over four months. Now we get her for real. -Coxswain
 	chosen_attack_num = 2
 
 /datum/action/innate/abnormality_attack/catch_breath/Activate()
-	addtimer(CALLBACK(A, .mob/living/simple_animal/hostile/abnormality/red_hood/proc/AttemptEvade), 1)
+	addtimer(CALLBACK(A, TYPE_PROC_REF(/mob/living/simple_animal/hostile/abnormality/red_hood, AttemptEvade)), 1)
 	to_chat(A, chosen_message)
 
 /mob/living/simple_animal/hostile/abnormality/red_hood/proc/AttemptEvade()

--- a/code/modules/mob/living/simple_animal/abnormality/waw/sphinx.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/sphinx.dm
@@ -310,7 +310,7 @@
 	var/mob/living/carbon/human/H = target
 	if(!(H.has_movespeed_modifier(/datum/movespeed_modifier/petrify_partial)))
 		H.add_movespeed_modifier(/datum/movespeed_modifier/petrify_partial)
-		addtimer(CALLBACK(H, .mob/proc/remove_movespeed_modifier, /datum/movespeed_modifier/petrify_partial), 3 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
+		addtimer(CALLBACK(H, TYPE_PROC_REF(/mob, remove_movespeed_modifier), /datum/movespeed_modifier/petrify_partial), 3 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
 		to_chat(H, span_warning("Your whole body feels heavy..."))
 		playsound(get_turf(H), 'sound/abnormalities/sphinx/petrify.ogg', 50, 0, 5)
 	else

--- a/code/modules/mob/living/simple_animal/abnormality/waw/thunder_bird.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/thunder_bird.dm
@@ -180,7 +180,7 @@
 			stop_charge = TRUE
 			break
 		if(D.density)
-			INVOKE_ASYNC(D, /obj/machinery/door/proc/open, 2)
+			INVOKE_ASYNC(D, TYPE_PROC_REF(/obj/machinery/door, open), 2)
 	if(stop_charge)
 		playsound(src, 'sound/abnormalities/thunderbird/tbird_bolt.ogg', 75, 1)
 		charging = FALSE

--- a/code/modules/mob/living/simple_animal/abnormality/waw/wrath_servant.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/wrath_servant.dm
@@ -652,7 +652,7 @@
 			playsound(SW, 'sound/abnormalities/wrath_servant/enrage.ogg', 100, FALSE, 40, falloff_distance = 20)
 			visible_message(span_userdanger("[src] plunges their staff into [SW]'s chest!"))
 			SW.stunned = TRUE
-			addtimer(CALLBACK(SW, /mob/living/simple_animal/hostile/abnormality/wrath_servant/proc/Unstun), 3 MINUTES)
+			addtimer(CALLBACK(SW, TYPE_PROC_REF(/mob/living/simple_animal/hostile/abnormality/wrath_servant, Unstun)), 3 MINUTES)
 			SW.status_flags |= GODMODE
 			SW.icon_state = "wrath_staff_stun"
 			SW.desc = "A large red monster with white bandages hanging from it. Its flesh oozes a bubble acid. A wooden staff is impaled in its chest, it can't seem to move!"

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/sleeping_beauty.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/sleeping_beauty.dm
@@ -169,12 +169,12 @@
 	var/mob/living/carbon/C = L
 	to_chat(C, span_warning("You feel tired..."))
 	C.blur_eyes(5)
-	addtimer(CALLBACK (C, .mob/living/proc/AdjustSleeping, 20), 2 SECONDS)
+	addtimer(CALLBACK (C, TYPE_PROC_REF(/mob/living, AdjustSleeping), 20), 2 SECONDS)
 	return ..()
 
 /datum/reagent/abnormality/sleeping/on_mob_life(mob/living/L)
 	if(!iscarbon(L))
 		return
 	var/mob/living/carbon/C = L
-	addtimer(CALLBACK (C, .mob/living/proc/AdjustSleeping, 20), 2 SECONDS)
+	addtimer(CALLBACK (C, TYPE_PROC_REF(/mob/living, AdjustSleeping), 20), 2 SECONDS)
 	return ..()

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -565,7 +565,7 @@ Pass a positive integer as an argument to override a bot's default speed.
 	var/datum/job/captain/All = new/datum/job/captain
 	all_access.access = All.get_access()
 
-	set_path(get_path_to(src, waypoint, /turf/proc/Distance_cardinal, 0, 200, id=all_access))
+	set_path(get_path_to(src, waypoint, TYPE_PROC_REF(/turf, Distance_cardinal), 0, 200, id=all_access))
 	calling_ai = caller //Link the AI to the bot!
 	ai_waypoint = waypoint
 
@@ -834,14 +834,14 @@ Pass a positive integer as an argument to override a bot's default speed.
 // given an optional turf to avoid
 /mob/living/simple_animal/bot/proc/calc_path(turf/avoid)
 	check_bot_access()
-	set_path(get_path_to(src, patrol_target, /turf/proc/Distance_cardinal, 0, 120, id=access_card, exclude=avoid))
+	set_path(get_path_to(src, patrol_target, TYPE_PROC_REF(/turf, Distance_cardinal), 0, 120, id=access_card, exclude=avoid))
 
 /mob/living/simple_animal/bot/proc/calc_summon_path(turf/avoid)
 	check_bot_access()
 	INVOKE_ASYNC(src, PROC_REF(do_calc_summon_path), avoid)
 
 /mob/living/simple_animal/bot/proc/do_calc_summon_path(turf/avoid)
-	set_path(get_path_to(src, summon_target, /turf/proc/Distance_cardinal, 0, 150, id=access_card, exclude=avoid))
+	set_path(get_path_to(src, summon_target, TYPE_PROC_REF(/turf, Distance_cardinal), 0, 150, id=access_card, exclude=avoid))
 	if(!length(path)) //Cannot reach target. Give up and announce the issue.
 		speak("Summon command failed, destination unreachable.",radio_channel)
 		bot_reset()

--- a/code/modules/mob/living/simple_animal/bot/cleanbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/cleanbot.dm
@@ -327,7 +327,7 @@
 
 		if(!path || path.len == 0) //No path, need a new one
 			//Try to produce a path to the target, and ignore airlocks to which it has access.
-			path = get_path_to(src, target.loc, /turf/proc/Distance_cardinal, 0, 30, id=access_card)
+			path = get_path_to(src, target.loc, TYPE_PROC_REF(/turf, Distance_cardinal), 0, 30, id=access_card)
 			if(!bot_move(target))
 				add_to_ignore(target)
 				target = null

--- a/code/modules/mob/living/simple_animal/bot/construction.dm
+++ b/code/modules/mob/living/simple_animal/bot/construction.dm
@@ -288,7 +288,7 @@
 				var/mob/living/simple_animal/bot/honkbot/S = new(drop_location())
 				S.name = created_name
 				S.limiting_spam = TRUE // only long enough to hear the first ping.
-				addtimer(CALLBACK (S, .mob/living/simple_animal/bot/honkbot/proc/react_ping), 5)
+				addtimer(CALLBACK (S, TYPE_PROC_REF(/mob/living/simple_animal/bot/honkbot, react_ping)), 5)
 				S.bikehorn = I.type
 				qdel(I)
 				qdel(src)

--- a/code/modules/mob/living/simple_animal/bot/firebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/firebot.dm
@@ -238,7 +238,7 @@
 
 	if(target_fire && (get_dist(src, target_fire) > 2))
 
-		path = get_path_to(src, get_turf(target_fire), /turf/proc/Distance_cardinal, 0, 30, 1, id=access_card)
+		path = get_path_to(src, get_turf(target_fire), TYPE_PROC_REF(/turf, Distance_cardinal), 0, 30, 1, id=access_card)
 		mode = BOT_MOVING
 		if(!path.len)
 			soft_reset()

--- a/code/modules/mob/living/simple_animal/bot/floorbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/floorbot.dm
@@ -265,9 +265,9 @@
 		if(path.len == 0)
 			if(!isturf(target))
 				var/turf/TL = get_turf(target)
-				path = get_path_to(src, TL, /turf/proc/Distance_cardinal, 0, 30, id=access_card,simulated_only = FALSE)
+				path = get_path_to(src, TL, TYPE_PROC_REF(/turf, Distance_cardinal), 0, 30, id=access_card,simulated_only = FALSE)
 			else
-				path = get_path_to(src, target, /turf/proc/Distance_cardinal, 0, 30, id=access_card,simulated_only = FALSE)
+				path = get_path_to(src, target, TYPE_PROC_REF(/turf, Distance_cardinal), 0, 30, id=access_card,simulated_only = FALSE)
 
 			if(!bot_move(target))
 				add_to_ignore(target)

--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -377,10 +377,10 @@
 		return
 
 	if(patient && path.len == 0 && (get_dist(src,patient) > 1))
-		path = get_path_to(src, get_turf(patient), /turf/proc/Distance_cardinal, 0, 30,id=access_card)
+		path = get_path_to(src, get_turf(patient), TYPE_PROC_REF(/turf, Distance_cardinal), 0, 30,id=access_card)
 		mode = BOT_MOVING
 		if(!path.len) //try to get closer if you can't reach the patient directly
-			path = get_path_to(src, get_turf(patient), /turf/proc/Distance_cardinal, 0, 30,1,id=access_card)
+			path = get_path_to(src, get_turf(patient), TYPE_PROC_REF(/turf, Distance_cardinal), 0, 30,1,id=access_card)
 			if(!path.len) //Do not chase a patient we cannot reach.
 				soft_reset()
 

--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -637,7 +637,7 @@
 // calculates a path to the current destination
 // given an optional turf to avoid
 /mob/living/simple_animal/bot/mulebot/calc_path(turf/avoid = null)
-	path = get_path_to(src, target, /turf/proc/Distance_cardinal, 0, 250, id=access_card, exclude=avoid)
+	path = get_path_to(src, target, TYPE_PROC_REF(/turf, Distance_cardinal), 0, 250, id=access_card, exclude=avoid)
 
 // sets the current destination
 // signals all beacons matching the delivery code

--- a/code/modules/mob/living/simple_animal/distortion/nightmare/black_hole_sun.dm
+++ b/code/modules/mob/living/simple_animal/distortion/nightmare/black_hole_sun.dm
@@ -63,10 +63,10 @@
 		if(!CanAttack(C))
 			continue
 		C.blur_eyes(5)
-		addtimer(CALLBACK (C, .mob/proc/blind_eyes, 2), 2 SECONDS)
+		addtimer(CALLBACK (C, TYPE_PROC_REF(/mob, blind_eyes), 2), 2 SECONDS)
 		var/new_overlay = mutable_appearance('ModularTegustation/Teguicons/tegu_effects.dmi', "enchanted", -HALO_LAYER)
 		C.add_overlay(new_overlay)
-		addtimer(CALLBACK (C, .atom/proc/cut_overlay, new_overlay), 4 SECONDS)
+		addtimer(CALLBACK (C, TYPE_PROC_REF(/atom, cut_overlay), new_overlay), 4 SECONDS)
 
 
 

--- a/code/modules/mob/living/simple_animal/distortion/plague/lantern.dm
+++ b/code/modules/mob/living/simple_animal/distortion/plague/lantern.dm
@@ -52,10 +52,10 @@
 		if(!CanAttack(C))
 			continue
 		C.blur_eyes(5)
-		addtimer(CALLBACK (C, .mob/proc/blind_eyes, 2), 2 SECONDS)
+		addtimer(CALLBACK (C, TYPE_PROC_REF(/mob, blind_eyes), 2), 2 SECONDS)
 		var/new_overlay = mutable_appearance('ModularTegustation/Teguicons/tegu_effects.dmi', "enchanted", -HALO_LAYER)
 		C.add_overlay(new_overlay)
-		addtimer(CALLBACK (C, .atom/proc/cut_overlay, new_overlay), 4 SECONDS)
+		addtimer(CALLBACK (C, TYPE_PROC_REF(/atom, cut_overlay), new_overlay), 4 SECONDS)
 
 
 

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -964,7 +964,7 @@
 	if(isnull(target_location)) // Sets a preset location for them to go to
 		return FALSE
 	patrol_reset() // Stop your current patrol for this one
-	patrol_path = get_path_to(src, target_location, /turf/proc/Distance_cardinal, 0, 200)
+	patrol_path = get_path_to(src, target_location, TYPE_PROC_REF(/turf, Distance_cardinal), 0, 200)
 	if(patrol_path.len <= 0)
 		return FALSE
 	patrol_move(patrol_path[patrol_path.len])
@@ -989,7 +989,7 @@
 		target_center = pick(GLOB.department_centers)
 	SEND_SIGNAL(src, COMSIG_PATROL_START, src, target_center)
 	SEND_GLOBAL_SIGNAL(src, COMSIG_GLOB_PATROL_START, src, target_center)
-	patrol_path = get_path_to(src, target_center, /turf/proc/Distance_cardinal, 0, 200)
+	patrol_path = get_path_to(src, target_center, TYPE_PROC_REF(/turf, Distance_cardinal), 0, 200)
 
 /mob/living/simple_animal/hostile/proc/patrol_reset()
 	patrol_path = list()

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -242,7 +242,7 @@
 /obj/effect/temp_visual/at_shield/Initialize(mapload, new_target)
 	. = ..()
 	target = new_target
-	INVOKE_ASYNC(src, /atom/movable/proc/orbit, target, 0, FALSE, 0, 0, FALSE, TRUE)
+	INVOKE_ASYNC(src, TYPE_PROC_REF(/atom/movable, orbit), target, 0, FALSE, 0, 0, FALSE, TRUE)
 
 /mob/living/simple_animal/hostile/megafauna/colossus/bullet_act(obj/projectile/P)
 	if(!stat)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/demonic_frost_miner.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/demonic_frost_miner.dm
@@ -179,7 +179,7 @@ Difficulty: Extremely Hard
 			P.original = target
 		P.set_homing_target(target)
 		P.fire(rand(0, 360))
-		addtimer(CALLBACK(P, /obj/projectile/frost_orb/proc/orb_explosion, projectile_speed_multiplier), 20) // make the orbs home in after a second
+		addtimer(CALLBACK(P, TYPE_PROC_REF(/obj/projectile/frost_orb, orb_explosion), projectile_speed_multiplier), 20) // make the orbs home in after a second
 		SLEEP_CHECK_DEATH(added_delay)
 	SetRecoveryTime(40, 60)
 

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
@@ -214,7 +214,7 @@ Difficulty: Hard
 			blinking = TRUE
 			SLEEP_CHECK_DEATH(4 + target_slowness)
 		animate(src, color = oldcolor, time = 8)
-		addtimer(CALLBACK(src, /atom/proc/update_atom_colour), 8)
+		addtimer(CALLBACK(src, TYPE_PROC_REF(/atom, update_atom_colour)), 8)
 		SLEEP_CHECK_DEATH(8)
 		blinking = FALSE
 	else
@@ -235,7 +235,7 @@ Difficulty: Hard
 			INVOKE_ASYNC(src, PROC_REF(blasts), target, GLOB.diagonals)
 		SLEEP_CHECK_DEATH(6 + target_slowness)
 	animate(src, color = oldcolor, time = 8)
-	addtimer(CALLBACK(src, /atom/proc/update_atom_colour), 8)
+	addtimer(CALLBACK(src, TYPE_PROC_REF(/atom, update_atom_colour)), 8)
 	SLEEP_CHECK_DEATH(8)
 	blinking = FALSE
 
@@ -263,7 +263,7 @@ Difficulty: Hard
 		SLEEP_CHECK_DEATH(8 + target_slowness)
 	chaser_cooldown = world.time + initial(chaser_cooldown)
 	animate(src, color = oldcolor, time = 8)
-	addtimer(CALLBACK(src, /atom/proc/update_atom_colour), 8)
+	addtimer(CALLBACK(src, TYPE_PROC_REF(/atom, update_atom_colour)), 8)
 	SLEEP_CHECK_DEATH(8)
 	blinking = FALSE
 

--- a/code/modules/mob/living/simple_animal/hostile/ordeal/gold.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/gold.dm
@@ -131,7 +131,7 @@
 			break
 		var/list/our_path = list()
 		for(var/o = 1 to 3) // Grand total of 3 retries
-			our_path = get_path_to(path_start, T, /turf/proc/Distance_cardinal, charge_max_distance)
+			our_path = get_path_to(path_start, T, TYPE_PROC_REF(/turf, Distance_cardinal), charge_max_distance)
 			if(islist(our_path) && LAZYLEN(our_path))
 				break
 			potential_turfs -= T // Couldn't find path to it, don't try again
@@ -169,7 +169,7 @@
 		W.obj_destruction("teeth")
 	for(var/obj/machinery/door/D in T.contents)
 		if(D.density)
-			addtimer(CALLBACK (D, .obj/machinery/door/proc/open))
+			addtimer(CALLBACK (D, TYPE_PROC_REF(/obj/machinery/door, open)))
 	forceMove(T)
 	if(prob(33))
 		playsound(T, 'sound/effects/ordeals/gold/rock_attack.ogg', 10, TRUE, 3)

--- a/code/modules/mob/living/simple_animal/hostile/ordeal/indigo.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/indigo.dm
@@ -416,7 +416,7 @@
 		target_turf = get_closest_atom(/turf/open, low_priority_turfs, src)
 
 	if(istype(target_turf))
-		patrol_path = get_path_to(src, target_turf, /turf/proc/Distance_cardinal, 0, 200)
+		patrol_path = get_path_to(src, target_turf, TYPE_PROC_REF(/turf, Distance_cardinal), 0, 200)
 		return TRUE
 	//unsure if this patrol reset will cause the patrol cooldown even if there is not patrol path.
 	patrol_reset()

--- a/code/modules/mob/living/simple_animal/hostile/ordeal/steel.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/steel.dm
@@ -262,7 +262,7 @@
 	else if(!troops.len)
 		var/area/forward_base = get_area(fob)
 		if(!istype(get_area(src), forward_base) && z == fob.z)
-			patrol_path = get_path_to(src, fob, /turf/proc/Distance_cardinal, 0, 200)
+			patrol_path = get_path_to(src, fob, TYPE_PROC_REF(/turf, Distance_cardinal), 0, 200)
 			return
 	..()
 

--- a/code/modules/mob/living/simple_animal/hostile/ordeal/white.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/white.dm
@@ -92,7 +92,7 @@
 	playsound(src, 'sound/effects/ordeals/white/black_ability_end.ogg', 100, FALSE, 30)
 	for(var/obj/machinery/computer/abnormality/A in urange(current_pulse_range, src))
 		if(prob(66) && !A.meltdown && A.datum_reference && A.datum_reference.current && A.datum_reference.qliphoth_meter)
-			INVOKE_ASYNC(A.datum_reference, /datum/abnormality/proc/qliphoth_change, pick(-1, -2))
+			INVOKE_ASYNC(A.datum_reference, TYPE_PROC_REF(/datum/abnormality, qliphoth_change), pick(-1, -2))
 	icon_state = icon_living
 	SLEEP_CHECK_DEATH(5)
 	pulse_cooldown = world.time + pulse_cooldown_time

--- a/code/modules/mob/living/simple_animal/hostile/wumborian_fugu.dm
+++ b/code/modules/mob/living/simple_animal/hostile/wumborian_fugu.dm
@@ -96,7 +96,7 @@
 	F.environment_smash = ENVIRONMENT_SMASH_WALLS
 	F.mob_size = MOB_SIZE_LARGE
 	F.speed = 1
-	addtimer(CALLBACK(F, /mob/living/simple_animal/hostile/asteroid/fugu/proc/Deflate), 100)
+	addtimer(CALLBACK(F, TYPE_PROC_REF(/mob/living/simple_animal/hostile/asteroid/fugu, Deflate)), 100)
 
 /mob/living/simple_animal/hostile/asteroid/fugu/proc/Deflate()
 	if(wumbo)

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -644,7 +644,7 @@
 					item = I
 					break
 		if(item)
-			if(!AStar(src, get_turf(item), /turf/proc/Distance_cardinal))
+			if(!AStar(src, get_turf(item), TYPE_PROC_REF(/turf, Distance_cardinal)))
 				item = null
 				continue
 			return item

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -515,7 +515,7 @@
 	/// our current intent, so we can go back to it after touching
 	var/previous_intent = a_intent
 	a_intent = INTENT_HELP
-	INVOKE_ASYNC(examined_thing, /atom/proc/attack_hand, src)
+	INVOKE_ASYNC(examined_thing, TYPE_PROC_REF(/atom, attack_hand), src)
 	a_intent = previous_intent
 	return TRUE
 

--- a/code/modules/modular_computers/computers/item/processor.dm
+++ b/code/modules/modular_computers/computers/item/processor.dm
@@ -38,7 +38,7 @@
 	integrity_failure = machinery_computer.integrity_failure
 	base_active_power_usage = machinery_computer.base_active_power_usage
 	base_idle_power_usage = machinery_computer.base_idle_power_usage
-	machinery_computer.RegisterSignal(src, COMSIG_ATOM_UPDATED_ICON, /atom/proc/update_icon) //when we update_icon, also update the computer
+	machinery_computer.RegisterSignal(src, COMSIG_ATOM_UPDATED_ICON, TYPE_PROC_REF(/atom, update_icon)) //when we update_icon, also update the computer
 
 /obj/item/modular_computer/processor/relay_qdel()
 	qdel(machinery_computer)

--- a/code/modules/ordeals/_ordeal.dm
+++ b/code/modules/ordeals/_ordeal.dm
@@ -67,10 +67,10 @@
 	/// If it was a midnight and we got to it before time limit
 	if(level == 4 && start_time <= CONFIG_GET(number/suppression_time_limit))
 		// Extra cores, and announced!
-		addtimer(CALLBACK(SSlobotomy_corp, /datum/controller/subsystem/lobotomy_corp/proc/PickPotentialSuppressions, TRUE, TRUE), 15 SECONDS)
+		addtimer(CALLBACK(SSlobotomy_corp, TYPE_PROC_REF(/datum/controller/subsystem/lobotomy_corp, PickPotentialSuppressions), TRUE, TRUE), 15 SECONDS)
 	/// If it was a dusk - we end running core suppression
 	else if(level == 3 && istype(SSlobotomy_corp.core_suppression))
-		addtimer(CALLBACK(SSlobotomy_corp.core_suppression, /datum/suppression/proc/End), 5 SECONDS)
+		addtimer(CALLBACK(SSlobotomy_corp.core_suppression, TYPE_PROC_REF(/datum/suppression, End)), 5 SECONDS)
 	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_ORDEAL_END, src)
 	qdel(src)
 	return

--- a/code/modules/ordeals/white_ordeals.dm
+++ b/code/modules/ordeals/white_ordeals.dm
@@ -100,5 +100,5 @@
 	if(istype(SSlobotomy_corp.core_suppression)) // If it all was a part of core suppression
 		SSlobotomy_corp.core_suppression_state = 3
 		SSticker.news_report = max(SSticker.news_report, CORE_SUPPRESSED_CLAW_DEAD)
-		addtimer(CALLBACK(SSlobotomy_corp.core_suppression, /datum/suppression/proc/End), 10 SECONDS)
+		addtimer(CALLBACK(SSlobotomy_corp.core_suppression, TYPE_PROC_REF(/datum/suppression, End)), 10 SECONDS)
 	return ..()

--- a/code/modules/power/gravitygenerator.dm
+++ b/code/modules/power/gravitygenerator.dm
@@ -162,7 +162,7 @@ GLOBAL_LIST_EMPTY(gravity_generators) // We will keep track of this by adding ne
 		part.main_part = src
 		parts += part
 		part.update_icon()
-		part.RegisterSignal(src, COMSIG_ATOM_UPDATED_ICON, /atom/proc/update_icon)
+		part.RegisterSignal(src, COMSIG_ATOM_UPDATED_ICON, TYPE_PROC_REF(/atom, update_icon))
 
 /obj/machinery/gravity_generator/main/proc/connected_parts()
 	return parts.len == 8

--- a/code/modules/power/singularity/boh_tear.dm
+++ b/code/modules/power/singularity/boh_tear.dm
@@ -40,7 +40,7 @@
 	to_chat(jedi, span_userdanger("You don't feel like you are real anymore."))
 	jedi.dust_animation()
 	jedi.spawn_dust()
-	addtimer(CALLBACK(src, /atom/proc/attack_hand, jedi), 0.5 SECONDS)
+	addtimer(CALLBACK(src, TYPE_PROC_REF(/atom, attack_hand), jedi), 0.5 SECONDS)
 	return COMPONENT_CANCEL_ATTACK_CHAIN
 
 #undef BOH_TEAR_CONSUME_RANGE

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -1213,7 +1213,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 		else if(isliving(target))//If we got a fleshbag on our hands
 			var/mob/living/creature = target
 			creature.set_shocked()
-			addtimer(CALLBACK(creature, /mob/living/proc/reset_shocked), 10)
+			addtimer(CALLBACK(creature, TYPE_PROC_REF(/mob/living, reset_shocked)), 10)
 			//3 shots a human with no resistance. 2 to crit, one to death. This is at at least 10000 power.
 			//There's no increase after that because the input power is effectivly capped at 10k
 			//Does 1.5 damage at the least

--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -334,7 +334,7 @@
 	if(closest_type == LIVING)
 		var/mob/living/closest_mob = closest_atom
 		closest_mob.set_shocked()
-		addtimer(CALLBACK(closest_mob, /mob/living/proc/reset_shocked), 10)
+		addtimer(CALLBACK(closest_mob, TYPE_PROC_REF(/mob/living, reset_shocked)), 10)
 		var/shock_damage = (zap_flags & ZAP_MOB_DAMAGE) ? (min(round(power/600), 90) + rand(-5, 5)) : 0
 		closest_mob.electrocute_act(shock_damage, source, 1, SHOCK_TESLA | ((zap_flags & ZAP_MOB_STUN) ? NONE : SHOCK_NOSTUN))
 		if(issilicon(closest_mob))

--- a/code/modules/projectiles/guns/ego_gun/special.dm
+++ b/code/modules/projectiles/guns/ego_gun/special.dm
@@ -112,7 +112,7 @@
 		if(NORTH)
 			S.pixel_y += 16
 			S.layer -= 0.1
-	addtimer(CALLBACK(S, .obj/effect/qoh_sygil/proc/fade_out), 3 SECONDS)
+	addtimer(CALLBACK(S, TYPE_PROC_REF(/obj/effect/qoh_sygil, fade_out)), 3 SECONDS)
 	if(do_after(user, 15, src))
 		var/aoe = blast_damage
 		var/userjust = (get_attribute_level(user, JUSTICE_ATTRIBUTE))

--- a/code/modules/projectiles/projectile/ego_bullets/aleph.dm
+++ b/code/modules/projectiles/projectile/ego_bullets/aleph.dm
@@ -23,7 +23,7 @@
 	if(!isbot(H) && isliving(H))
 		H.visible_message("<span class='warning'>[target] is hit by [src], they seem to wither away!</span>")
 		for(var/i = 1 to 14)
-			addtimer(CALLBACK(H, /mob/living/proc/apply_damage, rand(4,8), BLACK_DAMAGE, null, H.run_armor_check(null, BLACK_DAMAGE)), 2 SECONDS * i)
+			addtimer(CALLBACK(H, TYPE_PROC_REF(/mob/living, apply_damage), rand(4,8), BLACK_DAMAGE, null, H.run_armor_check(null, BLACK_DAMAGE)), 2 SECONDS * i)
 
 /obj/projectile/ego_bullet/melting_blob/aoe
 	color = "#6666BB"

--- a/code/modules/projectiles/projectile/magic/abnormality.dm
+++ b/code/modules/projectiles/projectile/magic/abnormality.dm
@@ -75,7 +75,7 @@
 		if(!isbot(L))
 			L.visible_message("<span class='warning'>[L] is hit by [src], they seem to wither away!</span>")
 			for(var/i = 1 to 10)
-				addtimer(CALLBACK(L, /mob/living/proc/apply_damage, rand(4,6), BLACK_DAMAGE, null, L.run_armor_check(null, BLACK_DAMAGE)), 2 SECONDS * i)
+				addtimer(CALLBACK(L, TYPE_PROC_REF(/mob/living, apply_damage), rand(4,6), BLACK_DAMAGE, null, L.run_armor_check(null, BLACK_DAMAGE)), 2 SECONDS * i)
 			return BULLET_ACT_HIT
 	return ..()
 
@@ -121,7 +121,7 @@
 		return ..()
 	var/mob/living/carbon/human/H = target
 	H.add_movespeed_modifier(/datum/movespeed_modifier/clowned)
-	addtimer(CALLBACK(H, .mob/proc/remove_movespeed_modifier, /datum/movespeed_modifier/clowned), 2 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
+	addtimer(CALLBACK(H, TYPE_PROC_REF(/mob, remove_movespeed_modifier), /datum/movespeed_modifier/clowned), 2 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
 	..()
 
 /datum/movespeed_modifier/clowned

--- a/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
@@ -306,7 +306,7 @@
 	if(!beaker || machine_stat & (NOPOWER|BROKEN))
 		return
 	operate_for(50, juicing = TRUE)
-	addtimer(CALLBACK(src, /obj/machinery/reagentgrinder/proc/mix_complete), 50)
+	addtimer(CALLBACK(src, TYPE_PROC_REF(/obj/machinery/reagentgrinder, mix_complete)), 50)
 
 /obj/machinery/reagentgrinder/proc/mix_complete()
 	if(beaker?.reagents.total_volume)

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -162,7 +162,7 @@
 			exposed_mob.emote("scream")
 		playsound(exposed_mob, 'sound/machines/fryer/deep_fryer_emerge.ogg', 25, TRUE)
 		ADD_TRAIT(exposed_mob, TRAIT_OIL_FRIED, "cooking_oil_react")
-		addtimer(CALLBACK(exposed_mob, /mob/living/proc/unfry_mob), 3)
+		addtimer(CALLBACK(exposed_mob, TYPE_PROC_REF(/mob/living, unfry_mob)), 3)
 	if(FryLoss)
 		exposed_mob.adjustFireLoss(FryLoss)
 

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1010,7 +1010,7 @@
 		to_chat(M, "<span class='warning'>You feel unstable...</span>")
 		M.Jitter(2)
 		current_cycle = 1
-		addtimer(CALLBACK(M, /mob/living/proc/bluespace_shuffle), 30)
+		addtimer(CALLBACK(M, TYPE_PROC_REF(/mob/living, bluespace_shuffle)), 30)
 	..()
 
 /mob/living/proc/bluespace_shuffle()

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -81,7 +81,7 @@
 					target.visible_message("<span class='danger'>[user] is trying to take a blood sample from [target]!</span>", \
 									"<span class='userdanger'>[user] is trying to take a blood sample from you!</span>")
 					busy = TRUE
-					if(!do_mob(user, target, CHEM_INTERACT_DELAY(3 SECONDS, user), extra_checks=CALLBACK(L, /mob/living/proc/can_inject, user, TRUE)))
+					if(!do_mob(user, target, CHEM_INTERACT_DELAY(3 SECONDS, user), extra_checks=CALLBACK(L, TYPE_PROC_REF(/mob/living, can_inject), user, TRUE)))
 						busy = FALSE
 						return
 					if(reagents.total_volume >= reagents.maximum_volume)
@@ -131,7 +131,7 @@
 				if(L != user)
 					L.visible_message("<span class='danger'>[user] is trying to inject [L]!</span>", \
 											"<span class='userdanger'>[user] is trying to inject you!</span>")
-					if(!do_mob(user, L, CHEM_INTERACT_DELAY(3 SECONDS, user), extra_checks=CALLBACK(L, /mob/living/proc/can_inject, user, TRUE)))
+					if(!do_mob(user, L, CHEM_INTERACT_DELAY(3 SECONDS, user), extra_checks=CALLBACK(L, TYPE_PROC_REF(/mob/living, can_inject), user, TRUE)))
 						return
 					if(!reagents.total_volume)
 						return

--- a/code/modules/research/rdmachines.dm
+++ b/code/modules/research/rdmachines.dm
@@ -96,4 +96,4 @@
 		stack_name = S.name
 		use_power(min(1000, (amount_inserted / 100)))
 	add_overlay("protolathe_[stack_name]")
-	addtimer(CALLBACK(src, /atom/proc/cut_overlay, "protolathe_[stack_name]"), 10)
+	addtimer(CALLBACK(src, TYPE_PROC_REF(/atom, cut_overlay), "protolathe_[stack_name]"), 10)

--- a/code/modules/shuttle/navigation_computer.dm
+++ b/code/modules/shuttle/navigation_computer.dm
@@ -141,7 +141,7 @@
 	if(designate_time && (landing_clear != SHUTTLE_DOCKER_BLOCKED))
 		to_chat(current_user, span_warning("Targeting transit location, please wait [DisplayTimeText(designate_time)]..."))
 		designating_target_loc = the_eye.loc
-		var/wait_completed = do_after(current_user, designate_time, designating_target_loc, timed_action_flags = IGNORE_HELD_ITEM, extra_checks = CALLBACK(src, /obj/machinery/computer/camera_advanced/shuttle_docker/proc/canDesignateTarget))
+		var/wait_completed = do_after(current_user, designate_time, designating_target_loc, timed_action_flags = IGNORE_HELD_ITEM, extra_checks = CALLBACK(src, TYPE_PROC_REF(/obj/machinery/computer/camera_advanced/shuttle_docker, canDesignateTarget)))
 		designating_target_loc = null
 		if(!current_user)
 			return

--- a/code/modules/shuttle/on_move.dm
+++ b/code/modules/shuttle/on_move.dm
@@ -396,4 +396,4 @@ All ShuttleMove procs go here
 
 /obj/effect/abstract/proximity_checker/onShuttleMove(turf/newT, turf/oldT, list/movement_force, move_dir, obj/docking_port/stationary/old_dock, obj/docking_port/mobile/moving_dock)
 	//timer so it only happens once
-	addtimer(CALLBACK(monitor, /datum/proximity_monitor/proc/SetRange, monitor.current_range, TRUE), 0, TIMER_UNIQUE)
+	addtimer(CALLBACK(monitor, TYPE_PROC_REF(/datum/proximity_monitor, SetRange), monitor.current_range, TRUE), 0, TIMER_UNIQUE)

--- a/code/modules/spells/ability_types/realized_aimed.dm
+++ b/code/modules/spells/ability_types/realized_aimed.dm
@@ -27,7 +27,7 @@
 					stop_charge = TRUE
 					break
 				if(MD.density)
-					INVOKE_ASYNC(MD, /obj/machinery/door/proc/open, 2)
+					INVOKE_ASYNC(MD, TYPE_PROC_REF(/obj/machinery/door, open), 2)
 		if(stop_charge)
 			break
 		target_turf = T
@@ -126,7 +126,7 @@
 		RP.xo = target_turf.x - T.x
 		RP.original = target_turf
 		RP.preparePixelProjectile(target_turf, T)
-		addtimer(CALLBACK (RP, .obj/projectile/proc/fire), 3)
+		addtimer(CALLBACK (RP, TYPE_PROC_REF(/obj/projectile, fire)), 3)
 	sleep(3)
 	playsound(target_turf, 'sound/abnormalities/despairknight/attack.ogg', 50, 0, 4)
 	return ..()
@@ -210,11 +210,11 @@
 		S.transform = M
 		if(speak)
 			if(custom_speech.len <= 0)
-				addtimer(CALLBACK(H, .atom/movable/proc/say, default_speech[i*2 - 1]))
-				addtimer(CALLBACK(H, .atom/movable/proc/say, default_speech[i*2]), 10)
+				addtimer(CALLBACK(H, TYPE_PROC_REF(/atom/movable, say), default_speech[i*2 - 1]))
+				addtimer(CALLBACK(H, TYPE_PROC_REF(/atom/movable, say), default_speech[i*2]), 10)
 			else
-				addtimer(CALLBACK(H, .atom/movable/proc/say, custom_speech[i*2 - 1]))
-				addtimer(CALLBACK(H, .atom/movable/proc/say, custom_speech[i*2]), 10)
+				addtimer(CALLBACK(H, TYPE_PROC_REF(/atom/movable, say), custom_speech[i*2 - 1]))
+				addtimer(CALLBACK(H, TYPE_PROC_REF(/atom/movable, say), custom_speech[i*2]), 10)
 		if(!Channel(H, 20))
 			CleanUp(user)
 			return
@@ -231,7 +231,7 @@
 	justice++
 	beam_damage *= justice
 	if(speak)
-		addtimer(CALLBACK(H, .atom/movable/proc/say, "ARCANA SLAVE!"))
+		addtimer(CALLBACK(H, TYPE_PROC_REF(/atom/movable, say), "ARCANA SLAVE!"))
 	for(var/o = 1 to 50) // Half duration but gets Justice Mod
 		var/list/already_hit = list()
 		if(accumulated_beam_damage >= 150 && beam_stage < 2)

--- a/code/modules/spells/spell_types/aimed.dm
+++ b/code/modules/spells/spell_types/aimed.dm
@@ -258,6 +258,6 @@
 			if(P.vars[V])
 				P.vv_edit_var(V, projectile_var_overrides[V])
 		ready_projectile(P, target, user, i)
-		addtimer(CALLBACK (P, .obj/projectile/proc/fire), fire_delay)
+		addtimer(CALLBACK (P, TYPE_PROC_REF(/obj/projectile, fire)), fire_delay)
 		fired_projs += P
 	return fired_projs

--- a/code/modules/suppressions/extraction.dm
+++ b/code/modules/suppressions/extraction.dm
@@ -213,7 +213,7 @@
 	charging = TRUE
 	icon_state = "arbiter_fairy"
 	if(prob(35))
-		INVOKE_ASYNC(src, .atom/movable/proc/say, pick("Disperse.", "Heed my words, Fairies.", "Analyze. Compress. Expand.", "Do not dare to stand before me."))
+		INVOKE_ASYNC(src, TYPE_PROC_REF(/atom/movable, say), pick("Disperse.", "Heed my words, Fairies.", "Analyze. Compress. Expand.", "Do not dare to stand before me."))
 
 	var/turf/target_loc = get_turf(target)
 	var/turf/start_loc = get_turf(src)
@@ -251,7 +251,7 @@
 	charging = TRUE
 	icon_state = "arbiter_ability"
 	if(prob(35))
-		INVOKE_ASYNC(src, .atom/movable/proc/say, pick("Condensing the Key.", "Focus.", "Open.", "Wreak havoc.", "Come on out.", "Crumble."))
+		INVOKE_ASYNC(src, TYPE_PROC_REF(/atom/movable, say), pick("Condensing the Key.", "Focus.", "Open.", "Wreak havoc.", "Come on out.", "Crumble."))
 
 	var/turf/target_loc = get_turf(target)
 	var/turf/start_loc = get_turf(src)
@@ -271,7 +271,7 @@
 	P.xo = target_loc.x - start_loc.x
 	P.original = target
 	P.preparePixelProjectile(target_loc, src)
-	addtimer(CALLBACK (P, .obj/projectile/proc/fire), 0.8 SECONDS)
+	addtimer(CALLBACK (P, TYPE_PROC_REF(/obj/projectile, fire)), 0.8 SECONDS)
 
 	SLEEP_CHECK_DEATH(0.8 SECONDS)
 

--- a/code/modules/suppressions/records.dm
+++ b/code/modules/suppressions/records.dm
@@ -148,7 +148,7 @@
 		T = pick(turf_list)
 		turf_list -= T
 		// Found good target turf
-		if(LAZYLEN(get_path_to(L, T, /turf/proc/Distance_cardinal, 0, teleport_max_distance * 2)))
+		if(LAZYLEN(get_path_to(L, T, TYPE_PROC_REF(/turf, Distance_cardinal), 0, teleport_max_distance * 2)))
 			break
 		T = null
 	// Didn't find anything, very sad

--- a/code/modules/surgery/organs/vocal_cords.dm
+++ b/code/modules/surgery/organs/vocal_cords.dm
@@ -355,7 +355,7 @@
 		cooldown = COOLDOWN_MEME
 		for(var/V in listeners)
 			var/mob/living/L = V
-			addtimer(CALLBACK(L, /atom/movable/proc/say, L.real_name), 5 * i)
+			addtimer(CALLBACK(L, TYPE_PROC_REF(/atom/movable, say), L.real_name), 5 * i)
 			i++
 
 	//SAY MY NAME
@@ -363,7 +363,7 @@
 		cooldown = COOLDOWN_MEME
 		for(var/V in listeners)
 			var/mob/living/L = V
-			addtimer(CALLBACK(L, /atom/movable/proc/say, user.name), 5 * i)
+			addtimer(CALLBACK(L, TYPE_PROC_REF(/atom/movable, say), user.name), 5 * i)
 			i++
 
 	//KNOCK KNOCK
@@ -371,7 +371,7 @@
 		cooldown = COOLDOWN_MEME
 		for(var/V in listeners)
 			var/mob/living/L = V
-			addtimer(CALLBACK(L, /atom/movable/proc/say, "Who's there?"), 5 * i)
+			addtimer(CALLBACK(L, TYPE_PROC_REF(/atom/movable, say), "Who's there?"), 5 * i)
 			i++
 
 	//STATE LAWS
@@ -418,7 +418,7 @@
 		cooldown = COOLDOWN_MEME
 		for(var/mob/living/carbon/human/H in listeners)
 			addtimer(CALLBACK(H, /mob/verb/a_intent_change, INTENT_HELP), i * 2)
-			addtimer(CALLBACK(H, /mob/proc/click_random_mob), i * 2)
+			addtimer(CALLBACK(H, TYPE_PROC_REF(/mob, click_random_mob)), i * 2)
 			i++
 
 	//DISARM INTENT
@@ -426,7 +426,7 @@
 		cooldown = COOLDOWN_MEME
 		for(var/mob/living/carbon/human/H in listeners)
 			addtimer(CALLBACK(H, /mob/verb/a_intent_change, INTENT_DISARM), i * 2)
-			addtimer(CALLBACK(H, /mob/proc/click_random_mob), i * 2)
+			addtimer(CALLBACK(H, TYPE_PROC_REF(/mob, click_random_mob)), i * 2)
 			i++
 
 	//GRAB INTENT
@@ -434,7 +434,7 @@
 		cooldown = COOLDOWN_MEME
 		for(var/mob/living/carbon/human/H in listeners)
 			addtimer(CALLBACK(H, /mob/verb/a_intent_change, INTENT_GRAB), i * 2)
-			addtimer(CALLBACK(H, /mob/proc/click_random_mob), i * 2)
+			addtimer(CALLBACK(H, TYPE_PROC_REF(/mob, click_random_mob)), i * 2)
 			i++
 
 	//HARM INTENT
@@ -442,7 +442,7 @@
 		cooldown = COOLDOWN_MEME
 		for(var/mob/living/carbon/human/H in listeners)
 			addtimer(CALLBACK(H, /mob/verb/a_intent_change, INTENT_HARM), i * 2)
-			addtimer(CALLBACK(H, /mob/proc/click_random_mob), i * 2)
+			addtimer(CALLBACK(H, TYPE_PROC_REF(/mob, click_random_mob)), i * 2)
 			i++
 
 	//THROW/CATCH
@@ -463,7 +463,7 @@
 		cooldown = COOLDOWN_MEME
 		for(var/V in listeners)
 			var/mob/living/L = V
-			addtimer(CALLBACK(L, /atom/movable/proc/say, pick_list_replacements(BRAIN_DAMAGE_FILE, "brain_damage")), 5 * i)
+			addtimer(CALLBACK(L, TYPE_PROC_REF(/atom/movable, say), pick_list_replacements(BRAIN_DAMAGE_FILE, "brain_damage")), 5 * i)
 			i++
 
 	//GET UP
@@ -505,7 +505,7 @@
 		for(var/V in listeners)
 			var/mob/living/L = V
 			if(prob(25))
-				addtimer(CALLBACK(L, /atom/movable/proc/say, "HOW HIGH?!!"), 5 * i)
+				addtimer(CALLBACK(L, TYPE_PROC_REF(/atom/movable, say), "HOW HIGH?!!"), 5 * i)
 			addtimer(CALLBACK(L, TYPE_PROC_REF(/mob/living, emote), "jump"), 5 * i)
 			i++
 

--- a/code/modules/unit_tests/surgeries.dm
+++ b/code/modules/unit_tests/surgeries.dm
@@ -64,7 +64,7 @@
 	var/datum/surgery_step/incise/surgery_step = new
 	var/datum/surgery/organ_manipulation/surgery_for_zero = new
 
-	INVOKE_ASYNC(surgery_step, /datum/surgery_step/proc/initiate, user, patient_zero, BODY_ZONE_CHEST, scalpel, surgery_for_zero)
+	INVOKE_ASYNC(surgery_step, TYPE_PROC_REF(/datum/surgery_step, initiate), user, patient_zero, BODY_ZONE_CHEST, scalpel, surgery_for_zero)
 	TEST_ASSERT(surgery_for_zero.step_in_progress, "Surgery on patient zero was not initiated")
 
 	var/datum/surgery/organ_manipulation/surgery_for_one = new
@@ -74,7 +74,7 @@
 	TEST_ASSERT(!surgery_for_one.step_in_progress, "Surgery for patient one is somehow in progress, despite not initiating")
 
 	user.apply_status_effect(STATUS_EFFECT_HIPPOCRATIC_OATH)
-	INVOKE_ASYNC(surgery_step, /datum/surgery_step/proc/initiate, user, patient_one, BODY_ZONE_CHEST, scalpel, surgery_for_one)
+	INVOKE_ASYNC(surgery_step, TYPE_PROC_REF(/datum/surgery_step, initiate), user, patient_one, BODY_ZONE_CHEST, scalpel, surgery_for_one)
 	TEST_ASSERT(surgery_for_one.step_in_progress, "Surgery on patient one was not initiated, despite having rod of asclepius")
 
 /datum/unit_test/tend_wounds/Run()

--- a/code/modules/vehicles/cars/car.dm
+++ b/code/modules/vehicles/cars/car.dm
@@ -57,7 +57,7 @@
 	if(occupant_amount() >= max_occupants)
 		return FALSE
 	var/atom/old_loc = loc
-	if(do_mob(forcer, M, get_enter_delay(M), extra_checks=CALLBACK(src, /obj/vehicle/sealed/car/proc/is_car_stationary, old_loc)))
+	if(do_mob(forcer, M, get_enter_delay(M), extra_checks=CALLBACK(src, TYPE_PROC_REF(/obj/vehicle/sealed/car, is_car_stationary), old_loc)))
 		mob_forced_enter(M, silent)
 		return TRUE
 	return FALSE

--- a/code/modules/vehicles/mecha/mech_fabricator.dm
+++ b/code/modules/vehicles/mecha/mech_fabricator.dm
@@ -642,7 +642,7 @@
 /obj/machinery/mecha_part_fabricator/proc/AfterMaterialInsert(item_inserted, id_inserted, amount_inserted)
 	var/datum/material/M = id_inserted
 	add_overlay("fab-load-[M.name]")
-	addtimer(CALLBACK(src, /atom/proc/cut_overlay, "fab-load-[M.name]"), 10)
+	addtimer(CALLBACK(src, TYPE_PROC_REF(/atom, cut_overlay), "fab-load-[M.name]"), 10)
 
 /obj/machinery/mecha_part_fabricator/screwdriver_act(mob/living/user, obj/item/I)
 	if(..())

--- a/code/modules/vehicles/mecha/mecha_control_console.dm
+++ b/code/modules/vehicles/mecha/mecha_control_console.dm
@@ -133,7 +133,7 @@
 		return
 	if(chassis)
 		chassis.emp_act(EMP_HEAVY)
-		addtimer(CALLBACK(src, /obj/item/mecha_parts/mecha_tracking/proc/recharge), 5 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
+		addtimer(CALLBACK(src, TYPE_PROC_REF(/obj/item/mecha_parts/mecha_tracking, recharge)), 5 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
 		recharging = TRUE
 
 /**

--- a/code/modules/vehicles/mecha/mecha_defense.dm
+++ b/code/modules/vehicles/mecha/mecha_defense.dm
@@ -170,7 +170,7 @@
 			occupant.update_mouse_pointer()
 	if(!equipment_disabled && LAZYLEN(occupants)) //prevent spamming this message with back-to-back EMPs
 		to_chat(occupants, "<span=danger>Error -- Connection to equipment control unit has been lost.</span>")
-	addtimer(CALLBACK(src, /obj/vehicle/sealed/mecha/proc/restore_equipment), 3 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
+	addtimer(CALLBACK(src, TYPE_PROC_REF(/obj/vehicle/sealed/mecha, restore_equipment)), 3 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
 	equipment_disabled = 1
 
 /obj/vehicle/sealed/mecha/should_atmos_process(datum/gas_mixture/air, exposed_temperature)

--- a/code/modules/vehicles/vehicle_key.dm
+++ b/code/modules/vehicles/vehicle_key.dm
@@ -42,7 +42,7 @@
 			user.visible_message(span_suicide("[user] is putting \the [src] in [user.p_their()] mouth and has skillfully become one with the janicart! It looks like [user.p_theyre()] trying to commit suicide!"))
 			user.AddElement(/datum/element/cleaning)
 			for(var/i in 1 to 100)
-				addtimer(CALLBACK(user, /atom/proc/add_atom_colour, (i % 2)? "#a245bb" : "#7a7d82", ADMIN_COLOUR_PRIORITY), i)
+				addtimer(CALLBACK(user, TYPE_PROC_REF(/atom, add_atom_colour), (i % 2)? "#a245bb" : "#7a7d82", ADMIN_COLOUR_PRIORITY), i)
 			addtimer(CALLBACK(src, PROC_REF(manual_suicide), user), 101)
 			return MANUAL_SUICIDE
 		if(SKILL_LEVEL_LEGENDARY to INFINITY) //Holy shit, look at that janny go!
@@ -51,7 +51,7 @@
 			playsound(src, 'sound//magic/lightning_chargeup.ogg', 50, TRUE, -1)
 			user.reagents.add_reagent(/datum/reagent/drug/methamphetamine, 10) //Gotta go fast!
 			for(var/i in 1 to 150)
-				addtimer(CALLBACK(user, /atom/proc/add_atom_colour, (i % 2)? "#a245bb" : "#7a7d82", ADMIN_COLOUR_PRIORITY), i)
+				addtimer(CALLBACK(user, TYPE_PROC_REF(/atom, add_atom_colour), (i % 2)? "#a245bb" : "#7a7d82", ADMIN_COLOUR_PRIORITY), i)
 			addtimer(CALLBACK(src, PROC_REF(manual_suicide), user), 151)
 			return MANUAL_SUICIDE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Replaces old procs with TYPE_PROC_REF
Excludes verb paths
regex used 
```
(?<!add_verb|remove_verb|list)(\(.*,) ?\.?/?([\w/]+?)/proc/(\w+)
$1 TYPE_PROC_REF(/$2, $3)
```
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Should fix some 515 issues like only calling parent proc instead of child's overriden version of the proc.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
refactor: changed some proc calls to work properly on 515
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
