### PR TITLE
Tweaks Naked Nest Cure Sources

### DIFF
--- a/code/datums/abnormality/_ego_datum/waw.dm
+++ b/code/datums/abnormality/_ego_datum/waw.dm
@@ -192,6 +192,12 @@
 	item_path = /obj/item/clothing/suit/armor/ego_gear/waw/exuviae
 	cost = 50
 
+/datum/ego_datum/exuviae
+	name = "Naked Nest Cure"
+	item_category = "Extract"
+	item_path = /obj/item/serpentspoison
+	cost = 20
+
 // Ebony Queen's Apple - Ebony Stem
 /datum/ego_datum/armor/ebony_stem
 	item_path = /obj/item/clothing/suit/armor/ego_gear/waw/ebony_stem

--- a/code/modules/mob/living/simple_animal/abnormality/waw/naked_nest.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/naked_nest.dm
@@ -28,6 +28,7 @@
 	ego_list = list(
 		/datum/ego_datum/weapon/exuviae,
 		/datum/ego_datum/armor/exuviae,
+		/datum/ego_datum/exuviae,
 	)
 	gift_type =  /datum/ego_gifts/exuviae
 	gift_message = "You manage to shave off a patch of scales."
@@ -44,12 +45,6 @@
 	death_sound = 'sound/effects/dismember.ogg'
 	var/serpentsnested = 4
 	var/origin_cooldown = 0
-
-/mob/living/simple_animal/hostile/abnormality/naked_nest/SuccessEffect(mob/living/carbon/human/user, work_type, pe)
-	. = ..()
-	to_chat(user, span_notice("The serpents seem to avoid areas of their nest covered in this solution."))
-	new /obj/item/serpentspoison(get_turf(user))
-	return
 
 /mob/living/simple_animal/hostile/abnormality/naked_nest/NeutralEffect(mob/living/carbon/human/user, work_type, pe)
 	. = ..()


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Moves the Naked Nest cure from something you get every time you do a good work to a purchasable EGO. Will reduce the amount of naked nest cures just laying around.
![image](https://github.com/vlggms/lobotomy-corp13/assets/109536843/5011c563-b9ac-46f8-b789-6c0dba4009a4)

## Why It's Good For The Game
Ive been told in the past by players that the cure is too common. One naked nest good work is 20 PE so making the cure 20 unique PE will make it essentially the same as getting it on good work. But a new issue arrives and thats requesting the cure from EO. Now, worst case senario this system will result in a EO denying cure requests because someone wants the naked nest EGO suit or weapon. If this senario is too real then i will try to think tank of some other method that isnt my original "each infection has a random bar reagent cure that is determined upon infection" idea. That idea can be used for abnormalities that have less lethal infections and are zayins.

I tested making a new item datum and it seems to work fine. No runtimes last time i tested it.

## Changelog
:cl:
tweak: naked nest cure source.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
