### PR TITLE
Adds the station charter to the manager, allowing them to change the facility's name less than 5 minutes into the game

### DIFF
--- a/code/modules/jobs/job_types/manager.dm
+++ b/code/modules/jobs/job_types/manager.dm
@@ -52,7 +52,6 @@
 	ears = /obj/item/radio/headset/heads/manager/alt
 	uniform = /obj/item/clothing/under/suit/lobotomy
 	suit =  /obj/item/clothing/suit/toggle/labcoat
-	backpack_contents = list()
+	backpack_contents = list(/obj/item/station_charter)
 	shoes = /obj/item/clothing/shoes/laceup
 	r_pocket = /obj/item/modular_computer/tablet/preset/advanced/command
-	l_pocket = /obj/item/station_charter

--- a/code/modules/jobs/job_types/manager.dm
+++ b/code/modules/jobs/job_types/manager.dm
@@ -55,3 +55,4 @@
 	backpack_contents = list()
 	shoes = /obj/item/clothing/shoes/laceup
 	r_pocket = /obj/item/modular_computer/tablet/preset/advanced/command
+	l_pocket = /obj/item/station_charter


### PR DESCRIPTION

## About The Pull Request

Managers can now re-name the facility however they like, as long as they are quick with it
No more "india alpha delta station" embrace "the melting love's chambers facility"

## Why It's Good For The Game

I think it adds some neat flavor without being too out of place

## Changelog
:cl:
add: Managers can now re-name the station using the charter in their pockets, as long as the station is less than 5 minutes into the game
/:cl:
