### PR TITLE
Adds a TGUI version of the sephirah panel as a button

### DIFF
--- a/ModularTegustation/tegu_items/debug_items.dm
+++ b/ModularTegustation/tegu_items/debug_items.dm
@@ -201,7 +201,12 @@
  */
 /obj/item/lc_debug/sephirah_action_granter
 	name = "debug sephirah action granter"
+	desc = "A strange wooden sign with the words\"THE ROBITS GRIFF ME!!!\" inscribed upon it"
 	icon_state = "picket"
+
+/obj/item/lc_debug/sephirah_action_granter/examine(mob/user)
+	. = ..()
+	. += span_mind_control("When used in hand it gives you a special button on the top-left of your screen to open the sephirah game panel.")
 
 /obj/item/lc_debug/sephirah_action_granter/attack_self(mob/living/user)
 	. = ..()

--- a/ModularTegustation/tegu_items/debug_items.dm
+++ b/ModularTegustation/tegu_items/debug_items.dm
@@ -193,6 +193,21 @@
 
 	to_chat(user, span_nicegreen("Console manipulated"))
 
+/**
+ * A simple item to grant the sephirah TGUI action panel
+ * relevant files:
+ * code/modules/jobs/job_types/trusted_player/sephirah.dm -- The panel's button and data
+ * tgui/packages/tgui/interfaces/SephirahPanel.js -- The panel's JS counterpart
+ */
+/obj/item/lc_debug/sephirah_action_granter
+	name = "debug sephirah action granter"
+	icon_state = "picket"
+
+/obj/item/lc_debug/sephirah_action_granter/attack_self(mob/living/user)
+	. = ..()
+	var/datum/action/sephirah_game_panel/new_action = new(user.mind || user)
+	new_action.Grant(user)
+
 //Test dummy and spawner
 /obj/item/lc_debug/debugdummyspawner
 	name = "dummy spawner"

--- a/code/modules/jobs/job_types/trusted_players/sephirah.dm
+++ b/code/modules/jobs/job_types/trusted_players/sephirah.dm
@@ -31,6 +31,9 @@
 	add_verb(H, /mob/living/carbon/human/proc/MeltIncrease)
 	add_verb(H, /mob/living/carbon/human/proc/MeltDecrease)
 	add_verb(H, /mob/living/carbon/human/proc/GameInfo)
+	// a TGUI menu that SHOULD contain all the above actions
+	var/datum/action/sephirah_game_panel/new_action = new(H.mind || H)
+	new_action.Grant(H)
 
 	H.apply_pref_name("sephirah", M.client)
 	H.name += " - [M.client.prefs.prefered_sephirah_department]"
