### PR TITLE
Makes knockback a variable on all EGO weapons, attack_speed variable clean up and correcting bad descriptions

### DIFF
--- a/code/__DEFINES/~lobotomy_defines/weapon.dm
+++ b/code/__DEFINES/~lobotomy_defines/weapon.dm
@@ -1,0 +1,4 @@
+// Knockback defines
+#define KNOCKBACK_LIGHT (1<<0)
+#define KNOCKBACK_MEDIUM (1<<1)
+#define KNOCKBACK_HEAVY (1<<2)

--- a/code/game/objects/items/ego_weapons/_ego_weapon.dm
+++ b/code/game/objects/items/ego_weapons/_ego_weapon.dm
@@ -64,19 +64,6 @@
 	if(throwforce>force)
 		. += span_notice("This weapon deals [throwforce] [damtype] damage when thrown.")
 
-	switch(knockback)
-		if(KNOCKBACK_LIGHT)
-			. += span_notice("This weapon has slight enemy knockback.")
-
-		if(KNOCKBACK_MEDIUM)
-			. += span_notice("This weapon has decent enemy knockback.")
-
-		if(KNOCKBACK_HEAVY)
-			. += span_notice("This weapon has neck-snapping enemy knockback.")
-
-		else
-			. += span_notice("This weapon has [knockback >= 10 ? "neck-snapping": ""] enemy knockback.")
-
 	switch(attack_speed)
 		if(-INFINITY to 0.39)
 			. += span_notice("This weapon has a very fast attack speed.")
@@ -99,6 +86,22 @@
 
 		if(2 to INFINITY)
 			. += span_notice("This weapon attacks extremely slow.")
+
+	if(!knockback)
+		return
+
+	switch(knockback)
+		if(KNOCKBACK_LIGHT)
+			. += span_notice("This weapon has slight enemy knockback.")
+
+		if(KNOCKBACK_MEDIUM)
+			. += span_notice("This weapon has decent enemy knockback.")
+
+		if(KNOCKBACK_HEAVY)
+			. += span_notice("This weapon has neck-snapping enemy knockback.")
+
+		else
+			. += span_notice("This weapon has [knockback >= 10 ? "neck-snapping": ""] enemy knockback.")
 
 /obj/item/ego_weapon/Topic(href, href_list)
 	. = ..()

--- a/code/game/objects/items/ego_weapons/_ego_weapon.dm
+++ b/code/game/objects/items/ego_weapons/_ego_weapon.dm
@@ -42,9 +42,8 @@
 		if(KNOCKBACK_HEAVY) // neck status: snapped
 			target.throw_at(throw_target, 7, 7, user)
 
-		else
-			knockback = FALSE // lets not repeat the error
-			CRASH("Invalid value ([knockback]) provided to the knockback variable on the ego weapon [src]")
+		else // should only be used by admins messing around in-game, please consider using above variables as a coder
+			target.throw_at(throw_target, (knockback * 0.5) , knockback, user)
 
 	return TRUE
 
@@ -67,13 +66,16 @@
 
 	switch(knockback)
 		if(KNOCKBACK_LIGHT)
-			. += span_notice("This weapon has slight enemy knockback")
+			. += span_notice("This weapon has slight enemy knockback.")
 
 		if(KNOCKBACK_MEDIUM)
 			. += span_notice("This weapon has decent enemy knockback.")
 
 		if(KNOCKBACK_HEAVY)
-			. += span_notice("This weapon has a neck-snapping enemy knockback.")
+			. += span_notice("This weapon has neck-snapping enemy knockback.")
+
+		else
+			. += span_notice("This weapon has [knockback >= 10 ? "neck-snapping": ""] enemy knockback.")
 
 	switch(attack_speed)
 		if(-INFINITY to 0.39)
@@ -86,6 +88,7 @@
 			. += span_notice("This weapon attacks slightly faster than normal.")
 
 		if(1) // why
+			attack_speed = FALSE
 			CRASH("[src] has a unique attack speed variable that does nothing, please inform coders to delete the variable")
 
 		if(1.01 to 1.49)

--- a/code/game/objects/items/ego_weapons/he.dm
+++ b/code/game/objects/items/ego_weapons/he.dm
@@ -222,27 +222,17 @@
 /obj/item/ego_weapon/christmas
 	name = "christmas"
 	desc = "With my infinite hatred, I give you this gift."
-	special = "This weapon has knockback."
 	icon_state = "christmas"
 	force = 54	//Still lower DPS
 	attack_speed = 2
 	damtype = WHITE_DAMAGE
+	knockback = KNOCKBACK_LIGHT
 	attack_verb_continuous = list("bashes", "clubs")
 	attack_verb_simple = list("bashes", "clubs")
 	hitsound = 'sound/weapons/fixer/generic/club1.ogg'
 	attribute_requirements = list(
 							FORTITUDE_ATTRIBUTE = 40
 							)
-
-/obj/item/ego_weapon/christmas/attack(mob/living/target, mob/living/user)
-	. = ..()
-	if(!.)
-		return FALSE
-	var/atom/throw_target = get_edge_target_turf(target, user.dir)
-	if(!target.anchored)
-		var/whack_speed = (prob(60) ? 1 : 4)
-		target.throw_at(throw_target, rand(1, 2), whack_speed, user)
-
 /obj/item/ego_weapon/logging
 	name = "logging"
 	desc = "A versatile equipment made to cut down trees and people alike."

