### PR TITLE
Fixes a bug with K-Corp armor purchase and N-Corp fading ampule purchase.

### DIFF
--- a/ModularTegustation/tegu_items/representative/research/kcorp.dm
+++ b/ModularTegustation/tegu_items/representative/research/kcorp.dm
@@ -147,6 +147,7 @@
 	ItemUnlock(caller.order_list, "K Corp Class-1 Armor", /obj/item/clothing/suit/armor/ego_gear/city/kcorp_l1/weak, 600)
 	ItemUnlock(caller.order_list, "K Corp L1 Helmet",	/obj/item/clothing/head/ego_hat/helmet/kcorp, 100)
 	ItemUnlock(caller.order_list, "K Corp L1 Visor Helmet",	/obj/item/clothing/head/ego_hat/helmet/kcorp/visor, 100)
+	..()
 
 //Spawners
 /datum/data/lc13research/kdrones

--- a/ModularTegustation/tegu_items/representative/research/ncorp.dm
+++ b/ModularTegustation/tegu_items/representative/research/ncorp.dm
@@ -108,7 +108,7 @@
 	corp = N_CORP_REP
 	required_research = /datum/data/lc13research/ntemp2
 
-/datum/data/lc13research/ntemp1/ResearchEffect(obj/structure/representative_console/caller)
+/datum/data/lc13research/ntemp3/ResearchEffect(obj/structure/representative_console/caller)
 	ItemUnlock(caller.order_list, "Focused Fading Fortitude Ampule",	/obj/item/attribute_temporary/fortitudebig, 1500)
 	ItemUnlock(caller.order_list, "Focused Fading Temperance Ampule",	/obj/item/attribute_temporary/temperancebig, 1500)
 	ItemUnlock(caller.order_list, "Focused Fading Prudence Ampule",	/obj/item/attribute_temporary/prudencebig, 1500)


### PR DESCRIPTION
Fixes buying K-Corp armor over and over and N-Corp unlocking tier III fading ampules at the tier I upgrade

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes two typos one which lead to the player infinitely buying the same upgrade at no benefit with K-Corp and one that allowed the player to get gear from the third tier of a upgrade with N-Corp
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
You shouldnt needlessly consume PE with no gain but you also shouldnt get end game gamer loot from the first upgrades.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: N-Corp early focused ampule bug
fix: K-Corp infinite armor upgrade bug
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
