### PR TITLE
No More Wormfood Vomit

### DIFF
--- a/ModularTegustation/tegufood.dm
+++ b/ModularTegustation/tegufood.dm
@@ -98,16 +98,16 @@
 	name = "Wormfood"
 	reqs = list(
 		/obj/item/food/meat/slab/worm = 1,
-		/obj/item/food/cheesewedge = 3
+		/obj/item/food/cheesewedge = 1
 	)
 	result = /obj/item/food/wormfood
 	subcategory = CAT_MEAT
 
 /obj/item/food/wormfood
 	name = "wormfood"
-	desc = "Something inside the meat is desperately consuming whatever is left."
+	desc = "Something inside the meat is eating endlessly to live. Inevitable depletion, garbage..."
 	icon_state = "wormfood1"
-	food_reagents = list(/datum/reagent/consumable/nutriment = 3, /datum/reagent/consumable/nutriment/vitamin = 2, /datum/reagent/drug/maint/tar = 1, /datum/reagent/yuck = 2)
+	food_reagents = list(/datum/reagent/consumable/nutriment = 3, /datum/reagent/consumable/nutriment/vitamin = 4, /datum/reagent/drug/mushroomhallucinogen = 1)
 	tastes = list("crunchy popping" = 1, "consumption" = 1)
 	foodtypes = MEAT | GROSS
 
@@ -118,8 +118,8 @@
 		qdel(src)
 
 /obj/item/food/wormfood_healthier //heals around 7 damage when consumed
-	name = "wormfood"
-	desc = "Their blind hunger ended in their own consumption." //Put better statement here later.
+	name = "perfect wormfood"
+	desc = "For some bizzare reason this wormfood has become a buttery meat. Their blind hunger ended in their own consumption." //Put better statement here later.
 	icon_state = "wormfood2"
 	food_reagents = list(/datum/reagent/consumable/nutriment = 4, /datum/reagent/consumable/nutriment/protein = 1, /datum/reagent/consumable/nutriment/vitamin = 2, /datum/reagent/consumable/vitfro = 2)
 	tastes = list("crunchy popping" = 1, "buttery meat" = 1)


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes some of the very bad stunning chems in wormfood and replaces them with something less harmful. Changes the name of healthier wormfood to indicate that its different.

## Why It's Good For The Game
I intended imperfect wormfood to be less useful than healtheir rather than actually toxic and a waste.

## Changelog
:cl:
tweak: wormfood
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
