### PR TITLE
Crew monitor vitals color now scales with maxhp

### DIFF
--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -238,6 +238,7 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 				"brutedam" = round(tracked_living_mob.getBruteLoss(), 1),
 				"sandam" = round(tracked_living_mob.getSanityLoss(), 1)
 			)
+			entry["maxhp"] = round(tracked_living_mob.maxHealth)
 
 		// Location
 		if (sensor_mode >= SENSOR_COORDS)

--- a/tgui/packages/tgui/interfaces/CrewConsole.js
+++ b/tgui/packages/tgui/interfaces/CrewConsole.js
@@ -5,12 +5,12 @@ import { COLORS } from '../constants';
 import { Window } from '../layouts';
 
 const HEALTH_COLOR_BY_LEVEL = [
-  '#17d568',
+  '#1dee6d',
   '#2ecc71',
-  '#e67e22',
-  '#ed5100',
-  '#e74c3c',
-  '#ed2814',
+  '#e69822',
+  '#eb6206',
+  '#ff4631',
+  '#da1f0a',
 ];
 
 const jobIsHead = jobId => jobId % 10 === 0;
@@ -46,9 +46,10 @@ const jobToColor = jobId => {
   return COLORS.department.other;
 };
 
-const healthToColor = (oxy, tox, burn, brute) => {
+const healthToColor = (oxy, tox, burn, brute, maxhp) => {
   const healthSum = oxy + tox + burn + brute;
-  const level = Math.min(Math.max(Math.ceil(healthSum / 25), 0), 5);
+  const healthQuarter = maxhp / 4
+  const level = Math.min(Math.max(Math.ceil(healthSum / healthQuarter), 0), 5);
   return HEALTH_COLOR_BY_LEVEL[level];
 };
 
@@ -125,6 +126,7 @@ const CrewTableEntry = (props, context) => {
     burndam,
     brutedam,
     sandam,
+    maxhp,
     area,
     can_track,
   } = sensor_data;
@@ -142,7 +144,8 @@ const CrewTableEntry = (props, context) => {
             oxydam,
             toxdam,
             burndam,
-            brutedam)} />
+            brutedam,
+            maxhp)} />
       </Table.Cell>
       <Table.Cell collapsing textAlign="center">
         {oxydam !== undefined ? (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The health status color on crew monitors now will take into account the tracked person's maxhp.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Clerks and manager will be able to properly tell who is dead or hurt and how much.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: crew monitors now take real maxhp into account when displaying status color.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
