### PR TITLE
Moves most duplicate alt refinery checks to the parent and some cleanup

### DIFF
--- a/ModularTegustation/tegu_items/refinery/alt_refinery/_refiner.dm
+++ b/ModularTegustation/tegu_items/refinery/alt_refinery/_refiner.dm
@@ -47,8 +47,8 @@
 /obj/structure/altrefiner/attackby(obj/item/I, mob/living/user, params)
 	. = ..()
 	if(!requires_item)
-		to_chat(user, span_warning("This machine does not accept objects!"))
-		playsound(get_turf(src), 'sound/machines/terminal_prompt_deny.ogg', 50, TRUE)
+		to_chat(user, span_notice("This machine does not accept objects, so instead you touched it"))
+		attack_hand(user)
 		return FALSE
 
 	if(officer_only && user?.mind?.assigned_role != "Extraction Officer")

--- a/ModularTegustation/tegu_items/refinery/alt_refinery/_refiner.dm
+++ b/ModularTegustation/tegu_items/refinery/alt_refinery/_refiner.dm
@@ -6,10 +6,46 @@
 	anchored = TRUE
 	density = TRUE
 	resistance_flags = INDESTRUCTIBLE
+	/// Toggles if only extraction officers can use the alt refinery
+	var/officer_only = TRUE
+	/// the PE cost that the refinery consumes upon use
+	var/extraction_cost = 0
 
-/obj/structure/altrefiner/Initialize()
+/obj/structure/altrefiner/Initialize(mapload)
 	. = ..()
 	GLOB.lobotomy_devices += src
+
+/obj/structure/altrefiner/attack_hand(mob/living/carbon/M)
+	. = ..()
+	SHOULD_CALL_PARENT(TRUE) // bit akward when you forget a parent call to an object that should most definetelly have it
+	if(officer_only && M?.mind?.assigned_role != "Extraction Officer")
+		to_chat(M, span_warning("Only the Extraction Officer can use this machine."))
+		playsound(get_turf(src), 'sound/machines/terminal_prompt_deny.ogg', 50, TRUE)
+		return FALSE
+
+	if(SSlobotomy_corp.available_box < extraction_cost)
+		to_chat(M, span_warning("Not enough PE boxes stored for this operation. [extraction_cost] PE is necessary for this operation. Current PE: [SSlobotomy_corp.available_box]."))
+		playsound(get_turf(src), 'sound/machines/terminal_prompt_deny.ogg', 50, TRUE)
+		return FALSE
+
+	SSlobotomy_corp.AdjustAvailableBoxes(-1 * extraction_cost)
+	return TRUE
+
+/obj/structure/altrefiner/attackby(obj/item/I, mob/living/user, params)
+	. = ..()
+	SHOULD_CALL_PARENT(TRUE) // yeah, it is
+	if(officer_only && user?.mind?.assigned_role != "Extraction Officer")
+		to_chat(user, span_warning("Only the Extraction Officer can use this machine."))
+		playsound(get_turf(src), 'sound/machines/terminal_prompt_deny.ogg', 50, TRUE)
+		return FALSE
+
+	if(SSlobotomy_corp.available_box < extraction_cost)
+		to_chat(user, span_warning("Not enough PE boxes stored for this operation. \n[extraction_cost] PE is necessary for this operation. Current PE: [SSlobotomy_corp.available_box]."))
+		playsound(get_turf(src), 'sound/machines/terminal_prompt_deny.ogg', 50, TRUE)
+		return FALSE
+
+	SSlobotomy_corp.AdjustAvailableBoxes(-1 * extraction_cost)
+	return TRUE
 
 /obj/structure/altrefiner/Destroy()
 	GLOB.lobotomy_devices -= src
