### PR TITLE
reworks heart of aspiration

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/_tools/teth/heart.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_tools/teth/heart.dm
@@ -30,25 +30,45 @@
 	duration = -1
 	alert_type = null
 	display_name = "heart"
+	var/panic_override = FALSE
 
 /datum/status_effect/display/aspiration/on_apply()
 	. = ..()
 	if(ishuman(owner))
 		var/mob/living/carbon/human/H = owner
 		H.adjust_attribute_buff(JUSTICE_ATTRIBUTE, 10)
-		H.adjust_attribute_buff(FORTITUDE_ATTRIBUTE, 10)
+		H.adjust_attribute_buff(FORTITUDE_ATTRIBUTE, 15)
 
 /datum/status_effect/display/aspiration/tick()
 	. = ..()
 	var/mob/living/carbon/human/H = owner
-	H.adjustBruteLoss(1) // Your health slowly ticks down
-	H.adjustSanityLoss(1) // Your health slowly ticks down
+	if(H.is_working)
+		playsound(get_turf(src), 'sound/abnormalities/nothingthere/heartbeat.ogg', 50, 0, 3)
+		H.adjustSanityLoss(10)
+	if(H.sanityhealth <= H.maxSanity * 0.2 && !H.sanity_lost)
+		H.adjustSanityLoss(999)
+	if(H.sanity_lost)
+		H.adjustBruteLoss(-4)
+	SanityCheck()
+
+/datum/status_effect/display/aspiration/proc/SanityCheck()
+	var/mob/living/carbon/human/status_holder = owner
+	if(status_holder.sanity_lost)
+		if(panic_override)
+			return
+		QDEL_NULL(status_holder.ai_controller)
+		status_holder.ai_controller = /datum/ai_controller/insane/murder
+		status_holder.InitializeAIController()
+		status_holder.apply_status_effect(/datum/status_effect/panicked_type/murder)
+		panic_override = TRUE
+		return
+	panic_override = FALSE
 
 /datum/status_effect/display/aspiration/on_remove()
 	. = ..()
 	if(ishuman(owner))
 		var/mob/living/carbon/human/H = owner
 		H.adjust_attribute_buff(JUSTICE_ATTRIBUTE, -10)
-		H.adjust_attribute_buff(FORTITUDE_ATTRIBUTE, -10)
+		H.adjust_attribute_buff(FORTITUDE_ATTRIBUTE, -15)
 
 #undef STATUS_EFFECT_ASPIRATION

--- a/code/modules/paperwork/records/info/tools.dm
+++ b/code/modules/paperwork/records/info/tools.dm
@@ -82,7 +82,9 @@
 	Name : Heart of Aspiration<br>
 	Risk Class: TETH <br>
 	- Those who equip The Heart of Aspiration will benefit from increased HP and Justice. <br>
-	- Heart of aspiration slowly drained the health and sanity of the person using it. "}
+	- Heart of aspiration slowly drained the sanity of the person using it during work. <br>
+	- When the person that equipped The Heart of Aspiration has their SP 20% or lower of their max SP, they went mad, <br>
+	- Should the person that equipped The Heart of Aspiration become insane, the person would become violent quickly."}
 
 //Bracelet
 /obj/item/paper/fluff/info/tool/bracelet


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Reworks heart of aspiration a bit. Buffs the justice boost to 15, and removed the damage over time. But to give it a down side it now does sp damage while working and causes you to go insane while at or bellow 20% sp. When insane, the user becomes fort insane and gains regen.

## Why It's Good For The Game

heart of aspiration was one of the worst tools in the game and needed a buff. Gives a niche of a good tool for battling while punishing working which makes it the inverse or research notes.

## Changelog
:cl:
tweak: tweaked heart of aspiration's info page
balance: rebalanced heart of aspiration
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
