### PR TITLE
Fetus buffs

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/he/nameless_fetus.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/nameless_fetus.dm
@@ -48,17 +48,17 @@
 				to_chat(H, span_userdanger("The creature grew hungry!"))
 
 /mob/living/simple_animal/hostile/abnormality/fetus/user_buckle_mob(mob/living/M, mob/user, check_loc)
-	if(M.stat != DEAD)
+	if(!IsContained() || user == src || !ishuman(M) || (GODMODE in M.status_flags))
 		return FALSE
-	if(do_after(user, 20, target = M))
-		if(!ishuman(M) || crying)
-			to_chat(user, span_warning("[src] rejects your offering!"))
-			return
-		to_chat(user, span_nicegreen("[src] is satisfied by your offering!"))
-		M.gib()
-		satisfied = TRUE
-		hunger += 4
-		playsound(get_turf(src),'sound/abnormalities/doomsdaycalendar/Limbus_Dead_Generic.ogg', 50, 1)
+		to_chat(user, span_warning("[src] rejects your offering!"))
+	. = ..()
+	to_chat(user, span_userdanger("The Woodsman swings his axe down and...!"))
+	SLEEP_CHECK_DEATH(2 SECONDS)
+	M.gib()
+	to_chat(user, span_nicegreen("[src] is satisfied by your offering!"))
+	satisfied = TRUE
+	hunger += 4
+	playsound(get_turf(src),'sound/abnormalities/doomsdaycalendar/Limbus_Dead_Generic.ogg', 50, 1)
 
 /mob/living/simple_animal/hostile/abnormality/fetus/ZeroQliphoth(mob/living/carbon/human/user)
 	if(satisfied)

--- a/code/modules/mob/living/simple_animal/abnormality/he/nameless_fetus.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/nameless_fetus.dm
@@ -32,12 +32,13 @@
 	var/satisfied = FALSE
 	var/hunger = 0
 	var/crying = FALSE
+	var/cry_amount = 0
 
 //Work-related
 /mob/living/simple_animal/hostile/abnormality/fetus/WorkChance(mob/living/carbon/human/user, chance, work_type) //Insight work has a qliphoth-based success rate
 	var/chance_modifier = 0
 	if(satisfied)
-		chance_modifier = 40//4 100% instict works might be too powerful
+		chance_modifier = 30//4 90% instict works might be too powerful
 	return chance + chance_modifier
 
 /mob/living/simple_animal/hostile/abnormality/fetus/PostWorkEffect(mob/living/carbon/human/user, work_type, pe)
@@ -87,6 +88,7 @@
 		satisfied = TRUE
 		hunger += 12 //Ehh might as well triple the effects of it being fed if you have to die.
 		crying = FALSE
+		cry_amount = 0
 		return
 
 	addtimer(CALLBACK(src, PROC_REF(check_range)), 2 SECONDS)
@@ -95,7 +97,14 @@
 /mob/living/simple_animal/hostile/abnormality/fetus/proc/check_players()
 	if(datum_reference.qliphoth_meter == 1)
 		return
-
+	if(cry_amount >= 20)//Fetus really should stop crying after a while and Kirie said she wanted it to cry 20 times before stoping.
+		for(var/mob/living/carbon/human/H in GLOB.player_list)
+			to_chat(H, span_userdanger("The creature stoped crying."))
+		notify_ghosts("The nameless fetus stop crying.", source = src, action = NOTIFY_ORBIT, header="Something Interesting!") // bless this mess
+		datum_reference.qliphoth_change(1)
+		cry_amount = 0
+		crying = FALSE
+		return
 	//Find a living player, they're the new target.
 	var/list/checking = list()
 	for(var/mob/living/carbon/human/H in GLOB.player_list)
@@ -107,7 +116,8 @@
 		//and make a global announce
 		for(var/mob/living/carbon/human/H in GLOB.player_list)
 			to_chat(H, span_userdanger("The fetus calls out for [calling.real_name]."))
-
+		//also adds 1 to the cry amount
+		cry_amount += 1
 		notify_ghosts("The fetus calls out for [calling.real_name].", source = src, action = NOTIFY_ORBIT, header="Something Interesting!") // bless this mess
 
 	var/list/qliphoth_abnos = list()

--- a/code/modules/mob/living/simple_animal/abnormality/he/nameless_fetus.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/nameless_fetus.dm
@@ -27,6 +27,7 @@
 	)
 	gift_type =  /datum/ego_gifts/syrinx
 	abnormality_origin = ABNORMALITY_ORIGIN_LOBOTOMY
+	can_buckle = TRUE
 	var/mob/living/carbon/human/calling = null
 	var/satisfied = FALSE
 	var/hunger = 0
@@ -36,7 +37,7 @@
 /mob/living/simple_animal/hostile/abnormality/fetus/WorkChance(mob/living/carbon/human/user, chance, work_type) //Insight work has a qliphoth-based success rate
 	var/chance_modifier = 0
 	if(satisfied)
-		chance_modifier = 40
+		chance_modifier = 40//4 100% instict works might be too powerful
 	return chance + chance_modifier
 
 /mob/living/simple_animal/hostile/abnormality/fetus/PostWorkEffect(mob/living/carbon/human/user, work_type, pe)
@@ -48,11 +49,11 @@
 				to_chat(H, span_userdanger("The creature grew hungry!"))
 
 /mob/living/simple_animal/hostile/abnormality/fetus/user_buckle_mob(mob/living/M, mob/user, check_loc)
-	if(!IsContained() || user == src || !ishuman(M) || (GODMODE in M.status_flags))
+	if(crying || user == src || !ishuman(M) || (GODMODE in M.status_flags))
 		return FALSE
 		to_chat(user, span_warning("[src] rejects your offering!"))
 	. = ..()
-	to_chat(user, span_userdanger("The Woodsman swings his axe down and...!"))
+	to_chat(user, span_userdanger("The fetus opens its maw and...!"))
 	SLEEP_CHECK_DEATH(2 SECONDS)
 	M.gib()
 	to_chat(user, span_nicegreen("[src] is satisfied by your offering!"))
@@ -66,7 +67,7 @@
 		hunger = 0
 		datum_reference.qliphoth_change(1)
 		for(var/mob/living/carbon/human/H in GLOB.player_list)
-			to_chat(H, span_userdanger("The creature grew hungry!"))
+			to_chat(H, span_userdanger("The fetus grew hungry!"))
 	else
 		crying = TRUE
 		check_players()

--- a/code/modules/mob/living/simple_animal/abnormality/he/nameless_fetus.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/nameless_fetus.dm
@@ -28,10 +28,49 @@
 	gift_type =  /datum/ego_gifts/syrinx
 	abnormality_origin = ABNORMALITY_ORIGIN_LOBOTOMY
 	var/mob/living/carbon/human/calling = null
+	var/satisfied = FALSE
+	var/hunger = 0
+	var/crying = FALSE
+
+//Work-related
+/mob/living/simple_animal/hostile/abnormality/fetus/WorkChance(mob/living/carbon/human/user, chance, work_type) //Insight work has a qliphoth-based success rate
+	var/chance_modifier = 0
+	if(satisfied)
+		chance_modifier = 40
+	return chance + chance_modifier
+
+/mob/living/simple_animal/hostile/abnormality/fetus/PostWorkEffect(mob/living/carbon/human/user, work_type, pe)
+	if(satisfied)
+		hunger--
+		if(hunger <= 0)
+			satisfied = FALSE
+			for(var/mob/living/carbon/human/H in GLOB.player_list)
+				to_chat(H, span_userdanger("The creature grew hungry!"))
+
+/mob/living/simple_animal/hostile/abnormality/fetus/user_buckle_mob(mob/living/M, mob/user, check_loc)
+	if(M.stat != DEAD)
+		return FALSE
+	if(do_after(user, 20, target = M))
+		if(!ishuman(M) || crying)
+			to_chat(user, span_warning("[src] rejects your offering!"))
+			return
+		to_chat(user, span_nicegreen("[src] is satisfied by your offering!"))
+		M.gib()
+		satisfied = TRUE
+		hunger += 4
+		playsound(get_turf(src),'sound/abnormalities/doomsdaycalendar/Limbus_Dead_Generic.ogg', 50, 1)
 
 /mob/living/simple_animal/hostile/abnormality/fetus/ZeroQliphoth(mob/living/carbon/human/user)
-	check_players()
-	check_range()
+	if(satisfied)
+		satisfied = FALSE
+		hunger = 0
+		datum_reference.qliphoth_change(1)
+		for(var/mob/living/carbon/human/H in GLOB.player_list)
+			to_chat(H, span_userdanger("The creature grew hungry!"))
+	else
+		crying = TRUE
+		check_players()
+		check_range()
 
 	//Are they nearby?
 /mob/living/simple_animal/hostile/abnormality/fetus/proc/check_range()
@@ -44,6 +83,9 @@
 
 		notify_ghosts("The nameless fetus is satisfied.", source = src, action = NOTIFY_ORBIT, header="Something Interesting!") // bless this mess
 		datum_reference.qliphoth_change(1)
+		satisfied = TRUE
+		hunger += 12 //Ehh might as well triple the effects of it being fed if you have to die.
+		crying = FALSE
 		return
 
 	addtimer(CALLBACK(src, PROC_REF(check_range)), 2 SECONDS)

--- a/code/modules/paperwork/records/info/he.dm
+++ b/code/modules/paperwork/records/info/he.dm
@@ -336,6 +336,8 @@
 	abno_info = list(
 		"When the work result was Normal, the Qliphoth Counter lowered with a low probability.",
 		"When the work result was Bad, the Qliphoth Counter lowered with a high probability.",
+		"Nameless Fetus can be fed corpses to temporarily satisfy it for a few works.",
+		"While satisfied, Nameless Fetus' work rates were increased and wouldn't cry when the Qliphoth Counter reached 0.",
 		"When the Qliphoth Counter reached 0, Nameless Fetus began crying. Employees who heard its wails complained of a headache. Furthermore, the Qliphoth Counters of all nearby Abnormalities gradually decreased over time.",
 		"While Nameless Fetus was in a crying state, the designated agent must approach it. After a moment of turmoil, the crying stopped.")
 

--- a/code/modules/projectiles/guns/ego_gun/he.dm
+++ b/code/modules/projectiles/guns/ego_gun/he.dm
@@ -266,9 +266,9 @@
 	special = "This weapon fires slow bullets with limited range."
 	ammo_type = /obj/item/ammo_casing/caseless/ego_syrinx
 	weapon_weight = WEAPON_HEAVY
-	spread = 40
+	spread = 30
 	fire_sound = 'sound/weapons/ego/ecstasy.ogg'
-	autofire = 0.08 SECONDS
+	autofire = 0.12 SECONDS
 	attribute_requirements = list(
 							PRUDENCE_ATTRIBUTE = 40
 	)

--- a/code/modules/projectiles/guns/ego_gun/he.dm
+++ b/code/modules/projectiles/guns/ego_gun/he.dm
@@ -268,7 +268,7 @@
 	weapon_weight = WEAPON_HEAVY
 	spread = 30
 	fire_sound = 'sound/weapons/ego/ecstasy.ogg'
-	autofire = 0.12 SECONDS
+	autofire = 0.06 SECONDS
 	attribute_requirements = list(
 							PRUDENCE_ATTRIBUTE = 40
 	)

--- a/code/modules/projectiles/projectile/ego_bullets/he.dm
+++ b/code/modules/projectiles/projectile/ego_bullets/he.dm
@@ -133,6 +133,6 @@
 	icon_state = "ecstasy"
 	damage_type = WHITE_DAMAGE
 	color = COLOR_GREEN
-	damage = 7
+	damage = 5
 	speed = 1.3
-	range = 6
+	range = 7

--- a/code/modules/projectiles/projectile/ego_bullets/he.dm
+++ b/code/modules/projectiles/projectile/ego_bullets/he.dm
@@ -133,6 +133,6 @@
 	icon_state = "ecstasy"
 	damage_type = WHITE_DAMAGE
 	color = COLOR_GREEN
-	damage = 5
+	damage = 7
 	speed = 1.3
 	range = 7


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Does many changes to fetus and its gun.
Fetus now stop crying after 20 times. I also gave it a silly gimmick that I might remove which is allow you to feed it corpses to boost work rates for a few works and allow it to not cry if its counter goes to 0 one time before needing more corpses.

Gun now has different stats to currents gun.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Kirie wanted fetus to stop crying after 20 times so I added it. Gives fetus a silly gimmick. The gun was currents gun stat wise for he.
## Changelog
:cl:
balance: rebalanced fetus and its gun
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
