### PR TITLE
Gacha is now always worth it + better odds on some crates + rcorp addition

### DIFF
--- a/ModularTegustation/tegu_items/refinery/crates/_crate.dm
+++ b/ModularTegustation/tegu_items/refinery/crates/_crate.dm
@@ -24,9 +24,11 @@
 	)
 
 	var/rareloot =	list(/obj/item/toy/plush/dante)
-	var/veryrareloot =	list()	//Only Kcorp uses these atm, because It's important that they have 3 tiers of weapons
+	var/veryrareloot =	list()
 	var/rarechance = 20
 	var/veryrarechance
+	var/cosmeticloot = list()
+	var/cosmeticchance = 33 //These do not count on the total odds of a crate
 
 /obj/structure/lootcrate/Initialize()
 	..()
@@ -36,6 +38,7 @@
 /obj/structure/lootcrate/attackby(obj/item/I, mob/living/user, params)
 	..()
 	var/loot
+	var/cloot
 	if(I.tool_behaviour != TOOL_CROWBAR)
 		return
 
@@ -51,6 +54,10 @@
 
 	else
 		loot = pick(lootlist)
+
+	if(cosmeticchance && prob(cosmeticchance))
+		cloot = pick(cosmeticloot)
+		new cloot(get_turf(src))
 
 	to_chat(user, span_notice("You open the crate!"))
 	new loot(get_turf(src))

--- a/ModularTegustation/tegu_items/refinery/crates/association.dm
+++ b/ModularTegustation/tegu_items/refinery/crates/association.dm
@@ -190,6 +190,7 @@
 	name = "Liu Association Crate"
 	desc = "A crate recieved from the liu association. Open with a Crowbar."
 	icon_state = "crate_liu"
+	rarechance = 20
 	lootlist =	list(
 		/obj/item/clothing/suit/armor/ego_gear/city/liu,
 		/obj/item/clothing/suit/armor/ego_gear/city/liu/section5,

--- a/ModularTegustation/tegu_items/refinery/crates/corporation.dm
+++ b/ModularTegustation/tegu_items/refinery/crates/corporation.dm
@@ -120,11 +120,18 @@
 	rareloot =	list(
 		/obj/item/ego_weapon/city/rabbit_blade,
 		/obj/item/ego_weapon/city/reindeer,
+		/obj/item/gun/energy/e_gun/rabbitdash/sniper,
+		/obj/item/gun/energy/e_gun/rabbitdash/laser,
+		/obj/item/gun/energy/e_gun/rabbitdash/heavy,
+		/obj/item/gun/energy/e_gun/rabbitdash/small,
+		/obj/item/gun/energy/e_gun/rabbitdash/shotgun,
 	)
 
 	veryrareloot =	list(
 		/obj/item/ego_weapon/city/rabbit_blade/command,
 		/obj/item/ego_weapon/city/reindeer/captain,
+		/obj/item/gun/energy/e_gun/rabbit/minigun,
+		/obj/item/gun/energy/e_gun/rabbit/nopin,
 	)
 
 	cosmeticloot = list(

--- a/ModularTegustation/tegu_items/refinery/crates/corporation.dm
+++ b/ModularTegustation/tegu_items/refinery/crates/corporation.dm
@@ -65,7 +65,7 @@
 
 	cosmeticloot = list(
 		/obj/item/toy/plush/bongy,
-		/obj/item/clothing/suit/armor/ego_gear/city/kcorp_sci
+		/obj/item/clothing/suit/armor/ego_gear/city/kcorp_sci,
 	)
 //N Corporation
 /obj/structure/lootcrate/n_corp
@@ -122,7 +122,7 @@
 		/obj/item/ego_weapon/city/reindeer,
 	)
 
-	veryrareloot =	list(\
+	veryrareloot =	list(
 		/obj/item/ego_weapon/city/rabbit_blade/command,
 		/obj/item/ego_weapon/city/reindeer/captain,
 	)
@@ -188,7 +188,7 @@
 		/obj/item/ego_weapon/city/charge/wcorp/shield/axe,
 	)
 
-cosmeticloot = list(
+	cosmeticloot = list(
 		/obj/item/clothing/head/ego_hat/wcorp,
 		/obj/item/clothing/under/suit/lobotomy/wcorp,
 	)

--- a/ModularTegustation/tegu_items/refinery/crates/corporation.dm
+++ b/ModularTegustation/tegu_items/refinery/crates/corporation.dm
@@ -39,7 +39,8 @@
 	desc = "A crate recieved from K-Corp. Open with a Crowbar."
 	icon_state = "crate_kcorp"
 	rarechance = 30
-	veryrarechance = 5
+	veryrarechance = 10
+	cosmeticchance = 5
 	lootlist =	list(
 		/obj/item/managerbullet,
 		/obj/item/ksyringe,
@@ -54,7 +55,6 @@
 	)
 
 	veryrareloot =	list(
-		/obj/item/clothing/suit/armor/ego_gear/city/kcorp_sci,
 		/obj/item/ego_weapon/city/kcorp/spear,
 		/obj/item/ego_weapon/city/kcorp/dspear,
 		/obj/item/gun/ego_gun/pistol/kcorp/smg,
@@ -63,7 +63,10 @@
 		/obj/item/toy/plush/bongy,
 	)
 
-
+	cosmeticloot = list(
+		/obj/item/toy/plush/bongy,
+		/obj/item/clothing/suit/armor/ego_gear/city/kcorp_sci
+	)
 //N Corporation
 /obj/structure/lootcrate/n_corp
 	name = "N Corp Crate"
@@ -107,27 +110,30 @@
 	icon_state = "crate_rcorp"
 	veryrarechance = 5
 	lootlist =	list(
-		/obj/item/clothing/under/suit/lobotomy/rabbit,
 		/obj/item/powered_gadget/detector_gadget/ordeal,
-		/obj/item/toy/plush/myo,
-		/obj/item/toy/plush/rabbit,
 		/obj/item/clothing/suit/space/hardsuit/rabbit,
 		/obj/item/clothing/suit/space/hardsuit/rabbit/leader,
 		/obj/item/gun/energy/e_gun/rabbitdash,
 		/obj/item/ego_weapon/city/rabbit_rush,
-		/obj/item/clothing/under/suit/lobotomy/rcorp_command,
 	)
 
 	rareloot =	list(
 		/obj/item/ego_weapon/city/rabbit_blade,
 		/obj/item/ego_weapon/city/reindeer,
-		/obj/item/clothing/head/beret/tegu/rcorp,
-		/obj/item/clothing/neck/cloak/rcorp,
 	)
 
-	veryrareloot =	list(
+	veryrareloot =	list(\
 		/obj/item/ego_weapon/city/rabbit_blade/command,
 		/obj/item/ego_weapon/city/reindeer/captain,
+	)
+
+	cosmeticloot = list(
+		/obj/item/clothing/under/suit/lobotomy/rabbit,
+		/obj/item/toy/plush/myo,
+		/obj/item/toy/plush/rabbit,
+		/obj/item/clothing/under/suit/lobotomy/rcorp_command,
+		/obj/item/clothing/head/beret/tegu/rcorp,
+		/obj/item/clothing/neck/cloak/rcorp,
 	)
 
 //S Corporation
@@ -157,10 +163,11 @@
 	name = "W Corp Crate"
 	desc = "A crate recieved from W-Corp. Open with a Crowbar."
 	icon_state = "crate_wcorp"
+	rarechance = 30
+	veryrarechance = 15
+	cosmeticchance = 25
 	lootlist =	list(
 		/obj/item/ego_weapon/city/charge/wcorp,
-		/obj/item/clothing/head/ego_hat/wcorp,
-		/obj/item/clothing/under/suit/lobotomy/wcorp,
 		/obj/item/clothing/suit/armor/ego_gear/wcorp,
 		/obj/item/powered_gadget/teleporter,
 	)
@@ -172,8 +179,16 @@
 		/obj/item/ego_weapon/city/charge/wcorp/dagger,
 		/obj/item/ego_weapon/city/charge/wcorp/hammer,
 		/obj/item/ego_weapon/city/charge/wcorp/hatchet,
+	)
+
+	veryrareloot = list(
 		/obj/item/ego_weapon/city/charge/wcorp/shield,
 		/obj/item/ego_weapon/city/charge/wcorp/shield/spear,
 		/obj/item/ego_weapon/city/charge/wcorp/shield/club,
 		/obj/item/ego_weapon/city/charge/wcorp/shield/axe,
+	)
+
+cosmeticloot = list(
+		/obj/item/clothing/head/ego_hat/wcorp,
+		/obj/item/clothing/under/suit/lobotomy/wcorp,
 	)

--- a/ModularTegustation/tegu_items/refinery/crates/misc.dm
+++ b/ModularTegustation/tegu_items/refinery/crates/misc.dm
@@ -3,7 +3,8 @@
 	name = "Limbus Company Crate"
 	desc = "A crate recieved from limbus company. Open with a Crowbar."
 	icon_state = "crate_lcb"
-	rarechance = 10
+	rarechance = 15
+	cosmeticchance = 25
 	lootlist =	list(
 		/obj/item/ego_weapon/mini/hayong,
 		/obj/item/ego_weapon/shield/walpurgisnacht,
@@ -20,10 +21,6 @@
 		/obj/item/ego_weapon/ungezifer,
 		/obj/item/clothing/suit/armor/ego_gear/limbus/limbus_coat,
 		/obj/item/clothing/suit/armor/ego_gear/limbus/limbus_coat_short,
-		/obj/item/clothing/under/limbus/shirt,
-		/obj/item/clothing/accessory/limbusvest,
-		/obj/item/clothing/under/limbus/prison,
-		/obj/item/clothing/neck/limbus_tie,
 	)
 
 	rareloot =	list(
@@ -34,6 +31,12 @@
 		/obj/item/clothing/suit/armor/ego_gear/limbus/ego/branch,
 	)
 
+	cosmeticloot = list(
+		/obj/item/clothing/under/limbus/shirt,
+		/obj/item/clothing/accessory/limbusvest,
+		/obj/item/clothing/under/limbus/prison,
+		/obj/item/clothing/neck/limbus_tie,
+	)
 /obj/structure/lootcrate/money
 	name = "Money Crate"
 	desc = "You think there's ahn in here. Open with a Crowbar."

--- a/ModularTegustation/tegu_items/refinery/crates/workshop.dm
+++ b/ModularTegustation/tegu_items/refinery/crates/workshop.dm
@@ -38,7 +38,7 @@
 	name = "allas workshop crate"
 	desc = "A crate recieved from the city workshop. Open with a Crowbar."
 	icon_state = "crate_allas"
-	rarechance = 20
+	rarechance = 25
 	veryrarechance = 1
 	lootlist =	list(
 		/obj/item/ego_weapon/city/fixerblade,
@@ -69,7 +69,7 @@
 	desc = "A crate recieved from the city workshop. Open with a Crowbar."
 	icon_state = "crate_zelkova"
 	veryrarechance = 20	//20% chance for rare stuff
-	rarechance = 50	//40% chance for weapons, rest is on armor.
+	rarechance = 40	//40% chance for weapons, rest is on armor.
 	lootlist =	list(
 		/obj/item/ego_weapon/city/dawn/sword,
 		/obj/item/ego_weapon/city/dawn/cello,

--- a/ModularTegustation/tegu_items/refinery/sales.dm
+++ b/ModularTegustation/tegu_items/refinery/sales.dm
@@ -103,7 +103,7 @@
 	desc = "A machine used to send PE to R-Corp."
 	icon_state = "machiner"
 	crate = /obj/structure/lootcrate/r_corp
-	crate_timer = 360	//The most expensive because it's R corp stuff
+	crate_timer = 420	//The most expensive because it's R corp stuff
 	our_corporation = "R corp"
 
 /obj/structure/pe_sales/s_corp


### PR DESCRIPTION
## About The Pull Request
Moved cosmetic items from gacha to a secondary lootpool that can drop alongside the main content of the crate (this primarly affect R Corp, W Corp, Limbus and K Corp), making every single crates worth something beside looking nice.
Also made some gacha slightly more generous (Liu, K Corp, W Corp, Limbus, Alas (not color gear))
R-Corp Crates was made slightly more expensive due to always granting valuable items, and fitted with new weaponary.
## Why It's Good For The Game
Better gacha experience, less of a a letdown when you open some crates, especially R corp which had raven cloak in its rare pool (total waste of PE). Slightly better odds is always nice as a whole, makes everyone happy.
New stuff on R corp as the selection was quite limited.
