### PR TITLE
Makes Smile non-dense in LCL and RCA

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/teth/simple_smile.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/simple_smile.dm
@@ -75,9 +75,9 @@
 	src.pulled(pick(pullable))
 
 /mob/living/simple_animal/hostile/abnormality/smile/Initialize()
-  ..()
-  if(IsCombatMap())
-    density = FALSE
+	..()
+	if(IsCombatMap())
+    	density = FALSE
 
 /mob/living/simple_animal/hostile/abnormality/smile/PostWorkEffect(mob/living/carbon/human/user, work_type, pe, work_time)
 	if(lucky_counter > 3)

--- a/code/modules/mob/living/simple_animal/abnormality/teth/simple_smile.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/simple_smile.dm
@@ -74,6 +74,10 @@
 
 	src.pulled(pick(pullable))
 
+/mob/living/simple_animal/hostile/abnormality/smile/Initialize()
+  if(IsCombatMap())
+    density = FALSE
+
 /mob/living/simple_animal/hostile/abnormality/smile/PostWorkEffect(mob/living/carbon/human/user, work_type, pe, work_time)
 	if(lucky_counter > 3)
 		datum_reference.qliphoth_change(-1)

--- a/code/modules/mob/living/simple_animal/abnormality/teth/simple_smile.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/simple_smile.dm
@@ -75,6 +75,7 @@
 	src.pulled(pick(pullable))
 
 /mob/living/simple_animal/hostile/abnormality/smile/Initialize()
+  ..()
   if(IsCombatMap())
     density = FALSE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Smile gains non-density in combat maps
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This is a teeny tiny buff to an abnormality that gets two shot by a stray rhino off screen 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added non-density to smile in combat maps
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
