### PR TITLE
New Chem Lesser Sange Rau

### DIFF
--- a/ModularTegustation/tegu_chemistry/recipes.dm
+++ b/ModularTegustation/tegu_chemistry/recipes.dm
@@ -16,12 +16,11 @@
 	results = list(/datum/reagent/abnormality/gaspilleur  = 1)
 	required_reagents = list(/datum/reagent/abnormality/focussyrup = 1, /datum/reagent/abnormality/nutrition = 1)
 	mix_message = "The mixture produces a rancid smell."
-/*
-/datum/chemical_reaction/sange_rau
-	results = list(/datum/reagent/abnormality/sange_rau  = 1)
+
+/datum/chemical_reaction/lesser_sange_rau
+	results = list(/datum/reagent/abnormality/lesser_sange_rau  = 1)
 	required_reagents = list(/datum/reagent/abnormality/tastesyrup = 1, /datum/reagent/abnormality/amusement = 1)
 	mix_message = "The mixture produces fumes that smell like suffocating under a lovers kiss."
-*/
 
 /datum/chemical_reaction/culpusumidus
 	results = list(/datum/reagent/abnormality/culpusumidus = 1)

--- a/code/modules/reagents/chemistry/reagents/abnormality_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/abnormality_reagents.dm
@@ -207,7 +207,7 @@
 		if(prob(20 + (0.5 * current_cycle)))
 			//Chance of stun increases by 0.5 per cycle
 			if(!H.IsStun())
-				to_chat(H, "Your limbs suddenly spasms and tightens like you have something stuck inside them.")
+				to_chat(H, "Your limbs suddenly spasm and tighten like you have pebbles stuck inside them.")
 				H.Stun(10*REM)
 		else
 			H.adjustBruteLoss(rand(-8,-4)*REM)
@@ -223,6 +223,21 @@
 	health_restore = 2
 	sanity_restore = 2
 	stat_changes = list(-40, -40, -40, -40)
+
+/datum/reagent/abnormality/lesser_sange_rau // Rapidly converts blood into health
+	name = "Lesser Sange Rau"
+	description = "Theorized to be an element of some abnormalities digestive systems. \
+		This fluid inefficently converts blood into regenerative tissue."
+	metabolization_rate = 1 * REAGENTS_METABOLISM
+	color = COLOR_MAROON
+
+/datum/reagent/abnormality/lesser_sange_rau/on_mob_life(mob/living/carbon/M)
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		if(H.blood_volume > (10 * REAGENTS_METABOLISM))
+			H.blood_volume -= (10 * REAGENTS_METABOLISM)
+			H.adjustBruteLoss(rand(-4,-1)*REM)
+	return ..()
 
 		//Subtypes
 /datum/reagent/abnormality/heartysyrup


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Tasteless Syrup + Amusment now creates Lesser Sange Rau a chemical that rapidly converts blood into health. You have enough blood to spare. Let them inside.

Converts 10 blood units out of the human max of 560 into 4 to 1 brute heal. 
15 units is enough to kill someone without outside interference.

## Why It's Good For The Game
Fills out the last missing recipie

## Changelog
:cl:
add: lesser_sange_rau
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
