### PR TITLE
Siltcurrent bug fixes

### DIFF
--- a/ModularTegustation/fishing/code/turfs.dm
+++ b/ModularTegustation/fishing/code/turfs.dm
@@ -339,7 +339,8 @@
 	loot_level1 = list(
 		/obj/item/stack/sheet/mineral/wood = 30,
 		/obj/item/food/grown/harebell = 35,
-		/obj/item/food/spiderling = 35
+		/obj/item/food/spiderling = 25,
+		/obj/item/food/fish/siltcurrent = 10
 		)
 	loot_level2 = list(
 		/obj/item/food/fish/siltcurrent = 35,
@@ -354,3 +355,6 @@
 		/obj/item/food/fish/siltcurrent = 60,
 		/obj/item/food/fish/emulsijack = 40,
 		)
+
+/turf/open/water/deep/obsessing_water/IsSafe()
+	return TRUE

--- a/code/game/objects/items/ego_weapons/waw.dm
+++ b/code/game/objects/items/ego_weapons/waw.dm
@@ -1856,7 +1856,9 @@
 		return ..()
 	speed_slowdown = 0
 	UnregisterSignal(current_holder, COMSIG_MOVABLE_MOVED)
+	PowerReset(user)
 	current_holder = null
+	user.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/anchor, multiplicative_slowdown = 0)
 	return ..()
 
 //Dropped setup
@@ -1866,7 +1868,9 @@
 		return
 	speed_slowdown = 0
 	UnregisterSignal(current_holder, COMSIG_MOVABLE_MOVED)
+	PowerReset(user)
 	current_holder = null
+	user.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/anchor, multiplicative_slowdown = 0)
 
 /obj/item/ego_weapon/blind_obsession/proc/UserMoved(mob/user)
 	SIGNAL_HANDLER
@@ -1887,7 +1891,7 @@
 		return
 	if(do_after(user, 12, src))
 		charged = TRUE
-		speed_slowdown = 2
+		speed_slowdown = 1
 		throwforce = 100//TIME TO DIE!
 		to_chat(user,span_warning("You put your strength behind this attack."))
 		power_timer = addtimer(CALLBACK(src, PROC_REF(PowerReset)), 3 SECONDS,user, TIMER_STOPPABLE)//prevents storing 3 powered up anchors and unloading all of them at once
@@ -1897,6 +1901,7 @@
 	charged = FALSE
 	speed_slowdown = 0
 	throwforce = 80
+	deltimer(power_timer)
 
 /obj/item/ego_weapon/blind_obsession/on_thrown(mob/living/carbon/user, atom/target)//No, clerks cannot hilariously kill others with this
 	if(!CanUseEgo(user))
@@ -1987,20 +1992,20 @@
 	..()
 	if(combo == 4)
 		can_attack = FALSE
-		if(do_after(user, 5, src))
-			playsound(get_turf(src), 'sound/abnormalities/piscinemermaid/waterjump.ogg', 20, 0, 3)
-			animate(user, alpha = 1,pixel_x = 0, pixel_z = -16, time = 0.1 SECONDS)
-			user.pixel_z = -16
-			sleep(0.5 SECONDS)
-			can_attack = TRUE
-			for(var/i in 2 to get_dist(user, A))
-				step_towards(user,A)
-			if((get_dist(user, A) < 2))
-				DiveAttack(A,user)
-			playsound(get_turf(src), 'sound/abnormalities/bloodbath/Bloodbath_EyeOn.ogg', 20, 0, 3)
-			to_chat(user, span_warning("You dive towards [A]!"))
-			animate(user, alpha = 255,pixel_x = 0, pixel_z = 16, time = 0.1 SECONDS)
-			user.pixel_z = 0
+		sleep(0.5 SECONDS)
+		playsound(get_turf(src), 'sound/abnormalities/piscinemermaid/waterjump.ogg', 20, 0, 3)
+		animate(user, alpha = 1,pixel_x = 0, pixel_z = -16, time = 0.1 SECONDS)
+		user.pixel_z = -16
+		sleep(0.5 SECONDS)
+		can_attack = TRUE
+		for(var/i in 2 to get_dist(user, A))
+			step_towards(user,A)
+		if((get_dist(user, A) < 2))
+			DiveAttack(A,user)
+		playsound(get_turf(src), 'sound/abnormalities/bloodbath/Bloodbath_EyeOn.ogg', 20, 0, 3)
+		to_chat(user, span_warning("You dive towards [A]!"))
+		animate(user, alpha = 255,pixel_x = 0, pixel_z = 16, time = 0.1 SECONDS)
+		user.pixel_z = 0
 
 /obj/item/ego_weapon/abyssal_route/proc/DiveAttack(atom/A, mob/living/user, proximity_flag, params)
 	A.attackby(src,user)

--- a/code/modules/mob/living/simple_animal/abnormality/waw/siltcurrent.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/siltcurrent.dm
@@ -68,9 +68,6 @@
 	//The amount of flotsams that should spawn in the hallways when it breaches
 	var/tube_spawn_amount = 6
 	var/list/spawned_flotsams = list()
-	//A way to get to another target
-	var/teleport_cooldown
-	var/teleport_cooldown_time = 10 SECONDS
 	var/list/water = list()
 
 	//PLAYABLES ATTACKS
@@ -90,8 +87,6 @@
 
 /mob/living/simple_animal/hostile/abnormality/siltcurrent/Life()
 	. = ..()
-	if(!target)
-		TeleDive()
 	if(!.) // Dead
 		return FALSE
 
@@ -110,55 +105,6 @@
 	if(diving || stunned)
 		return FALSE
 	return ..()
-
-/mob/living/simple_animal/hostile/abnormality/siltcurrent/proc/TeleDive()
-	if(diving || stunned)
-		return
-	if(teleport_cooldown > world.time)
-		return FALSE
-	if(diving)
-		return FALSE
-	if(target && !client) // Actively fighting
-		return FALSE
-	var/targets_in_range = 0
-	for(var/mob/living/L in view(8, src))
-		if(!faction_check_mob(L) && L.stat != DEAD && !(L.status_flags & GODMODE))
-			targets_in_range += 1
-			break
-	if(targets_in_range >= 1)
-		to_chat(src, span_warning("You cannot dive to a new target while enemies are nearby!"))
-		return FALSE
-	teleport_cooldown = world.time + teleport_cooldown_time
-	diving = TRUE
-	var/list/teleport_potential = list()
-	for(var/mob/living/L in get_turf(water))
-		if(L.stat == DEAD || L.z != z || L.status_flags & GODMODE || faction_check_mob(L))
-			continue
-		if(!ishuman(L))
-			continue
-		if(ishuman(L))
-			var/mob/living/carbon/human/H = L
-			if(H.is_working)
-				continue
-		teleport_potential += L
-	if(!LAZYLEN(teleport_potential))
-		diving = FALSE
-		to_chat(src, span_warning("There is noone you can dive to!"))
-		return FALSE
-	var/mob/living/carbon/human/H = pick(teleport_potential)
-	SLEEP_CHECK_DEATH(0.4 SECONDS)
-	animate(src, alpha = 1,pixel_x = -32, pixel_z = -32, time = 0.2 SECONDS)
-	src.pixel_z = -32
-	playsound(src, "sound/abnormalities/piscinemermaid/waterjump.ogg", 10, TRUE, 3)
-	var/turf/target_turf = get_turf(H)
-	SLEEP_CHECK_DEATH(0.75 SECONDS)
-	forceMove(target_turf) //look out, someone is rushing you!
-	visible_message(span_boldwarning("[src] dives towards [H]!"))
-	playsound(src, 'sound/abnormalities/bloodbath/Bloodbath_EyeOn.ogg', 50, FALSE, 4)
-	animate(src, alpha = 255,pixel_x = -32, pixel_z = 32, time = 0.1 SECONDS)
-	src.pixel_z = 0
-	SLEEP_CHECK_DEATH(0.5 SECONDS)
-	diving = FALSE
 
 /mob/living/simple_animal/hostile/abnormality/siltcurrent/Goto(target, delay, minimum_distance)
 	if(diving || stunned)

--- a/code/modules/mob/living/simple_animal/abnormality/waw/siltcurrent.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/siltcurrent.dm
@@ -68,7 +68,9 @@
 	//The amount of flotsams that should spawn in the hallways when it breaches
 	var/tube_spawn_amount = 6
 	var/list/spawned_flotsams = list()
-
+	//A way to get to another target
+	var/teleport_cooldown
+	var/teleport_cooldown_time = 10 SECONDS
 	var/list/water = list()
 
 	//PLAYABLES ATTACKS
@@ -88,6 +90,8 @@
 
 /mob/living/simple_animal/hostile/abnormality/siltcurrent/Life()
 	. = ..()
+	if(!target)
+		TeleDive()
 	if(!.) // Dead
 		return FALSE
 
@@ -106,6 +110,55 @@
 	if(diving || stunned)
 		return FALSE
 	return ..()
+
+/mob/living/simple_animal/hostile/abnormality/siltcurrent/proc/TeleDive()
+	if(diving || stunned)
+		return
+	if(teleport_cooldown > world.time)
+		return FALSE
+	if(diving)
+		return FALSE
+	if(target && !client) // Actively fighting
+		return FALSE
+	var/targets_in_range = 0
+	for(var/mob/living/L in view(8, src))
+		if(!faction_check_mob(L) && L.stat != DEAD && !(L.status_flags & GODMODE))
+			targets_in_range += 1
+			break
+	if(targets_in_range >= 1)
+		to_chat(src, span_warning("You cannot dive to a new target while enemies are nearby!"))
+		return FALSE
+	teleport_cooldown = world.time + teleport_cooldown_time
+	diving = TRUE
+	var/list/teleport_potential = list()
+	for(var/mob/living/L in get_turf(water))
+		if(L.stat == DEAD || L.z != z || L.status_flags & GODMODE || faction_check_mob(L))
+			continue
+		if(!ishuman(L))
+			continue
+		if(ishuman(L))
+			var/mob/living/carbon/human/H = L
+			if(H.is_working)
+				continue
+		teleport_potential += L
+	if(!LAZYLEN(teleport_potential))
+		diving = FALSE
+		to_chat(src, span_warning("There is noone you can dive to!"))
+		return FALSE
+	var/mob/living/carbon/human/H = pick(teleport_potential)
+	SLEEP_CHECK_DEATH(0.4 SECONDS)
+	animate(src, alpha = 1,pixel_x = -32, pixel_z = -32, time = 0.2 SECONDS)
+	src.pixel_z = -32
+	playsound(src, "sound/abnormalities/piscinemermaid/waterjump.ogg", 10, TRUE, 3)
+	var/turf/target_turf = get_turf(H)
+	SLEEP_CHECK_DEATH(0.75 SECONDS)
+	forceMove(target_turf) //look out, someone is rushing you!
+	visible_message(span_boldwarning("[src] dives towards [H]!"))
+	playsound(src, 'sound/abnormalities/bloodbath/Bloodbath_EyeOn.ogg', 50, FALSE, 4)
+	animate(src, alpha = 255,pixel_x = -32, pixel_z = 32, time = 0.1 SECONDS)
+	src.pixel_z = 0
+	SLEEP_CHECK_DEATH(0.5 SECONDS)
+	diving = FALSE
 
 /mob/living/simple_animal/hostile/abnormality/siltcurrent/Goto(target, delay, minimum_distance)
 	if(diving || stunned)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Fixes abyssal route being able to brick it self. Fixes blind obsession not resetting when dropping or putting it in the bag correctly. Siltcurrent's cell water doesn't drown you and the ones it spawns while moving have their sprites back. Also Blind obsession slows you down less.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Siltcurrents stuff was buggy. Blind obsession was too slow when charged up honestly.

## Changelog
:cl:
balance: made blind obsession's slow down a bit less
fix: fixed siltcurrent and its ego
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
