### PR TITLE
Turn Ecstasy into a one-handed weapon instead of a two-handed one

### DIFF
--- a/code/modules/projectiles/guns/ego_gun/waw.dm
+++ b/code/modules/projectiles/guns/ego_gun/waw.dm
@@ -203,7 +203,7 @@
 							JUSTICE_ATTRIBUTE = 60
 	)
 
-/obj/item/gun/ego_gun/ecstasy
+/obj/item/gun/pistol/ecstasy
 	name = "ecstasy"
 	desc = "Tell the kid today's treat is going to be grape-flavored candy. It's his favorite."
 	icon_state = "ecstasy"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Turns ecstasy from a 2hand into a 1hand

## Why It's Good For The Game

WHY DOES ECSTASY HAVE A 1-HANDED SPRITE BUT USE 2 HANDS, ITS STUPID

## Changelog
:cl:

tweak: tweaked a few things

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
