### PR TITLE
Fix crate not breaking if they roll cosmetic

### DIFF
--- a/ModularTegustation/tegu_items/refinery/crates/_crate.dm
+++ b/ModularTegustation/tegu_items/refinery/crates/_crate.dm
@@ -28,7 +28,7 @@
 	var/rarechance = 20
 	var/veryrarechance
 	var/cosmeticloot = list()
-	var/cosmeticchance = 33 //These do not count on the total odds of a crate
+	var/cosmeticchance = 0 //These do not count on the total odds of a crate
 
 /obj/structure/lootcrate/Initialize()
 	..()

--- a/ModularTegustation/tegu_items/refinery/crates/corporation.dm
+++ b/ModularTegustation/tegu_items/refinery/crates/corporation.dm
@@ -109,6 +109,7 @@
 	desc = "A crate recieved from R-Corp. Open with a Crowbar."
 	icon_state = "crate_rcorp"
 	veryrarechance = 5
+	cosmeticchance = 33
 	lootlist =	list(
 		/obj/item/powered_gadget/detector_gadget/ordeal,
 		/obj/item/clothing/suit/space/hardsuit/rabbit,


### PR DESCRIPTION
## About The Pull Request
#2021 introduced cosmetic list for gacha crates, however, if a crate did NOT have a cosmetic list and succesfully rolled for the cosmetic chance (33%), the crate failed to complete its task and didnt break at all. This would result in people having to hit many crates a few times to break them open.
Remedied by setting the default cosmetic chance to 0% to prevent crates from trying to give you non existent cosmetic.
## Why It's Good For The Game
Did a oopsie, had to be fixed

