### PR TITLE
Voices of the Slab - the cap changening

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/_tools/he/theonite_slab.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_tools/he/theonite_slab.dm
@@ -19,7 +19,7 @@
 		return //You don't need any more.
 
 	flick(icon_state, src)
-	user.adjust_attribute_buff(JUSTICE_ATTRIBUTE, 5)
+	user.adjust_attribute_buff(JUSTICE_ATTRIBUTE, 10)
 	var/datum/status_effect/stacking/slab/S = user.has_status_effect(/datum/status_effect/stacking/slab)
 	if(!(user in users))
 		users += user

--- a/code/modules/mob/living/simple_animal/abnormality/_tools/he/theonite_slab.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_tools/he/theonite_slab.dm
@@ -14,7 +14,7 @@
 	..()
 	if(!do_after(user, 6, user))
 		return
-	if(get_level_buff(user, JUSTICE_ATTRIBUTE) >= 50)
+	if(get_level_buff(user, JUSTICE_ATTRIBUTE) >= 100)
 		to_chat(user, span_notice("That's enough."))
 		return //You don't need any more.
 

--- a/code/modules/mob/living/simple_animal/abnormality/_tools/he/vivavoce.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_tools/he/vivavoce.dm
@@ -18,7 +18,7 @@
 		to_chat(user, span_notice("It's silent."))
 		return //You don't need any more.
 
-	user.adjust_attribute_buff(TEMPERANCE_ATTRIBUTE, 5)
+	user.adjust_attribute_buff(TEMPERANCE_ATTRIBUTE, 10)
 	var/datum/status_effect/stacking/rolecall/R = user.has_status_effect(/datum/status_effect/stacking/rolecall)
 	if(!(user in users))
 		users += user

--- a/code/modules/mob/living/simple_animal/abnormality/_tools/he/vivavoce.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_tools/he/vivavoce.dm
@@ -14,7 +14,7 @@
 	..()
 	if(!do_after(user, 6, user))
 		return
-	if(get_level_buff(user, TEMPERANCE_ATTRIBUTE) >= 50)
+	if(get_level_buff(user, TEMPERANCE_ATTRIBUTE) >= 100)
 		to_chat(user, span_notice("It's silent."))
 		return //You don't need any more.
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes the cap for Viva voice and Theonite slab from 50 to 100
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
first off, found the consistency a little silly when compared to the other two stat boosters. and second, given that you'll be taking extra damage against one of the most common damage type and one of the most dangerous damage type in black and pale respectively, even though you'll do works better and be faster/do more damage, especially in late game you can get barred from WaW+ and Aleph abnos either because you cant work them or because their breach would annihilate you.

this is also my first time messing with code and thought this would be simple enough without any actual knowledge (please dont kill me)
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: changes viva and slab to be consistent with the other stat tools
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
