### PR TITLE
Distorted form can now transform into You're Bald...

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/aleph/distortedform.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/distortedform.dm
@@ -1443,30 +1443,37 @@
 	can_move = FALSE
 	can_attack = FALSE
 	can_act = FALSE //we stay transformed until the skill finishes firing
-	addtimer(CALLBACK(src, PROC_REF(BaldBlast)), 5)
+	addtimer(CALLBACK(src, PROC_REF(BaldBlast), FALSE), 5)
 
 
-/mob/living/simple_animal/hostile/abnormality/distortedform/proc/BaldBlast()
-	icon_state = "bald3"
-	src.set_light(12, 12, "FFFFFF", TRUE)
-	playsound(get_turf(src), 'sound/abnormalities/sphinx/stone_ready.ogg', 50, 0, 5)
+/mob/living/simple_animal/hostile/abnormality/distortedform/proc/BaldBlast(attack_chain)
+	if(!attack_chain)
+		icon_state = "bald3"
+		src.set_light(12, 12, "FFFFFF", TRUE)
+		playsound(get_turf(src), 'sound/abnormalities/sphinx/stone_ready.ogg', 50, 0, 5)
 	SLEEP_CHECK_DEATH(12)
-	for(var/mob/living/L in viewers(12, src))
-		if(!ishuman(L))
-			continue
-		var/mob/living/carbon/human/H = L
-		if(!H.is_blind() && is_A_facing_B(H,src))
-			if(!HAS_TRAIT(H, TRAIT_BALD))
-				H.emote("scream")
-				H.Stun(20)
-				H.adjust_blindness(2)
-				to_chat(H, span_notice("You feel awesome?"))
-				ADD_TRAIT(H, TRAIT_BALD, "ABNORMALITY_BALD")
-				H.hairstyle = "Bald"
-				H.update_hair()
-				H.apply_damage(100, WHITE_DAMAGE, null, H.run_armor_check(null, WHITE_DAMAGE), spread_damage = TRUE)
-				if(H.sanity_lost) // They can't deal with being bald
-					H.dust()
+	if(attack_chain)
+		for(var/mob/living/L in viewers(12, src))
+			if(!ishuman(L))
+				continue
+			var/mob/living/carbon/human/H = L
+			if(!H.is_blind() && is_A_facing_B(H,src))
+				if(!HAS_TRAIT(H, TRAIT_BALD))
+					H.emote("scream")
+					H.Stun(20)
+					H.Paralyze(20)
+					H.Knockdown(200)
+					H.adjust_blindness(2)
+					to_chat(H, span_notice("You feel awesome?"))
+					ADD_TRAIT(H, TRAIT_BALD, "ABNORMALITY_BALD")
+					H.hairstyle = "Bald"
+					H.update_hair()
+					H.apply_damage(100, WHITE_DAMAGE, null, H.run_armor_check(null, WHITE_DAMAGE), spread_damage = TRUE)
+					if(H.sanity_lost) // They can't deal with being bald
+						H.dust()
+	if(!attack_chain)
+		BaldBlast(TRUE)
+		return
 	src.set_light(0, 0, null, FALSE) //using all params takes care of the other procs.
 	can_act = TRUE
 

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/distortedform.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/distortedform.dm
@@ -1445,7 +1445,6 @@
 	can_act = FALSE //we stay transformed until the skill finishes firing
 	addtimer(CALLBACK(src, PROC_REF(BaldBlast), FALSE), 5)
 
-
 /mob/living/simple_animal/hostile/abnormality/distortedform/proc/BaldBlast(attack_chain)
 	if(!attack_chain)
 		icon_state = "bald3"
@@ -1463,14 +1462,15 @@
 					H.Stun(20)
 					H.Paralyze(20)
 					H.Knockdown(200)
-					H.adjust_blindness(2)
 					to_chat(H, span_notice("You feel awesome?"))
 					ADD_TRAIT(H, TRAIT_BALD, "ABNORMALITY_BALD")
 					H.hairstyle = "Bald"
 					H.update_hair()
-					H.apply_damage(100, WHITE_DAMAGE, null, H.run_armor_check(null, WHITE_DAMAGE), spread_damage = TRUE)
-					if(H.sanity_lost) // They can't deal with being bald
-						H.dust()
+				H.adjust_blindness(2)
+				to_chat(L, span_userdanger("IT BURNS!!"))
+				H.apply_damage(100, WHITE_DAMAGE, null, H.run_armor_check(null, WHITE_DAMAGE), spread_damage = TRUE)
+				if(H.sanity_lost) // They can't deal with being bald
+					H.dust()
 	if(!attack_chain)
 		BaldBlast(TRUE)
 		return

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/distortedform.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/distortedform.dm
@@ -1651,18 +1651,17 @@
 		chosen_targets -= Y
 		if(Y.stat == DEAD) //they chose to die instead of facing the fear
 			continue
-		if(!(Y in view(src, 8)))
-			continue
 		var/turf/jump_turf = get_step(Y, pick(GLOB.alldirs))
 		if(jump_turf.is_blocked_turf(exclude_mobs = TRUE))
 			jump_turf = get_turf(Y)
 		forceMove(jump_turf)
 		if(ishuman(Y))
 			var/mob/living/carbon/human/H = Y
-			H.Stun(9)
+			H.Stun(20)
 		SLEEP_CHECK_DEATH(6)
 		playsound(Y, 'sound/abnormalities/crumbling/attack.ogg', 50, TRUE)
 		BaldBlast()
+		SLEEP_CHECK_DEATH(1.5 SECONDS)
 	forceMove(start)
 
 /mob/living/simple_animal/hostile/abnormality/distortedform/proc/BaldBlast()

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/distortedform.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/distortedform.dm
@@ -97,7 +97,8 @@
 		"Bloodbath",
 		"Price of Silence",
 	)
-	var/list/transform_list_longrange = list("Doomsday Calendar", "Blue Star", "Der Freischutz", "Apocalypse bird", "Siren")
+	//var/list/transform_list_longrange = list("Doomsday Calendar", "Blue Star", "Der Freischutz", "Apocalypse bird", "Siren")
+	var/list/transform_list_longrange = list("You’re Bald...")
 	var/list/transform_list_jump = list("Light", "Medium", "Heavy")
 	var/transform_count = 0
 	var/jump_ready = FALSE
@@ -448,6 +449,8 @@
 			ChangeSiren()
 		if("Apocalypse bird")
 			ChangeApoc()
+		if("You’re Bald...")
+			ChangeBald()
 		if("Jump")
 			ReadyJump()
 		if("Pause") // Unused for now
@@ -1601,6 +1604,82 @@
 				ABNO.datum_reference.qliphoth_change(-1)
 				continue
 
+//You’re Bald...
+/mob/living/simple_animal/hostile/abnormality/distortedform/proc/ChangeBald()//man roleplayers are going to hate this one
+	transform_cooldown = transform_cooldown_time_short + world.time
+	name = "You’re Bald..."
+	desc = "A helpful sphere, you think."
+	icon = 'ModularTegustation/Teguicons/tegumobs.dmi'
+	icon_state = "bald1"
+	icon_living = "bald1"
+	pixel_x = 0
+	base_pixel_x = 0
+	pixel_y = 0
+	base_pixel_y = 0
+	can_move = FALSE
+	can_attack = FALSE
+	addtimer(CALLBACK(src, .proc/BaldAttack), 5)
+
+
+/mob/living/simple_animal/hostile/abnormality/distortedform/proc/BaldAttack()
+	var/list/potential_targets = list()
+	var/list/chosen_targets = list()
+	var/mob/living/Y
+	var/turf/start = get_turf(src)
+	potential_targets += target
+	for(var/mob/living/carbon/human/L in GLOB.player_list)
+		if(faction_check_mob(L, FALSE) || L.stat >= HARD_CRIT || z != L.z || (L.status_flags & GODMODE)) // Dead or in hard crit, insane, or on a different Z level.
+			continue
+		if(HAS_TRAIT(L, TRAIT_BALD))
+			continue
+		potential_targets += L
+		if((LAZYLEN(potential_targets)) > 5)
+			break
+	for(var/i = LAZYLEN(potential_targets), i >= 1, i--)
+		if(potential_targets.len <= 0)
+			break
+		Y = pick(potential_targets)
+		potential_targets -= Y
+		if(Y.stat == DEAD) //they chose to die instead of facing the fear
+			continue
+		chosen_targets += Y
+	SLEEP_CHECK_DEATH(10)
+	for(var/i = LAZYLEN(chosen_targets), i >= 1, i--)
+		if(chosen_targets.len <= 0)
+			break
+		Y = pick(chosen_targets)
+		chosen_targets -= Y
+		if(Y.stat == DEAD) //they chose to die instead of facing the fear
+			continue
+		if(!(Y in view(src, 8)))
+			continue
+		var/turf/jump_turf = get_step(Y, pick(GLOB.alldirs))
+		if(jump_turf.is_blocked_turf(exclude_mobs = TRUE))
+			jump_turf = get_turf(Y)
+		forceMove(jump_turf)
+		if(ishuman(Y))
+			var/mob/living/carbon/human/H = Y
+			H.Stun(9)
+		SLEEP_CHECK_DEATH(6)
+		playsound(Y, 'sound/abnormalities/crumbling/attack.ogg', 50, TRUE)
+		BaldBlast()
+	forceMove(start)
+
+/mob/living/simple_animal/hostile/abnormality/distortedform/proc/BaldBlast()
+	for(var/mob/living/L in livinginrange(12, src))
+		if(L.z != z)
+			continue
+		if(faction_check_mob(L))
+			continue
+		if(!ishuman(L))
+			continue
+		var/mob/living/carbon/human/H = L
+		if(!HAS_TRAIT(H, TRAIT_BALD))
+			to_chat(H, span_notice("You feel awesome?"))
+			ADD_TRAIT(H, TRAIT_BALD, "ABNORMALITY_BALD")
+			H.hairstyle = "Bald"
+			H.update_hair()
+			H.apply_damage(100, WHITE_DAMAGE, null, H.run_armor_check(null, WHITE_DAMAGE), spread_damage = TRUE)
 
 //Apocalypse Bird
 /mob/living/simple_animal/hostile/abnormality/distortedform/proc/ChangeApoc()

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/distortedform.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/distortedform.dm
@@ -1451,7 +1451,7 @@
 		icon_state = "bald3"
 		src.set_light(12, 12, "FFFFFF", TRUE)
 		playsound(get_turf(src), 'sound/abnormalities/sphinx/stone_ready.ogg', 50, 0, 5)
-	SLEEP_CHECK_DEATH(12)
+	SLEEP_CHECK_DEATH(9)
 	if(attack_chain)
 		for(var/mob/living/L in viewers(12, src))
 			if(!ishuman(L))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Distorted form can now transform into You're Bald... While Bald, Df will just sit there and make a light after a half a second, when someone stares at the light for too long they become bald, get blinded, stunned, take white damage, and die if they're insane. People who are already bald are immune to this.

## Why It's Good For The Game
Cox wanted Distorted form to have a bald form.

## Changelog
:cl:
add: Added Bald to the list of forms df can become
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
