### PR TITLE
Extraction Shipments

### DIFF
--- a/code/game/machinery/computer/abnormality_ego.dm
+++ b/code/game/machinery/computer/abnormality_ego.dm
@@ -4,7 +4,7 @@
 	resistance_flags = INDESTRUCTIBLE
 	/// Currently selected(shown) level of abnormalities whose EGO will be on the interface
 	var/selected_level = ZAYIN_LEVEL
-	var/delay = 5 SECONDS
+	var/delay = 15 SECONDS
 
 /obj/machinery/computer/ego_purchase/ui_interact(mob/user)
 	. = ..()

--- a/code/game/machinery/computer/abnormality_ego.dm
+++ b/code/game/machinery/computer/abnormality_ego.dm
@@ -63,7 +63,7 @@
 
 			else
 				addtimer(CALLBACK(src, PROC_REF(ShipOut), E.item_path),delay)
-				to_chat(usr, span_notice("[E.item_path] is on the way of being dispensed!"))
+				audible_message(span_notice("[usr.name] has purchased a [E.item_path]"))
 
 			A.stored_boxes -= E.cost
 			playsound(get_turf(src), 'sound/machines/terminal_prompt_confirm.ogg', 50, TRUE)

--- a/code/game/machinery/computer/abnormality_ego.dm
+++ b/code/game/machinery/computer/abnormality_ego.dm
@@ -63,7 +63,7 @@
 
 			else
 				addtimer(CALLBACK(src, PROC_REF(ShipOut), E.item_path),delay)
-				audible_message(span_notice("[usr.name] has purchased a [E.item_path]"))
+				audible_message(span_notice("[usr.name] has purchased a [E]"))
 
 			A.stored_boxes -= E.cost
 			playsound(get_turf(src), 'sound/machines/terminal_prompt_confirm.ogg', 50, TRUE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Extracting as non-EO now gives an audible message as well as takes 15 seconds to pod in.
It prefers to land on a table but if there is no table it will land on the machine itself.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
People have started stealing EGO again, even when they're reserved. This should encourage them to ask the EO instead of just gunning past them.
Unlike the last PR, this one is a click and it'll arrive, not a click and sit there for 30 seconds.

Players also complain a LOT about things that can be easily addressed via communication; and I want to encourage more communication.
I feel that we're in a point in our game's life where we can start to do things like this.

The game is ultimately a multiplayer game with a focus on communication.
We need to start punishing people who don't want to communicate.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added Extraction shipments.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