@@ -87,6 +90,7 @@ GLOBAL_LIST_INIT(sephirah_names, list(
 		if(Q.locked)
 			to_chat(src, span_danger("The abnormality was already randomized."))
 			return
+
 		Q.UpdateAnomaly(target_type, "fucked it lets rolled", TRUE)
 		SSabnormality_queue.AnnounceLock()
 		SSabnormality_queue.ClearChoices()
@@ -200,3 +204,88 @@ GLOBAL_VAR_INIT(Sephirahmeltmodifier, 0)
 	to_chat(src, span_notice("Sephirah Meltdown Modifier: [GLOB.Sephirahmeltmodifier]."))
 	to_chat(src, span_notice("Sephirah Workmelt Modifier: [GLOB.Sephirahordealspeed]."))
 	to_chat(src, span_notice("Abnormality Extraction Speed Modifier: [GLOB.Sephirahordealspeed]."))
+
+// TGUI stuff below
+
+/datum/action/sephirah_game_panel
+	name = "Open the sephirah game control panel"
+	desc = "This lets you manipulate the game in various ways, abuse may lead to a trusted player ban"
+	button_icon_state = "round_end"
+
+/datum/action/sephirah_game_panel/ui_state(mob/user)
+	return GLOB.always_state // this line of code is actually needed, else it IMMEDIATELLY closes itself. Luv myself TGUI <3
+
+/datum/action/sephirah_game_panel/Trigger(trigger_flags)
+	. = ..()
+	if(!.)
+		return FALSE
+	message_admins("[owner] has opened the sephirah game control panel")
+	ui_interact(owner)
+
+/datum/action/sephirah_game_panel/ui_interact(mob/user, datum/tgui/ui)
+	. = ..()
+	ui = SStgui.try_update_ui(user, src, ui)
+	if(!ui)
+		ui = new(user, src, "SephirahPanel")
+		ui.open()
+		ui.set_autoupdate(TRUE)
+
+/datum/action/sephirah_game_panel/ui_data(mob/user)
+	. = ..()
+	var/list/data = list()
+
+	data["abno_number"] = SSabnormality_queue.spawned_abnos
+
+	data["abnormality_arrival"] = GLOB.Sephirahspeed
+	data["meltdown_speed"] = GLOB.Sephirahordealspeed
+
+
+	var/mob/living/simple_animal/hostile/abnormality/queued_abno = SSabnormality_queue.queued_abnormality
+	data["queued_abno"] = initial(queued_abno.name)
+
+	/* Scrapped due to difficulty -- to be implemented
+	// START OF ARRIVAL INFORMATION
+	var/safe_abnormality_delay
+	if(SSabnormality_queue.next_abno_spawn != INFINITY) // happens when starting abnormalities are being selected, or things break
+		safe_abnormality_delay = SSabnormality_queue.next_abno_spawn
+	else
+		safe_abnormality_delay = ABNORMALITY_DELAY
+
+	data["current_arrival"] = safe_abnormality_delay
+	data["next_arrival"] = safe_abnormality_delay + SSabnormality_queue.next_abno_spawn_time + ((min(16, (SSabnormality_queue.spawned_abnos + 1)) - 6) * 6) SECONDS
+	data["progress_component"] = (world.time - ABNORMALITY_DELAY) / safe_abnormality_delay
+	// END OF ARRIVAL INFORMATION
+	*/
+
+	return data
+
+/datum/action/sephirah_game_panel/ui_act(action, list/params)
+	. = ..()
+	if(.)
+		return
+
+	if(!ishuman(owner)) // we are calling human procs, so processing actions from non-humans is dangerous
+		return
+	var/mob/living/carbon/human/hooman = owner
+
+	switch(action) // maybe change labels?
+		if("Randomize abnormality")
+			hooman.RandomAbno()
+
+		if("Slow abnormality arrival")
+			hooman.SlowGame()
+
+		if("Quicken abnormality arrival")
+			hooman.QuickenGame()
+
+		if("Increase Work per Meltdown ratio")
+			hooman.WorkMeltIncrease()
+
+		if("Decrease Work per Meltdown ratio")
+			hooman.WorkMeltDecrease()
+
+		if("Increase abnormality per meltdown ratio")
+			hooman.MeltIncrease()
+
+		if("Decrease abnormality per meltdown")
+			hooman.MeltDecrease()

--- a/tgui/packages/tgui/interfaces/SephirahPanel.js
+++ b/tgui/packages/tgui/interfaces/SephirahPanel.js
@@ -81,8 +81,7 @@ const ButtonPanel = (props, context) => {
                 minValue={-3}
                 maxValue={3}
                 value={abnormality_arrival}>
-                <AnimatedNumber value={abnormality_arrival}
-              />
+                <AnimatedNumber value={abnormality_arrival} />
               </ProgressBar>
             </LabeledList.Item>
             <LabeledList.Item
@@ -114,8 +113,7 @@ const ButtonPanel = (props, context) => {
                 minValue={-4}
                 maxValue={6}
                 value={meltdown_speed}>
-                <AnimatedNumber value={meltdown_speed}
-              />
+                <AnimatedNumber value={meltdown_speed} />
               </ProgressBar>
             </LabeledList.Item>
             <LabeledList.Item

--- a/tgui/packages/tgui/interfaces/SephirahPanel.js
+++ b/tgui/packages/tgui/interfaces/SephirahPanel.js
@@ -1,0 +1,178 @@
+// THIS IS A LOBOTOMYCORPORATION UI FILE
+
+import { useBackend } from '../backend';
+import { Box, Button, Collapsible, ProgressBar, AnimatedNumber, Section, LabeledList } from '../components';
+import { Window } from '../layouts';
+
+export const SephirahPanel = (props, context) => {
+  return (
+    <Window title="Sephirah game control panel" width="1000" height="550">
+      <Window.Content>
+        <AbnoInfo />
+        <ButtonPanel />
+      </Window.Content>
+    </Window>
+  );
+};
+
+const AbnoInfo = (props, context) => {
+  const { data } = useBackend(context);
+  const {
+    abno_number,
+    queued_abno,
+    minimum_arrival,
+    current_arrival,
+    next_arrival,
+    maximum_arrival,
+    progress_component,
+  } = data;
+
+  return (
+    <Section title="Master Facility Information">
+      <LabeledList>
+        <LabeledList.Item label="Current number of abnormalities: ">
+          {abno_number}
+        </LabeledList.Item>
+        <LabeledList.Item label="Currently queued abnormality: ">
+          {queued_abno}
+        </LabeledList.Item>
+        {/*
+        <LabeledList.Item label="Current abnormality arrival time">
+          <ProgressBar
+            value={progress_component}>
+            <AnimatedNumber value={current_arrival / 10 + ' seconds, (estimated next arrival: ' + next_arrival / 10 + ' seconds)'}/>
+          </ProgressBar>
+        </LabeledList.Item>
+        */}
+      </LabeledList>
+    </Section>
+  );
+};
+
+const ButtonPanel = (props, context) => {
+  const { act, data } = useBackend(context);
+  const { abnormality_arrival, meltdown_speed } = data;
+
+  return (
+    <Section title="Avaible actions">
+      <Box mt="0.5em">
+        <LabeledList>
+          <Collapsible title="Randomize abnormality">
+            <LabeledList.Item
+              labelWrap
+              label="Randomizes the current abnormality, only works if the abnormality has not yet been randomized at its current state"
+              buttons={
+                <Button
+                  content={'Randomize abnormality'}
+                  color={'green'}
+                  onClick={() => act('Randomize Abnormality')}
+                />
+              }
+            />
+          </Collapsible>
+          <Collapsible title="Manipulate abnormality arrival time">
+            <LabeledList.Item>
+              <ProgressBar
+                minValue = {-3}
+                maxValue = {3}
+                value={abnormality_arrival}>
+                <AnimatedNumber value={abnormality_arrival}/>
+              </ProgressBar>
+            </LabeledList.Item>
+            <LabeledList.Item
+              labelWrap
+              label="Makes all abnormalities arrive 20% quicker (multiplicativelly)"
+              buttons={
+                <Button
+                  content={abnormality_arrival < 3 ? 'Quicken abnormality arrival' : 'Speed at maximum!'}
+                  color={abnormality_arrival < 3 ? 'green' : 'red'}
+                  onClick={() => act('Quicken abnormality arrival')}
+                />
+              }
+            />
+            <LabeledList.Item
+              labelWrap
+              label="Makes all abnormalities arrive 20% slower (multiplicativelly)"
+              buttons={
+                <Button
+                  content={abnormality_arrival > -3 ? 'Slow abnormality arrival': 'Speed at minimum!'}
+                  color={abnormality_arrival > -3 ? 'green' : 'red'}
+                  onClick={() => act('Slow abnormality arrival')}
+                />
+              }
+            />
+          </Collapsible>
+          <Collapsible title="Manipulate Work per Meltdown ratio">
+            <LabeledList.Item>
+              <ProgressBar
+                minValue = {-4}
+                maxValue = {6}
+                value={meltdown_speed}>
+                <AnimatedNumber value={meltdown_speed}/>
+              </ProgressBar>
+            </LabeledList.Item>
+            <LabeledList.Item
+              labelWrap
+              label="All meltdowns will take one more work before accuring"
+              buttons={
+                <Button
+                  content={meltdown_speed > 6 ? 'Increase Work per Meltdown ratio': 'Additional meltdown works at maximum!'}
+                  color={meltdown_speed > 6 ? 'green' : 'red'}
+                  onClick={() => act('Increase Work per Meltdown ratio')}
+                />
+              }
+            />
+            <LabeledList.Item
+              labelWrap
+              label="All meltdowns will take one less work before accuring"
+              buttons={
+                <Button
+                  content={meltdown_speed < -4 ? 'Decrease Work per Meltdown ratio': 'Additional meltdown works at minimum!'}
+                  color={meltdown_speed < -4 ? 'green' : 'red'}
+                  onClick={() => act('Decrease Work per Meltdown ratio')}
+                />
+              }
+            />
+          </Collapsible>
+          <Collapsible title="Manipulate Abnormalities melting down per meltdown">
+            <LabeledList.Item
+              labelWrap
+              label="One more abnormality will melt per event"
+              buttons={
+                <Button
+                  content={'Increase abnormality per meltdown ratio'}
+                  color={'green'}
+                  onClick={() => act('Increase abnormality per meltdown ratio')}
+                />
+              }
+            />
+            <LabeledList.Item
+              labelWrap
+              label="One less abnormality will melt per event"
+              buttons={
+                <Button
+                  content={'Decrease abnormality per meltdown'}
+                  color={'green'}
+                  onClick={() => act('Decrease abnormality per meltdown')}
+                />
+              }
+            />
+          </Collapsible>
+          <Collapsible title="Challenge a player">
+            <LabeledList.Item
+              labelWrap
+              label="Causes a specific player to take 40% more damage from abnormality work"
+              buttons={
+                <Button
+                  content={'Challenge a player'}
+                  color={'green'}
+                  onClick={() => act('Challenge a player')}
+                />
+              }
+            />
+          </Collapsible>
+        </LabeledList>
+      </Box>
+    </Section>
+  );
+};

--- a/tgui/packages/tgui/interfaces/SephirahPanel.js
+++ b/tgui/packages/tgui/interfaces/SephirahPanel.js
@@ -65,7 +65,7 @@ const ButtonPanel = (props, context) => {
                 <Button
                   content={'Randomize abnormality'}
                   color={'green'}
-                  onClick={() => act('Randomize Abnormality')}
+                  onClick={() => act('Randomize abnormality')}
                 />
               }
             />
@@ -154,19 +154,6 @@ const ButtonPanel = (props, context) => {
                   content={'Decrease abnormality per meltdown'}
                   color={'green'}
                   onClick={() => act('Decrease abnormality per meltdown')}
-                />
-              }
-            />
-          </Collapsible>
-          <Collapsible title="Challenge a player">
-            <LabeledList.Item
-              labelWrap
-              label="Causes a specific player to take 40% more damage from abnormality work"
-              buttons={
-                <Button
-                  content={'Challenge a player'}
-                  color={'green'}
-                  onClick={() => act('Challenge a player')}
                 />
               }
             />

--- a/tgui/packages/tgui/interfaces/SephirahPanel.js
+++ b/tgui/packages/tgui/interfaces/SephirahPanel.js
@@ -116,8 +116,8 @@ const ButtonPanel = (props, context) => {
               label="All meltdowns will take one more work before accuring"
               buttons={
                 <Button
-                  content={meltdown_speed > 6 ? 'Increase Work per Meltdown ratio': 'Additional meltdown works at maximum!'}
-                  color={meltdown_speed > 6 ? 'green' : 'red'}
+                  content={meltdown_speed < 6 ? 'Increase Work per Meltdown ratio': 'Additional meltdown works at maximum!'}
+                  color={meltdown_speed < 6 ? 'green' : 'red'}
                   onClick={() => act('Increase Work per Meltdown ratio')}
                 />
               }
@@ -127,8 +127,8 @@ const ButtonPanel = (props, context) => {
               label="All meltdowns will take one less work before accuring"
               buttons={
                 <Button
-                  content={meltdown_speed < -4 ? 'Decrease Work per Meltdown ratio': 'Additional meltdown works at minimum!'}
-                  color={meltdown_speed < -4 ? 'green' : 'red'}
+                  content={meltdown_speed > -4 ? 'Decrease Work per Meltdown ratio': 'Additional meltdown works at minimum!'}
+                  color={meltdown_speed > -4 ? 'green' : 'red'}
                   onClick={() => act('Decrease Work per Meltdown ratio')}
                 />
               }

--- a/tgui/packages/tgui/interfaces/SephirahPanel.js
+++ b/tgui/packages/tgui/interfaces/SephirahPanel.js
@@ -40,7 +40,12 @@ const AbnoInfo = (props, context) => {
         <LabeledList.Item label="Current abnormality arrival time">
           <ProgressBar
             value={progress_component}>
-            <AnimatedNumber value={current_arrival / 10 + ' seconds, (estimated next arrival: ' + next_arrival / 10 + ' seconds)'}/>
+            <AnimatedNumber
+              value={current_arrival / 10
+              + ' seconds, (estimated next arrival: '
+              + next_arrival / 10
+              + ' seconds)'}
+            />
           </ProgressBar>
         </LabeledList.Item>
         */}
@@ -73,10 +78,11 @@ const ButtonPanel = (props, context) => {
           <Collapsible title="Manipulate abnormality arrival time">
             <LabeledList.Item>
               <ProgressBar
-                minValue = {-3}
-                maxValue = {3}
+                minValue={-3}
+                maxValue={3}
                 value={abnormality_arrival}>
-                <AnimatedNumber value={abnormality_arrival}/>
+                <AnimatedNumber value={abnormality_arrival}
+              />
               </ProgressBar>
             </LabeledList.Item>
             <LabeledList.Item
@@ -105,10 +111,11 @@ const ButtonPanel = (props, context) => {
           <Collapsible title="Manipulate Work per Meltdown ratio">
             <LabeledList.Item>
               <ProgressBar
-                minValue = {-4}
-                maxValue = {6}
+                minValue={-4}
+                maxValue={6}
                 value={meltdown_speed}>
-                <AnimatedNumber value={meltdown_speed}/>
+                <AnimatedNumber value={meltdown_speed}
+              />
               </ProgressBar>
             </LabeledList.Item>
             <LabeledList.Item


### PR DESCRIPTION

## About The Pull Request

Adds a special button in the hud of a sephirah to open a TGUI panel with all of the game mastering powers and their information

(the video's a slightly bit out-dated, the challenge player part is gone)

https://github.com/vlggms/lobotomy-corp13/assets/82319946/dc9e16b2-b7b3-40a5-9390-cfd24e7aa2b4

## Why It's Good For The Game

some people would prefer a TGUI that automatically does the GameInfo() and NextAbno() verbs automatically, along with explaining the abilities

## Changelog
:cl:
add: Adds a sephirah TGUI gamemaster panel for some easier messing
/:cl: