### PR TITLE
Wounded Courage lets you dual wield Blind Rage

### DIFF
--- a/code/game/objects/items/ego_weapons/waw.dm
+++ b/code/game/objects/items/ego_weapons/waw.dm
@@ -1031,7 +1031,6 @@
 	. = ..()
 	if(!.)
 		return FALSE
-
 	attacks++
 	attacks %= 3
 	switch(attacks)
@@ -1054,6 +1053,34 @@
 		user.HurtInTurf(T, list(), damage, aoe_damage_type, hurt_mechs = TRUE, hurt_structure = TRUE, break_not_destroy = TRUE)
 		if(prob(5))
 			new /obj/effect/gibspawner/generic/silent/wrath_acid(T) // The non-damaging one
+	var/combo = FALSE
+	var/mob/living/carbon/human/myman = user
+	var/obj/item/ego_weapon/blind_rage/Y = myman.get_inactive_held_item()
+	var/obj/item/clothing/suit/armor/ego_gear/realization/woundedcourage/Z = myman.get_item_by_slot(ITEM_SLOT_OCLOTHING)
+	if((istype(Y)) & (istype(Z))) //dual wielding and wearing Wounded Courage? if so...
+		combo = TRUE //hits twice
+	else
+		combo = FALSE
+	if(combo)
+		if(M in view(reach,user))
+			Y.attacks++
+			Y.attacks %=3
+			switch(attacks)
+				if(0)
+					hitsound = 'sound/abnormalities/wrath_servant/big_smash1.ogg'
+				if(1)
+					hitsound = 'sound/abnormalities/wrath_servant/big_smash2.ogg'
+				if(2)
+					hitsound = 'sound/abnormalities/wrath_servant/big_smash3.ogg'
+			M.attacked_by(src, user)
+			M.send_item_attack_message(src, user,M)
+			user.do_attack_animation(M)
+			playsound(loc, hitsound, get_clamped_volume(), TRUE, extrarange = stealthy_audio ? SILENCED_SOUND_EXTRARANGE : -1, falloff_distance = 0)
+			for(var/turf/open/T in range(aoe_range, M))
+				var/obj/effect/temp_visual/small_smoke/halfsecond/smonk = new(T)
+				smonk.color = COLOR_GREEN
+				user.HurtInTurf(T, list(M), damage, damtype, hurt_mechs = TRUE, hurt_structure = TRUE, break_not_destroy = TRUE)
+				user.HurtInTurf(T, list(), damage, aoe_damage_type, hurt_mechs = TRUE, hurt_structure = TRUE, break_not_destroy = TRUE)
 
 /obj/item/ego_weapon/blind_rage/attackby(obj/item/I, mob/living/user, params)
 	..()

--- a/code/modules/clothing/suits/ego_gear/realized.dm
+++ b/code/modules/clothing/suits/ego_gear/realized.dm
@@ -260,7 +260,7 @@ No Ability	250
 	desc = "'Tis better to have loved and lost than never to have loved at all.\
 	Grants you the ability to use a Blind Rage in both hands and attack with both at the same time."
 	icon_state = "woundedcourage"
-	armor = list(RED_DAMAGE = 70, WHITE_DAMAGE = 30, BLACK_DAMAGE = 70, PALE_DAMAGE = 50)		//Support
+	armor = list(RED_DAMAGE = 70, WHITE_DAMAGE = 50, BLACK_DAMAGE = 70, PALE_DAMAGE = 50)		//Melee
 	flags_inv = HIDEJUMPSUIT | HIDEGLOVES | HIDESHOES
 	realized_ability = /obj/effect/proc_holder/ability/justice_and_balance
 	hat = /obj/item/clothing/head/ego_hat/woundedcourage_hat

--- a/code/modules/clothing/suits/ego_gear/realized.dm
+++ b/code/modules/clothing/suits/ego_gear/realized.dm
@@ -257,7 +257,8 @@ No Ability	250
 
 /obj/item/clothing/suit/armor/ego_gear/realization/woundedcourage
 	name = "wounded courage"
-	desc = "'Tis better to have loved and lost than never to have loved at all."
+	desc = "'Tis better to have loved and lost than never to have loved at all.\
+	Grants you the ability to use a Blind Rage in both hands and attack with both at the same time."
 	icon_state = "woundedcourage"
 	armor = list(RED_DAMAGE = 70, WHITE_DAMAGE = 30, BLACK_DAMAGE = 70, PALE_DAMAGE = 50)		//Support
 	flags_inv = HIDEJUMPSUIT | HIDEGLOVES | HIDESHOES

--- a/code/modules/clothing/suits/ego_gear/realized.dm
+++ b/code/modules/clothing/suits/ego_gear/realized.dm
@@ -260,7 +260,7 @@ No Ability	250
 	desc = "'Tis better to have loved and lost than never to have loved at all.\
 	Grants you the ability to use a Blind Rage in both hands and attack with both at the same time."
 	icon_state = "woundedcourage"
-	armor = list(RED_DAMAGE = 70, WHITE_DAMAGE = 50, BLACK_DAMAGE = 70, PALE_DAMAGE = 50)		//Melee
+	armor = list(RED_DAMAGE = 70, WHITE_DAMAGE = 40, BLACK_DAMAGE = 70, PALE_DAMAGE = 50)		//Melee
 	flags_inv = HIDEJUMPSUIT | HIDEGLOVES | HIDESHOES
 	realized_ability = /obj/effect/proc_holder/ability/justice_and_balance
 	hat = /obj/item/clothing/head/ego_hat/woundedcourage_hat


### PR DESCRIPTION
## About The Pull Request
If you are wearing Wounded Courage (the realization of Blind Rage, Servant of Wrath's EGO), you are given the ability to use a Blind Rage weapon in each hand and attack with both at the same time in 1 attack.
**People are still vulnerable to the AOE, so be careful**
## Why It's Good For The Game
Main few reasons of this addition:
- Thematically, it's accurate to what it's refering to, as SOW monster form have her use 2 hammer shaped hands for devasting AOE attacks
- This gives a significant damage increase potential to a WAW weapon. With the dual wield feature, its slightly weaker than an ALEPH weapon, but start outdamaging it when faced with multiple enemies.
- With the potential of seemingly "infinite" dps as you have an AOE attack, you now run the risk of causing greater harms to your friends. This goes back to the first point as being thematically accurate
- Makes a somewhat "eh" realization more interesting to play. Being on the squishier side in regards to white (30) and pale somewhat (50) due to its somewhat average ability, this should bring it in par with more "usable" realizations, as the advantage granted can be quite significant in the right scenario if you are fine with the lower resistances.