--- a/code/game/objects/items/ego_weapons/special.dm
+++ b/code/game/objects/items/ego_weapons/special.dm
@@ -103,14 +103,12 @@
 		return FALSE
 
 /obj/item/ego_weapon/lance/famiglia/attack(mob/living/target, mob/living/user)
-	if(!CanUseEgo(user))
-		return
-	. = ..()
 	if(raised)
-		var/atom/throw_target = get_edge_target_turf(target, user.dir)
-		if(!target.anchored)
-			var/whack_speed = (prob(60) ? 1 : 4)
-			target.throw_at(throw_target, rand(1, 2), whack_speed, user)
+		knockback = KNOCKBACK_LIGHT
+	else
+		knockback = FALSE
+
+	return ..()
 
 /obj/item/ego_weapon/lance/famiglia/LowerLance(mob/user)
 	hitsound = 'sound/weapons/ego/spear1.ogg'

--- a/code/game/objects/items/ego_weapons/teth.dm
+++ b/code/game/objects/items/ego_weapons/teth.dm
@@ -58,23 +58,14 @@
 /obj/item/ego_weapon/eyes
 	name = "red eyes"
 	desc = "It is likely able to hear, touch, smell, as well as see. And most importantly, taste."
-	special = "Knocks certain enemies backwards."
 	icon_state = "eyes"
-	force = 35					//Still less DPS, replaces baseball bat
+	force = 35 //Still less DPS, replaces baseball bat
 	attack_speed = 1.6
 	damtype = RED_DAMAGE
+	knockback = KNOCKBACK_LIGHT
 	attack_verb_continuous = list("beats", "smacks")
 	attack_verb_simple = list("beat", "smack")
 	hitsound = 'sound/weapons/fixer/generic/gen1.ogg'
-
-/obj/item/ego_weapon/eyes/attack(mob/living/target, mob/living/user)
-	. = ..()
-	if(!.)
-		return FALSE
-	var/atom/throw_target = get_edge_target_turf(target, user.dir)
-	if(!target.anchored)
-		var/whack_speed = (prob(60) ? 1 : 4)
-		target.throw_at(throw_target, rand(1, 2), whack_speed, user)
 
 /obj/item/ego_weapon/mini/wrist
 	name = "wrist cutter"
@@ -531,23 +522,14 @@
 /obj/item/ego_weapon/sanitizer
 	name = "sanitizer"
 	desc = "It's very shocking."
-	special = "Knocks certain enemies backwards."
 	icon_state = "sanitizer"
-	force = 35					//Still less DPS, replaces baseball bat
+	force = 35 //Still less DPS, replaces baseball bat?
 	attack_speed = 1.6
 	damtype = BLACK_DAMAGE
+	knockback = KNOCKBACK_LIGHT
 	attack_verb_continuous = list("beats", "smacks")
 	attack_verb_simple = list("beat", "smack")
 	hitsound = 'sound/weapons/fixer/generic/gen1.ogg'
-
-/obj/item/ego_weapon/sanitizer/attack(mob/living/target, mob/living/user)
-	. = ..()
-	if(!.)
-		return FALSE
-	var/atom/throw_target = get_edge_target_turf(target, user.dir)
-	if(!target.anchored)
-		var/whack_speed = (prob(60) ? 1 : 4)
-		target.throw_at(throw_target, rand(1, 2), whack_speed, user)
 
 /obj/item/ego_weapon/lance/curfew
 	name = "curfew"

--- a/lobotomy-corp13.dme
+++ b/lobotomy-corp13.dme
@@ -153,6 +153,7 @@
 #include "code\__DEFINES\dcs\signals_fish.dm"
 #include "code\__DEFINES\research\anomalies.dm"
 #include "code\__DEFINES\~lobotomy_defines\adventure.dm"
+#include "code\__DEFINES\~lobotomy_defines\weapon.dm"
 #include "code\__HELPERS\_lists.dm"
 #include "code\__HELPERS\_logging.dm"
 #include "code\__HELPERS\_string_lists.dm"


### PR DESCRIPTION
## About The Pull Request

- `knockback` is now a variable on all EGO weapons

- `attack_speed` is now a switch instead of a million if else() statements in the examine text

- Removes `return FALSE`, replacing it with `return` on some pieces of code

- Replaces the "Knocks certain enemies backwards" special knockback descriptions as a side effect of point 1, correcting the "certain enemies" part accidentally

- Changes the oberon's attacks to throw people shorter distances, but at a faster speed as a consequence of making knockbacks standard, this is the only knockback that was not in-line with others

## Why It's Good For The Game

>`knockback` is now a variable on all EGO weapons
- This allows us to do less copy-paste code and admins can set knockback on any EGO weapon they desire (this can't possibly go wrong, can it?)

>`attack_speed` is now a switch instead of a million if else() statements in the examine text
- It was supposed to be a switch, but nobody knew how to make one in the original PR and then everyone forgot about it

>Removes `return FALSE`, replacing it with `return` on some pieces of code
- return FALSE only matters for children of objects, really. and i dont think we are going to make children of EGO weapons

## Changelog
:cl:
admin: admins can now set knockback on ego weapons to any value they desire by editing the "knockback" variable
/:cl:
