### PR TITLE
Big and Will be Bad Wolf hp and work damage nerf

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/waw/big_wolf.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/big_wolf.dm
@@ -16,8 +16,8 @@
 	pixel_x = -16
 	base_pixel_x = -16
 
-	maxHealth = 2000
-	health = 2000
+	maxHealth = 2500
+	health = 2500
 	del_on_death = FALSE
 	damage_coeff = list(BRUTE = 1, RED_DAMAGE = 1, WHITE_DAMAGE = 0.7, BLACK_DAMAGE = 0.7, PALE_DAMAGE = 1)
 	see_in_dark = 10

--- a/code/modules/mob/living/simple_animal/abnormality/waw/big_wolf.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/big_wolf.dm
@@ -38,7 +38,7 @@
 		ABNORMALITY_WORK_ATTACHMENT = list(45, 50, 50, 55, 55),
 		ABNORMALITY_WORK_REPRESSION = 0,
 	)
-	work_damage_amount = 10
+	work_damage_amount = 12
 	work_damage_type = RED_DAMAGE
 	melee_damage_type = RED_DAMAGE
 	melee_damage_lower = 20

--- a/code/modules/mob/living/simple_animal/abnormality/waw/big_wolf.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/big_wolf.dm
@@ -16,8 +16,8 @@
 	pixel_x = -16
 	base_pixel_x = -16
 
-	maxHealth = 4000
-	health = 4000
+	maxHealth = 2000
+	health = 2000
 	del_on_death = FALSE
 	damage_coeff = list(BRUTE = 1, RED_DAMAGE = 1, WHITE_DAMAGE = 0.7, BLACK_DAMAGE = 0.7, PALE_DAMAGE = 1)
 	see_in_dark = 10

--- a/code/modules/mob/living/simple_animal/abnormality/waw/big_wolf.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/big_wolf.dm
@@ -38,7 +38,7 @@
 		ABNORMALITY_WORK_ATTACHMENT = list(45, 50, 50, 55, 55),
 		ABNORMALITY_WORK_REPRESSION = 0,
 	)
-	work_damage_amount = 16
+	work_damage_amount = 10
 	work_damage_type = RED_DAMAGE
 	melee_damage_type = RED_DAMAGE
 	melee_damage_lower = 20


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Lowers Big and Will be Bad Wolf's hp from 4000 to 2500 and work damage from 16 to 10
## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Wolf really shouldn't have the same hp as alephs(melting love, blue star, nothing there, and a few others have 4k)  while being a waw that runs away, takes normal damage at most, and can breach other stuff. So it having 2.5k would make it a bit bulkier compared to other waws hp wise without it having more hp than some alephs. Also why did it have the same work damage as nothing there when it should have been 10 like with the other red work damage waws?
## Changelog
:cl:
balance: Lowers Big and Will be Bad Wolf's hp to 2500 and work damage to 10.
fix: fixed a few things
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
