### PR TITLE
Adventure console exchange shop and tweaks

### DIFF
--- a/ModularTegustation/_adventure_console/adventure_layout.dm
+++ b/ModularTegustation/_adventure_console/adventure_layout.dm
@@ -3,6 +3,11 @@
  * Adventures that are mostly predefined paths.
  * This was difficult to finalize since i havent made a text based adventure before.
  * Special defines such as button macros are in the code/_DEFINES/~lobotomy_defines.dm
+ *
+ * The way i made this system is unusual to say the least. Its a stand alone datum that
+ * is vaguely connected to the console that created it. While this does make the program
+ * portable it also makes it so that when the console is destroyed there is just a datum
+ * floating around in the code. Unsure how bad this is. -IP
  */
 
 /datum/adventure_layout
@@ -58,6 +63,21 @@
 		"<b>Recorded Rat</b>:A low life from the backstreets. Their face is disfigured beyond recognition, all you can make out are their eyes.<br>",
 		"<b>Digital Reflection</b>:Its you! Well it looks LIKE you.<br>",
 	)
+	/*
+	* Exchange shop for digital coins. The only other use for coins is during events
+	* where you want to increase your chance of success in a event or have a unique
+	* interaction. For defeating enemeies the calculation for coins rewarded is
+	* enemy_coin = round((sides of damage die * amount of damage die)/5)
+	* this means that enemies that deal 1d5 damage will grant 1 coin. theoretically
+	* beelining enemy encounters will result in about 5 coins before the user is
+	* defeated. -IP
+	*/
+	var/list/exchange_shop_list = list(
+		new /datum/data/extraction_cargo("SNAP POP	",	/obj/item/toy/snappop,			10) = 1,
+		new /datum/data/extraction_cargo("CAT TOY	",	/obj/item/toy/cattoy,			15) = 1,
+		new /datum/data/extraction_cargo("CHILDRENS TOY",/obj/item/toy/prize/ripley,	20) = 1,
+		new /datum/data/extraction_cargo("HOURGLASS",	/obj/item/hourglass,			25) = 1,
+	)
 
 /datum/adventure_layout/New(set_debug_menu = FALSE)
 	. = ..()
@@ -99,7 +119,7 @@
 			|ENVY:[virtual_stats[ENVY_STAT]]|<br>\
 			</tt>"
 		//From highest menu define to lowest. -IP
-		for(var/mode_option = NORMAL_TEXT_DISPLAY to ADVENTURE_TEXT_DISPLAY)
+		for(var/mode_option = NORMAL_TEXT_DISPLAY to EXCHANGE_TEXT_DISPLAY)
 			. += "<A href='byond://?src=[REF(caller)];set_display=[mode_option]'>[mode_option == display_mode ? "<b><u>[nameMenu(mode_option)]</u></b>" : "[nameMenu(mode_option)]"]</A>"
 		if(debug_menu)
 			. += "<A href='byond://?src=[REF(caller)];set_display=[DEBUG_TEXT_DISPLAY]'>[display_mode == DEBUG_TEXT_DISPLAY ? "<b><u>[nameMenu(DEBUG_TEXT_DISPLAY)]</u></b>" : "[nameMenu(DEBUG_TEXT_DISPLAY)]"]</A>"
@@ -158,6 +178,15 @@
 
 		if(ADVENTURE_TEXT_DISPLAY)
 			. += "[TravelUI(interfacer)]"
+
+		if(EXCHANGE_TEXT_DISPLAY)
+			. += "COIN EXCHANGE <br> \
+				<tt>--------------------| </tt><br>\
+				PHYSICAL_MERCHANDISE<br>"
+			//Code taken from fish_market.dm
+			for(var/datum/data/extraction_cargo/A in exchange_shop_list)
+				. += " <A href='byond://?src=[REF(interfacer)];purchase=[REF(A)]'>[A.equipment_name]([A.cost] Points)</A><br>"
+			. += "<tt>--------------------| </tt><br>"
 
 /datum/adventure_layout/proc/TravelUI(obj/machinery/call_machine)
 	switch(travel_mode)
@@ -404,28 +433,30 @@
 //for each catagory please place the number its defined as -IP
 /datum/adventure_layout/proc/nameMenu(cat)
 	switch(cat)
-		if(1)
+		if(DEBUG_TEXT_DISPLAY)
 			return "CHOOSE EVENT"
-		if(2)
+		if(NORMAL_TEXT_DISPLAY)
 			return "MAIN MENU"
-		if(3)
+		if(ADVENTURE_TEXT_DISPLAY)
 			return "ADVENTURE"
+		if(EXCHANGE_TEXT_DISPLAY)
+			return "COIN SHOP"
 
 /datum/adventure_layout/proc/nameStat(stat_named)
 	switch(stat_named)
-		if(1)
+		if(WRATH_STAT)
 			return "WRATH"
-		if(2)
+		if(LUST_STAT)
 			return "LUST"
-		if(3)
+		if(SLOTH_STAT)
 			return "SLOTH"
-		if(4)
+		if(GLUTT_STAT)
 			return "GLUTT"
-		if(5)
+		if(GLOOM_STAT)
 			return "GLOOM"
-		if(6)
+		if(PRIDE_STAT)
 			return "PRIDE"
-		if(7)
+		if(ENVY_STAT)
 			return "ENVY"
 
 //Recover Health based on time. I may scrap this because the thought of mobile game stamina makes me feel sick -IP

--- a/code/__DEFINES/~lobotomy_defines/adventure.dm
+++ b/code/__DEFINES/~lobotomy_defines/adventure.dm
@@ -3,6 +3,7 @@
 #define DEBUG_TEXT_DISPLAY 1
 #define NORMAL_TEXT_DISPLAY 2
 #define ADVENTURE_TEXT_DISPLAY 3
+#define EXCHANGE_TEXT_DISPLAY 4
 
 //Modes for what is displayed on the adventure panel.
 #define ADVENTURE_MODE_TRAVEL 1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The new shop menu where users can spend those goofy coins they earn during gameplay to buy material things. Right now its just toys like binoculars and snap pops. 

Due to this shop thing and the sudden thought that someone could "make all 5 profiles and easily access and apply passwords to all of them making the console useless to anyone else" i have now made the first profile made be a public profile that anyone can access. EO can make the second profile and password protect that.

Changed sound effect to pressing travel buttons since the constant confirm sound while spamming movement felt annoying.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The shop was requested by kirie so that more substantial rewards can be added to the console. Right now the console only has toys and such. 

## Changelog
:cl:
add: adventure console coin shop menu
add: public profile
tweak: changed the statName and windowName variables from numbers to defines for easier manipulation.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
