### PR TITLE
EO is now immune from EGO damage from non-insane agents.

### DIFF
--- a/code/game/objects/items/ego_weapons/_ego_weapon.dm
+++ b/code/game/objects/items/ego_weapons/_ego_weapon.dm
@@ -22,6 +22,8 @@
 /obj/item/ego_weapon/attack(mob/living/target, mob/living/user)
 	if(!CanUseEgo(user))
 		return FALSE
+	if(!CheckRole(target,user))
+		return FALSE
 	. = ..()
 	if(attack_speed)
 		user.changeNext_move(CLICK_CD_MELEE * attack_speed)
@@ -141,6 +143,16 @@
 			return FALSE
 	if(!SpecialEgoCheck(H))
 		return FALSE
+	return TRUE
+
+/obj/item/ego_weapon/proc/CheckRole(mob/living/target, mob/living/user)
+	if(user.sanity_lost)
+		return TRUE
+	var/list/immune = list("Sephirah", "Extraction Officer")		//These people should never be killed
+	if(target.mind)
+		if(target.mind.assigned_role in immune)
+			to_chat(H, span_notice("You lock up and can't swing your weapon!"))
+			return FALSE
 	return TRUE
 
 /obj/item/ego_weapon/proc/SpecialEgoCheck(mob/living/carbon/human/H)

--- a/code/game/objects/items/ego_weapons/_ego_weapon.dm
+++ b/code/game/objects/items/ego_weapons/_ego_weapon.dm
@@ -146,7 +146,10 @@
 	return TRUE
 
 /obj/item/ego_weapon/proc/CheckRole(mob/living/target, mob/living/user)
-	if(user.sanity_lost)
+	if(!ishuman(user))
+		return TRUE
+	var/mob/living/carbon/human/H = user
+	if(H.sanity_lost)
 		return TRUE
 	var/list/immune = list("Sephirah", "Extraction Officer")		//These people should never be killed.
 	if(target.mind)

--- a/code/game/objects/items/ego_weapons/_ego_weapon.dm
+++ b/code/game/objects/items/ego_weapons/_ego_weapon.dm
@@ -148,7 +148,7 @@
 /obj/item/ego_weapon/proc/CheckRole(mob/living/target, mob/living/user)
 	if(user.sanity_lost)
 		return TRUE
-	var/list/immune = list("Sephirah", "Extraction Officer")		//These people should never be killed
+	var/list/immune = list("Sephirah", "Extraction Officer")		//These people should never be killed.
 	if(target.mind)
 		if(target.mind.assigned_role in immune)
 			to_chat(H, span_notice("You lock up and can't swing your weapon!"))

--- a/code/modules/projectiles/projectile/ego_bullet.dm
+++ b/code/modules/projectiles/projectile/ego_bullet.dm
@@ -6,3 +6,13 @@
 	wound_bonus = -100
 	bare_wound_bonus = -100
 	speed = 0.4
+
+/obj/projectile/ego_bullet/on_hit(target)
+	var/mob/living/carbon/human/user = firer
+	if(ishuman(target) && ishuman(firer) && !user.sanity_lost)
+		var/list/immune = list("Sephirah", "Extraction Officer")		//These people should never be killed.
+		var/mob/living/carbon/human/newtarget = target
+		if(newtarget.mind)
+			if(newtarget.mind.assigned_role in immune)
+				return BULLET_ACT_BLOCK
+	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
EO and sephirah are both now immune to EGO damage from non insane agents.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
People think it's funny to kill these two roles that affect their specific round negatively. 
Sephirah for randomizing abnos and EO for making extraction 5 seconds slower.
I'm removing the functionality to kill them at your whim.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Sane agents can no longer kill roles that are slightly harmful to their specific round.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
