### PR TITLE
Abno queue null entry fix

### DIFF
--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -316,6 +316,23 @@
 
 	return null
 
+/proc/PickWeightRealNumber(list/L)
+	var/total = 0.0
+	var/item
+	for (item in L)
+		if (!L[item])
+			L[item] = 1.0
+		total += L[item]
+	var/generator/G = generator("num", 0.0, total, UNIFORM_RAND)
+	total = G.Rand()
+	for (item in L)
+		total -= L[item]
+		if (total <= 0.000001)
+			return item
+	if(LAZYLEN(L))
+		log_runtime("PickWeightRealNumber failed with leftover total = [total]")
+	return null
+
 /proc/pickweightAllowZero(list/L) //The original pickweight proc will sometimes pick entries with zero weight.  I'm not sure if changing the original will break anything, so I left it be.
 	var/total = 0
 	var/item

--- a/code/controllers/subsystem/abnormality_queue.dm
+++ b/code/controllers/subsystem/abnormality_queue.dm
@@ -141,7 +141,7 @@ SUBSYSTEM_DEF(abnormality_queue)
 		picked_levs |= lev
 		if(!LAZYLEN(possible_abnormalities[lev] - picking_abnormalities))
 			continue
-		var/chosen_abno = pickweight(possible_abnormalities[lev] - picking_abnormalities)
+		var/chosen_abno = PickWeightRealNumber(possible_abnormalities[lev] - picking_abnormalities)
 		picking_abnormalities += chosen_abno
 	if(!LAZYLEN(picking_abnormalities))
 		return FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The original pickweight proc relies on integer weights but group abno modifiers turn some of them into real numbers which creates an edgecase that results in it returning null.
Created a new pick weight proc that uses real numbers.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Should be no more null abno choices in the queue.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: should be no more null abno queue entries
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