@@ -28,7 +64,7 @@ GLOBAL_LIST_INIT(unspawned_refiners, list(
 	icon = 'icons/effects/landmarks_static.dmi'
 	icon_state = "x4"
 
-/obj/effect/landmark/refinerspawn/Initialize()
+/obj/effect/landmark/refinerspawn/Initialize(mapload)
 	..()
 	if(!LAZYLEN(GLOB.unspawned_refiners))
 		return INITIALIZE_HINT_QDEL

--- a/ModularTegustation/tegu_items/refinery/alt_refinery/blood.dm
+++ b/ModularTegustation/tegu_items/refinery/alt_refinery/blood.dm
@@ -2,25 +2,16 @@
 	name = "Blood Refinery"
 	desc = "A machine used by the Extraction Officer to give all but 1 of their HP for a chance at a PE box."
 	icon_state = "dominator-red"
-	var/pecost = 100
+	extraction_cost = 100
 
 /obj/structure/altrefiner/blood/attack_hand(mob/living/carbon/M)
-	..()
-	//Only the EO may use it
-	if(M?.mind?.assigned_role != "Extraction Officer")
-		to_chat(M, span_warning("Only the Extraction Officer can use this machine."))
-		playsound(get_turf(src), 'sound/machines/terminal_prompt_deny.ogg', 50, TRUE)
-		return
-
 	if(M.health <= 20)
 		to_chat(M, span_warning("You have no more blood to give."))
 		playsound(get_turf(src), 'sound/machines/terminal_prompt_deny.ogg', 50, TRUE)
 		return
 
-	//This is more expensive than regular refining still
-	if(SSlobotomy_corp.available_box < pecost)
-		to_chat(M, span_warning("Not enough PE boxes stored for this operation. 100 PE is necessary for this operation. Current PE: [SSlobotomy_corp.available_box]."))
-		playsound(get_turf(src), 'sound/machines/terminal_prompt_deny.ogg', 50, TRUE)
+	. = ..()
+	if(!.)
 		return
 
 	//Gamble it
@@ -35,5 +26,3 @@
 	else
 		playsound(get_turf(src), 'sound/machines/terminal_prompt_deny.ogg', 50, TRUE)
 		to_chat(M, span_warning("Refining failure. Please try again."))
-	SSlobotomy_corp.AdjustAvailableBoxes(-1 * pecost)
-

--- a/ModularTegustation/tegu_items/refinery/alt_refinery/chance.dm
+++ b/ModularTegustation/tegu_items/refinery/alt_refinery/chance.dm
@@ -2,20 +2,11 @@
 	name = "Chance Refinery"
 	desc = "A machine used by the Extraction Officer to coinflip for a PE box. Costs 25 cargo PE."
 	icon_state = "dominator-purple"
-	var/pecost = 25
+	extraction_cost = 25
 
 /obj/structure/altrefiner/chance/attack_hand(mob/living/carbon/M)
-	..()
-	//Only the EO may use it
-	if(M?.mind?.assigned_role != "Extraction Officer")
-		to_chat(M, span_warning("Only the Extraction Officer can use this machine."))
-		playsound(get_turf(src), 'sound/machines/terminal_prompt_deny.ogg', 50, TRUE)
-		return
-
-	//This is more expensive than regular refining still
-	if(SSlobotomy_corp.available_box < pecost)
-		to_chat(M, span_warning("Not enough PE boxes stored for this operation. 25 PE is necessary for this operation. Current PE: [SSlobotomy_corp.available_box]."))
-		playsound(get_turf(src), 'sound/machines/terminal_prompt_deny.ogg', 50, TRUE)
+	. = ..()
+	if(!.)
 		return
 
 	if(prob(50))
@@ -25,5 +16,3 @@
 	else
 		playsound(get_turf(src), 'sound/machines/terminal_prompt_deny.ogg', 50, TRUE)
 		to_chat(M, span_warning("Refining failure. Please try again."))
-	SSlobotomy_corp.AdjustAvailableBoxes(-1 * pecost)
-

--- a/ModularTegustation/tegu_items/refinery/alt_refinery/quickrefine.dm
+++ b/ModularTegustation/tegu_items/refinery/alt_refinery/quickrefine.dm
@@ -4,9 +4,8 @@
 	icon_state = "dominator-yellow"
 
 /obj/structure/altrefiner/quick/attackby(obj/item/I, mob/living/user, params)
-	if(user?.mind?.assigned_role != "Extraction Officer")
-		to_chat(user, span_warning("Only the Extraction Officer can use this machine."))
-		playsound(get_turf(src), 'sound/machines/terminal_prompt_deny.ogg', 50, TRUE)
+	. = ..()
+	if(!.)
 		return
 
 	if(I.type != /obj/item/rawpe)

--- a/ModularTegustation/tegu_items/refinery/alt_refinery/quickrefine.dm
+++ b/ModularTegustation/tegu_items/refinery/alt_refinery/quickrefine.dm
@@ -2,6 +2,7 @@
 	name = "Quick Refinery"
 	desc = "A machine used by the Extraction Officer to ship PE to command to refine."
 	icon_state = "dominator-yellow"
+	requires_item = TRUE
 
 /obj/structure/altrefiner/quick/attackby(obj/item/I, mob/living/user, params)
 	. = ..()

--- a/ModularTegustation/tegu_items/refinery/alt_refinery/timed.dm
+++ b/ModularTegustation/tegu_items/refinery/alt_refinery/timed.dm
@@ -2,7 +2,7 @@
 	name = "Timed Auto-Refinery"
 	desc = "A machine used by the Extraction Officer to automatically refine PE at the rate of 5 boxes every 5 minutes."
 	icon_state = "dominator-blue"
-	var/pecost = 500
+	extraction_cost = 500
 	var/ready = TRUE
 
 /obj/structure/altrefiner/timed/proc/reset()
@@ -10,30 +10,18 @@
 	ready = TRUE
 
 /obj/structure/altrefiner/timed/attack_hand(mob/living/carbon/M)
-	..()
-	//Only the EO may use it
-	if(M?.mind?.assigned_role != "Extraction Officer")
-		to_chat(M, span_warning("Only the Extraction Officer can use this machine."))
-		playsound(get_turf(src), 'sound/machines/terminal_prompt_deny.ogg', 50, TRUE)
-		return
-
-	//and you actually need the boxes
-	if(SSlobotomy_corp.available_box < pecost)
-		to_chat(M, span_warning("Not enough PE boxes stored for this operation. 500 PE is necessary for this operation. Current PE: [SSlobotomy_corp.available_box]."))
-		playsound(get_turf(src), 'sound/machines/terminal_prompt_deny.ogg', 50, TRUE)
-		return
-
 	if(!ready)
 		to_chat(M, span_warning("This machine is not yet ready."))
 		playsound(get_turf(src), 'sound/machines/terminal_prompt_deny.ogg', 50, TRUE)
 		return
 
+	. = ..()
+	if(!.)
+		return
+
 	playsound(get_turf(src), 'sound/machines/terminal_prompt_confirm.ogg', 50, TRUE)
-	SSlobotomy_corp.AdjustAvailableBoxes(-1 * pecost)
-	new /obj/item/refinedpe(get_turf(src))
-	new /obj/item/refinedpe(get_turf(src))
-	new /obj/item/refinedpe(get_turf(src))
-	new /obj/item/refinedpe(get_turf(src))
-	new /obj/item/refinedpe(get_turf(src))
+	for(var/i in 1 to 5)
+		new /obj/item/refinedpe(get_turf(src))
+
 	ready = FALSE
 	addtimer(CALLBACK(src, PROC_REF(reset)), 5 MINUTES)

--- a/ModularTegustation/tegu_items/refinery/alt_refinery/weapon.dm
+++ b/ModularTegustation/tegu_items/refinery/alt_refinery/weapon.dm
@@ -2,6 +2,7 @@
 	name = "EGO Refinery"
 	desc = "A machine used by the Extraction Officer to automatically melt EGO and potentially spit out a refined PE."
 	icon_state = "dominator-green"
+	requires_item = TRUE
 	var/list/meltable
 
 /obj/structure/altrefiner/weapon/Initialize(mapload)

--- a/ModularTegustation/tegu_items/refinery/alt_refinery/weapon.dm
+++ b/ModularTegustation/tegu_items/refinery/alt_refinery/weapon.dm
@@ -4,26 +4,24 @@
 	icon_state = "dominator-green"
 	var/list/meltable
 
-/obj/structure/altrefiner/weapon/Initialize()
+/obj/structure/altrefiner/weapon/Initialize(mapload)
 	var/list/processing = list(/obj/item/ego_weapon, /obj/item/gun/ego_gun, /obj/item/clothing/suit/armor/ego_gear)
 	var/list/banned = list(/obj/item/ego_weapon/city/ncorp_mark)
 	for(var/Y in processing)
 		meltable += subtypesof(Y)
 	for(var/X in banned)
 		meltable -= subtypesof(X)
-	..()
+	return ..()
 
 /obj/structure/altrefiner/weapon/attackby(obj/item/I, mob/living/user, params)
-	if(user?.mind?.assigned_role != "Extraction Officer")
-		to_chat(user, span_warning("Only the Extraction Officer can use this machine."))
-		playsound(get_turf(src), 'sound/machines/terminal_prompt_deny.ogg', 50, TRUE)
+	. = ..()
+	if(!.)
 		return
 
 	if(!(I.type in meltable))
 		to_chat(user, span_warning("Only EGO is accepted by the machine."))
 		playsound(get_turf(src), 'sound/machines/terminal_prompt_deny.ogg', 50, TRUE)
 		return
-
 
 	qdel(I)
 	if(prob(50))
@@ -34,5 +32,3 @@
 	to_chat(user, span_notice("Refining success."))
 	playsound(get_turf(src), 'sound/machines/terminal_prompt_confirm.ogg', 50, TRUE)
 	new /obj/item/refinedpe(get_turf(src))
-
-


### PR DESCRIPTION
## About The Pull Request

Moves the following to the alt refineries parent:
- extraction officer check
- PE check (disabled by default)
- Removing PE

Replaces timed refineries 5 lines of code with 2, using for(var/i in 1 to 5) instead of copy-pasting new() 5 times

Makes the machines tell you that you need to input in an item if they need it both on examine and trying to click them with one.
Also causes the refineries to call attack_hand() if you touch them with an item whilst they do not need any items

Also added mapload argument to the refineries initialize, because im quite sure its supposed to be there

## Why It's Good For The Game

Bit less copy-paste

## Changelog
:cl:
qol: PE refineries will now tell you if you need to insert in an item
code: Moved some code around in alt refineries
/:cl:
