### PR TITLE
Fixes Amber Ordeal Runtime on Dungeon Map

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/ordeal/amber.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/amber.dm
@@ -103,7 +103,11 @@
 
 /mob/living/simple_animal/hostile/ordeal/amber_bug/proc/BurrowIn(turf/T)
 	if(!T)
-		T = pick(GLOB.xeno_spawn)
+		if(GLOB.xeno_spawn.len)
+			T = pick(GLOB.xeno_spawn)
+		else
+			can_burrow_solo = FALSE
+			return
 	burrowing = TRUE
 	visible_message(span_danger("[src] burrows into the ground!"))
 	playsound(get_turf(src), 'sound/effects/ordeals/amber/dawn_dig_in.ogg', 25, 1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Amber ordeals were stuck picking from a empty list without turning off their own burrowing.

## Changelog
:cl:
fix: Amber Ordeals
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
