### PR TITLE
Adds TGUI to the auxiliary console

### DIFF
--- a/code/game/machinery/computer/abnormality_auxiliary.dm
+++ b/code/game/machinery/computer/abnormality_auxiliary.dm
@@ -273,6 +273,19 @@
 				SSlobotomy_corp.available_core_suppressions = subtypesof(/datum/suppression)
 				update_static_data_for_all_viewers()
 
+			if("Disable Core Supression")
+				log_game("[usr] has used admin powers to disable all core supressions")
+				message_admins("[usr] has used admin powers to disable all core supressions")
+				SSlobotomy_corp.ResetPotentialSuppressions()
+				update_static_data_for_all_viewers()
+
+			if("End Core Supression")
+				log_game("[usr] has used admin powers to end the current core supression (persistence not saved)")
+				message_admins("[usr] has used admin powers to end the current core supression (persistence not saved)")
+				SSlobotomy_corp.core_suppression.legitimate = FALSE // let admins mess around without worrying about persistence
+				SSlobotomy_corp.core_suppression.End()
+				update_static_data_for_all_viewers()
+
 			if("Change LOB Points")
 				var/amount = params["LOB_amount"]
 				log_game("[usr] has used admin powers to [amount > 0 ? "add" : "remove"] [amount] LOB point[(amount > 1 || amount < -1) ? "s" : ""] in the auxiliary console")

--- a/code/game/machinery/computer/abnormality_auxiliary.dm
+++ b/code/game/machinery/computer/abnormality_auxiliary.dm
@@ -212,47 +212,37 @@
 		if(upgrade.value >= upgrade.max_value)
 			available = FALSE
 
+		var/modified_upgrade_name
+		if(upgrade.value == 0) // if the upgrade is just a toggle, there's no point in showing its value now, is there?
+			modified_upgrade_name = upgrade.name
+		else
+			modified_upgrade_name = "[upgrade.name] ([upgrade.value])"
+
+
+		var/list/upgrade_data = list(list(
+			"name" = modified_upgrade_name,
+			"ref" = REF(upgrade),
+			"cost" = upgrade.cost,
+			"available" = available,
+		))
+
+
 		var/upgrade_category = upgrade.category
-		switch(upgrade_category) // surelly there's a better way to handle this than copypasta
+		switch(upgrade_category) // sort them into different lists depending on what category they fit in
 			if("Bullets")
-				bullet_upgrades += list(list(
-					"name" = upgrade.name,
-					"ref" = REF(upgrade),
-					"cost" = upgrade.cost,
-					"available" = available,
-				))
+				bullet_upgrades += upgrade_data
 
 			if("Bullet Upgrades")
-				real_bullet_upgrades += list(list(
-					"name" = "[upgrade.name] ([upgrade.value])",
-					"ref" = REF(upgrade),
-					"cost" = upgrade.cost,
-					"available" = available,
-				))
+				real_bullet_upgrades += upgrade_data
 
 			if("Agent")
-				agent_upgrades += list(list(
-					"name" = "[upgrade.name] ([upgrade.value])",
-					"ref" = REF(upgrade),
-					"cost" = upgrade.cost,
-					"available" = available,
-				))
+				agent_upgrades += upgrade_data
 
 			if("Abnormalities")
-				abnormality_upgrades += list(list(
-					"name" = "[upgrade.name] ([upgrade.value])",
-					"ref" = REF(upgrade),
-					"cost" = upgrade.cost,
-					"available" = available,
-				))
+				abnormality_upgrades += upgrade_data
 
 			else
-				you_didnt_give_it_a_proper_category_dammit_upgrades += list(list(
-					"name" = "[upgrade.name] ([upgrade.value])",
-					"ref" = REF(upgrade),
-					"cost" = upgrade.cost,
-					"available" = available,
-				))
+				you_didnt_give_it_a_proper_category_dammit_upgrades += upgrade_data
 
 	data["bullet_upgrades"] = bullet_upgrades
 	data["real_bullet_upgrades"] = real_bullet_upgrades

--- a/code/game/machinery/computer/abnormality_auxiliary.dm
+++ b/code/game/machinery/computer/abnormality_auxiliary.dm
@@ -159,6 +159,40 @@
 
 // TGUI stuff onwards, all beware ye who enter
 
+// gather all the assets needed for optional decorative stuff
+/datum/asset/simple/sephirah
+	assets = list(
+		// upper layer
+
+		"SEPHIRAH.yellow.png" = icon('icons/obj/plushes.dmi', "malkuth"),
+		"SEPHIRAH.purple.png" = icon('icons/obj/plushes.dmi', "yesod"),
+		"SEPHIRAH.green.png" = icon('icons/obj/plushes.dmi', "netzach"),
+		"SEPHIRAH.orange.png" = icon('icons/obj/plushes.dmi', "hod"),
+
+		// middle layer
+
+		// command overriden
+		"SEPHIRAH.blue.png" = icon('icons/obj/plushes.dmi', "chesed"),
+		"SEPHIRAH.red.png" = icon('icons/obj/plushes.dmi', "gebura"),
+
+		// lower layer
+
+		// extraction overriden
+		"SEPHIRAH.white.png" = icon('icons/obj/plushes.dmi', "hokma"),
+
+		// icon overrides
+
+		"SEPHIRAH.AYIN.png" = icon('icons/obj/plushes.dmi', "ayin"), // fuck you *turns ayin into a sephirah*
+		"SEPHIRAH.TWINS.png" = icon('icons/obj/plushes.dmi', "lisa"),
+		"SEPHIRAH.BINAH.png" = icon('icons/obj/plushes.dmi', "binah"),
+
+	)
+
+/obj/machinery/computer/abnormality_auxiliary/ui_assets(mob/user)
+	return list(
+		get_asset_datum(/datum/asset/simple/sephirah),
+	)
+
 /obj/machinery/computer/abnormality_auxiliary/ui_data(mob/user)
 	. = ..()
 	var/list/data = list()
@@ -236,6 +270,7 @@
 
 		data["current_suppression"] = core_suppression_name
 		data["selected_core_color"] = "red"
+		var/icon_override = FALSE // normally the assets are fetched via the color of the core being supressed, this overrides it
 		switch(core_suppression_name) // we choose the core's color once its locked in place here, the mother of all switches
 			// upper layer
 			if(CONTROL_CORE_SUPPRESSION)
@@ -254,6 +289,7 @@
 
 			if(COMMAND_CORE_SUPPRESSION)
 				data["selected_core_color"] = "yellow"
+				icon_override = "TWINS"
 
 			if(WELFARE_CORE_SUPPRESSION)
 				data["selected_core_color"] = "blue"
@@ -264,6 +300,7 @@
 			// bottom layer
 			if(EXTRACTION_CORE_SUPPRESSION)
 				data["selected_core_color"] = "yellow"
+				icon_override = "BINAH"
 
 			if(RECORDS_CORE_SUPPRESSION)
 				data["selected_core_color"] = "white"
@@ -273,10 +310,16 @@
 			// should divide them and give them colors later, but no clue what they could have for now
 			if(DAY46_CORE_SUPPRESSION, DAY47_CORE_SUPPRESSION, DAY48_CORE_SUPPRESSION, DAY49_CORE_SUPPRESSION, DAY50_CORE_SUPPRESSION)
 				data["selected_core_color"] = "white"
+				icon_override = "AYIN"
 
 			// you didnt set a proper core layer
 			else
 				data["selected_core_color"] = "red"
+
+		if(icon_override)
+			data["selected_core_icon"] = "SEPHIRAH.[icon_override].png"
+		else
+			data["selected_core_icon"] = "SEPHIRAH.[data["selected_core_color"]].png"
 
 	if(ispath(selected_core_type))
 		data["selected_core_name"] = initial(selected_core_type.name)

--- a/code/game/machinery/computer/abnormality_auxiliary.dm
+++ b/code/game/machinery/computer/abnormality_auxiliary.dm
@@ -309,45 +309,10 @@
 
 /obj/machinery/computer/abnormality_auxiliary/ui_act(action, list/params)
 	. = ..()
-	if(usr.client.holder) // allows admins to bypass typical TGUI checks for admin actions, including proximity and not being a ghost
-		switch(action)
-			if("Unlock All Cores")
-				log_game("[usr] has used admin powers to make all cores avaible in the auxiliary console")
-				message_admins("[usr] has used admin powers to make all cores avaible in the auxiliary console")
-
-				SSlobotomy_corp.available_core_suppressions = subtypesof(/datum/suppression)
-				update_static_data_for_all_viewers()
-				return
-
-			if("Disable Core Suppression")
-				log_game("[usr] has used admin powers to disable all core suppressions")
-				message_admins("[usr] has used admin powers to disable all core suppressions")
-
-				SSlobotomy_corp.ResetPotentialSuppressions()
-				update_static_data_for_all_viewers()
-				return
-
-			if("End Core Suppression")
-				log_game("[usr] has used admin powers to end the current core suppression (persistence not saved)")
-				message_admins("[usr] has used admin powers to end the current core suppression (persistence not saved)")
-
-				SSlobotomy_corp.core_suppression.legitimate = FALSE // let admins mess around without worrying about persistence
-				SSlobotomy_corp.core_suppression.End()
-				update_static_data_for_all_viewers()
-				return
-
-			if("Change LOB Points")
-				var/amount = params["LOB_amount"]
-				log_game("[usr] has used admin powers to [amount > 0 ? "add" : "remove"] [amount] LOB point[(amount > 1 || amount < -1) ? "s" : ""] in the auxiliary console")
-				message_admins("[usr] has used admin powers to [amount > 0 ? "add" : "remove"] [amount] LOB point[(amount > 1 || amount < -1) ? "s" : ""] in the auxiliary console")
-
-				SSlobotomy_corp.lob_points += amount
-				return
-
-	if (.)
+	if(. && !usr.client.holder) // the usr.client.holder check allows admins to bypass the typical TGUI proximity checks
 		return
 
-	switch(action) // player actions
+	switch(action)
 		if("Select Core Suppression") // selects a core suppression
 			var/core_suppression = locate(params["selected_core"]) in SSlobotomy_corp.available_core_suppressions
 			if(!ispath(core_suppression) || !(core_suppression in SSlobotomy_corp.available_core_suppressions))
@@ -380,5 +345,52 @@
 
 			U.Upgrade()
 			playsound(get_turf(src), 'sound/machines/terminal_prompt_confirm.ogg', 50, TRUE)
-		else // they probably called an admin proc, lets update the static data to resolve deadmin edge cases
+
+		// admin-only actions, remember to put a if(usr.client.holder) check
+		if("Unlock All Cores")
+			if(!usr.client.holder)
+				message_admins("[usr] has used an admin-only option in the auxiliary console TGUI whilst not an admin!")
+				return
+
+			log_game("[usr] has used admin powers to make all cores avaible in the auxiliary console")
+			message_admins("[usr] has used admin powers to make all cores avaible in the auxiliary console")
+
+			SSlobotomy_corp.available_core_suppressions = subtypesof(/datum/suppression)
+			update_static_data_for_all_viewers()
+
+		if("Disable Core Suppression")
+			if(!usr.client.holder)
+				message_admins("[usr] has used an admin-only option in the auxiliary console TGUI whilst not an admin!")
+				return
+
+			log_game("[usr] has used admin powers to disable all core suppressions")
+			message_admins("[usr] has used admin powers to disable all core suppressions")
+
+			SSlobotomy_corp.ResetPotentialSuppressions()
+			update_static_data_for_all_viewers()
+
+		if("End Core Suppression")
+			if(!usr.client.holder)
+				message_admins("[usr] has used an admin-only option in the auxiliary console TGUI whilst not an admin!")
+				return
+
+			log_game("[usr] has used admin powers to end the current core suppression (persistence not saved)")
+			message_admins("[usr] has used admin powers to end the current core suppression (persistence not saved)")
+
+			SSlobotomy_corp.core_suppression.legitimate = FALSE // let admins mess around without worrying about persistence
+			SSlobotomy_corp.core_suppression.End()
+			update_static_data_for_all_viewers()
+
+		if("Change LOB Points")
+			if(!usr.client.holder)
+				message_admins("[usr] has used an admin-only option in the auxiliary console TGUI whilst not an admin!")
+				return
+
+			var/amount = params["LOB_amount"]
+			log_game("[usr] has used admin powers to [amount > 0 ? "add" : "remove"] [amount] LOB point[(amount > 1 || amount < -1) ? "s" : ""] in the auxiliary console")
+			message_admins("[usr] has used admin powers to [amount > 0 ? "add" : "remove"] [amount] LOB point[(amount > 1 || amount < -1) ? "s" : ""] in the auxiliary console")
+
+			SSlobotomy_corp.lob_points += amount
+
+		else // something bad happened, refresh the data and it hopefully fixes itself
 			update_static_data_for_all_viewers()

--- a/code/game/machinery/computer/abnormality_auxiliary.dm
+++ b/code/game/machinery/computer/abnormality_auxiliary.dm
@@ -108,6 +108,7 @@
 	. = ..()
 	if(.)
 		return .
+
 	if(ishuman(usr))
 		usr.set_machine(src)
 		add_fingerprint(usr)
@@ -174,10 +175,6 @@
 	if(istype(SSlobotomy_corp.core_suppression))
 		data["current_supression"] = SSlobotomy_corp.core_suppression.name
 
-	data["selected_core_name"] = FALSE
-	data["selected_core_description"] = "Select a core to see its description"
-	data["selected_core_goal"] = "Select a core to see its goal"
-	data["selected_core_reward"] = "Select a core to see its rewards obtained upon completing it"
 	if(ispath(selected_core_type))
 		data["selected_core_name"] = initial(selected_core_type.name)
 		data["selected_core_description"] = initial(selected_core_type.desc)
@@ -187,9 +184,7 @@
 
 	// start facility upgrade info
 	data["Upgrade_points"] = round(SSlobotomy_corp.lob_points, 0.1)
-	// end facility upgrade info
 
-	// start facility upgrade info
 	// preferably this would be in static, but the cost and avaibility needs to be updated whenever an action is performed
 
 	var/list/bullet_upgrades = list()
@@ -270,6 +265,20 @@
 
 /obj/machinery/computer/abnormality_auxiliary/ui_act(action, list/params)
 	. = ..()
+	if(usr.client.holder) // allows admins to bypass typical TGUI checks for admin actions, including proximity and not being a ghost
+		switch(action)
+			if("Unlock All Cores")
+				log_game("[usr] has used admin powers to make all cores avaible in the auxiliary console")
+				message_admins("[usr] has used admin powers to make all cores avaible in the auxiliary console")
+				SSlobotomy_corp.available_core_suppressions = subtypesof(/datum/suppression)
+				update_static_data_for_all_viewers()
+
+			if("Change LOB Points")
+				var/amount = params["LOB_amount"]
+				log_game("[usr] has used admin powers to [amount > 0 ? "add" : "remove"] [amount] LOB point[(amount > 1 || amount < -1) ? "s" : ""] in the auxiliary console")
+				message_admins("[usr] has used admin powers to [amount > 0 ? "add" : "remove"] [amount] LOB point[(amount > 1 || amount < -1) ? "s" : ""] in the auxiliary console")
+				SSlobotomy_corp.lob_points += amount
+
 	if (.)
 		return
 
@@ -303,19 +312,3 @@
 
 			U.Upgrade()
 			playsound(get_turf(src), 'sound/machines/terminal_prompt_confirm.ogg', 50, TRUE)
-
-	if(!usr.client.holder)
-		return
-
-	switch(action) // admin actions
-		if("Unlock All Cores")
-			log_game("[usr] has used admin powers to make all cores avaible in the auxiliary console")
-			message_admins("[usr] has used admin powers to make all cores avaible in the auxiliary console")
-			SSlobotomy_corp.available_core_suppressions = subtypesof(/datum/suppression)
-			SStgui.close_uis(src) // cores are static, so we need to close the TGUI to forcibly update static data
-
-		if("Change LOB Points")
-			var/amount = params["LOB_amount"]
-			log_game("[usr] has used admin powers to [amount > 0 ? "add" : "remove"] [amount] LOB point[(amount > 1 || amount < -1) ? "s" : ""] in the auxiliary console")
-			message_admins("[usr] has used admin powers to [amount > 0 ? "add" : "remove"] [amount] LOB point[(amount > 1 || amount < -1) ? "s" : ""] in the auxiliary console")
-			SSlobotomy_corp.lob_points += amount

--- a/code/game/machinery/computer/abnormality_auxiliary.dm
+++ b/code/game/machinery/computer/abnormality_auxiliary.dm
@@ -293,13 +293,24 @@
 
 	var/list/available_suppressions = list()
 	for(var/core_type in SSlobotomy_corp.available_core_suppressions)
-		var/datum/suppression/available_suppression = core_type
+		var/datum/suppression/core_suppression = core_type
 		available_suppressions += list(list(
-			"name" = available_suppression.name,
-			"ref" = REF(available_suppression),
+			"name" = core_suppression.name,
+			"ref" = REF(core_suppression),
 		))
 
 	data["available_suppressions"] = available_suppressions
+
+	var/list/pre_made_core_suppressions = subtypesof(/datum/suppression)
+	var/list/all_core_suppressions = list()
+	for(var/core_type in pre_made_core_suppressions)
+		var/datum/suppression/core_suppression = core_type
+		all_core_suppressions += list(list(
+			"name" = core_suppression.name,
+			"ref" = REF(core_suppression),
+		))
+
+	data["all_core_suppressions"] = all_core_suppressions
 	// end core suppression info
 
 	data["is_admin"] = is_admin // used to determine if we unlock special admin-only options
@@ -354,13 +365,23 @@
 			playsound(get_turf(src), 'sound/machines/terminal_prompt_confirm.ogg', 50, TRUE)
 
 		// admin-only actions, remember to put a if(!log_action) check with a proper return
-		if("Unlock All Cores")
+		if("Unlock Core Suppressions")
 			if(!log_action(usr, admin_action = TRUE,
-				message_override = "[usr] has used admin powers to make all cores avaible in the auxiliary console"
+				message_override = "[usr] has used admin powers to manipulate the avaible cores in the auxiliary console"
 			))
 				return
 
-			SSlobotomy_corp.available_core_suppressions = subtypesof(/datum/suppression)
+			var/core_to_unlock = params["core_unlock"]
+
+			if(core_to_unlock != 1)
+				var/list/all_cores = subtypesof(/datum/suppression)
+				var/selected_core = locate(params["core_unlock"]) in all_cores
+
+				SSlobotomy_corp.available_core_suppressions += selected_core
+
+			else // unlock all of them if the core to unlock is not specified
+				SSlobotomy_corp.available_core_suppressions = subtypesof(/datum/suppression)
+
 			update_static_data_for_all_viewers()
 
 		if("Disable Core Suppression")

--- a/code/game/machinery/computer/abnormality_auxiliary.dm
+++ b/code/game/machinery/computer/abnormality_auxiliary.dm
@@ -264,7 +264,8 @@
 			if(WELFARE_CORE_SUPPRESSION)
 				data["selected_core_color"] = "blue"
 
-			// where gebura?
+			if(DISCIPLINARY_CORE_SUPPRESSION)
+				data["selected_core_color"] = "red"
 
 			// bottom layer
 			if(EXTRACTION_CORE_SUPPRESSION)
@@ -277,7 +278,7 @@
 
 			// should divide them and give them colors later, but no clue what they could have for now
 			if(DAY46_CORE_SUPPRESSION, DAY47_CORE_SUPPRESSION, DAY48_CORE_SUPPRESSION, DAY49_CORE_SUPPRESSION, DAY50_CORE_SUPPRESSION)
-				data["selected_core_color"] = "red"
+				data["selected_core_color"] = "white"
 
 			// you didnt set a proper core layer
 			else
@@ -312,26 +313,30 @@
 			if("Unlock All Cores")
 				log_game("[usr] has used admin powers to make all cores avaible in the auxiliary console")
 				message_admins("[usr] has used admin powers to make all cores avaible in the auxiliary console")
+
 				SSlobotomy_corp.available_core_suppressions = subtypesof(/datum/suppression)
 				update_static_data_for_all_viewers()
 
 			if("Disable Core Suppression")
 				log_game("[usr] has used admin powers to disable all core suppressions")
 				message_admins("[usr] has used admin powers to disable all core suppressions")
+
 				SSlobotomy_corp.ResetPotentialSuppressions()
 				update_static_data_for_all_viewers()
 
 			if("End Core Suppression")
 				log_game("[usr] has used admin powers to end the current core suppression (persistence not saved)")
 				message_admins("[usr] has used admin powers to end the current core suppression (persistence not saved)")
+
 				SSlobotomy_corp.core_suppression.legitimate = FALSE // let admins mess around without worrying about persistence
 				SSlobotomy_corp.core_suppression.End()
 				update_static_data_for_all_viewers()
 
 			if("Change LOB Points")
-				var/amount = params["LOB_amount"]
 				log_game("[usr] has used admin powers to [amount > 0 ? "add" : "remove"] [amount] LOB point[(amount > 1 || amount < -1) ? "s" : ""] in the auxiliary console")
 				message_admins("[usr] has used admin powers to [amount > 0 ? "add" : "remove"] [amount] LOB point[(amount > 1 || amount < -1) ? "s" : ""] in the auxiliary console")
+
+				var/amount = params["LOB_amount"]
 				SSlobotomy_corp.lob_points += amount
 
 	if (.)
@@ -342,6 +347,7 @@
 			var/core_suppression = locate(params["selected_core"]) in SSlobotomy_corp.available_core_suppressions
 			if(!ispath(core_suppression) || !(core_suppression in SSlobotomy_corp.available_core_suppressions))
 				return FALSE
+
 			selected_core_type = core_suppression
 			say("[initial(selected_core_type.name)] has been selected!")
 			playsound(get_turf(src), 'sound/machines/terminal_prompt_confirm.ogg', 50, TRUE)

--- a/code/game/machinery/computer/abnormality_auxiliary.dm
+++ b/code/game/machinery/computer/abnormality_auxiliary.dm
@@ -334,13 +334,14 @@
 			SSlobotomy_corp.available_core_suppressions = subtypesof(/datum/suppression)
 			SStgui.close_uis(src) // cores are static, so we need to close the UI
 
-		if("Add Lobotomy Point")
+		if("Change LOB Points")
 			if(!usr.client.holder)
 				is_admin = -1
 				log_game("An admin-only option was selected by a non-admin ([usr]), emergency shutting off all admin-procs on the auxiliary console for the rest of the shift!")
 				message_admins("An admin-only option was selected by a non-admin ([usr]), emergency shutting off all admin-procs on the auxiliary console for the rest of the shift!")
 				return
 
-			log_game("[usr] has used admin powers to add a LOB point in the auxiliary console")
-			message_admins("[usr] has used admin powers to add a LOB point in the auxiliary console")
-			SSlobotomy_corp.lob_points += 1
+			var/amount = params["LOB_amount"]
+			log_game("[usr] has used admin powers to [amount > 0 ? "add" : "remove"] [amount] LOB point[(amount > 1 || amount < -1) ? "s" : ""] in the auxiliary console")
+			message_admins("[usr] has used admin powers to [amount > 0 ? "add" : "remove"] [amount] LOB point[(amount > 1 || amount < -1) ? "s" : ""] in the auxiliary console")
+			SSlobotomy_corp.lob_points += amount

--- a/code/game/machinery/computer/abnormality_auxiliary.dm
+++ b/code/game/machinery/computer/abnormality_auxiliary.dm
@@ -385,6 +385,10 @@
 			update_static_data_for_all_viewers()
 
 		if("Disable Core Suppression")
+			if(istype(SSlobotomy_corp.core_suppression) || !LAZYLEN(SSlobotomy_corp.available_core_suppressions))
+				message_admins("[usr] has tried to disable all core suppressions but there were none, all admins laugh at them!")
+				return
+
 			if(!log_action(usr, admin_action = TRUE,
 				message_override = "[usr] has used admin powers to disable all core suppressions!"
 			))

--- a/code/game/machinery/computer/abnormality_auxiliary.dm
+++ b/code/game/machinery/computer/abnormality_auxiliary.dm
@@ -227,6 +227,7 @@
 	data["agent_upgrades"] = agent_upgrades
 	data["abnormality_upgrades"] = abnormality_upgrades
 	data["misc_upgrades"] = you_didnt_give_it_a_proper_category_dammit_upgrades
+	// end facility upgrade info
 
 	return data
 
@@ -333,10 +334,10 @@
 				update_static_data_for_all_viewers()
 
 			if("Change LOB Points")
+				var/amount = params["LOB_amount"]
 				log_game("[usr] has used admin powers to [amount > 0 ? "add" : "remove"] [amount] LOB point[(amount > 1 || amount < -1) ? "s" : ""] in the auxiliary console")
 				message_admins("[usr] has used admin powers to [amount > 0 ? "add" : "remove"] [amount] LOB point[(amount > 1 || amount < -1) ? "s" : ""] in the auxiliary console")
 
-				var/amount = params["LOB_amount"]
 				SSlobotomy_corp.lob_points += amount
 
 	if (.)

--- a/code/game/machinery/computer/abnormality_auxiliary.dm
+++ b/code/game/machinery/computer/abnormality_auxiliary.dm
@@ -170,18 +170,6 @@
 	. = ..()
 	var/list/data = list()
 
-	// start core supression info
-	data["current_supression"] = FALSE
-	if(istype(SSlobotomy_corp.core_suppression))
-		data["current_supression"] = SSlobotomy_corp.core_suppression.name
-
-	if(ispath(selected_core_type))
-		data["selected_core_name"] = initial(selected_core_type.name)
-		data["selected_core_description"] = initial(selected_core_type.desc)
-		data["selected_core_goal"] = initial(selected_core_type.goal_text)
-		data["selected_core_reward"] = initial(selected_core_type.reward_text)
-	// end core supression info
-
 	// start facility upgrade info
 	data["Upgrade_points"] = round(SSlobotomy_corp.lob_points, 0.1)
 
@@ -247,16 +235,70 @@
 	. = ..()
 	var/list/data = list()
 
-	// start core supression info
-	var/list/available_supressions = list()
+	// start core suppression info
+	data["current_suppression"] = FALSE // if the type check fails, we send FALSE instead
+	if(istype(SSlobotomy_corp.core_suppression))
+		var/core_suppression_name = SSlobotomy_corp.core_suppression.name
+
+		data["current_suppression"] = core_suppression_name
+		data["selected_core_color"] = "red"
+		switch(core_suppression_name) // we choose the core's color once its locked in place here, the mother of all switches
+			// upper layer
+			if(CONTROL_CORE_SUPPRESSION)
+				data["selected_core_color"] = "yellow"
+
+			if(INFORMATION_CORE_SUPPRESSION)
+				data["selected_core_color"] = "purple"
+
+			if(SAFETY_CORE_SUPPRESSION)
+				data["selected_core_color"] = "green"
+
+			if(TRAINING_CORE_SUPPRESSION)
+				data["selected_core_color"] = "orange"
+
+			// middle layer
+
+			if(COMMAND_CORE_SUPPRESSION)
+				data["selected_core_color"] = "yellow"
+
+			if(WELFARE_CORE_SUPPRESSION)
+				data["selected_core_color"] = "blue"
+
+			// where gebura?
+
+			// bottom layer
+			if(EXTRACTION_CORE_SUPPRESSION)
+				data["selected_core_color"] = "yellow"
+
+			if(RECORDS_CORE_SUPPRESSION)
+				data["selected_core_color"] = "white"
+
+			// literal hell layer
+
+			// should divide them and give them colors later, but no clue what they could have for now
+			if(DAY46_CORE_SUPPRESSION, DAY47_CORE_SUPPRESSION, DAY48_CORE_SUPPRESSION, DAY49_CORE_SUPPRESSION, DAY50_CORE_SUPPRESSION)
+				data["selected_core_color"] = "red"
+
+			// you didnt set a proper core layer
+			else
+				data["selected_core_color"] = "red"
+
+	if(ispath(selected_core_type))
+		data["selected_core_name"] = initial(selected_core_type.name)
+		data["selected_core_description"] = initial(selected_core_type.desc)
+		data["selected_core_goal"] = initial(selected_core_type.goal_text)
+		data["selected_core_reward"] = initial(selected_core_type.reward_text)
+
+	var/list/available_suppressions = list()
 	for(var/core_type in SSlobotomy_corp.available_core_suppressions)
 		var/datum/suppression/available_suppression = core_type
-		available_supressions += list(list(
+		available_suppressions += list(list(
 			"name" = available_suppression.name,
 			"ref" = REF(available_suppression),
 		))
-	data["available_suppressions"] = available_supressions
-	// end core supression info
+
+	data["available_suppressions"] = available_suppressions
+	// end core suppression info
 
 	data["is_admin"] = is_admin // used to determine if we unlock special admin-only options
 
@@ -273,15 +315,15 @@
 				SSlobotomy_corp.available_core_suppressions = subtypesof(/datum/suppression)
 				update_static_data_for_all_viewers()
 
-			if("Disable Core Supression")
-				log_game("[usr] has used admin powers to disable all core supressions")
-				message_admins("[usr] has used admin powers to disable all core supressions")
+			if("Disable Core Suppression")
+				log_game("[usr] has used admin powers to disable all core suppressions")
+				message_admins("[usr] has used admin powers to disable all core suppressions")
 				SSlobotomy_corp.ResetPotentialSuppressions()
 				update_static_data_for_all_viewers()
 
-			if("End Core Supression")
-				log_game("[usr] has used admin powers to end the current core supression (persistence not saved)")
-				message_admins("[usr] has used admin powers to end the current core supression (persistence not saved)")
+			if("End Core Suppression")
+				log_game("[usr] has used admin powers to end the current core suppression (persistence not saved)")
+				message_admins("[usr] has used admin powers to end the current core suppression (persistence not saved)")
 				SSlobotomy_corp.core_suppression.legitimate = FALSE // let admins mess around without worrying about persistence
 				SSlobotomy_corp.core_suppression.End()
 				update_static_data_for_all_viewers()
@@ -296,19 +338,20 @@
 		return
 
 	switch(action) // player actions
-		if("Select Core Suppression") // selects a core supression
-			var/core_supression = locate(params["selected_core"]) in SSlobotomy_corp.available_core_suppressions
-			if(!ispath(core_supression) || !(core_supression in SSlobotomy_corp.available_core_suppressions))
+		if("Select Core Suppression") // selects a core suppression
+			var/core_suppression = locate(params["selected_core"]) in SSlobotomy_corp.available_core_suppressions
+			if(!ispath(core_suppression) || !(core_suppression in SSlobotomy_corp.available_core_suppressions))
 				return FALSE
-			selected_core_type = core_supression
+			selected_core_type = core_suppression
 			say("[initial(selected_core_type.name)] has been selected!")
 			playsound(get_turf(src), 'sound/machines/terminal_prompt_confirm.ogg', 50, TRUE)
+			update_static_data_for_all_viewers()
 
-		if("Activate Core Suppression") // activates the currently selected core supression
+		if("Activate Core Suppression") // activates the currently selected core suppression
 			if(!ispath(selected_core_type) || !(selected_core_type in SSlobotomy_corp.available_core_suppressions))
 				return FALSE
 			if(istype(SSlobotomy_corp.core_suppression))
-				CRASH("[src] has attempted to activate a core supression via TGUI whilst its not possible!")
+				CRASH("[src] has attempted to activate a core suppression via TGUI whilst its not possible!")
 
 			say("[initial(selected_core_type.name)] protocol activated, good luck manager.")
 			SSlobotomy_corp.core_suppression = new selected_core_type
@@ -317,6 +360,7 @@
 			selected_core_type = null
 			playsound(get_turf(src), 'sound/machines/terminal_prompt_confirm.ogg', 50, TRUE)
 			addtimer(CALLBACK(SSlobotomy_corp.core_suppression, TYPE_PROC_REF(/datum/suppression, Run)), 2 SECONDS)
+			update_static_data_for_all_viewers()
 
 		if("Buy Upgrade") // Buys an upgrade, looking for a parameter that is given to the upgrade thats being bought on the TGUI side
 			var/datum/facility_upgrade/U = locate(params["selected_upgrade"]) in SSlobotomy_corp.upgrades

--- a/code/game/machinery/computer/abnormality_auxiliary.dm
+++ b/code/game/machinery/computer/abnormality_auxiliary.dm
@@ -409,7 +409,7 @@
 		// admin-only actions, remember to put a if(!log_action) check with a proper return
 		if("Unlock Core Suppressions")
 			if(!log_action(usr, admin_action = TRUE,
-				message_override = "[usr] has used admin powers to manipulate the avaible cores in the auxiliary console"
+				message_override = "[usr] has used admin powers to manipulate the available cores in the auxiliary console"
 			))
 				update_static_data_for_all_viewers()
 				return

--- a/code/game/machinery/computer/abnormality_auxiliary.dm
+++ b/code/game/machinery/computer/abnormality_auxiliary.dm
@@ -317,6 +317,7 @@
 
 				SSlobotomy_corp.available_core_suppressions = subtypesof(/datum/suppression)
 				update_static_data_for_all_viewers()
+				return
 
 			if("Disable Core Suppression")
 				log_game("[usr] has used admin powers to disable all core suppressions")
@@ -324,6 +325,7 @@
 
 				SSlobotomy_corp.ResetPotentialSuppressions()
 				update_static_data_for_all_viewers()
+				return
 
 			if("End Core Suppression")
 				log_game("[usr] has used admin powers to end the current core suppression (persistence not saved)")
@@ -332,6 +334,7 @@
 				SSlobotomy_corp.core_suppression.legitimate = FALSE // let admins mess around without worrying about persistence
 				SSlobotomy_corp.core_suppression.End()
 				update_static_data_for_all_viewers()
+				return
 
 			if("Change LOB Points")
 				var/amount = params["LOB_amount"]
@@ -339,6 +342,7 @@
 				message_admins("[usr] has used admin powers to [amount > 0 ? "add" : "remove"] [amount] LOB point[(amount > 1 || amount < -1) ? "s" : ""] in the auxiliary console")
 
 				SSlobotomy_corp.lob_points += amount
+				return
 
 	if (.)
 		return
@@ -376,3 +380,5 @@
 
 			U.Upgrade()
 			playsound(get_turf(src), 'sound/machines/terminal_prompt_confirm.ogg', 50, TRUE)
+		else // they probably called an admin proc, lets update the static data to resolve deadmin edge cases
+			update_static_data_for_all_viewers()

--- a/code/modules/tgui/external.dm
+++ b/code/modules/tgui/external.dm
@@ -65,6 +65,17 @@
 /**
  * public
  *
+ * Will force an update on static data for all viewers.
+ * Should be done manually whenever something happens to
+ * change static data.
+ */
+/datum/proc/update_static_data_for_all_viewers()
+	for (var/datum/tgui/window as anything in SStgui.open_uis_by_src[REF(src)])
+		window.send_full_update()
+
+/**
+ * public
+ *
  * Called on a UI when the UI receieves a href.
  * Think of this as Topic().
  *

--- a/tgui/packages/tgui/interfaces/AuxiliaryManagerConsole.js
+++ b/tgui/packages/tgui/interfaces/AuxiliaryManagerConsole.js
@@ -147,13 +147,13 @@ const CoreSuppressionSelector = (props, context) => {
           />
         )}
         <Box textColor="red" textAlign="center">
-          WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING
+          WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNIN
         </Box>
         <NoticeBox color={selected_core_color} bold textAlign="center" fontSize="40px">
           {current_suppression} in progress!
         </NoticeBox>
         <Box textColor="red" textAlign="center">
-          WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING
+          WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNIN
         </Box>
       </Section>
     );

--- a/tgui/packages/tgui/interfaces/AuxiliaryManagerConsole.js
+++ b/tgui/packages/tgui/interfaces/AuxiliaryManagerConsole.js
@@ -147,13 +147,17 @@ const CoreSuppressionSelector = (props, context) => {
           />
         )}
         <Box textColor="red" textAlign="center">
-          WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNIN
+          WARNING WARNING WARNING
+          WARNING WARNING WARNING
+          WARNING WARNING WARNING
         </Box>
         <NoticeBox color={selected_core_color} bold textAlign="center" fontSize="40px">
           {current_suppression} in progress!
         </NoticeBox>
         <Box textColor="red" textAlign="center">
-          WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNIN
+          WARNING WARNING WARNING
+          WARNING WARNING WARNING
+          WARNING WARNING WARNING
         </Box>
       </Section>
     );

--- a/tgui/packages/tgui/interfaces/AuxiliaryManagerConsole.js
+++ b/tgui/packages/tgui/interfaces/AuxiliaryManagerConsole.js
@@ -41,7 +41,8 @@ const FacilityUpgrades = (props, context) => {
     <Section title="Master facility upgrade systems">
       {is_admin === 1 && (
         <NoticeBox danger bold textAlign="center">
-          !! Due to being adminned, your proximity and living checks are bypassed !!
+          !! Due to being adminned,
+          your proximity and living checks are bypassed !!
         </NoticeBox>
       )}
       {is_admin === 1 && (
@@ -187,7 +188,8 @@ const CoreSuppressionSelector = (props, context) => {
     <Section title="Master core suppression systems">
       {is_admin === 1 && (
         <NoticeBox danger bold textAlign="center">
-          !! Due to being adminned, your proximity and living checks are bypassed !!
+          !! Due to being adminned,
+          your proximity and living checks are bypassed !!
         </NoticeBox>
       )}
       {is_admin === 1 && (

--- a/tgui/packages/tgui/interfaces/AuxiliaryManagerConsole.js
+++ b/tgui/packages/tgui/interfaces/AuxiliaryManagerConsole.js
@@ -40,6 +40,11 @@ const FacilityUpgrades = (props, context) => {
   return (
     <Section title="Master facility upgrade systems">
       {is_admin === 1 && (
+        <NoticeBox danger bold textAlign="center">
+          !! Due to being adminned, your proximity and living checks are bypassed !!
+        </NoticeBox>
+      )}
+      {is_admin === 1 && (
         <Box mt="0.5em" backgroundColor="purple">
           (ADMIN ONLY) Add/Subtract LOB points:
           <Button
@@ -101,7 +106,7 @@ const FacilityUpgrades = (props, context) => {
         </Box>
       )}
       <LabeledList>
-        <LabeledList.Item label="available LOB points: ">
+        <LabeledList.Item label="available LOB points">
           {Upgrade_points}
         </LabeledList.Item>
       </LabeledList>
@@ -111,27 +116,27 @@ const FacilityUpgrades = (props, context) => {
       Surelly there's a better way to do this
       */}
       <Box textColor="blue" mt="1em" fontSize="20px" nowrap>
-        available unlockable bullets:
+        Available unlockable bullets:
       </Box>
       <BulletUpgrades />
 
       <Box textColor="blue" mt="1em" fontSize="20px" nowrap>
-        available bullet upgrades:
+        Available bullet upgrades:
       </Box>
       <MoreBulletUpgrades />
 
       <Box textColor="blue" mt="1em" fontSize="20px" nowrap>
-        available agent upgrades:
+        Available agent upgrades:
       </Box>
       <AgentUpgrades />
 
       <Box textColor="blue" mt="1em" fontSize="20px" nowrap>
-        available abnormality cell upgrades:
+        Available abnormality cell upgrades:
       </Box>
       <AbnormalityUpgrades />
 
       <Box textColor="blue" mt="1em" fontSize="20px" nowrap>
-        available uncategorized upgrades:
+        Available uncategorized upgrades:
       </Box>
       <MiscUpgrades />
     </Section>
@@ -180,6 +185,11 @@ const CoreSuppressionSelector = (props, context) => {
 
   return (
     <Section title="Master core suppression systems">
+      {is_admin === 1 && (
+        <NoticeBox danger bold textAlign="center">
+          !! Due to being adminned, your proximity and living checks are bypassed !!
+        </NoticeBox>
+      )}
       {is_admin === 1 && (
         <Box mt="0.5em">
           <Button

--- a/tgui/packages/tgui/interfaces/AuxiliaryManagerConsole.js
+++ b/tgui/packages/tgui/interfaces/AuxiliaryManagerConsole.js
@@ -40,47 +40,62 @@ const FacilityUpgrades = (props, context) => {
   return (
     <Section title="Master facility upgrade systems">
       {is_admin === 1 && (
-        <Box mt="0.5em">
+        <Box mt="0.5em" backgroundColor='purple'>
+          (ADMIN ONLY) Add/Subtract LOB points:
           <Button
-            content={'ADMIN: Remove 1 LOB point'}
-            color={'purple'}
+            content={'-100'}
+            color={'red'}
             onClick={() => act('Change LOB Points', {
-              LOB_amount: -1,
+              LOB_amount: -100,
             })}
           />
           <Button
-            content={'ADMIN: Remove 5 LOB points'}
-            color={'purple'}
-            onClick={() => act('Change LOB Points', {
-              LOB_amount: -5,
-            })}
-          />
-          <Button
-            content={'ADMIN: Remove 10 LOB points'}
-            color={'purple'}
+            content={'-10'}
+            color={'red'}
             onClick={() => act('Change LOB Points', {
               LOB_amount: -10,
             })}
           />
           <Button
-            content={'ADMIN: Add 1 LOB point'}
-            color={'purple'}
+            content={'-5'}
+            color={'red'}
+            onClick={() => act('Change LOB Points', {
+              LOB_amount: -5,
+            })}
+          />
+          <Button
+            content={'-1'}
+            color={'red'}
+            onClick={() => act('Change LOB Points', {
+              LOB_amount: -1,
+            })}
+          />
+          <Button
+            content={'+1'}
+            color={'green'}
             onClick={() => act('Change LOB Points', {
               LOB_amount: 1,
             })}
           />
           <Button
-            content={'ADMIN: Add 5 LOB points'}
-            color={'purple'}
+            content={'+5'}
+            color={'green'}
             onClick={() => act('Change LOB Points', {
               LOB_amount: 5,
             })}
           />
           <Button
-            content={'ADMIN: Add 10 LOB points'}
-            color={'purple'}
+            content={'+10'}
+            color={'green'}
             onClick={() => act('Change LOB Points', {
               LOB_amount: 10,
+            })}
+          />
+          <Button
+            content={'+100'}
+            color={'green'}
+            onClick={() => act('Change LOB Points', {
+              LOB_amount: 100,
             })}
           />
         </Box>

--- a/tgui/packages/tgui/interfaces/AuxiliaryManagerConsole.js
+++ b/tgui/packages/tgui/interfaces/AuxiliaryManagerConsole.js
@@ -40,11 +40,50 @@ const FacilityUpgrades = (props, context) => {
   return (
     <Section title="Master facility upgrade systems">
       {is_admin === 1 && (
-        <Button
-          content={'ADMIN: Add a LOB point'}
+        <Box mt="0.5em">
+          <Button
+            content={'ADMIN: Remove 10 LOB points'}
+            color={'purple'}
+            onClick={() => act('Change LOB Points', {
+              LOB_amount: -10,
+            })}
+          />
+          <Button
+            content={'ADMIN: Remove 5 LOB points'}
+            color={'purple'}
+            onClick={() => act('Change LOB Points', {
+              LOB_amount: -5,
+            })}
+          />
+          <Button
+            content={'ADMIN: Remove 1 LOB point'}
+            color={'purple'}
+            onClick={() => act('Change LOB Points', {
+              LOB_amount: -1,
+            })}
+          />
+          <Button
+            content={'ADMIN: Add 1 LOB point'}
+            color={'purple'}
+            onClick={() => act('Change LOB Points', {
+              LOB_amount: 1,
+            })}
+          />
+          <Button
+            content={'ADMIN: Add 5 LOB points'}
+            color={'purple'}
+            onClick={() => act('Change LOB Points', {
+              LOB_amount: 5,
+            })}
+          />
+          <Button
+          content={'ADMIN: Add 10 LOB points'}
           color={'purple'}
-          onClick={() => act('Add Lobotomy Point')}
-        />
+          onClick={() => act('Change LOB Points', {
+            LOB_amount: 10,
+          })}
+          />
+      </Box>
       )}
       <LabeledList>
         <LabeledList.Item label="available LOB points: ">

--- a/tgui/packages/tgui/interfaces/AuxiliaryManagerConsole.js
+++ b/tgui/packages/tgui/interfaces/AuxiliaryManagerConsole.js
@@ -35,14 +35,7 @@ export const AuxiliaryManagerConsole = (props, context) => {
 
 const FacilityUpgrades = (props, context) => {
   const { data } = useBackend(context);
-  const {
-    Upgrade_points,
-    bullet_upgrades,
-    real_bullet_upgrades,
-    agent_upgrades,
-    abnormality_upgrades,
-    misc_upgrades,
-  } = data;
+  const { Upgrade_points } = data;
 
   return (
     <Section title="Master facility upgrade systems">
@@ -53,7 +46,7 @@ const FacilityUpgrades = (props, context) => {
       </LabeledList>
       {/*
       All of the upgrade parts are basically the same,
-      except they have different mapping variables so we can sort out categories.
+      except they have different mapping variables so we can sort out categories
       Surelly there's a better way to do this
       */}
       <Box textColor="blue" mt="1em" ml="0.5em" fontSize="20px" nowrap>
@@ -109,7 +102,7 @@ const CoreSupressionSelector = (props, context) => {
     <Section title="Master core supression systems">
       {available_suppressions.length > 0 && (
         <LabeledList>
-          {available_suppressions.map((available_suppressions) => (
+          {available_suppressions.map(available_suppressions => (
             <LabeledList.Item
               key={available_suppressions.name}
               label={available_suppressions.name}
@@ -120,8 +113,7 @@ const CoreSupressionSelector = (props, context) => {
                   onClick={() =>
                     act('Select Core Suppression', {
                       selected_core: available_suppressions.ref,
-                    })
-                  }
+                    })}
                 />
               }
             />
@@ -161,7 +153,7 @@ const BulletUpgrades = (props, context) => {
 
   return (
     <LabeledList>
-      {bullet_upgrades.map((bullet_upgrades) => (
+      {bullet_upgrades.map(bullet_upgrades => (
         <LabeledList.Item
           key={bullet_upgrades.name}
           label={bullet_upgrades.name}
@@ -169,22 +161,21 @@ const BulletUpgrades = (props, context) => {
             <Button
               content={
                 bullet_upgrades.available === 1
-                  ? 'Purchase the bullet for ' +
-                  bullet_upgrades.cost +
-                  ' LOB points'
+                  ? 'Purchase the bullet for '
+                  + bullet_upgrades.cost
+                  + ' LOB points'
                   : 'UPGRADE PURCHASED'
               }
               color={
-                Upgrade_points >= bullet_upgrades.cost &&
-                bullet_upgrades.available === 1
+                Upgrade_points >= bullet_upgrades.cost
+                && bullet_upgrades.available === 1
                   ? 'green'
                   : 'red'
               }
               onClick={() =>
                 act('Buy Upgrade', {
                   selected_upgrade: bullet_upgrades.ref,
-                })
-              }
+                })}
             />
           }
         />
@@ -203,7 +194,7 @@ const MoreBulletUpgrades = (props, context) => {
 
   return (
     <LabeledList>
-      {real_bullet_upgrades.map((real_bullet_upgrades) => (
+      {real_bullet_upgrades.map(real_bullet_upgrades => (
         <LabeledList.Item
           key={real_bullet_upgrades.name}
           label={real_bullet_upgrades.name}
@@ -211,22 +202,21 @@ const MoreBulletUpgrades = (props, context) => {
             <Button
               content={
                 real_bullet_upgrades.available === 1
-                  ? 'Purchase the bullet upgrade for ' +
-                  real_bullet_upgrades.cost +
-                  ' LOB points'
+                  ? 'Purchase the bullet upgrade for '
+                  + real_bullet_upgrades.cost
+                  + ' LOB points'
                   : 'UPGRADE PURCHASED'
               }
               color={
-                Upgrade_points >= real_bullet_upgrades.cost &&
-                real_bullet_upgrades.available === 1
+                Upgrade_points >= real_bullet_upgrades.cost
+                && real_bullet_upgrades.available === 1
                   ? 'green'
                   : 'red'
               }
               onClick={() =>
                 act('Buy Upgrade', {
                   selected_upgrade: real_bullet_upgrades.ref,
-                })
-              }
+                })}
             />
           }
         />
@@ -245,7 +235,7 @@ const AgentUpgrades = (props, context) => {
 
   return (
     <LabeledList>
-      {agent_upgrades.map((agent_upgrades) => (
+      {agent_upgrades.map(agent_upgrades => (
         <LabeledList.Item
           key={agent_upgrades.name}
           label={agent_upgrades.name}
@@ -253,22 +243,21 @@ const AgentUpgrades = (props, context) => {
             <Button
               content={
                 agent_upgrades.available === 1
-                  ? 'Purchase the agent upgrade for ' +
-                  agent_upgrades.cost +
-                  ' LOB points'
+                  ? 'Purchase the agent upgrade for '
+                  + agent_upgrades.cost
+                  + ' LOB points'
                   : 'UPGRADE PURCHASED'
               }
               color={
-                Upgrade_points >= agent_upgrades.cost &&
-                agent_upgrades.available === 1
+                Upgrade_points >= agent_upgrades.cost
+                && agent_upgrades.available === 1
                   ? 'green'
                   : 'red'
               }
               onClick={() =>
                 act('Buy Upgrade', {
                   selected_upgrade: agent_upgrades.ref,
-                })
-              }
+                })}
             />
           }
         />
@@ -287,7 +276,7 @@ const AbnormalityUpgrades = (props, context) => {
 
   return (
     <LabeledList>
-      {abnormality_upgrades.map((abnormality_upgrades) => (
+      {abnormality_upgrades.map(abnormality_upgrades => (
         <LabeledList.Item
           key={abnormality_upgrades.name}
           label={abnormality_upgrades.name}
@@ -295,22 +284,21 @@ const AbnormalityUpgrades = (props, context) => {
             <Button
               content={
                 abnormality_upgrades.available === 1
-                  ? 'Purchase the abnormality cell upgrade for ' +
-                  abnormality_upgrades.cost +
-                  ' LOB points'
+                  ? 'Purchase the abnormality cell upgrade for '
+                  + abnormality_upgrades.cost
+                  + ' LOB points'
                   : 'UPGRADE PURCHASED'
               }
               color={
-                Upgrade_points >= abnormality_upgrades.cost &&
-                abnormality_upgrades.available === 1
+                Upgrade_points >= abnormality_upgrades.cost
+                && abnormality_upgrades.available === 1
                   ? 'green'
                   : 'red'
               }
               onClick={() =>
                 act('Buy Upgrade', {
                   selected_upgrade: abnormality_upgrades.ref,
-                })
-              }
+                })}
             />
           }
         />
@@ -329,7 +317,7 @@ const MiscUpgrades = (props, context) => {
 
   return (
     <LabeledList>
-      {misc_upgrades.map((misc_upgrades) => (
+      {misc_upgrades.map(misc_upgrades => (
         <LabeledList.Item
           key={misc_upgrades.name}
           label={misc_upgrades.name}
@@ -337,22 +325,21 @@ const MiscUpgrades = (props, context) => {
             <Button
               content={
                 misc_upgrades.available === 1
-                  ? 'Purchase the upgrade for ' +
-                  misc_upgrades.cost +
-                  ' LOB points'
+                  ? 'Purchase the upgrade for '
+                  + misc_upgrades.cost
+                  + ' LOB points'
                   : 'UPGRADE PURCHASED'
               }
               color={
-                Upgrade_points >= misc_upgrades.cost &&
-                misc_upgrades.available === 1
+                Upgrade_points >= misc_upgrades.cost
+                && misc_upgrades.available === 1
                   ? 'green'
                   : 'red'
               }
               onClick={() =>
                 act('Buy Upgrade', {
                   selected_upgrade: misc_upgrades.ref,
-                })
-              }
+                })}
             />
           }
         />

--- a/tgui/packages/tgui/interfaces/AuxiliaryManagerConsole.js
+++ b/tgui/packages/tgui/interfaces/AuxiliaryManagerConsole.js
@@ -138,6 +138,13 @@ const CoreSupressionSelector = (props, context) => {
   if (current_supression) {
     return (
       <Section minHeight="220px">
+        {is_admin === 1 && (
+          <Button
+            content={'ADMIN: End core suppression'}
+            color={'purple'}
+            onClick={() => act('End Core Supression')}
+          />
+        )}
         <Box mt="0.5em" bold textAlign="center" fontSize="40px">
           {current_supression} in progress!
         </Box>
@@ -148,11 +155,18 @@ const CoreSupressionSelector = (props, context) => {
   return (
     <Section title="Master core supression systems">
       {is_admin === 1 && (
-        <Button
-          content={'ADMIN: Unlock all core supressions'}
-          color={'purple'}
-          onClick={() => act('Unlock All Cores')}
-        />
+        <Box mt="0.5em">
+          <Button
+            content={'ADMIN: Unlock all core supressions'}
+            color={'purple'}
+            onClick={() => act('Unlock All Cores')}
+          />
+          <Button
+            content={'ADMIN: Disable all core supressions'}
+            color={'purple'}
+            onClick={() => act('Disable Core Supression')}
+          />
+        </Box>
       )}
       {available_suppressions.length > 0 && (
         <LabeledList>

--- a/tgui/packages/tgui/interfaces/AuxiliaryManagerConsole.js
+++ b/tgui/packages/tgui/interfaces/AuxiliaryManagerConsole.js
@@ -236,6 +236,11 @@ const CoreSuppressionSelector = (props, context) => {
           ))}
         </LabeledList>
       )}
+      {available_suppressions.length === 0 && (
+        <NoticeBox info bold textAlign="center" fontSize="40px" fontFamily="Baskerville">
+          Core suppressions not avaible!
+        </NoticeBox>
+      )}
       {selected_core_name && (
         <LabeledList>
           <LabeledList.Item label="Selected core name: ">

--- a/tgui/packages/tgui/interfaces/AuxiliaryManagerConsole.js
+++ b/tgui/packages/tgui/interfaces/AuxiliaryManagerConsole.js
@@ -242,7 +242,7 @@ const CoreSuppressionSelector = (props, context) => {
       )}
       {available_suppressions.length === 0 && (
         <NoticeBox info bold textAlign="center" fontSize="40px" fontFamily="Baskerville">
-          Core suppressions not avaible!
+          Core suppressions not available!
         </NoticeBox>
       )}
       {selected_core_name && (
@@ -496,7 +496,7 @@ const AllCores = (props, context) => {
           label={all_core_suppressions.name}
           buttons={
             <Button
-              content={'Add core suppression to the avaible cores pool'}
+              content={'Add core suppression to the available cores pool'}
               color={'purple'}
               onClick={() =>
                 act('Unlock Core Suppressions', {

--- a/tgui/packages/tgui/interfaces/AuxiliaryManagerConsole.js
+++ b/tgui/packages/tgui/interfaces/AuxiliaryManagerConsole.js
@@ -40,7 +40,7 @@ const FacilityUpgrades = (props, context) => {
   return (
     <Section title="Master facility upgrade systems">
       {is_admin === 1 && (
-        <Box mt="0.5em" backgroundColor='purple'>
+        <Box mt="0.5em" backgroundColor="purple">
           (ADMIN ONLY) Add/Subtract LOB points:
           <Button
             content={'-100'}
@@ -110,27 +110,27 @@ const FacilityUpgrades = (props, context) => {
       except they have different mapping variables so we can sort out categories
       Surelly there's a better way to do this
       */}
-      <Box textColor="blue" mt="1em" ml="0.5em" fontSize="20px" nowrap>
+      <Box textColor="blue" mt="1em" fontSize="20px" nowrap>
         available unlockable bullets:
       </Box>
       <BulletUpgrades />
 
-      <Box textColor="blue" mt="1em" ml="1em" fontSize="20px" nowrap>
+      <Box textColor="blue" mt="1em" fontSize="20px" nowrap>
         available bullet upgrades:
       </Box>
       <MoreBulletUpgrades />
 
-      <Box textColor="blue" mt="1em" ml="1em" fontSize="20px" nowrap>
+      <Box textColor="blue" mt="1em" fontSize="20px" nowrap>
         available agent upgrades:
       </Box>
       <AgentUpgrades />
 
-      <Box textColor="blue" mt="1em" ml="1em" fontSize="20px" nowrap>
+      <Box textColor="blue" mt="1em" fontSize="20px" nowrap>
         available abnormality cell upgrades:
       </Box>
       <AbnormalityUpgrades />
 
-      <Box textColor="blue" mt="1em" ml="1em" fontSize="20px" nowrap>
+      <Box textColor="blue" mt="1em" fontSize="20px" nowrap>
         available uncategorized upgrades:
       </Box>
       <MiscUpgrades />
@@ -298,6 +298,7 @@ const MoreBulletUpgrades = (props, context) => {
         <LabeledList.Item
           key={real_bullet_upgrades.name}
           label={real_bullet_upgrades.name}
+          ml="1em"
           buttons={
             <Button
               content={

--- a/tgui/packages/tgui/interfaces/AuxiliaryManagerConsole.js
+++ b/tgui/packages/tgui/interfaces/AuxiliaryManagerConsole.js
@@ -77,13 +77,13 @@ const FacilityUpgrades = (props, context) => {
             })}
           />
           <Button
-          content={'ADMIN: Add 10 LOB points'}
-          color={'purple'}
-          onClick={() => act('Change LOB Points', {
-            LOB_amount: 10,
-          })}
+            content={'ADMIN: Add 10 LOB points'}
+            color={'purple'}
+            onClick={() => act('Change LOB Points', {
+              LOB_amount: 10,
+            })}
           />
-      </Box>
+        </Box>
       )}
       <LabeledList>
         <LabeledList.Item label="available LOB points: ">

--- a/tgui/packages/tgui/interfaces/AuxiliaryManagerConsole.js
+++ b/tgui/packages/tgui/interfaces/AuxiliaryManagerConsole.js
@@ -1,7 +1,7 @@
 // THIS IS A LOBOTOMYCORPORATION UI FILE
 
 import { useBackend, useLocalState } from '../backend';
-import { Box, Button, LabeledList, NoticeBox, Section, Tabs } from '../components';
+import { Box, Button, LabeledList, NoticeBox, Section, Tabs, Collapsible } from '../components';
 import { Window } from '../layouts';
 
 export const AuxiliaryManagerConsole = (props, context) => {
@@ -197,7 +197,10 @@ const CoreSuppressionSelector = (props, context) => {
           <Button
             content={'ADMIN: Unlock all core suppressions'}
             color={'purple'}
-            onClick={() => act('Unlock All Cores')}
+            onClick={() =>
+              act('Unlock Core Suppressions', {
+                core_unlock: 1,
+              })}
           />
           <Button
             content={'ADMIN: Disable all core suppressions'}
@@ -205,6 +208,13 @@ const CoreSuppressionSelector = (props, context) => {
             onClick={() => act('Disable Core Suppression')}
           />
         </Box>
+      )}
+      {is_admin === 1 && (
+        <Collapsible
+        title="ADMIN: Select a specific core suppression to unlock"
+        color='purple'>
+          <AllCores />
+        </Collapsible>
       )}
       {available_suppressions.length > 0 && (
         <LabeledList>
@@ -452,6 +462,36 @@ const MiscUpgrades = (props, context) => {
               onClick={() =>
                 act('Buy Upgrade', {
                   selected_upgrade: misc_upgrades.ref,
+                })}
+            />
+          }
+        />
+      ))}
+    </LabeledList>
+  );
+};
+
+const AllCores = (props, context) => {
+  const { act, data } = useBackend(context);
+  const { all_core_suppressions } = data;
+
+  if (all_core_suppressions.length < 1) {
+    return;
+  }
+
+  return (
+    <LabeledList>
+      {all_core_suppressions.map(all_core_suppressions => (
+        <LabeledList.Item
+          key={all_core_suppressions.name}
+          label={all_core_suppressions.name}
+          buttons={
+            <Button
+              content={'Add core suppression to the avaible cores pool'}
+              color={'purple'}
+              onClick={() =>
+                act('Unlock Core Suppressions', {
+                  core_unlock: all_core_suppressions.ref,
                 })}
             />
           }

--- a/tgui/packages/tgui/interfaces/AuxiliaryManagerConsole.js
+++ b/tgui/packages/tgui/interfaces/AuxiliaryManagerConsole.js
@@ -42,10 +42,10 @@ const FacilityUpgrades = (props, context) => {
       {is_admin === 1 && (
         <Box mt="0.5em">
           <Button
-            content={'ADMIN: Remove 10 LOB points'}
+            content={'ADMIN: Remove 1 LOB point'}
             color={'purple'}
             onClick={() => act('Change LOB Points', {
-              LOB_amount: -10,
+              LOB_amount: -1,
             })}
           />
           <Button
@@ -56,10 +56,10 @@ const FacilityUpgrades = (props, context) => {
             })}
           />
           <Button
-            content={'ADMIN: Remove 1 LOB point'}
+            content={'ADMIN: Remove 10 LOB points'}
             color={'purple'}
             onClick={() => act('Change LOB Points', {
-              LOB_amount: -1,
+              LOB_amount: -10,
             })}
           />
           <Button

--- a/tgui/packages/tgui/interfaces/AuxiliaryManagerConsole.js
+++ b/tgui/packages/tgui/interfaces/AuxiliaryManagerConsole.js
@@ -1,7 +1,7 @@
 // THIS IS A LOBOTOMYCORPORATION UI FILE
 
 import { useBackend, useLocalState } from '../backend';
-import { Box, Button, LabeledList, Section, Tabs } from '../components';
+import { Box, Button, LabeledList, NoticeBox, Section, Tabs } from '../components';
 import { Window } from '../layouts';
 
 export const AuxiliaryManagerConsole = (props, context) => {
@@ -27,7 +27,7 @@ export const AuxiliaryManagerConsole = (props, context) => {
           </Tabs.Tab>
         </Tabs>
         {tab === 1 && <FacilityUpgrades />}
-        {tab === 2 && <CoreSupressionSelector />}
+        {tab === 2 && <CoreSuppressionSelector />}
       </Window.Content>
     </Window>
   );
@@ -123,48 +123,55 @@ const FacilityUpgrades = (props, context) => {
   );
 };
 
-const CoreSupressionSelector = (props, context) => {
+const CoreSuppressionSelector = (props, context) => {
   const { act, data } = useBackend(context);
   const {
     is_admin,
-    current_supression,
+    current_suppression,
     available_suppressions,
     selected_core_name,
     selected_core_description,
     selected_core_goal,
     selected_core_reward,
+    selected_core_color,
   } = data;
 
-  if (current_supression) {
+  if (current_suppression) {
     return (
       <Section minHeight="220px">
         {is_admin === 1 && (
           <Button
             content={'ADMIN: End core suppression'}
             color={'purple'}
-            onClick={() => act('End Core Supression')}
+            onClick={() => act('End Core Suppression')}
           />
         )}
-        <Box mt="0.5em" bold textAlign="center" fontSize="40px">
-          {current_supression} in progress!
+        <Box textColor="red" textAlign="center">
+          WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING
+        </Box>
+        <NoticeBox color={selected_core_color} bold textAlign="center" fontSize="40px">
+          {current_suppression} in progress!
+        </NoticeBox>
+        <Box textColor="red" textAlign="center">
+          WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING
         </Box>
       </Section>
     );
   }
 
   return (
-    <Section title="Master core supression systems">
+    <Section title="Master core suppression systems">
       {is_admin === 1 && (
         <Box mt="0.5em">
           <Button
-            content={'ADMIN: Unlock all core supressions'}
+            content={'ADMIN: Unlock all core suppressions'}
             color={'purple'}
             onClick={() => act('Unlock All Cores')}
           />
           <Button
-            content={'ADMIN: Disable all core supressions'}
+            content={'ADMIN: Disable all core suppressions'}
             color={'purple'}
-            onClick={() => act('Disable Core Supression')}
+            onClick={() => act('Disable Core Suppression')}
           />
         </Box>
       )}
@@ -176,7 +183,7 @@ const CoreSupressionSelector = (props, context) => {
               label={available_suppressions.name}
               buttons={
                 <Button
-                  content={'Choose core supression'}
+                  content={'Choose core suppression'}
                   color={'green'}
                   onClick={() =>
                     act('Select Core Suppression', {

--- a/tgui/packages/tgui/interfaces/AuxiliaryManagerConsole.js
+++ b/tgui/packages/tgui/interfaces/AuxiliaryManagerConsole.js
@@ -175,9 +175,9 @@ const CoreSuppressionSelector = (props, context) => {
           WARNING WARNING WARNING
         </Box>
         <NoticeBox color={selected_core_color} bold textAlign="center" fontSize="40px" fontFamily="Baskerville">
-          <img src={resolveAsset(selected_core_icon)}/>
+          <img src={resolveAsset(selected_core_icon)} />
           {current_suppression} in progress!
-          <img src={resolveAsset(selected_core_icon)}/>
+          <img src={resolveAsset(selected_core_icon)} />
         </NoticeBox>
         <Box textColor="red" textAlign="center" fontFamily="Baskerville">
           WARNING WARNING WARNING

--- a/tgui/packages/tgui/interfaces/AuxiliaryManagerConsole.js
+++ b/tgui/packages/tgui/interfaces/AuxiliaryManagerConsole.js
@@ -34,11 +34,18 @@ export const AuxiliaryManagerConsole = (props, context) => {
 };
 
 const FacilityUpgrades = (props, context) => {
-  const { data } = useBackend(context);
-  const { Upgrade_points } = data;
+  const { act, data } = useBackend(context);
+  const { Upgrade_points, is_admin } = data;
 
   return (
     <Section title="Master facility upgrade systems">
+      {is_admin === 1 && (
+        <Button
+          content={'ADMIN: Add a LOB point'}
+          color={'purple'}
+          onClick={() => act('Add Lobotomy Point')}
+        />
+      )}
       <LabeledList>
         <LabeledList.Item label="available LOB points: ">
           {Upgrade_points}
@@ -80,6 +87,7 @@ const FacilityUpgrades = (props, context) => {
 const CoreSupressionSelector = (props, context) => {
   const { act, data } = useBackend(context);
   const {
+    is_admin,
     current_supression,
     available_suppressions,
     selected_core_name,
@@ -100,6 +108,13 @@ const CoreSupressionSelector = (props, context) => {
 
   return (
     <Section title="Master core supression systems">
+      {is_admin === 1 && (
+        <Button
+          content={'ADMIN: Unlock all core supressions (needs a TGUI restart)'}
+          color={'purple'}
+          onClick={() => act('Unlock All Cores')}
+        />
+      )}
       {available_suppressions.length > 0 && (
         <LabeledList>
           {available_suppressions.map(available_suppressions => (

--- a/tgui/packages/tgui/interfaces/AuxiliaryManagerConsole.js
+++ b/tgui/packages/tgui/interfaces/AuxiliaryManagerConsole.js
@@ -146,15 +146,15 @@ const CoreSuppressionSelector = (props, context) => {
             onClick={() => act('End Core Suppression')}
           />
         )}
-        <Box textColor="red" textAlign="center">
+        <Box textColor="red" textAlign="center" fontFamily="Baskerville">
           WARNING WARNING WARNING
           WARNING WARNING WARNING
           WARNING WARNING WARNING
         </Box>
-        <NoticeBox color={selected_core_color} bold textAlign="center" fontSize="40px">
+        <NoticeBox color={selected_core_color} bold textAlign="center" fontSize="40px" fontFamily="Baskerville">
           {current_suppression} in progress!
         </NoticeBox>
-        <Box textColor="red" textAlign="center">
+        <Box textColor="red" textAlign="center" fontFamily="Baskerville">
           WARNING WARNING WARNING
           WARNING WARNING WARNING
           WARNING WARNING WARNING

--- a/tgui/packages/tgui/interfaces/AuxiliaryManagerConsole.js
+++ b/tgui/packages/tgui/interfaces/AuxiliaryManagerConsole.js
@@ -224,6 +224,10 @@ const CoreSuppressionSelector = (props, context) => {
   );
 };
 
+/**
+ * Tons of copy paste down below
+ */
+
 const BulletUpgrades = (props, context) => {
   const { act, data } = useBackend(context);
   const { Upgrade_points, bullet_upgrades } = data;

--- a/tgui/packages/tgui/interfaces/AuxiliaryManagerConsole.js
+++ b/tgui/packages/tgui/interfaces/AuxiliaryManagerConsole.js
@@ -1,5 +1,6 @@
 // THIS IS A LOBOTOMYCORPORATION UI FILE
 
+import { resolveAsset } from '../assets';
 import { useBackend, useLocalState } from '../backend';
 import { Box, Button, LabeledList, NoticeBox, Section, Tabs, Collapsible } from '../components';
 import { Window } from '../layouts';
@@ -8,7 +9,7 @@ export const AuxiliaryManagerConsole = (props, context) => {
   const [tab, setTab] = useLocalState(context, 'tab', 1);
 
   return (
-    <Window title="Auxiliary Managerial Console" width="650" height="600">
+    <Window title="Auxiliary Managerial Console" width="850" height="600">
       <Window.Content>
         <Tabs>
           <Tabs.Tab
@@ -155,6 +156,7 @@ const CoreSuppressionSelector = (props, context) => {
     selected_core_goal,
     selected_core_reward,
     selected_core_color,
+    selected_core_icon,
   } = data;
 
   if (current_suppression) {
@@ -173,7 +175,9 @@ const CoreSuppressionSelector = (props, context) => {
           WARNING WARNING WARNING
         </Box>
         <NoticeBox color={selected_core_color} bold textAlign="center" fontSize="40px" fontFamily="Baskerville">
+          <img src={resolveAsset(selected_core_icon)}/>
           {current_suppression} in progress!
+          <img src={resolveAsset(selected_core_icon)}/>
         </NoticeBox>
         <Box textColor="red" textAlign="center" fontFamily="Baskerville">
           WARNING WARNING WARNING

--- a/tgui/packages/tgui/interfaces/AuxiliaryManagerConsole.js
+++ b/tgui/packages/tgui/interfaces/AuxiliaryManagerConsole.js
@@ -211,8 +211,8 @@ const CoreSuppressionSelector = (props, context) => {
       )}
       {is_admin === 1 && (
         <Collapsible
-        title="ADMIN: Select a specific core suppression to unlock"
-        color='purple'>
+          title="ADMIN: Select a specific core suppression to unlock"
+          color="purple">
           <AllCores />
         </Collapsible>
       )}

--- a/tgui/packages/tgui/interfaces/AuxiliaryManagerConsole.js
+++ b/tgui/packages/tgui/interfaces/AuxiliaryManagerConsole.js
@@ -149,7 +149,7 @@ const CoreSupressionSelector = (props, context) => {
     <Section title="Master core supression systems">
       {is_admin === 1 && (
         <Button
-          content={'ADMIN: Unlock all core supressions (needs a TGUI restart)'}
+          content={'ADMIN: Unlock all core supressions'}
           color={'purple'}
           onClick={() => act('Unlock All Cores')}
         />
@@ -174,25 +174,27 @@ const CoreSupressionSelector = (props, context) => {
           ))}
         </LabeledList>
       )}
-      <LabeledList>
-        <LabeledList.Item label="Selected core name: ">
-          {selected_core_name}
-        </LabeledList.Item>
-        <LabeledList.Item label="Selected core description: ">
-          {selected_core_description}
-        </LabeledList.Item>
-        <LabeledList.Item label="Selected core goal: ">
-          {selected_core_goal}
-        </LabeledList.Item>
-        <LabeledList.Item label="Selected core reward: ">
-          {selected_core_reward}
-        </LabeledList.Item>
-      </LabeledList>
-      <Button
-        content={'Confirm core selection'}
-        color={selected_core_name ? 'green' : 'red'}
-        onClick={() => act('Activate Core Suppression')}
-      />
+      {selected_core_name && (
+        <LabeledList>
+          <LabeledList.Item label="Selected core name: ">
+            {selected_core_name}
+          </LabeledList.Item>
+          <LabeledList.Item label="Selected core description: ">
+            {selected_core_description}
+          </LabeledList.Item>
+          <LabeledList.Item label="Selected core goal: ">
+            {selected_core_goal}
+          </LabeledList.Item>
+          <LabeledList.Item label="Selected core reward: ">
+            {selected_core_reward}
+          </LabeledList.Item>
+          <Button mt="1em" ml="0.5em"
+            content={'Confirm core selection'}
+            color={'green'}
+            onClick={() => act('Activate Core Suppression')}
+          />
+        </LabeledList>
+      )}
     </Section>
   );
 };

--- a/tgui/packages/tgui/interfaces/AuxiliaryManagerConsole.js
+++ b/tgui/packages/tgui/interfaces/AuxiliaryManagerConsole.js
@@ -1,0 +1,362 @@
+// THIS IS A LOBOTOMYCORPORATION UI FILE
+
+import { useBackend, useLocalState } from '../backend';
+import { Box, Button, LabeledList, Section, Tabs } from '../components';
+import { Window } from '../layouts';
+
+export const AuxiliaryManagerConsole = (props, context) => {
+  const [tab, setTab] = useLocalState(context, 'tab', 1);
+
+  return (
+    <Window title="Auxiliary Managerial Console" width="650" height="600">
+      <Window.Content>
+        <Tabs>
+          <Tabs.Tab
+            icon="list"
+            lineHeight="23px"
+            selected={tab === 1}
+            onClick={() => setTab(1)}>
+            Facility Upgrade system
+          </Tabs.Tab>
+          <Tabs.Tab
+            icon="list"
+            lineHeight="23px"
+            selected={tab === 2}
+            onClick={() => setTab(2)}>
+            Core Suppression system
+          </Tabs.Tab>
+        </Tabs>
+        {tab === 1 && <FacilityUpgrades />}
+        {tab === 2 && <CoreSupressionSelector />}
+      </Window.Content>
+    </Window>
+  );
+};
+
+const FacilityUpgrades = (props, context) => {
+  const { data } = useBackend(context);
+  const {
+    Upgrade_points,
+    bullet_upgrades,
+    real_bullet_upgrades,
+    agent_upgrades,
+    abnormality_upgrades,
+    misc_upgrades,
+  } = data;
+
+  return (
+    <Section title="Master facility upgrade systems">
+      <LabeledList>
+        <LabeledList.Item label="available LOB points: ">
+          {Upgrade_points}
+        </LabeledList.Item>
+      </LabeledList>
+      {/*
+      All of the upgrade parts are basically the same,
+      except they have different mapping variables so we can sort out categories.
+      Surelly there's a better way to do this
+      */}
+      <Box textColor="blue" mt="1em" ml="0.5em" fontSize="20px" nowrap>
+        available unlockable bullets:
+      </Box>
+      <BulletUpgrades />
+
+      <Box textColor="blue" mt="1em" ml="1em" fontSize="20px" nowrap>
+        available bullet upgrades:
+      </Box>
+      <MoreBulletUpgrades />
+
+      <Box textColor="blue" mt="1em" ml="1em" fontSize="20px" nowrap>
+        available agent upgrades:
+      </Box>
+      <AgentUpgrades />
+
+      <Box textColor="blue" mt="1em" ml="1em" fontSize="20px" nowrap>
+        available abnormality cell upgrades:
+      </Box>
+      <AbnormalityUpgrades />
+
+      <Box textColor="blue" mt="1em" ml="1em" fontSize="20px" nowrap>
+        available uncategorized upgrades:
+      </Box>
+      <MiscUpgrades />
+    </Section>
+  );
+};
+
+const CoreSupressionSelector = (props, context) => {
+  const { act, data } = useBackend(context);
+  const {
+    current_supression,
+    available_suppressions,
+    selected_core_name,
+    selected_core_description,
+    selected_core_goal,
+    selected_core_reward,
+  } = data;
+
+  if (current_supression) {
+    return (
+      <Section minHeight="220px">
+        <Box mt="0.5em" bold textAlign="center" fontSize="40px">
+          {current_supression} in progress!
+        </Box>
+      </Section>
+    );
+  }
+
+  return (
+    <Section title="Master core supression systems">
+      {available_suppressions.length > 0 && (
+        <LabeledList>
+          {available_suppressions.map((available_suppressions) => (
+            <LabeledList.Item
+              key={available_suppressions.name}
+              label={available_suppressions.name}
+              buttons={
+                <Button
+                  content={'Choose core supression'}
+                  color={'green'}
+                  onClick={() =>
+                    act('Select Core Suppression', {
+                      selected_core: available_suppressions.ref,
+                    })
+                  }
+                />
+              }
+            />
+          ))}
+        </LabeledList>
+      )}
+      <LabeledList>
+        <LabeledList.Item label="Selected core name: ">
+          {selected_core_name}
+        </LabeledList.Item>
+        <LabeledList.Item label="Selected core description: ">
+          {selected_core_description}
+        </LabeledList.Item>
+        <LabeledList.Item label="Selected core goal: ">
+          {selected_core_goal}
+        </LabeledList.Item>
+        <LabeledList.Item label="Selected core reward: ">
+          {selected_core_reward}
+        </LabeledList.Item>
+      </LabeledList>
+      <Button
+        content={'Confirm core selection'}
+        color={selected_core_name ? 'green' : 'red'}
+        onClick={() => act('Activate Core Suppression')}
+      />
+    </Section>
+  );
+};
+
+const BulletUpgrades = (props, context) => {
+  const { act, data } = useBackend(context);
+  const { Upgrade_points, bullet_upgrades } = data;
+
+  if (bullet_upgrades.length < 1) {
+    return;
+  }
+
+  return (
+    <LabeledList>
+      {bullet_upgrades.map((bullet_upgrades) => (
+        <LabeledList.Item
+          key={bullet_upgrades.name}
+          label={bullet_upgrades.name}
+          buttons={
+            <Button
+              content={
+                bullet_upgrades.available === 1
+                  ? 'Purchase the bullet for ' +
+                  bullet_upgrades.cost +
+                  ' LOB points'
+                  : 'UPGRADE PURCHASED'
+              }
+              color={
+                Upgrade_points >= bullet_upgrades.cost &&
+                bullet_upgrades.available === 1
+                  ? 'green'
+                  : 'red'
+              }
+              onClick={() =>
+                act('Buy Upgrade', {
+                  selected_upgrade: bullet_upgrades.ref,
+                })
+              }
+            />
+          }
+        />
+      ))}
+    </LabeledList>
+  );
+};
+
+const MoreBulletUpgrades = (props, context) => {
+  const { act, data } = useBackend(context);
+  const { Upgrade_points, real_bullet_upgrades } = data;
+
+  if (real_bullet_upgrades.length < 1) {
+    return;
+  }
+
+  return (
+    <LabeledList>
+      {real_bullet_upgrades.map((real_bullet_upgrades) => (
+        <LabeledList.Item
+          key={real_bullet_upgrades.name}
+          label={real_bullet_upgrades.name}
+          buttons={
+            <Button
+              content={
+                real_bullet_upgrades.available === 1
+                  ? 'Purchase the bullet upgrade for ' +
+                  real_bullet_upgrades.cost +
+                  ' LOB points'
+                  : 'UPGRADE PURCHASED'
+              }
+              color={
+                Upgrade_points >= real_bullet_upgrades.cost &&
+                real_bullet_upgrades.available === 1
+                  ? 'green'
+                  : 'red'
+              }
+              onClick={() =>
+                act('Buy Upgrade', {
+                  selected_upgrade: real_bullet_upgrades.ref,
+                })
+              }
+            />
+          }
+        />
+      ))}
+    </LabeledList>
+  );
+};
+
+const AgentUpgrades = (props, context) => {
+  const { act, data } = useBackend(context);
+  const { Upgrade_points, agent_upgrades } = data;
+
+  if (agent_upgrades.length < 1) {
+    return;
+  }
+
+  return (
+    <LabeledList>
+      {agent_upgrades.map((agent_upgrades) => (
+        <LabeledList.Item
+          key={agent_upgrades.name}
+          label={agent_upgrades.name}
+          buttons={
+            <Button
+              content={
+                agent_upgrades.available === 1
+                  ? 'Purchase the agent upgrade for ' +
+                  agent_upgrades.cost +
+                  ' LOB points'
+                  : 'UPGRADE PURCHASED'
+              }
+              color={
+                Upgrade_points >= agent_upgrades.cost &&
+                agent_upgrades.available === 1
+                  ? 'green'
+                  : 'red'
+              }
+              onClick={() =>
+                act('Buy Upgrade', {
+                  selected_upgrade: agent_upgrades.ref,
+                })
+              }
+            />
+          }
+        />
+      ))}
+    </LabeledList>
+  );
+};
+
+const AbnormalityUpgrades = (props, context) => {
+  const { act, data } = useBackend(context);
+  const { Upgrade_points, abnormality_upgrades } = data;
+
+  if (abnormality_upgrades.length < 1) {
+    return;
+  }
+
+  return (
+    <LabeledList>
+      {abnormality_upgrades.map((abnormality_upgrades) => (
+        <LabeledList.Item
+          key={abnormality_upgrades.name}
+          label={abnormality_upgrades.name}
+          buttons={
+            <Button
+              content={
+                abnormality_upgrades.available === 1
+                  ? 'Purchase the abnormality cell upgrade for ' +
+                  abnormality_upgrades.cost +
+                  ' LOB points'
+                  : 'UPGRADE PURCHASED'
+              }
+              color={
+                Upgrade_points >= abnormality_upgrades.cost &&
+                abnormality_upgrades.available === 1
+                  ? 'green'
+                  : 'red'
+              }
+              onClick={() =>
+                act('Buy Upgrade', {
+                  selected_upgrade: abnormality_upgrades.ref,
+                })
+              }
+            />
+          }
+        />
+      ))}
+    </LabeledList>
+  );
+};
+
+const MiscUpgrades = (props, context) => {
+  const { act, data } = useBackend(context);
+  const { Upgrade_points, misc_upgrades } = data;
+
+  if (misc_upgrades.length < 1) {
+    return;
+  }
+
+  return (
+    <LabeledList>
+      {misc_upgrades.map((misc_upgrades) => (
+        <LabeledList.Item
+          key={misc_upgrades.name}
+          label={misc_upgrades.name}
+          buttons={
+            <Button
+              content={
+                misc_upgrades.available === 1
+                  ? 'Purchase the upgrade for ' +
+                  misc_upgrades.cost +
+                  ' LOB points'
+                  : 'UPGRADE PURCHASED'
+              }
+              color={
+                Upgrade_points >= misc_upgrades.cost &&
+                misc_upgrades.available === 1
+                  ? 'green'
+                  : 'red'
+              }
+              onClick={() =>
+                act('Buy Upgrade', {
+                  selected_upgrade: misc_upgrades.ref,
+                })
+              }
+            />
+          }
+        />
+      ))}
+    </LabeledList>
+  );
+};


### PR DESCRIPTION
## About The Pull Request

Makes it so instead of an UI, the auxiliary consoles give you TGUI
The UI is not removed, being kept as a failsafe in case TGUI ever fails for whatever reason. And can be toggled by players on alt+click

Le video:

https://github.com/vlggms/lobotomy-corp13/assets/82319946/7c754d88-fa73-4a05-a099-faf193d68e6a

## Why It's Good For The Game

TGUI has quite a few advantages compared to normal UI along with having these features:
- Has much more control over the looks of the console, making it nicer to look at
- Automatically updates LOB points, just a lil bit of QoL.
- The buttons change color to green/red depending on if you are able to buy the upgrades or not

And if TGUI on the console breaks, like it sometimes does. It does not prevent players from using the normal UI

## Changelog
:cl:
add: The auxiliary console can now has TGUI, you can turn it off by alt+clicking
/:cl:
