### PR TITLE
Makes secret abnormality skins into variables and a proc on the base abnormality

### DIFF
--- a/ModularTegustation/tegu_items/debug_items.dm
+++ b/ModularTegustation/tegu_items/debug_items.dm
@@ -123,7 +123,12 @@
 		playsound(get_turf(user), 'sound/items/toysqueak2.ogg', 10, 3, 3)
 		return
 
-	var/datum/ego_gifts/target_gift = new target.gift_type
+	var/datum/ego_gifts/target_gift
+	if(target.secret_abnormality && target.secret_gift)
+		target_gift = new target.secret_gift
+	else
+		target_gift = new target.gift_type
+
 	user.Apply_Gift(target_gift)
 	to_chat(user, span_nicegreen("[target.gift_message]"))
 	playsound(get_turf(user), 'sound/items/toysqueak2.ogg', 10, 3, 3)

--- a/code/modules/mob/living/simple_animal/abnormality/_abnormality.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_abnormality.dm
@@ -93,28 +93,25 @@
 
 	// secret skin variables ahead
 
-	/// Toggles if the abnormality has a secret form, if not FALSE this variable will control the chance for it to appear
+	/// Toggles if the abnormality has a secret form and can spawn naturally
 	var/secret_chance = FALSE
 	/// tracks if the current abnormality is in its secret form
 	var/secret_abnormality = FALSE
 
 	/// if assigned, this gift will be given instead of a normal one on a successfull gift aquisition whilst a secret skin is in effect
-	var/secret_gift = FALSE
+	var/secret_gift
 
 	/// An icon state assigned to the abnormality in its secret form
-	var/secret_icon_state = FALSE
+	var/secret_icon_state
 	/// An icon state assigned when an abnormality is alive
-	var/secret_icon_living = FALSE
+	var/secret_icon_living
 	/// An icon file assigned to the abnormality in its secret form, usually should not be needed to change
-	var/secret_icon_file = FALSE
-
+	var/secret_icon_file
 
 	/// Offset for secret skins in the X axis
 	var/secret_horizontal_offset = 0
 	/// Offset for secret skins in the Y axis
 	var/secret_vertical_offset = 0
-	/// Offset for secret skins in both the X and Y axis
-	var/secret_total_offset = 0
 
 /mob/living/simple_animal/hostile/abnormality/Initialize(mapload)
 	SHOULD_CALL_PARENT(TRUE)
@@ -150,10 +147,10 @@
 	else
 		gift_message += "\nYou are granted a gift by [src]!"
 
-	if(secret_chance && (prob(secret_chance)))
-		Initialize_secret_icon()
+	if(secret_chance && (prob(1)))
+		InitializeSecretIcon()
 
-/mob/living/simple_animal/hostile/abnormality/proc/Initialize_secret_icon()
+/mob/living/simple_animal/hostile/abnormality/proc/InitializeSecretIcon()
 	SHOULD_CALL_PARENT(TRUE) // if you ever need to override this proc, consider adding onto it instead or not using all the variables given
 	secret_abnormality = TRUE
 
@@ -167,19 +164,14 @@
 		icon_living = secret_icon_living
 
 	if(secret_horizontal_offset)
-		pixel_x = secret_horizontal_offset
+		base_pixel_x = secret_horizontal_offset
 
 	if(secret_vertical_offset)
-		pixel_y = secret_vertical_offset
-
-	if(secret_total_offset)
-		pixel_x = secret_horizontal_offset
-		pixel_y = secret_vertical_offset
+		base_pixel_y = secret_vertical_offset
 
 /mob/living/simple_animal/hostile/abnormality/Destroy()
 	SHOULD_CALL_PARENT(TRUE)
 	if(istype(datum_reference)) // Respawn the mob on death
-		secret_abnormality = FALSE
 		datum_reference.current = null
 		addtimer(CALLBACK (datum_reference, TYPE_PROC_REF(/datum/abnormality, RespawnAbno)), 30 SECONDS)
 	..()
@@ -320,8 +312,6 @@
 // Called by datum_reference when the abnormality has been fully spawned
 /mob/living/simple_animal/hostile/abnormality/proc/PostSpawn()
 	SHOULD_CALL_PARENT(TRUE)
-	if(secret_chance && (prob(secret_chance)))
-		Initialize_secret_icon()
 	HandleStructures()
 	return
 

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/mountain.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/mountain.dm
@@ -41,6 +41,11 @@
 	)
 	gift_type =  /datum/ego_gifts/smile
 	abnormality_origin = ABNORMALITY_ORIGIN_LOBOTOMY
+
+	secret_chance = TRUE // Kirie, why
+	secret_icon_state = "amog"
+	secret_gift = /datum/ego_gifts/amogus
+
 	/// Is user performing work hurt at the beginning?
 	var/agent_hurt = FALSE
 	var/death_counter = 0
@@ -62,9 +67,6 @@
 /mob/living/simple_animal/hostile/abnormality/mountain/Initialize()		//1 in 100 chance for amogus MOSB
 	. = ..()
 	RegisterSignal(SSdcs, COMSIG_GLOB_MOB_DEATH, PROC_REF(on_mob_death))
-	if(prob(1)) // Kirie, why
-		icon_state = "amog"
-		gift_type =  /datum/ego_gifts/amogus
 
 /mob/living/simple_animal/hostile/abnormality/mountain/Destroy()
 	UnregisterSignal(SSdcs, COMSIG_GLOB_MOB_DEATH)

--- a/code/modules/mob/living/simple_animal/abnormality/teth/crumbling_armor.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/crumbling_armor.dm
@@ -25,17 +25,15 @@
 	gift_type = null
 	gift_chance = 100
 	abnormality_origin = ABNORMALITY_ORIGIN_LOBOTOMY
+
+	secret_chance = TRUE
+	secret_icon_state = "megalovania"
+
 	var/buff_icon = 'ModularTegustation/Teguicons/tegu_effects.dmi'
 	var/user_armored
 	var/numbermarked
 	var/meltdown_cooldown //no spamming the meltdown effect
 	var/meltdown_cooldown_time = 30 SECONDS
-
-/mob/living/simple_animal/hostile/abnormality/crumbling_armor/Initialize(mapload)
-	. = ..()
-	// Megalovania?
-	if (prob(1))
-		icon_state = "megalovania"
 
 /mob/living/simple_animal/hostile/abnormality/crumbling_armor/SuccessEffect(mob/living/carbon/human/user, work_type, pe)
 	. = ..()

--- a/code/modules/mob/living/simple_animal/abnormality/teth/pale_horse.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/pale_horse.dm
@@ -35,6 +35,9 @@
 	gift_type =  /datum/ego_gifts/revelation
 	gift_message = "He will wipe away every tear from their eyes, and death shall be evermore."
 
+	secret_chance = TRUE // peter, the horse is here
+	secret_icon_state = "palehorse_hungry"
+
 	//teleport
 	var/can_act = TRUE
 	var/teleport_cooldown
@@ -60,8 +63,6 @@
 /mob/living/simple_animal/hostile/abnormality/pale_horse/Initialize()
 	. = ..()
 	RegisterSignal(SSdcs, COMSIG_GLOB_MOB_DEATH, PROC_REF(OnMobDeath))
-	if(prob(1))
-		icon_state = "palehorse_hungry"
 
 /mob/living/simple_animal/hostile/abnormality/pale_horse/Destroy()
 	UnregisterSignal(SSdcs, COMSIG_GLOB_MOB_DEATH)

--- a/code/modules/mob/living/simple_animal/abnormality/teth/training_rabbit.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/training_rabbit.dm
@@ -27,13 +27,11 @@
 	can_patrol = FALSE
 	abnormality_origin = ABNORMALITY_ORIGIN_LOBOTOMY
 
-/mob/living/simple_animal/hostile/abnormality/training_rabbit/Initialize()	//1 in 100 chance for bunny girl waifu
-	. = ..()
-	if(prob(1))
-		icon = 'ModularTegustation/Teguicons/64x64.dmi'
-		icon_state = "Bungal"
-		pixel_x = -16
-		gift_type =  /datum/ego_gifts/bunny
+	secret_chance = TRUE // people NEEDED a bunny girl waifu
+	secret_icon_file = 'ModularTegustation/Teguicons/64x64.dmi'
+	secret_icon_state = "Bungal"
+	secret_horizontal_offset = -16
+	secret_gift = /datum/ego_gifts/bunny
 
 /mob/living/simple_animal/hostile/abnormality/training_rabbit/BreachEffect(mob/living/carbon/human/user, breach_type)
 	. = ..()

--- a/code/modules/mob/living/simple_animal/abnormality/waw/dreaming_current.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/dreaming_current.dm
@@ -55,17 +55,16 @@
 	/// Maximum AStar pathfinding distances from one point to another
 	var/dash_max_distance = 40
 	var/datum/looping_sound/dreamingcurrent/soundloop
-	var/alt_icon = FALSE
+
+	secret_chance = TRUE
+	secret_icon_state = "blahaj"
+	secret_icon_living = "blahaj"
+	secret_horizontal_offset = -16
+	secret_gift = /datum/ego_gifts/blahaj
 
 /mob/living/simple_animal/hostile/abnormality/dreaming_current/Initialize()
 	. = ..()
 	soundloop = new(list(src), TRUE)
