### PR TITLE
Makes Porccubus able to dash on any tile, adds it to Rcorp

### DIFF
--- a/ModularTegustation/tegu_items/rcorp/!abno_overwrites.dm
+++ b/ModularTegustation/tegu_items/rcorp/!abno_overwrites.dm
@@ -49,3 +49,11 @@
 	if(IsCombatMap())
 		return
 	..()
+
+//Porccubus gets a much shorter dash cooldown to better maneuver itself with how big of a commitment dashing is.
+//May unironically be too much as the thing is slippery as a eel with how big the dash is but i'd rather it be mobile than feeling ass to play as.
+/mob/living/simple_animal/hostile/abnormality/porccubus/Initialize()
+	. = ..()
+	if(IsCombatMap())
+		ranged_cooldown_time = 6 SECONDS
+

--- a/ModularTegustation/tegu_items/rcorp/landmarks.dm
+++ b/ModularTegustation/tegu_items/rcorp/landmarks.dm
@@ -22,6 +22,7 @@ GLOBAL_LIST_INIT(easytank, list(
 	/mob/living/simple_animal/hostile/abnormality/kqe,
 	/mob/living/simple_animal/hostile/abnormality/warden,
 	/mob/living/simple_animal/hostile/abnormality/golden_apple,
+	/mob/living/simple_animal/hostile/abnormality/porccubus,
 ))
 
 GLOBAL_LIST_INIT(hardcombat, list(

--- a/code/modules/mob/living/simple_animal/abnormality/he/porccubus.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/porccubus.dm
@@ -177,6 +177,7 @@
 /mob/living/simple_animal/hostile/abnormality/porccubus/proc/PorcDash(atom/target)//additionally, it can dash to its target every 15 seconds if it's out of range
 	var/dist = get_dist(target, src)
 	if(dist > 2 && ranged_cooldown < world.time)
+		ranged_cooldown = world.time + ranged_cooldown_time
 		var/list/dash_line = getline(src, target)
 		for(var/turf/line_turf in dash_line) //checks if there's a valid path between the turf and the friend
 			if(line_turf.is_blocked_turf(exclude_mobs = TRUE))
@@ -184,7 +185,6 @@
 			forceMove(line_turf)
 			SLEEP_CHECK_DEATH(0.8)
 		playsound(src, 'sound/abnormalities/porccubus/head_explode_laugh.ogg', 50, FALSE, 4)
-		ranged_cooldown = world.time + ranged_cooldown_time
 
 /mob/living/simple_animal/hostile/abnormality/porccubus/AttackingTarget()
 	var/mob/living/carbon/human/H

--- a/code/modules/mob/living/simple_animal/abnormality/he/porccubus.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/porccubus.dm
@@ -125,10 +125,11 @@
 	playsound(src, 'sound/abnormalities/porccubus/head_explode_laugh.ogg', 50, FALSE, 4)
 	icon_living = "porrcubus"
 	icon_state = icon_living
-	var/turf/T = pick(GLOB.xeno_spawn)
-	forceMove(T)
 	ranged_cooldown = world.time + ranged_cooldown_time
-	teleport_cooldown = world.time + teleport_cooldown_time
+	if(!IsCombatMap())
+		var/turf/T = pick(GLOB.xeno_spawn)
+		forceMove(T)
+		teleport_cooldown = world.time + teleport_cooldown_time
 
 /mob/living/simple_animal/hostile/abnormality/porccubus/Move()
 	return FALSE
@@ -136,6 +137,8 @@
 /mob/living/simple_animal/hostile/abnormality/porccubus/Life()
 	. = ..()
 	if(status_flags & GODMODE)
+		return
+	if(IsCombatMap())
 		return
 	if(teleport_cooldown < world.time) //if porccubus hasn't taken damage for 5 minutes we make him move so he doesn't stay stuck in whatever cell he got thrown in.
 		teleport_cooldown = world.time + teleport_cooldown_time
@@ -167,11 +170,11 @@
 
 	if(!target)
 		return
-	PorcDash(target)
-
-/mob/living/simple_animal/hostile/abnormality/porccubus/proc/PorcDash(mob/living/target)//additionally, it can dash to its target every 15 seconds if it's out of range
-	if(!istype(target))
+	if(!isliving(target))
 		return
+	PorcDash(A)
+
+/mob/living/simple_animal/hostile/abnormality/porccubus/proc/PorcDash(atom/target)//additionally, it can dash to its target every 15 seconds if it's out of range
 	var/dist = get_dist(target, src)
 	if(dist > 2 && ranged_cooldown < world.time)
 		var/list/dash_line = getline(src, target)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Lets porccubus target atoms for the dash instead of living targets so that players can move around when possesing it, and adds it to rcorp as a EasyTank (it has full immunity to bullets).
Gives it slightly faster dash speed on combat maps.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
More abnos with playables support, more abnos for Rcorp and LCL too.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: porccubus to rcorp
tweak: tweaked porccubus to let it dash on any tile instead of only on human targets
balance: gave porccubus lower dash cooldown on rcorp
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
