### PR TITLE
Mob Speed Improvements

### DIFF
--- a/ModularTegustation/tegu_mobs/lc13_outskirtdwellers.dm
+++ b/ModularTegustation/tegu_mobs/lc13_outskirtdwellers.dm
@@ -798,7 +798,7 @@ Mobs that mostly focus on dealing RED damage, they are all a bit more frail than
 		icon_state = icon_living
 	current_stage = 2
 	//Speed changed from 6 to 4
-	SpeedChange(-counter_speed)
+	ChangeMoveToDelayBy(-counter_speed)
 	attack_delay = 1 SECONDS
 	counter_threshold = 300
 	playsound(get_turf(src), 'sound/creatures/lc13/lovetown/abomination_stagetransition.ogg', 75, 0, 3)

--- a/code/__DEFINES/movespeed_modification.dm
+++ b/code/__DEFINES/movespeed_modification.dm
@@ -1,5 +1,6 @@
 //flags
 #define IGNORE_NOSLOW	(1 << 0)
+#define IS_ACTUALLY_MULTIPLICATIVE (1 << 1)
 
 //conflict types
 

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -981,7 +981,7 @@
 
 
 //~~~LC13 General Debuffs~~~
-#define CARBON_HALFSPEED /datum/movespeed_modifier/qliphothoverload
+#define MOB_HALFSPEED /datum/movespeed_modifier/qliphothoverload
 /datum/status_effect/qliphothoverload
 	id = "qliphoth intervention field"
 	duration = 15 SECONDS
@@ -991,12 +991,7 @@
 
 /datum/status_effect/qliphothoverload/on_apply()
 	. = ..()
-	if(ishostile(owner))
-		var/mob/living/simple_animal/hostile/L = owner
-		L.TemporarySpeedChange(4, duration)
-	if(iscarbon(owner))
-		var/mob/living/carbon/M = owner
-		M.add_movespeed_modifier(CARBON_HALFSPEED)
+	owner.add_movespeed_modifier(MOB_HALFSPEED)
 
 	var/mutable_appearance/effectvisual = mutable_appearance('icons/obj/clockwork_objects.dmi', "vanguard")
 	effectvisual.pixel_x = -owner.pixel_x
@@ -1005,9 +1000,7 @@
 	owner.add_overlay(statuseffectvisual)
 
 /datum/status_effect/qliphothoverload/on_remove()
-	if(iscarbon(owner))
-		var/mob/living/carbon/M = owner
-		M.remove_movespeed_modifier(CARBON_HALFSPEED)
+	owner.remove_movespeed_modifier(MOB_HALFSPEED)
 
 	owner.cut_overlay(statuseffectvisual)
 	return ..()
@@ -1081,7 +1074,7 @@
 		var/mob/living/simple_animal/M = owner
 		M.RemoveModifier(/datum/dc_change/rend/black)
 
-#undef CARBON_HALFSPEED
+#undef MOB_HALFSPEED
 
 #define STATUS_EFFECT_LCBURN /datum/status_effect/stacking/lc_burn // Deals true damage every 5 sec, can't be applied to godmode (contained abos)
 /datum/status_effect/stacking/lc_burn

--- a/code/game/objects/items/ego_weapons/he.dm
+++ b/code/game/objects/items/ego_weapons/he.dm
@@ -1630,7 +1630,7 @@
 	if(!isanimal(owner))
 		return
 	var/mob/living/simple_animal/hostile/M = owner
-	M.TemporarySpeedChange(M.move_to_delay*0.25 , 3 SECONDS)
+	M.TemporarySpeedChange(1.25 , 3 SECONDS, TRUE)
 
 /atom/movable/screen/alert/status_effect/brown_bricks
 	name = "Yello Bricks"

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/army_in_black.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/army_in_black.dm
@@ -270,7 +270,7 @@ GLOBAL_LIST_EMPTY(army)
 		SetSpeed()//wait for a patrol path. What could possibly go wrong?
 		return
 	var/dist_travelled = LAZYLEN(patrol_path)
-	move_to_delay -= clamp((dist_travelled / 4), 0, 15)//armies that spawn closest to dept centers can actually be suppressed this way, while further ones remain a threat. Math needs tweaking
+	ChangeMoveToDelayBy(-clamp((dist_travelled / 4), 0, 15)) //armies that spawn closest to dept centers can actually be suppressed this way, while further ones remain a threat. Math needs tweaking
 
 /mob/living/simple_animal/hostile/army_enemy/proc/FearEffect()
 	for(var/mob/living/carbon/human/H in view(7, src))

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/crying_children.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/crying_children.dm
@@ -464,7 +464,7 @@
 	maxHealth = 4000
 	damage_coeff = list(RED_DAMAGE = 0.4, WHITE_DAMAGE = 0.8, BLACK_DAMAGE = 0.4, PALE_DAMAGE = 1)
 	revive(full_heal = TRUE, admin_revive = FALSE)
-	move_to_delay = 4
+	ChangeMoveToDelay(4)
 	burn_mod = 2
 	can_act = TRUE
 	charge = 0

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/distortedform.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/distortedform.dm
@@ -499,6 +499,7 @@
 	attack_sound = 'sound/abnormalities/distortedform/slam.ogg'
 	melee_damage_type = RED_DAMAGE
 	ChangeResistances(list(RED_DAMAGE = 0.4, WHITE_DAMAGE = 0.4, BLACK_DAMAGE = 0.4, PALE_DAMAGE = 0.8))
+	ChangeMoveToDelay(3)
 	melee_damage_lower = 55
 	melee_damage_upper = 65
 	rapid_melee = 1
@@ -764,8 +765,7 @@
 	ChangeResistances(list(RED_DAMAGE = 0, WHITE_DAMAGE = 0.4, BLACK_DAMAGE = 0.4, PALE_DAMAGE = 0.8))
 	melee_damage_lower = 65
 	melee_damage_upper = 75
-	move_to_delay = 4.5
-	UpdateSpeed()
+	ChangeMoveToDelay(4.5)
 	can_move = TRUE
 	addtimer(CALLBACK(src, PROC_REF(Goodbye)), 30)
 	special_attack = PROC_REF(Hello)
@@ -838,8 +838,7 @@
 	attack_verb_continuous = "slashes"
 	attack_verb_simple = "slash"
 	rapid_melee = 4
-	move_to_delay = 2.5
-	UpdateSpeed()
+	ChangeMoveToDelay(2.5)
 	can_move = TRUE
 	can_attack = TRUE
 	special_attack = PROC_REF(Execute)
@@ -1040,7 +1039,7 @@
 	melee_damage_upper = 30
 	pixel_x = -8
 	base_pixel_x = -8
-	move_to_delay = 5
+	ChangeMoveToDelay(5)
 	can_move = TRUE
 	special_attack = PROC_REF(SpearAttack)
 	addtimer(CALLBACK(src, PROC_REF(ScytheAttack)), 30)
@@ -1192,7 +1191,7 @@
 	attack_sound = 'sound/abnormalities/blubbering_toad/attack.ogg'
 	attack_verb_continuous = "mauls"
 	attack_verb_simple = "maul"
-	UpdateSpeed()
+	ChangeMoveToDelay(3)
 	can_move = TRUE
 	special_attack = PROC_REF(ToadAttack)
 
@@ -1271,14 +1270,13 @@
 	ChangeResistances(list(RED_DAMAGE = 0.3, WHITE_DAMAGE = 0.3, BLACK_DAMAGE = 0.5, PALE_DAMAGE = 0.8))
 	melee_damage_lower = 65
 	melee_damage_upper = 75
-	move_to_delay = 4.5
+	ChangeMoveToDelay(4.5)
 	melee_damage_type = WHITE_DAMAGE
 	pixel_x = -8
 	base_pixel_x = -8
 	attack_sound = 'sound/abnormalities/ichthys/slap.ogg'
 	attack_verb_continuous = "mauls"
 	attack_verb_simple = "maul"
-	UpdateSpeed()
 	can_move = TRUE
 	addtimer(CALLBACK(src, PROC_REF(BloodBathBeamPrep)), 30)
 	special_attack = PROC_REF(BloodBathSlam)

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/melting_love.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/melting_love.dm
@@ -227,7 +227,7 @@
 	return TRUE
 
 /mob/living/simple_animal/hostile/abnormality/melting_love/proc/Empower()
-	SpeedChange(-0.5)
+	ChangeMoveToDelayBy(-0.5)
 	melee_damage_lower = 80
 	melee_damage_upper = 85
 	projectiletype = /obj/projectile/melting_blob/enraged

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/mountain.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/mountain.dm
@@ -222,15 +222,13 @@
 			base_pixel_x = -32
 			if(phase == 3)
 				icon_living = "mosb_breach2"
-				SpeedChange(1)
+				ChangeMoveToDelay(5)
 				patrol_cooldown_time = 30 SECONDS
 			if(phase == 2)
 				icon_living = "mosb_breach"
-				SpeedChange(2)
+				ChangeMoveToDelay(4)
 				patrol_cooldown_time = 20 SECONDS
 			icon_state = icon_living
-			update_simplemob_varspeed()
-		UpdateSpeed()
 		return
 	// Decrease stage
 	if(phase <= 1) // Death
@@ -244,17 +242,15 @@
 		icon = 'ModularTegustation/Teguicons/64x64.dmi'
 		pixel_x = -16
 		base_pixel_x = -16
-		SpeedChange(-2)
+		ChangeMoveToDelay(2)
 		patrol_cooldown_time = 10 SECONDS
 	if(phase == 2)
 		icon = 'ModularTegustation/Teguicons/96x96.dmi'
 		pixel_x = -32
 		base_pixel_x = -32
-		SpeedChange(-1)
+		ChangeMoveToDelay(4)
 		patrol_cooldown_time = 20 SECONDS
 	icon_state = icon_living
-	UpdateSpeed()
-	update_simplemob_varspeed()
 	return TRUE
 
 /* Special attacks */

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/nobody_is.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/nobody_is.dm
@@ -260,8 +260,7 @@
 			icon_state = icon_living
 			ChangeResistances(list(RED_DAMAGE = 0.6, WHITE_DAMAGE = 0.6, BLACK_DAMAGE = 0, PALE_DAMAGE = 1.2))
 			can_act = TRUE
-			SpeedChange(1.5)
-	UpdateSpeed()
+			ChangeMoveToDelayBy(1.5)
 	current_stage = clamp(current_stage + 1, 1, 3)
 
 /mob/living/simple_animal/hostile/abnormality/nobody_is/apply_damage(damage, damagetype, def_zone, blocked, forced, spread_damage, wound_bonus, bare_wound_bonus, sharpness, white_healable)

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/nothing_there.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/nothing_there.dm
@@ -266,7 +266,7 @@
 	if(!istype(disguise))
 		return
 	next_transform = world.time + rand(30 SECONDS, 40 SECONDS)
-	SpeedChange(1.5)
+	ChangeMoveToDelayBy(1.5)
 	appearance = saved_appearance
 	disguise.forceMove(get_turf(src))
 	disguise.gib()
@@ -298,10 +298,9 @@
 			can_act = TRUE
 			melee_damage_lower = 65
 			melee_damage_upper = 75
-			SpeedChange(1.5)
+			ChangeMoveToDelayBy(1.5)
 			heartbeat.stop()
 			breachloop.start()
-	UpdateSpeed()
 	adjustBruteLoss(-maxHealth)
 	current_stage = clamp(current_stage + 1, 1, 3)
 
@@ -399,8 +398,7 @@
 	// Teleport us somewhere where nobody will see us at first
 	disguiseloop.stop()
 	fear_level = 0 // So it doesn't inflict fear to those around them
-	SpeedChange(-1.5) // This will make them move at a speed similar to normal players
-	UpdateSpeed()
+	ChangeMoveToDelayBy(-1.5) // This will make them move at a speed similar to normal players
 	var/list/priority_list = list()
 	for(var/turf/T in GLOB.xeno_spawn)
 		var/people_in_range = 0

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/titania.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/titania.dm
@@ -96,7 +96,7 @@
 	. = ..()
 
 	if(H.stat == DEAD && target == nemesis)		//Does she slay Oberon personally? If so, get buffed.
-		SpeedChange(-1)
+		ChangeMoveToDelayBy(-1)
 		melee_damage_lower = 110
 		melee_damage_upper = 140
 		adjustBruteLoss(-maxHealth) // Round 2, baby

--- a/code/modules/mob/living/simple_animal/abnormality/he/blue_shepherd.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/blue_shepherd.dm
@@ -248,7 +248,7 @@
 		slash_damage = 50
 		melee_damage_lower = 30
 		melee_damage_upper = 40
-		SpeedChange(-0.5)
+		ChangeMoveToDelayBy(-0.5)
 		maxHealth = maxHealth * 4 //5000 health, will get hurt by buddy's howl to make up for the high health
 		set_health(health * 4)
 		med_hud_set_health()

--- a/code/modules/mob/living/simple_animal/abnormality/he/golden_false_apple.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/golden_false_apple.dm
@@ -281,7 +281,7 @@
 	melee_damage_type = BLACK_DAMAGE
 	fear_level = WAW_LEVEL
 	is_maggot = TRUE
-	SpeedChange(-1)
+	ChangeMoveToDelayBy(-1)
 
 /mob/living/simple_animal/hostile/abnormality/golden_apple/AttackingTarget()//regular attacks or AOE. Determines the outcome for both players and the AI behavior
 	if(!can_act)
@@ -330,7 +330,7 @@
 	victim_name = "Yuri"
 	maxHealth = 1500
 	BecomeRotten()
-	SpeedChange(-0.5)
+	ChangeMoveToDelayBy(-0.5)
 	ChangeResistances(list(RED_DAMAGE = 1, WHITE_DAMAGE = 1, BLACK_DAMAGE = 0.8, PALE_DAMAGE = 0.3))
 	if(H)
 		victim_name = H.real_name

--- a/code/modules/mob/living/simple_animal/abnormality/he/red_buddy.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/red_buddy.dm
@@ -175,8 +175,7 @@
 		awoo_cooldown = 0 //resets the awoo cooldown too
 		melee_damage_lower = 60
 		melee_damage_upper = 80
-		SpeedChange(-1) //this doesn't matter as much as you'd think because he can't move before shepherd
-		UpdateSpeed()
+		ChangeMoveToDelayBy(-1) //this doesn't matter as much as you'd think because he can't move before shepherd
 		vision_range = 3
 		aggro_vision_range = 3 //red buddy should only move for things it can actually reach, in this case somewhat within shepherd's reach
 		can_patrol = FALSE //just in case
@@ -244,7 +243,7 @@
 		awakened_master.melee_damage_lower = 10
 		awakened_master.melee_damage_upper = 15
 		awakened_master.slash_damage = 20
-		awakened_master.SpeedChange(-0.8) //we severely nerf shepherd's damage but make him way faster on buddy's death, it's last one tango.
+		awakened_master.ChangeMoveToDelayBy(-0.8) //we severely nerf shepherd's damage but make him way faster on buddy's death, it's last one tango.
 		awakened_master.say("A wolf. A wolf. Why won't you believe me? it's right there. IT WAS RIGHT THERE!")
 	awakened_master = null
 	density = FALSE

--- a/code/modules/mob/living/simple_animal/abnormality/he/woodsman.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/woodsman.dm
@@ -176,8 +176,7 @@
 	melee_damage_upper = initial_melee_damage_upper + (ramping * 3)
 	flurry_delay = initial_flurry_delay - (ramping * 0.1) SECONDS
 	flurry_pause = initial_flurry_pause - (ramping * 0.01) SECONDS
-	move_to_delay = initial_move_to_delay - (ramping * 0.22)
-	UpdateSpeed()
+	ChangeMoveToDelay(initial_move_to_delay - (ramping * 0.22))
 
 /mob/living/simple_animal/hostile/abnormality/woodsman/proc/Heal(mob/living/carbon/human/body)
 	src.visible_message(span_warning("[src] plunges their hand into [body]'s chest and rips out their heart!"), \

--- a/code/modules/mob/living/simple_animal/abnormality/he/you_strong.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/you_strong.dm
@@ -253,11 +253,11 @@
 	melee_damage_lower = 3*gear
 	melee_damage_upper = 5*gear
 	//Reset the speed. First proc changes this only with 0.
-	SpeedChange(gear_speed)
+	ChangeMoveToDelayBy(gear_speed)
 	//Calculate speed change.
 	gear_speed = FLOOR(gear / 3, 1)
 	//CRANK UP THE SPEED.
-	SpeedChange(-gear_speed)
+	ChangeMoveToDelayBy(-gear_speed)
 	rapid_melee = gear > 7 ? 2 : 1
 
 /mob/living/simple_animal/hostile/grown_strong/Life()

--- a/code/modules/mob/living/simple_animal/abnormality/teth/so_that_no_cry.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/so_that_no_cry.dm
@@ -204,11 +204,10 @@
 	talismans += 1
 	if(talismans > 10)
 		TalismanStun()
-		move_to_delay = initial(move_to_delay)
+		ChangeMoveToDelay(initial(move_to_delay))
 		return
 	new /obj/effect/temp_visual/talisman(get_turf(src))
-	move_to_delay = (3 + (talismans / 10))
-	UpdateSpeed()
+	ChangeMoveToDelay(3 + (talismans / 10))
 
 /mob/living/simple_animal/hostile/abnormality/so_that_no_cry/proc/TalismanStun()
 	if(!can_act)

--- a/code/modules/mob/living/simple_animal/abnormality/teth/void_dream.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/void_dream.dm
@@ -77,7 +77,7 @@
 		return
 	icon = 'ModularTegustation/Teguicons/32x64.dmi'
 	punched = TRUE
-	SpeedChange(-2)
+	ChangeMoveToDelayBy(-2)
 	ability_cooldown_time = 8 SECONDS
 	ability_cooldown = 0
 	REMOVE_TRAIT(src, TRAIT_MOVE_FLYING, ROUNDSTART_TRAIT)

--- a/code/modules/mob/living/simple_animal/abnormality/waw/nosferatu.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/nosferatu.dm
@@ -160,7 +160,7 @@
 	animate(src, transform = matrix()*1.2, color = "#FF0000", time = 10)
 	playsound(get_turf(src), 'sound/abnormalities/nosferatu/transform.ogg', 35, 8)
 	bloodlust_cooldown = clamp(bloodlust_cooldown - 2, 0, 4)
-	SpeedChange(-1)
+	ChangeMoveToDelayBy(-1)
 	berzerk = TRUE
 
 /mob/living/simple_animal/hostile/abnormality/nosferatu/add_splatter_floor(turf/T, small_drip) //no spilling blood, it just works.

--- a/code/modules/mob/living/simple_animal/abnormality/waw/warden.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/warden.dm
@@ -62,12 +62,11 @@
 
 			// it gets faster.
 			if(move_to_delay>1)
-				SpeedChange(-move_to_delay*0.25)
+				ChangeMoveToDelayBy(0.75, TRUE)
 				if(melee_damage_lower > 30)
 					melee_damage_lower -=5
 
 			adjustBruteLoss(-(maxHealth*0.2)) // Heals 20% HP, fuck you that's why. Still not as bad as judgement or big bird
-			update_simplemob_varspeed()
 
 			finishing = FALSE
 			icon_state = "warden"

--- a/code/modules/mob/living/simple_animal/distortion/plague/bunnyman.dm
+++ b/code/modules/mob/living/simple_animal/distortion/plague/bunnyman.dm
@@ -98,5 +98,5 @@
 	melee_damage_lower = 30
 	melee_damage_upper = 45
 	rapid_melee = 3
-	move_to_delay = 2
+	ChangeMoveToDelay(2)
 	icon_state = "bunnyman_enraged"

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -236,14 +236,12 @@
 /mob/living/simple_animal/hostile/proc/TemporarySpeedChange(amount = 0, time = 0, is_multiplier = FALSE)
 	if(time <= 0)
 		return
-	if(amount == 0)
-		return
-	if(is_multiplier)
-		ChangeMoveToDelayBy(amount, TRUE)
-		addtimer(CALLBACK(src, TYPE_PROC_REF(/mob/living/simple_animal/hostile, ChangeMoveToDelayBy), 1/amount, TRUE), time) // Reset the speed to previous value
-	else
-		ChangeMoveToDelayBy(amount)
-		addtimer(CALLBACK(src, TYPE_PROC_REF(/mob/living/simple_animal/hostile, ChangeMoveToDelayBy), -amount), time)
+	if(is_multiplier && amount > 0)
+		add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/variable_hostile_speed_multiplier, TRUE, amount, TRUE)
+		addtimer(CALLBACK(src, TYPE_PROC_REF(/mob, add_or_update_variable_movespeed_modifier), /datum/movespeed_modifier/variable_hostile_speed_multiplier, TRUE, 1 / amount, TRUE), time) // Reset the speed to previous value
+	else if(amount != 0)
+		add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/variable_hostile_speed_bonus, TRUE, amount, TRUE)
+		addtimer(CALLBACK(src, TYPE_PROC_REF(/mob, add_or_update_variable_movespeed_modifier), /datum/movespeed_modifier/variable_hostile_speed_bonus, TRUE, -amount, TRUE), time)
 
 /mob/living/simple_animal/hostile/attacked_by(obj/item/I, mob/living/user)
 	if(stat == CONSCIOUS && !target && AIStatus != AI_OFF && !client && user)

--- a/code/modules/mob/living/simple_animal/hostile/ordeal/indigo.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/indigo.dm
@@ -463,7 +463,7 @@
 
 	maxHealth = 4000
 	ChangeResistances(list(RED_DAMAGE = 0.4, WHITE_DAMAGE = 0.6, BLACK_DAMAGE = 0.25, PALE_DAMAGE = 0.8))
-	SpeedChange(phasespeedchange)
+	ChangeMoveToDelayBy(phasespeedchange)
 	rapid_melee +=1
 	melee_damage_lower -= 10
 	melee_damage_upper -= 10
@@ -481,7 +481,7 @@
 
 	maxHealth = 3000
 	ChangeResistances(list(RED_DAMAGE = 0.5, WHITE_DAMAGE = 0.8, BLACK_DAMAGE = 0.3, PALE_DAMAGE = 1))
-	SpeedChange(phasespeedchange)
+	ChangeMoveToDelayBy(phasespeedchange)
 	rapid_melee += 2
 	melee_damage_lower -= 15
 	melee_damage_upper -= 15

--- a/code/modules/movespeed/_movespeed_modifier.dm
+++ b/code/modules/movespeed/_movespeed_modifier.dm
@@ -113,34 +113,34 @@ GLOBAL_LIST_EMPTY(movespeed_modification_cache)
 /mob/proc/add_or_update_variable_movespeed_modifier(datum/movespeed_modifier/type_id_datum, update = TRUE, multiplicative_slowdown)
 	var/modified = FALSE
 	var/inject = FALSE
-	var/datum/movespeed_modifier/final
+	var/datum/movespeed_modifier/final_value
 	if(istext(type_id_datum))
-		final = LAZYACCESS(movespeed_modification, type_id_datum)
-		if(!final)
+		final_value = LAZYACCESS(movespeed_modification, type_id_datum)
+		if(!final_value)
 			CRASH("Couldn't find existing modification when provided a text ID.")
 	else if(ispath(type_id_datum))
 		if(!initial(type_id_datum.variable))
 			CRASH("Not a variable modifier")
-		final = LAZYACCESS(movespeed_modification, initial(type_id_datum.id) || "[type_id_datum]")
-		if(!final)
-			final = new type_id_datum
+		final_value = LAZYACCESS(movespeed_modification, initial(type_id_datum.id) || "[type_id_datum]")
+		if(!final_value)
+			final_value = new type_id_datum
 			inject = TRUE
 			modified = TRUE
 	else
 		if(!initial(type_id_datum.variable))
 			CRASH("Not a variable modifier")
-		final = type_id_datum
-		if(!LAZYACCESS(movespeed_modification, final.id))
+		final_value = type_id_datum
+		if(!LAZYACCESS(movespeed_modification, final_value.id))
 			inject = TRUE
 			modified = TRUE
 	if(!isnull(multiplicative_slowdown))
-		final.multiplicative_slowdown = multiplicative_slowdown
+		final_value.multiplicative_slowdown = multiplicative_slowdown
 		modified = TRUE
 	if(inject)
-		add_movespeed_modifier(final, FALSE)
+		add_movespeed_modifier(final_value, FALSE)
 	if(update && modified)
 		update_movespeed(TRUE)
-	return final
+	return final_value
 
 
 ///Is there a movespeed modifier for this mob
@@ -168,6 +168,7 @@ GLOBAL_LIST_EMPTY(movespeed_modification_cache)
 /// Go through the list of movespeed modifiers and calculate a final movespeed. ANY ADD/REMOVE DONE IN UPDATE_MOVESPEED MUST HAVE THE UPDATE ARGUMENT SET AS FALSE!
 /mob/proc/update_movespeed()
 	. = 0
+	var/multiplier = 1
 	var/list/conflict_tracker = list()
 	for(var/key in get_movespeed_modifiers())
 		var/datum/movespeed_modifier/M = movespeed_modification[key]
@@ -184,8 +185,17 @@ GLOBAL_LIST_EMPTY(movespeed_modification_cache)
 				conflict_tracker[conflict] = amt
 			else
 				continue
-		. += amt
+		if((M.flags & IS_ACTUALLY_MULTIPLICATIVE) && amt > 0)
+			multiplier *= amt
+		else
+			. += amt
+	. *= multiplier
 	cached_multiplicative_slowdown = .
+
+//cached_multiplicative_slowdown is the delay for clients while move_to_delay is for ai, they must be equal
+/mob/living/simple_animal/hostile/update_movespeed()
+	. = ..()
+	move_to_delay = .
 
 /// Get the move speed modifiers list of the mob
 /mob/proc/get_movespeed_modifiers()

--- a/code/modules/movespeed/_movespeed_modifier.dm
+++ b/code/modules/movespeed/_movespeed_modifier.dm
@@ -110,7 +110,7 @@ GLOBAL_LIST_EMPTY(movespeed_modification_cache)
 	4. If any of the rest of the args are not null (see: multiplicative slowdown), modify the datum
 	5. Update if necessary
 */
-/mob/proc/add_or_update_variable_movespeed_modifier(datum/movespeed_modifier/type_id_datum, update = TRUE, multiplicative_slowdown)
+/mob/proc/add_or_update_variable_movespeed_modifier(datum/movespeed_modifier/type_id_datum, update = TRUE, multiplicative_slowdown, apply_to_existing_modifier = FALSE)
 	var/modified = FALSE
 	var/inject = FALSE
 	var/datum/movespeed_modifier/final_value
@@ -134,7 +134,13 @@ GLOBAL_LIST_EMPTY(movespeed_modification_cache)
 			inject = TRUE
 			modified = TRUE
 	if(!isnull(multiplicative_slowdown))
-		final_value.multiplicative_slowdown = multiplicative_slowdown
+		if(apply_to_existing_modifier)
+			if(final_value.flags & IS_ACTUALLY_MULTIPLICATIVE)
+				final_value.multiplicative_slowdown *= multiplicative_slowdown
+			else
+				final_value.multiplicative_slowdown += multiplicative_slowdown
+		else
+			final_value.multiplicative_slowdown = multiplicative_slowdown
 		modified = TRUE
 	if(inject)
 		add_movespeed_modifier(final_value, FALSE)

--- a/code/modules/movespeed/modifiers/mobs.dm
+++ b/code/modules/movespeed/modifiers/mobs.dm
@@ -123,5 +123,14 @@
 	variable = TRUE
 	multiplicative_slowdown = 0
 
+/datum/movespeed_modifier/hostile_stamina_loss
+	variable = TRUE
+	multiplicative_slowdown = 0
+
 /datum/movespeed_modifier/qliphothoverload
-	multiplicative_slowdown = 4
+	flags = IS_ACTUALLY_MULTIPLICATIVE
+	multiplicative_slowdown = 2
+
+/datum/movespeed_modifier/brown_bricks
+	flags = IS_ACTUALLY_MULTIPLICATIVE
+	multiplicative_slowdown = 1.25

--- a/code/modules/movespeed/modifiers/mobs.dm
+++ b/code/modules/movespeed/modifiers/mobs.dm
@@ -127,10 +127,15 @@
 	variable = TRUE
 	multiplicative_slowdown = 0
 
+/datum/movespeed_modifier/variable_hostile_speed_multiplier
+	variable = TRUE
+	flags = IS_ACTUALLY_MULTIPLICATIVE
+	multiplicative_slowdown = 1
+
+/datum/movespeed_modifier/variable_hostile_speed_bonus
+	variable = TRUE
+	multiplicative_slowdown = 0
+
 /datum/movespeed_modifier/qliphothoverload
 	flags = IS_ACTUALLY_MULTIPLICATIVE
 	multiplicative_slowdown = 2
-
-/datum/movespeed_modifier/brown_bricks
-	flags = IS_ACTUALLY_MULTIPLICATIVE
-	multiplicative_slowdown = 1.25

--- a/code/modules/spells/ability_types/realized.dm
+++ b/code/modules/spells/ability_types/realized.dm
@@ -78,7 +78,7 @@
 		if(ishostile(L))
 			var/mob/living/simple_animal/hostile/H = L
 			H.apply_status_effect(/datum/status_effect/salvation)
-			H.TemporarySpeedChange(H.move_to_delay*debuff_slowdown , 15 SECONDS) // Slow down_status_effect(/datum/status_effect/salvation)
+			H.TemporarySpeedChange(1 + debuff_slowdown , 15 SECONDS, TRUE) // Slow down_status_effect(/datum/status_effect/salvation)
 	return ..()
 
 /datum/status_effect/salvation

--- a/code/modules/spells/ability_types/realized_aimed.dm
+++ b/code/modules/spells/ability_types/realized_aimed.dm
@@ -377,7 +377,7 @@
 		L.apply_damage(ishuman(L) ? damage_amount*0.5 : damage_amount, RED_DAMAGE, null, L.run_armor_check(null, RED_DAMAGE), spread_damage = TRUE)
 		if(ishostile(L))
 			var/mob/living/simple_animal/hostile/H = L
-			H.TemporarySpeedChange(H.move_to_delay * damage_slowdown, 10 SECONDS) // Slow down
+			H.TemporarySpeedChange(1 + damage_slowdown, 10 SECONDS, TRUE) // Slow down
 
 /mob/living/simple_animal/cocoonability
 	name = "Cocoon"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes hostile mob movement speed behave the same way damage coefficients do: move_to_delay is a final value that must not be touched, speed var stores the base delay value that can be changed through ChangeMoveToDelay, ChangeMoveToDelayBy, and TemporarySpeedChange procs.
Movement modifiers affect mob move_to_delay.
Status effects that add movement speed modifiers dont change speed var but do affect move_to_delay properly.
Makes hostile mob move_to_delay match client move delay.
Allows for real speed multipliers on all mobs.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes it easier to deal with mob speeds.
Fixes issues with status effects that adjusted move_to_delay directly turbocharging mobs due to them also changing their own move_to_delay during the effect.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: can now do real speed multipliers
fix: certain mobs wont become super fast when slowdowns expire
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
