### PR TITLE
Removes xenomorph embryos from City of Light.

### DIFF
--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -304,7 +304,8 @@
 		/obj/item/organ/heart/gland/slime = 4,
 		/obj/item/organ/heart/gland/spiderman = 5,
 		/obj/item/organ/heart/gland/ventcrawling = 1,
-		/obj/item/organ/body_egg/alien_embryo = 1,
+//		/obj/item/organ/body_egg/alien_embryo = 1, Removed due to the fact that this has a chance of spawning in every loot room with this spawner.
+//		I do not have to explain why xenos are bad for the game
 		/obj/item/organ/regenerative_core = 2)
 	lootcount = 3
 


### PR DESCRIPTION
Removes alien embryos from the organ loot pool, we dont need players to face xenomorphs, especially with how bullshit can be done with them

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes the alien embryo organ from the organ loot pools which are all over the CoL backstreets loot rooms
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
We do not want players making sentient hardstun ayyliens, especially with the bullshit that can be pulled with facehuggers and sentinels and how they have no counter if the xeno player knows the basics of tgmorphs 101. We already removed most stuns the only ones remaining are batons which often crit you before they fully stun you, Level 4 fixer skills, bodythrowing and bottle smashes there are far more niche stuns within the city sure but these are very situational and require the player to be completely still.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Removed xeno embryos from the lootpool due to spitecode
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