-	if(prob(1))
-		icon_state = "blahaj"
-		icon_living = "blahaj"
-		alt_icon = TRUE
-		pixel_x = -16
-		gift_type =  /datum/ego_gifts/blahaj
 
 /mob/living/simple_animal/hostile/abnormality/dreaming_current/Destroy()
 	QDEL_NULL(soundloop)
@@ -84,7 +83,7 @@
 /mob/living/simple_animal/hostile/abnormality/dreaming_current/Life()
 	. = ..()
 	if((status_flags & GODMODE) && prob(2)) // Contained
-		if(!alt_icon)
+		if(!secret_abnormality)
 			icon_state = "current_bubble"
 		playsound(src, "sound/effects/bubbles.ogg", 30, TRUE)
 		SLEEP_CHECK_DEATH(12)
@@ -146,14 +145,14 @@
 		potential_turfs -= T
 	if(!LAZYLEN(movement_path))
 		return FALSE
-	if(!alt_icon)
+	if(!secret_abnormality)
 		icon_state = "current_prepare"
 	playsound(src, "sound/effects/bubbles.ogg", 50, TRUE, 7)
 	for(var/turf/T in movement_path) // Warning before charging
 		new /obj/effect/temp_visual/sparks/quantum(T)
 	SLEEP_CHECK_DEATH(18)
 	been_hit = list()
-	if(!alt_icon)
+	if(!secret_abnormality)
 		icon_state = "current_attack"
 	for(var/turf/T in movement_path)
 		if(QDELETED(T))
@@ -212,6 +211,6 @@
 /mob/living/simple_animal/hostile/abnormality/dreaming_current/BreachEffect(mob/living/carbon/human/user, breach_type)
 	. = ..()
 	ADD_TRAIT(src, TRAIT_MOVE_FLYING, ROUNDSTART_TRAIT) // Floating
-	if(!alt_icon)
+	if(!secret_abnormality)
 		icon_living = "current_breach"
 		icon_state = icon_living

--- a/code/modules/mob/living/simple_animal/abnormality/waw/sphinx.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/sphinx.dm
@@ -44,6 +44,10 @@
 	gift_type =  /datum/ego_gifts/pharaoh
 	abnormality_origin = ABNORMALITY_ORIGIN_ARTBOOK
 
+	secret_chance = TRUE // Why do we live, just to suffer?
+	secret_icon_file = 'ModularTegustation/Teguicons/64x64.dmi'
+	secret_icon_state = "sphonx"
+
 	//work-related
 	var/happy = FALSE
 	var/demand
@@ -87,6 +91,10 @@
 	transparent_when_unavailable = TRUE
 	cooldown_time = SPHINX_GAZE_COOLDOWN //12 seconds
 
+/mob/living/simple_animal/hostile/abnormality/sphinx/Initialize_secret_icon()
+	. = ..()
+	icon_aggro = "sphonx_eye"
+
 /datum/action/cooldown/sphinx_gaze/Trigger()
 	if(!..())
 		return FALSE
@@ -98,14 +106,6 @@
 	StartCooldown()
 	sphinx.StoneVision(FALSE)
 	return TRUE
-
-
-/mob/living/simple_animal/hostile/abnormality/sphinx/Initialize() //1 in 100 chance for cringe aah aah sphinx by popular demand
-	. = ..()
-	if(prob(1)) // Why do we live, just to suffer?
-		icon = 'ModularTegustation/Teguicons/64x64.dmi'
-		icon_state = "sphonx"
-		icon_aggro = "sphonx_eye"
 
 /mob/living/simple_animal/hostile/abnormality/sphinx/PostSpawn()
 	..()

--- a/code/modules/mob/living/simple_animal/abnormality/waw/sphinx.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/sphinx.dm
@@ -91,7 +91,7 @@
 	transparent_when_unavailable = TRUE
 	cooldown_time = SPHINX_GAZE_COOLDOWN //12 seconds
 
-/mob/living/simple_animal/hostile/abnormality/sphinx/Initialize_secret_icon()
+/mob/living/simple_animal/hostile/abnormality/sphinx/InitializeSecretIcon()
 	. = ..()
 	icon_aggro = "sphonx_eye"
 


### PR DESCRIPTION

## About The Pull Request

Makes the secret gifts/abnormality skins into variables and a proc (Initialize_secret_icon) on the base abnormality mob

## Why It's Good For The Game

I think it would be handy to make this a seperate proc as im hoping that will semi-encurage more secret skins.
Also this allows admins to change an abnormality into its secret form at any time they want by just calling the proc

## Changelog
:cl:
admin: Admins can now call the proc "Initialize_secret_icon" on any abnormality to make it into its secret form (if it has one)
/:cl:
