### PR TITLE
Hp and sp bullets can no longer heal working agents

### DIFF
--- a/code/game/machinery/computer/manager_camera.dm
+++ b/code/game/machinery/computer/manager_camera.dm
@@ -207,8 +207,14 @@
 
 	switch(bullet_type)
 		if(MANAGER_HP_BULLET)
+			if(H.is_working)
+				to_chat(owner, span_warning("ERROR: TARGET IS CURRENTLY WORKING."))
+				return FALSE
 			H.adjustBruteLoss(-GetFacilityUpgradeValue(UPGRADE_BULLET_HEAL)*H.maxHealth)
 		if(MANAGER_SP_BULLET)
+			if(H.is_working)
+				to_chat(owner, span_warning("ERROR: TARGET IS CURRENTLY WORKING."))
+				return FALSE
 			H.adjustSanityLoss(-GetFacilityUpgradeValue(UPGRADE_BULLET_HEAL)*H.maxSanity)
 		if(MANAGER_RED_BULLET)
 			H.apply_status_effect(/datum/status_effect/interventionshield)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Prevents hp and sp bullets from healing agents that were working. This should be test merged only to test
## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Being able to use hp and sp bullets to heal working agents was a bug.
## Changelog
:cl:
fix: fixed hp and sp bullets being able to heal working agents
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
