### PR TITLE
Minor Bullet Changes

### DIFF
--- a/ModularTegustation/tegu_items/gadgets/manager_bullets.dm
+++ b/ModularTegustation/tegu_items/gadgets/manager_bullets.dm
@@ -33,7 +33,7 @@
 
 /datum/status_effect/interventionshield
 	id = "physical intervention shield"
-	duration = 15 SECONDS
+	duration = 30 SECONDS
 	status_type = STATUS_EFFECT_REPLACE
 	alert_type = null
 	var/inherentarmorcheck

--- a/code/datums/facility_upgrade.dm
+++ b/code/datums/facility_upgrade.dm
@@ -118,17 +118,19 @@
 	. = ..()
 	cost = min(max_cost, cost + 1)
 
+//Healing bullets ended up being too much, and managers basically neglected shield bullets for them.
+//I'm hoping to keep them as a way to emergency mitigate HP and bring players out of crit and not instantly heal 60% HP. -Kitsunemitsu/Kirie
 /datum/facility_upgrade/bullet_heal_increase
 	name = UPGRADE_BULLET_HEAL
 	category = "Bullet Upgrades"
-	value = 0.15
-	max_value = 0.6
+	value = 0.1
+	max_value = 0.3
 	requires_one_of = list(HP_BULLET, SP_BULLET)
 
 /datum/facility_upgrade/bullet_heal_increase/Upgrade()
-	value = min(max_value, value + 0.15)
+	value = min(max_value, value + 0.1)
 	. = ..()
-	cost += 1
+	cost += 2
 
 /datum/facility_upgrade/bullet_heal_increase/DisplayValue()
 	return "[value * 100]%"

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -984,7 +984,7 @@
 #define CARBON_HALFSPEED /datum/movespeed_modifier/qliphothoverload
 /datum/status_effect/qliphothoverload
 	id = "qliphoth intervention field"
-	duration = 10 SECONDS
+	duration = 15 SECONDS
 	alert_type = null
 	status_type = STATUS_EFFECT_REFRESH
 	var/statuseffectvisual


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes some changes to some bullets to make purchasing not HP bullets a little more desirable.

- Shield bullets now last twice as long
- Slow bullets now last 50% longer
- HP and SP bullets now cost more after the first purchase, as well as heal significantly less.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Managers pretty much always max out Healing bullets immediately, and I don't really think that this is good design.
I want shield bullets to be more desirable as well as HP/SP bullets. 

I gave general buffs to the length of both Shield and slow bullets to make those more desirable
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: rebalanced manager bullets in general
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
