### PR TITLE
Returns Adventure Console Defines to Numbers

### DIFF
--- a/ModularTegustation/_adventure_console/adventure_layout.dm
+++ b/ModularTegustation/_adventure_console/adventure_layout.dm
@@ -2,6 +2,7 @@
  * TEXT BASED ADVENTURES
  * Adventures that are mostly predefined paths.
  * This was difficult to finalize since i havent made a text based adventure before.
+ * Special defines such as button macros are in the code/_DEFINES/~lobotomy_defines.dm
  */
 
 /datum/adventure_layout
@@ -160,7 +161,7 @@
 
 /datum/adventure_layout/proc/TravelUI(obj/machinery/call_machine)
 	switch(travel_mode)
-		if(ADVENTURE_MODE_BATTLE to ADVENTURE_MODE_EVENT_BATTLE)
+		if(ADVENTURE_MODE_BATTLE, ADVENTURE_MODE_EVENT_BATTLE)
 			if(!enemy_desc)
 				GenerateEnemy()
 			. += BattleModeDisplay(call_machine)
@@ -259,7 +260,7 @@
 
 		/*I put || in here and the code got upset so i have to do TO instead
 			Eugh maybe we will fix it later on if adventure mode event battle stops being 3. -IP*/
-		if(ADVENTURE_MODE_BATTLE to ADVENTURE_MODE_EVENT_BATTLE)
+		if(ADVENTURE_MODE_BATTLE, ADVENTURE_MODE_EVENT_BATTLE)
 			BattleModeReact(num)
 
 //Reactions for adventure based on mode.
@@ -291,6 +292,9 @@
 					temp_text += "<br>YOU RUN AWAY FROM YOUR OPPONENT<br>5 DAMAGE HEALED<br>EVENT PROGRESS -5<br>"
 					AdjustHP(5)
 					AdjustProgress(-5)
+					paths_to_tread.Cut()
+					enemy_desc = null
+					travel_mode = ADVENTURE_MODE_TRAVEL
 				else
 					DoBattle(0)
 					temp_text += "<br>YOU FAIL TO ESCAPE THE ENEMY<br>"

--- a/code/__DEFINES/~lobotomy_defines/adventure.dm
+++ b/code/__DEFINES/~lobotomy_defines/adventure.dm
@@ -1,13 +1,13 @@
 // defines used in ModularTegustation/_adventure_console
 
-#define DEBUG_TEXT_DISPLAY (1<<0)
-#define NORMAL_TEXT_DISPLAY (1<<1)
-#define ADVENTURE_TEXT_DISPLAY (1<<2)
+#define DEBUG_TEXT_DISPLAY 1
+#define NORMAL_TEXT_DISPLAY 2
+#define ADVENTURE_TEXT_DISPLAY 3
 
 //Modes for what is displayed on the adventure panel.
-#define ADVENTURE_MODE_TRAVEL (1<<0)
-#define ADVENTURE_MODE_BATTLE (1<<1)
-#define ADVENTURE_MODE_EVENT_BATTLE (1<<2)
+#define ADVENTURE_MODE_TRAVEL 1
+#define ADVENTURE_MODE_BATTLE 2
+#define ADVENTURE_MODE_EVENT_BATTLE 3
 
 //Stats defined. I honestly didnt want to make it have limbus company sins but here we are.
 #define WRATH_STAT 1


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Areas where the change to flags kinda broke the code in adventure_layout.dm. Adventure proc in line 102
TravelUI proc in line 164
AdventureModeReact proc in line 263

The href also returns a number solution of the define rather than the flat text so thats also messed up on the console.

## Changelog
:cl:
fix: Adventure Console
fix: running from combat used to just say you ran away but didnt actually end combat.
tweak: adventure console travel UI code
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
