### PR TITLE
Wishing well bugfix

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/_tools/zayin/wishwell.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_tools/zayin/wishwell.dm
@@ -191,6 +191,8 @@
 //End of loot lists
 /obj/structure/toolabnormality/wishwell/attackby(obj/item/I, mob/living/carbon/human/user)
 	//Accepts money, any EGO item except realized armor & clerk pistols and compares them to the lists
+	if(istype(I, /obj/item/tool_extractor))
+		return ..()
 	if(!do_after(user, 0.5 SECONDS))
 		return
 	RunGacha(I, user)
@@ -296,7 +298,7 @@
 		Dispense(gift)
 
 /obj/structure/toolabnormality/wishwell/proc/Dispense(atom/dispenseobject)
-	playsound(src, 'sound/abnormalities/bloodbath/Bloodbath_EyeOn.ogg', 80, TRUE, -3)
+	playsound(src, 'sound/abnormalities/bloodbath/Bloodbath_EyeOn.ogg', 80, FALSE, -3)
 	var/turf/dispense_turf = get_step(src, pick(1,2,4,5,6,8,9,10))
 	new dispenseobject(dispense_turf)
 	var/list/water_area = range(1, dispense_turf)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes an issue where tool extractors could no longer be used on wishing well.
Also an extremely minor sound adjustment.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Less bugs
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixed tool extractors not working on wishing well
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
