### PR TITLE
Hostile ai tweak

### DIFF
--- a/ModularTegustation/ego_weapons/melee/aleph.dm
+++ b/ModularTegustation/ego_weapons/melee/aleph.dm
@@ -750,6 +750,10 @@
 
 	attacking = TRUE //ALWAYS blocking ranged attacks
 
+/obj/item/ego_weapon/shield/distortion/Initialize()
+	. = ..()
+	aggro_on_block *= 4
+
 /obj/item/ego_weapon/shield/distortion/EgoAttackInfo(mob/user)
 	return span_notice("It deals [force * 4] red, white, black and pale damage combined.")
 

--- a/ModularTegustation/ego_weapons/melee/subtype/shield.dm
+++ b/ModularTegustation/ego_weapons/melee/subtype/shield.dm
@@ -43,6 +43,7 @@
 	var/block_sound_volume = 50
 	var/projectile_timer
 	var/parry_timer
+	var/aggro_on_block
 
 /obj/item/ego_weapon/shield/Initialize()
 	. = ..()
@@ -56,6 +57,7 @@
 		resistances_list += list("BLACK" = reductions[3])
 	if(reductions[4] != 0)
 		resistances_list += list("PALE" = reductions[4])
+	aggro_on_block = force * 3
 
 //Allows the user to deflect projectiles for however long recovery time is set to on a hit
 /obj/item/ego_weapon/shield/melee_attack_chain(mob/user, atom/target, params)
@@ -96,6 +98,10 @@
 		shield_user.physiology.black_mod *= max(0.001, (1 - ((reductions[3]) / 100)))
 		shield_user.physiology.pale_mod *= max(0.001, (1 - ((reductions[4]) / 100)))
 		RegisterSignal(user, COMSIG_MOB_APPLY_DAMGE, PROC_REF(AnnounceBlock))
+		for(var/mob/living/simple_animal/hostile/H in hearers(3, user))
+			if(H.stat != CONSCIOUS || H.AIStatus == AI_OFF || H.client)
+				continue
+			H.RegisterAggroValue(user, aggro_on_block, AGGRO_DAMAGE)
 		if(QDELING(src))
 			DisableBlock(shield_user)
 		else

--- a/ModularTegustation/tegu_mobs/lc13_corrosions.dm
+++ b/ModularTegustation/tegu_mobs/lc13_corrosions.dm
@@ -247,12 +247,12 @@
 		return FALSE
 	..()
 
-/mob/living/simple_animal/hostile/ordeal/snake_corrosion/AttackingTarget()
+/mob/living/simple_animal/hostile/ordeal/snake_corrosion/AttackingTarget(atom/attacked_target)
 	if(!can_act)
 		return FALSE
-	..()
-	if(isliving(target))
-		var/mob/living/H = target
+	. = ..()
+	if(isliving(attacked_target))
+		var/mob/living/H = attacked_target
 		H.apply_venom(applied_venom)
 
 /mob/living/simple_animal/hostile/ordeal/snake_corrosion/OpenFire()
@@ -409,16 +409,16 @@
 		return
 	..()
 
-/mob/living/simple_animal/hostile/ordeal/dog_corrosion/AttackingTarget()
+/mob/living/simple_animal/hostile/ordeal/dog_corrosion/AttackingTarget(atom/attacked_target)
 	if(charging)
 		return
 	if(dash_cooldown <= world.time && !client && charge_ready)
-		PrepCharge(target)
+		PrepCharge(attacked_target)
 		return
 	. = ..()
-	if(!ishuman(target))
+	if(!ishuman(attacked_target))
 		return
-	var/mob/living/carbon/human/H = target
+	var/mob/living/carbon/human/H = attacked_target
 	if(H.health < 0)
 		H.gib()
 		playsound(src, "sound/abnormalities/clouded_monk/eat.ogg", 75, 1)

--- a/ModularTegustation/tegu_mobs/lc13_humanoids.dm
+++ b/ModularTegustation/tegu_mobs/lc13_humanoids.dm
@@ -120,12 +120,12 @@ Skittish, they prefer to move in groups and will run away if the enemies are in 
 		return FALSE
 	return ..()
 
-/mob/living/simple_animal/hostile/humanoid/rat/knife/AttackingTarget()
+/mob/living/simple_animal/hostile/humanoid/rat/knife/AttackingTarget(atom/attacked_target)
 	if(!can_act)
 		return
 	..()
 	if(dash_cooldown < world.time)
-		BackstreetsDash(target)
+		BackstreetsDash(attacked_target)
 		return
 
 /mob/living/simple_animal/hostile/humanoid/rat/knife/OpenFire()
@@ -653,8 +653,8 @@ Skittish, they prefer to move in groups and will run away if the enemies are in 
 		return
 
 	. = ..()
-	if (istype(target, /mob/living))
-		var/mob/living/L = target
+	if (istype(attacked_target, /mob/living))
+		var/mob/living/L = attacked_target
 		L.apply_lc_burn(burn_stacks)
 	TripleDash()
 

--- a/ModularTegustation/tegu_mobs/lc13_outskirtdwellers.dm
+++ b/ModularTegustation/tegu_mobs/lc13_outskirtdwellers.dm
@@ -52,10 +52,10 @@
 	if(maxHealth >= 250)
 		. += span_notice("Drag yourself onto [src] in order to ride them.")
 
-/mob/living/simple_animal/hostile/morsel/AttackingTarget()
+/mob/living/simple_animal/hostile/morsel/AttackingTarget(atom/attacked_target)
 	retreat_distance = 0
-	if(is_type_in_typecache(target,wanted_objects)) //we eats
-		qdel(target)
+	if(is_type_in_typecache(attacked_target, wanted_objects)) //we eats
+		qdel(attacked_target)
 		buffed = (buffed + 1)
 		if(buffed >= 10)
 			PustuleChurn()
@@ -87,10 +87,10 @@
 		return
 	return ..()
 
-/mob/living/simple_animal/hostile/morsel/AttackingTarget()
+/mob/living/simple_animal/hostile/morsel/AttackingTarget(atom/attacked_target)
 	. = ..()
 	if(.)
-		var/dir_to_target = get_dir(get_turf(src), get_turf(target))
+		var/dir_to_target = get_dir(get_turf(src), get_turf(attacked_target))
 		animate(src, pixel_y = (base_pixel_y + 18), time = 2)
 		addtimer(CALLBACK(src, PROC_REF(AnimateBack)), 2)
 		for(var/i = 1 to 2)
@@ -735,11 +735,11 @@ Mobs that mostly focus on dealing RED damage, they are all a bit more frail than
 		return FALSE
 	return ..()
 
-/mob/living/simple_animal/hostile/lovetown/slumberer/AttackingTarget()
+/mob/living/simple_animal/hostile/lovetown/slumberer/AttackingTarget(atom/attacked_target)
 	if(countering)
 		return
 	if(grab_ready)
-		return OpenFire(target)
+		return OpenFire(attacked_target)
 	return ..()
 
 /mob/living/simple_animal/hostile/lovetown/slumberer/OpenFire(target)
@@ -1039,8 +1039,8 @@ Mobs that mostly focus on dealing RED damage, they are all a bit more frail than
 	if(current_stage == 2)
 		adjustBruteLoss(-40) //self damages at stage 2
 
-	if(ishuman(target))
-		if(Finisher(target))
+	if(ishuman(attacked_target))
+		if(Finisher(attacked_target))
 			return
 
 	if(countering)
@@ -1053,7 +1053,7 @@ Mobs that mostly focus on dealing RED damage, they are all a bit more frail than
 		DisableCounter()
 		return
 	if(counter_ready)
-		return OpenFire(target)
+		return OpenFire(attacked_target)
 	return AoeAttack()
 
 /mob/living/simple_animal/hostile/lovetown/abomination/OpenFire(target)

--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -50,6 +50,8 @@
 #define BLACK_DAMAGE		"black"
 /// Deals brute damage in percents.
 #define PALE_DAMAGE			"pale"
+/// Fake damage used for hostile ai targetting
+#define AGGRO_DAMAGE		"aggro"
 
 //bitflag damage defines used for suicide_act
 #define BRUTELOSS 	            	(1<<0)

--- a/code/modules/mob/living/simple_animal/abnormality/_auxiliary_modes/community/aleph/crying_children.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_auxiliary_modes/community/aleph/crying_children.dm
@@ -262,24 +262,24 @@
 		Combusting_Courage()
 	return
 
-/mob/living/simple_animal/hostile/abnormality/crying_children/AttackingTarget()
+/mob/living/simple_animal/hostile/abnormality/crying_children/AttackingTarget(atom/attacked_target)
 	if(!can_act)
 		return FALSE
 	if(!client)
 		if(desperate && (courage_cooldown <= world.time) && prob(30))
 			return Combusting_Courage()
 		if(sorrow_cooldown <= world.time && prob(25))
-			return Wounds_Of_Sorrow(target)
+			return Wounds_Of_Sorrow(attacked_target)
 
 	if(prob(35))
-		return Bygone_Illusion(target)
+		return Bygone_Illusion(attacked_target)
 
 	// Distorted Illusion
 	can_act = FALSE
 	icon_state = "[icon_phase]_salvador"
 	. = ..()
-	if(isliving(target))
-		var/mob/living/L = target
+	if(isliving(attacked_target))
+		var/mob/living/L = attacked_target
 		L.apply_lc_burn(5*burn_mod)
 	SLEEP_CHECK_DEATH(10)
 	icon_state = "[icon_phase]_idle"
@@ -508,7 +508,7 @@
 			if(!target)
 				target = H
 		if(target in view(1, src))
-			AttackingTarget()
+			AttackingTarget(target)
 		tagged = TRUE
 
 // Unseeing

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/censored.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/censored.dm
@@ -116,15 +116,15 @@
 			return FALSE
 	return ..()
 
-/mob/living/simple_animal/hostile/abnormality/censored/AttackingTarget()
+/mob/living/simple_animal/hostile/abnormality/censored/AttackingTarget(atom/attacked_target)
 	. = ..()
 	if(!can_act)
 		return
 
-	if(!ishuman(target))
+	if(!ishuman(attacked_target))
 		return
 
-	var/mob/living/carbon/human/H = target
+	var/mob/living/carbon/human/H = attacked_target
 	if(H.stat >= SOFT_CRIT || H.health < 0)
 		return Convert(H)
 

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/melting_love.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/melting_love.dm
@@ -100,16 +100,16 @@
 		return FALSE
 	return ..()
 
-/mob/living/simple_animal/hostile/abnormality/melting_love/AttackingTarget()
+/mob/living/simple_animal/hostile/abnormality/melting_love/AttackingTarget(atom/attacked_target)
 	// Convert
-	if(ishuman(target))
-		var/mob/living/carbon/human/H = target
+	if(ishuman(attacked_target))
+		var/mob/living/carbon/human/H = attacked_target
 		if(H.stat == DEAD || H.health <= HEALTH_THRESHOLD_DEAD)
 			return SlimeConvert(H)
 
 	// Consume a slime. Cannot work on the big one, so the check is not istype()
-	if(target.type == /mob/living/simple_animal/hostile/slime)
-		var/mob/living/simple_animal/hostile/slime/S = target
+	if(attacked_target.type == /mob/living/simple_animal/hostile/slime)
+		var/mob/living/simple_animal/hostile/slime/S = attacked_target
 		visible_message(span_warning("[src] consumes \the [S], restoring its own health."))
 		. = ..() // We do a normal attack without AOE and then consume the slime to restore HP
 		adjustBruteLoss(-maxHealth * 0.2)
@@ -117,9 +117,9 @@
 		return .
 
 	// AOE attack
-	if(isliving(target) || ismecha(target))
-		new /obj/effect/gibspawner/generic/silent/melty_slime(get_turf(target))
-		for(var/turf/open/T in view(1, target))
+	if(isliving(attacked_target) || ismecha(attacked_target))
+		new /obj/effect/gibspawner/generic/silent/melty_slime(get_turf(attacked_target))
+		for(var/turf/open/T in view(1, attacked_target))
 			var/obj/effect/temp_visual/small_smoke/halfsecond/S = new(T)
 			S.color = "#FF0081"
 			var/list/got_hit = list()
@@ -326,10 +326,10 @@
 			return FALSE
 	return ..()
 
-/mob/living/simple_animal/hostile/slime/AttackingTarget()
+/mob/living/simple_animal/hostile/slime/AttackingTarget(atom/attacked_target)
 	// Convert
-	if(ishuman(target))
-		var/mob/living/carbon/human/H = target
+	if(ishuman(attacked_target))
+		var/mob/living/carbon/human/H = attacked_target
 		if(H.stat == DEAD || H.health <= HEALTH_THRESHOLD_DEAD)
 			return SlimeConvert(H)
 		if(prob(statuschance))

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/mountain.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/mountain.dm
@@ -120,16 +120,16 @@
 			return TRUE
 	return FALSE
 
-/mob/living/simple_animal/hostile/abnormality/mountain/AttackingTarget()
+/mob/living/simple_animal/hostile/abnormality/mountain/AttackingTarget(atom/attacked_target)
 	if(finishing)
 		return FALSE
 	if(phase >= 2)
 		if(prob(35) && OpenFire())
 			return
 	. = ..()
-	if(. && isliving(target))
-		var/mob/living/L = target
-		if(isliving(target) && (L.health < 0 || L.stat == DEAD))
+	if(. && isliving(attacked_target))
+		var/mob/living/L = attacked_target
+		if(isliving(attacked_target) && (L.health < 0 || L.stat == DEAD))
 			finishing = TRUE
 			if(phase == 3)
 				icon_state = "mosb_bite2"

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/nobody_is.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/nobody_is.dm
@@ -625,8 +625,8 @@
 			for(var/i = 1 to 3)
 				target_turf = get_step(target_turf, get_dir(get_turf(src), target_turf))
 			return WhipAttack(target_turf)
-	if(isliving(target))
-		var/mob/living/L = target
+	if(isliving(attacked_target))
+		var/mob/living/L = attacked_target
 		if(L.health <= 0)
 			if(ishuman(L))
 				var/mob/living/carbon/human/H = L

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/seasons.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/seasons.dm
@@ -348,8 +348,8 @@
 			return ConeAttack(target)
 		if((slam_cooldown <= world.time) && prob(35))
 			return Slam()
-	if(ishuman(target))
-		if(Finisher(target))
+	if(ishuman(attacked_target))
+		if(Finisher(attacked_target))
 			return
 	return ..()
 

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/titania.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/titania.dm
@@ -77,10 +77,10 @@
 	return ..()
 
 //Attacking code
-/mob/living/simple_animal/hostile/abnormality/titania/AttackingTarget()
+/mob/living/simple_animal/hostile/abnormality/titania/AttackingTarget(atom/attacked_target)
 	if(fused)
 		return FALSE
-	var/mob/living/carbon/human/H = target
+	var/mob/living/carbon/human/H = attacked_target
 	//Kills the weak immediately.
 	if(get_user_level(H) < 4 && (ishuman(H)))
 		say("I rid you of your pain, mere human.")

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/white_night.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/white_night.dm
@@ -310,16 +310,16 @@ GLOBAL_LIST_EMPTY(apostles)
 		return FALSE
 	return ..()
 
-/mob/living/simple_animal/hostile/apostle/AttackingTarget()
+/mob/living/simple_animal/hostile/apostle/AttackingTarget(atom/attacked_target)
 	if(!can_act)
 		return
 
-	if(isliving(target))
-		var/mob/living/L = target
+	if(isliving(attacked_target))
+		var/mob/living/L = attacked_target
 		if(faction_check_mob(L))
 			return
 	. = ..()
-	if(. && isliving(target))
+	if(. && isliving(attacked_target))
 		if(!client && ranged && ranged_cooldown <= world.time)
 			OpenFire()
 

--- a/code/modules/mob/living/simple_animal/abnormality/he/KQE.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/KQE.dm
@@ -218,7 +218,7 @@
 	if(!can_act)
 		return FALSE
 	if ((grab_cooldown <= world.time) && prob(35) && (!client))//checks for client since you can still use the claw if you click nearby
-		var/turf/target_turf = get_turf(target)
+		var/turf/target_turf = get_turf(attacked_target)
 		return ClawGrab(target_turf)
 	return Whip_Attack()
 

--- a/code/modules/mob/living/simple_animal/abnormality/he/basilisoup.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/basilisoup.dm
@@ -159,11 +159,11 @@
 	density = TRUE
 	mouse_opacity = MOUSE_OPACITY_ICON
 
-/mob/living/simple_animal/hostile/abnormality/basilisoup/AttackingTarget()
+/mob/living/simple_animal/hostile/abnormality/basilisoup/AttackingTarget(atom/attacked_target)
 	if(!can_act)
 		return
-	if(ishuman(target))
-		var/mob/living/carbon/human/H = target
+	if(ishuman(attacked_target))
+		var/mob/living/carbon/human/H = attacked_target
 		if(H.nutrition >= NUTRITION_LEVEL_FAT)
 			playsound(get_turf(src), 'sound/abnormalities/bigbird/bite.ogg', 50, 1, 2)
 			H.gib()

--- a/code/modules/mob/living/simple_animal/abnormality/he/better_memories.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/better_memories.dm
@@ -203,12 +203,12 @@
 		if(target_memory[the_target] <= 100)
 			return FALSE
 
-/mob/living/simple_animal/hostile/better_memories_minion/AttackingTarget()
+/mob/living/simple_animal/hostile/better_memories_minion/AttackingTarget(atom/attacked_target)
 	if(!can_act)
 		return FALSE
 	if(!client)
-		if(ishuman(target))
-			var/mob/living/carbon/human/H = target
+		if(ishuman(attacked_target))
+			var/mob/living/carbon/human/H = attacked_target
 			/* Dont jab those standing
 			still for their picture.
 			Death is not our goal */

--- a/code/modules/mob/living/simple_animal/abnormality/he/blue_shepherd.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/blue_shepherd.dm
@@ -205,12 +205,12 @@
 		hired = FALSE
 	return ..()
 
-/mob/living/simple_animal/hostile/abnormality/blue_shepherd/AttackingTarget()
+/mob/living/simple_animal/hostile/abnormality/blue_shepherd/AttackingTarget(atom/attacked_target)
 	. = ..()
 	if(client)
 		switch(chosen_attack)
 			if(1)
-				if(isliving(target))
+				if(isliving(attacked_target))
 					slash_current-=1
 				return OpenFire()
 			if(2)
@@ -224,7 +224,7 @@
 		slashing = TRUE
 		slash()
 	if(awakened_buddy)
-		awakened_buddy.GiveTarget(target)
+		awakened_buddy.GiveTarget(attacked_target)
 
 /mob/living/simple_animal/hostile/abnormality/blue_shepherd/OpenFire()
 	if(slash_current == 0)

--- a/code/modules/mob/living/simple_animal/abnormality/he/eris.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/eris.dm
@@ -127,10 +127,10 @@
 	return FALSE
 
 /mob/living/simple_animal/hostile/abnormality/eris/AttackingTarget(atom/attacked_target)
-	if(ishuman(target))
-		var/mob/living/H = target
+	if(ishuman(attacked_target))
+		var/mob/living/H = attacked_target
 		if(H.stat >= SOFT_CRIT)
-			Dine(target)
+			Dine(attacked_target)
 			return
 	..()
 

--- a/code/modules/mob/living/simple_animal/abnormality/he/golden_false_apple.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/golden_false_apple.dm
@@ -294,13 +294,13 @@
 	is_maggot = TRUE
 	ChangeMoveToDelayBy(-1)
 
-/mob/living/simple_animal/hostile/abnormality/golden_apple/AttackingTarget()//regular attacks or AOE. Determines the outcome for both players and the AI behavior
+/mob/living/simple_animal/hostile/abnormality/golden_apple/AttackingTarget(atom/attacked_target)//regular attacks or AOE. Determines the outcome for both players and the AI behavior
 	if(!can_act)
 		return FALSE
 	if(!is_maggot)//Is it still in the first form? Start building sheen pulses
 		if(pulse_count < pulse_maximum)
-			if(isliving(target))
-				var/mob/living/hit = target
+			if(isliving(attacked_target))
+				var/mob/living/hit = attacked_target
 				if((hit.stat == DEAD) ||!ishuman(hit))//if the target is dead or not human
 					return ..()
 				if(istype(target, /mob/living/carbon/human/species/pinocchio))
@@ -319,12 +319,12 @@
 	if(client && smash_cooldown < world.time)//playable behavior is nested under here
 		switch(chosen_attack)
 			if(1)
-				Smash(target)
+				Smash(attacked_target)
 			if(2)
-				Smash(target, wide = FALSE)
+				Smash(attacked_target, wide = FALSE)
 		return
 	if(prob(50) && (smash_cooldown < world.time))//AI behavior goes here
-		Smash(target, wide = pick(TRUE, FALSE))
+		Smash(attacked_target, wide = pick(TRUE, FALSE))
 		return
 	return ..()
 

--- a/code/modules/mob/living/simple_animal/abnormality/he/headless_ichthys.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/headless_ichthys.dm
@@ -189,14 +189,14 @@
 	can_act = TRUE
 
 // Breach Stuff
-/mob/living/simple_animal/hostile/abnormality/headless_ichthys/AttackingTarget()
+/mob/living/simple_animal/hostile/abnormality/headless_ichthys/AttackingTarget(atom/attacked_target)
 	if(!can_act)
 		return
 	if(jump_cooldown <= world.time && prob(10) && !client)
-		IchthysJump(target)
+		IchthysJump(attacked_target)
 		return
 	if(cannon_cooldown <= world.time && prob(5) && !client)
-		BloodCannon(target)
+		BloodCannon(attacked_target)
 		return
 	return ..()
 

--- a/code/modules/mob/living/simple_animal/abnormality/he/jangsan.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/jangsan.dm
@@ -256,9 +256,9 @@
 		return FALSE
 	return ..()
 
-/mob/living/simple_animal/hostile/abnormality/jangsan/AttackingTarget()
+/mob/living/simple_animal/hostile/abnormality/jangsan/AttackingTarget(atom/attacked_target)
 	if(bite_cooldown < world.time)
-		KillCheck(target)
+		KillCheck(attacked_target)
 	icon_state = icon_aggro
 	return ..()
 

--- a/code/modules/mob/living/simple_animal/abnormality/he/porccubus.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/porccubus.dm
@@ -197,10 +197,10 @@
 		playsound(src, 'sound/abnormalities/porccubus/porccu_giggle.ogg', 10, FALSE, 4) // This thing is absurdly loud
 		ranged_cooldown = world.time + ranged_cooldown_time
 
-/mob/living/simple_animal/hostile/abnormality/porccubus/AttackingTarget()
+/mob/living/simple_animal/hostile/abnormality/porccubus/AttackingTarget(atom/attacked_target)
 	var/mob/living/carbon/human/H
-	if(ishuman(target))
-		H = target
+	if(ishuman(attacked_target))
+		H = attacked_target
 	. = ..()
 	if(.)
 		if(!H)

--- a/code/modules/mob/living/simple_animal/abnormality/he/red_shoes.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/red_shoes.dm
@@ -223,11 +223,11 @@
 		if(S.stat != DEAD && !S.target && !S.client && faction_check_mob(S))//cannibalized from steel ordeals
 			S.Goto(src,S.move_to_delay,1)
 
-/mob/living/simple_animal/hostile/abnormality/red_shoes/AttackingTarget()
+/mob/living/simple_animal/hostile/abnormality/red_shoes/AttackingTarget(atom/attacked_target)
 	. = ..()
-	if(!ishuman(target))
+	if(!ishuman(attacked_target))
 		return
-	var/mob/living/carbon/human/H = target
+	var/mob/living/carbon/human/H = attacked_target
 	if(H.stat >= SOFT_CRIT || H.health < 0)
 		ChopFeet(H)
 
@@ -392,11 +392,11 @@
 	move_to_delay = 3
 	var/steppy = 0
 
-/mob/living/simple_animal/hostile/red_shoe/AttackingTarget()
+/mob/living/simple_animal/hostile/red_shoe/AttackingTarget(atom/attacked_target)
 	. = ..()
-	if(!ishuman(target))
+	if(!ishuman(attacked_target))
 		return
-	var/mob/living/carbon/human/H = target
+	var/mob/living/carbon/human/H = attacked_target
 	if(H.stat >= SOFT_CRIT || H.health < 0)
 		ChopFeet(H)
 

--- a/code/modules/mob/living/simple_animal/abnormality/he/scarecrow.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/scarecrow.dm
@@ -75,12 +75,12 @@
 	QDEL_IN(src, 10 SECONDS)
 	..()
 
-/mob/living/simple_animal/hostile/abnormality/scarecrow/AttackingTarget()
+/mob/living/simple_animal/hostile/abnormality/scarecrow/AttackingTarget(atom/attacked_target)
 	. = ..()
 	if(.)
-		if(!istype(target, /mob/living/carbon/human))
+		if(!istype(attacked_target, /mob/living/carbon/human))
 			return
-		var/mob/living/carbon/human/H = target
+		var/mob/living/carbon/human/H = attacked_target
 		if(H.health < 0 && stat != DEAD && !finishing && H.getorgan(/obj/item/organ/brain))
 			finishing = TRUE
 			H.Stun(10 SECONDS)

--- a/code/modules/mob/living/simple_animal/abnormality/he/shock_centipede.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/shock_centipede.dm
@@ -234,13 +234,13 @@
 		AT.pixel_y += random_y
 		return 0
 
-/mob/living/simple_animal/hostile/abnormality/shock_centipede/AttackingTarget()
+/mob/living/simple_animal/hostile/abnormality/shock_centipede/AttackingTarget(atom/attacked_target)
 	if (shield > 0 || !can_act)  // dont attack if coiled or stunned
 		return FALSE
 	if(!client)
 		TryCoil()
 		if(tail_attack_cooldown < world.time)
-			var/turf/target_turf = get_turf(target)
+			var/turf/target_turf = get_turf(attacked_target)
 			for(var/i = 1 to tailattack_range - 2)
 				target_turf = get_step(target_turf, get_dir(get_turf(src), target_turf))
 			TailAttack(target_turf)

--- a/code/modules/mob/living/simple_animal/abnormality/he/snow_queen.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/snow_queen.dm
@@ -204,14 +204,14 @@
 		return TRUE
 	return ..()
 
-/mob/living/simple_animal/hostile/abnormality/snow_queen/AttackingTarget()
+/mob/living/simple_animal/hostile/abnormality/snow_queen/AttackingTarget(atom/attacked_target)
 	if(!can_act)
 		return FALSE
 	if(client)
 		return ..()
 	//Destroy them. They lost the duel.
-	if(ishuman(target))
-		var/mob/living/carbon/human/H = target
+	if(ishuman(attacked_target))
+		var/mob/living/carbon/human/H = attacked_target
 		if(H.stat == DEAD && (H == storybook_hero || H == frozen_employee))
 			H.dust(TRUE, FALSE)
 			return FALSE
@@ -224,7 +224,7 @@
 				can_act = TRUE
 				return
 			can_act = TRUE
-		Slash(target, wide = pick(TRUE, FALSE))
+		Slash(attacked_target, wide = pick(TRUE, FALSE))
 		return
 	//Dont do normal attacks if in the arena.
 	if(!arena_attacks)

--- a/code/modules/mob/living/simple_animal/abnormality/he/woodsman.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/woodsman.dm
@@ -129,8 +129,8 @@
 /mob/living/simple_animal/hostile/abnormality/woodsman/AttackingTarget(atom/attacked_target)
 	if(!can_act)
 		return FALSE
-	if(ishuman(target))
-		var/mob/living/carbon/human/H = target
+	if(ishuman(attacked_target))
+		var/mob/living/carbon/human/H = attacked_target
 		if(H.stat == DEAD || (H.health <= HEALTH_THRESHOLD_DEAD && HAS_TRAIT(H, TRAIT_NODEATH)) || H.health <= -30)
 			Heal(H)
 			return ..()
@@ -140,12 +140,12 @@
 	if(client)
 		switch(chosen_attack)
 			if(1)
-				Woodsman_Flurry(target)
+				Woodsman_Flurry(attacked_target)
 			if(2)
 				return ..()
 		return ..()
-	if(isliving(target) && flurry_cooldown <= world.time && get_dist(src, target) <= 2 && prob(30))
-		Woodsman_Flurry(target)
+	if(isliving(attacked_target) && flurry_cooldown <= world.time && get_dist(src, attacked_target) <= 2 && prob(30))
+		Woodsman_Flurry(attacked_target)
 	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/woodsman/PickTarget(list/Targets) // We attack corpses first if there are any

--- a/code/modules/mob/living/simple_animal/abnormality/teth/fairy_gentleman.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/fairy_gentleman.dm
@@ -131,16 +131,16 @@
 	is_flying_animal = TRUE
 	ADD_TRAIT(src, TRAIT_MOVE_FLYING, INNATE_TRAIT)
 
-/mob/living/simple_animal/hostile/abnormality/fairy_gentleman/AttackingTarget()
+/mob/living/simple_animal/hostile/abnormality/fairy_gentleman/AttackingTarget(atom/attacked_target)
 	if(!can_act)
 		return
 	melee_damage_type = WHITE_DAMAGE
 	if(jump_cooldown <= world.time && prob(10) && !client)
-		FairyJump(target)
+		FairyJump(attacked_target)
 		return
-	if(!ishuman(target))
+	if(!ishuman(attacked_target))
 		return ..()
-	var/mob/living/carbon/human/H = target
+	var/mob/living/carbon/human/H = attacked_target
 	H.drunkenness += 5
 	to_chat(H, span_warning("Yuck, some of it got in your mouth!"))
 	if(H.sanity_lost)

--- a/code/modules/mob/living/simple_animal/abnormality/teth/fairy_long_legs.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/fairy_long_legs.dm
@@ -157,10 +157,10 @@
 	icon_state = "fairy_longlegs"
 
 //Breach Stuff
-/mob/living/simple_animal/hostile/abnormality/fairy_longlegs/AttackingTarget()
+/mob/living/simple_animal/hostile/abnormality/fairy_longlegs/AttackingTarget(atom/attacked_target)
 	if(finishing)
 		return FALSE
-	if(!istype(target, /mob/living/carbon/human))
+	if(!istype(attacked_target, /mob/living/carbon/human))
 		return ..()
 	finishing = TRUE
 	icon_state = "fairy_longlegs_healing"

--- a/code/modules/mob/living/simple_animal/abnormality/teth/pale_horse.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/pale_horse.dm
@@ -136,11 +136,11 @@
 	for(var/turf/T in view(1, target_turf))
 		new /obj/effect/temp_visual/palefog(T)
 
-/mob/living/simple_animal/hostile/abnormality/pale_horse/AttackingTarget()
+/mob/living/simple_animal/hostile/abnormality/pale_horse/AttackingTarget(atom/attacked_target)
 	. = ..()
-	if(!ishuman(target))
+	if(!ishuman(attacked_target))
 		return FALSE
-	var/mob/living/carbon/human/T = target
+	var/mob/living/carbon/human/T = attacked_target
 	if(T.health > 0)
 		var/datum/status_effect/mortis/M = T.has_status_effect(/datum/status_effect/mortis)
 		if(!M)

--- a/code/modules/mob/living/simple_animal/abnormality/teth/ppodae.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/ppodae.dm
@@ -53,11 +53,11 @@
 		return FALSE
 	return ..()
 
-/mob/living/simple_animal/hostile/abnormality/ppodae/AttackingTarget()
+/mob/living/simple_animal/hostile/abnormality/ppodae/AttackingTarget(atom/attacked_target)
 	if(!can_act)
 		return FALSE
-	var/mob/living/carbon/L = target
-	if(iscarbon(target) && (L.health < 0 || L.stat == DEAD))
+	var/mob/living/carbon/L = attacked_target
+	if(iscarbon(attacked_target) && (L.health < 0 || L.stat == DEAD))
 		if(HAS_TRAIT(L, TRAIT_NODISMEMBER))
 			return
 		var/list/parts = list()
@@ -72,7 +72,7 @@
 			bp.forceMove(get_turf(datum_reference.landmark)) // Teleports limb to containment
 			QDEL_NULL(src)
 			// Taken from eldritch_demons.dm
-	return Smash(target)
+	return Smash(attacked_target)
 
 //AoE attack taken from woodsman
 /mob/living/simple_animal/hostile/abnormality/ppodae/proc/Smash(target)

--- a/code/modules/mob/living/simple_animal/abnormality/teth/punishing_bird.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/punishing_bird.dm
@@ -166,8 +166,8 @@
 			var/mob/living/carbon/le_target = pick(potential_mobs)
 			pecking_targets |= le_target
 
-/mob/living/simple_animal/hostile/abnormality/punishing_bird/AttackingTarget()
-	if(ishuman(target) && bird_angry)
+/mob/living/simple_animal/hostile/abnormality/punishing_bird/AttackingTarget(atom/attacked_target)
+	if(ishuman(attacked_target) && bird_angry)
 		melee_damage_lower = angry_damage_human
 		melee_damage_upper = angry_damage_human
 
@@ -179,8 +179,8 @@
 		melee_damage_lower = 1
 		melee_damage_upper = 2
 
-	if(isliving(target))
-		var/mob/living/L = target
+	if(isliving(attacked_target))
+		var/mob/living/L = attacked_target
 		if(!(L in enemies) && obj_damage > 0) // The target didn't attack us and we've transformed
 			to_chat(src, span_warning("You can't punish innocent people!"))
 			return

--- a/code/modules/mob/living/simple_animal/abnormality/teth/scorched_girl.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/scorched_girl.dm
@@ -84,7 +84,7 @@
 	var/highestcount = 0
 	for(var/turf/T in GLOB.department_centers)
 		var/targets_at_tile = 0
-		for(var/mob/living/L in view(10, T))
+		for(var/mob/living/L in ohearers(10, T))
 			if(!faction_check_mob(L) && L.stat != DEAD)
 				targets_at_tile++
 		if(targets_at_tile > highestcount)
@@ -104,7 +104,7 @@
 		return
 
 	var/amount_inview = 0
-	for(var/mob/living/carbon/human/H in view(7, src))
+	for(var/mob/living/carbon/human/H in ohearers(7, src))
 		if(!faction_check_mob(H) && H.stat != DEAD)
 			amount_inview += 1
 	if(prob(amount_inview*20))
@@ -122,7 +122,15 @@
 	return FALSE
 
 /mob/living/simple_animal/hostile/abnormality/scorched_girl/AttackingTarget(atom/attacked_target)
-	explode()
+	if(client)
+		explode()
+		return
+	var/amount_inview = 0
+	for(var/mob/living/carbon/human/H in ohearers(7, src))
+		if(!faction_check_mob(H) && H.stat != DEAD)
+			amount_inview += 1
+	if(prob(amount_inview * 20))
+		explode()
 	return
 
 /mob/living/simple_animal/hostile/abnormality/scorched_girl/proc/explode()

--- a/code/modules/mob/living/simple_animal/abnormality/teth/simple_smile.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/simple_smile.dm
@@ -64,10 +64,10 @@
 
 
 
-/mob/living/simple_animal/hostile/abnormality/smile/AttackingTarget()
+/mob/living/simple_animal/hostile/abnormality/smile/AttackingTarget(atom/attacked_target)
 	. = ..()
-	if(ishuman(target))
-		var/mob/living/carbon/human/L = target
+	if(ishuman(attacked_target))
+		var/mob/living/carbon/human/L = attacked_target
 		L.Knockdown(20)
 		var/obj/item/held = L.get_active_held_item()
 		L.dropItemToGround(held) //Drop weapon

--- a/code/modules/mob/living/simple_animal/abnormality/teth/so_that_no_cry.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/so_that_no_cry.dm
@@ -193,12 +193,12 @@
 	can_act = TRUE
 
 //Talisman Stuff
-/mob/living/simple_animal/hostile/abnormality/so_that_no_cry/AttackingTarget()
+/mob/living/simple_animal/hostile/abnormality/so_that_no_cry/AttackingTarget(atom/attacked_target)
 	if(!can_act)
 		return
-	if(!ishuman(target))
+	if(!ishuman(attacked_target))
 		return ..()
-	var/mob/living/carbon/human/H = target
+	var/mob/living/carbon/human/H = attacked_target
 	Apply_Talisman(H)
 	return ..()
 

--- a/code/modules/mob/living/simple_animal/abnormality/waw/apex_predator.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/apex_predator.dm
@@ -115,7 +115,7 @@
 	Cloak()
 	GiveTarget(user)
 
-/mob/living/simple_animal/hostile/abnormality/apex_predator/AttackingTarget()
+/mob/living/simple_animal/hostile/abnormality/apex_predator/AttackingTarget(atom/attacked_target)
 	if(!can_act)
 		return
 	if(!revealed)
@@ -126,23 +126,23 @@
 		Decloak()
 		SLEEP_CHECK_DEATH(3)
 		//Backstab
-		if(target in range(1, src))
-			if(isliving(target))
-				var/mob/living/V = target
-				visible_message(span_danger("The [src] rips out [target]'s guts!"))
+		if(attacked_target in range(1, src))
+			if(isliving(attacked_target))
+				var/mob/living/V = attacked_target
+				visible_message(span_danger("The [src] rips out [attacked_target]'s guts!"))
 				new /obj/effect/gibspawner/generic(get_turf(V))
 				V.deal_damage(backstab_damage, RED_DAMAGE)
 			//Backstab succeeds from any one of 3 tiles behind a mecha, backstab from directly behind gets boosted by mecha directional armor weakness
-			else if(ismecha(target))
-				var/relative_angle = abs(dir2angle(target.dir) - dir2angle(get_dir(target, src)))
+			else if(ismecha(attacked_target))
+				var/relative_angle = abs(dir2angle(attacked_target.dir) - dir2angle(get_dir(attacked_target, src)))
 				relative_angle = relative_angle > 180 ? 360 - relative_angle : relative_angle
 				if(relative_angle >= 135)
-					visible_message(span_danger("The [src] shreds [target]'s armor!"))
-					var/obj/vehicle/sealed/mecha/M = target
+					visible_message(span_danger("The [src] shreds [attacked_target]'s armor!"))
+					var/obj/vehicle/sealed/mecha/M = attacked_target
 					M.take_damage(backstab_damage, RED_DAMAGE, attack_dir = get_dir(M, src))
 					new /obj/effect/temp_visual/kinetic_blast(get_turf(M))
 				else
-					visible_message(span_danger("The [src]'s attack misses [target]'s weakspots!"))
+					visible_message(span_danger("The [src]'s attack misses [attacked_target]'s weakspots!"))
 					..()
 			else
 				..()

--- a/code/modules/mob/living/simple_animal/abnormality/waw/big_bird.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/big_bird.dm
@@ -128,11 +128,11 @@
 			return FALSE
 	return ..()
 
-/mob/living/simple_animal/hostile/abnormality/big_bird/AttackingTarget()
-	if(ishuman(target))
+/mob/living/simple_animal/hostile/abnormality/big_bird/AttackingTarget(atom/attacked_target)
+	if(ishuman(attacked_target))
 		if(bite_cooldown > world.time)
 			return FALSE
-		var/mob/living/carbon/human/H = target
+		var/mob/living/carbon/human/H = attacked_target
 		var/obj/item/bodypart/head/head = H.get_bodypart("head")
 		if(QDELETED(head))
 			return

--- a/code/modules/mob/living/simple_animal/abnormality/waw/big_wolf.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/big_wolf.dm
@@ -369,9 +369,9 @@
 	cut_overlay(visual_overlay)
 	can_act = TRUE
 
-/mob/living/simple_animal/hostile/abnormality/big_wolf/AttackingTarget()
-	if(istype(target, /mob/living/simple_animal/hostile/abnormality/red_hood)) //Red takes triple damage from the wolf, becauser her resistances are high
-		var/mob/living/simple_animal/hostile/abnormality/red_hood/mercenary = target
+/mob/living/simple_animal/hostile/abnormality/big_wolf/AttackingTarget(atom/attacked_target)
+	if(istype(attacked_target, /mob/living/simple_animal/hostile/abnormality/red_hood)) //Red takes triple damage from the wolf, becauser her resistances are high
+		var/mob/living/simple_animal/hostile/abnormality/red_hood/mercenary = attacked_target
 		var/bonus_damage_dealt = 2 * (rand(melee_damage_lower,melee_damage_upper))
 		mercenary.deal_damage(bonus_damage_dealt, RED_DAMAGE)
 	return ..()

--- a/code/modules/mob/living/simple_animal/abnormality/waw/clown_smiling.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/clown_smiling.dm
@@ -109,12 +109,12 @@
 			return FALSE
 	return ..()
 
-/mob/living/simple_animal/hostile/abnormality/clown/AttackingTarget()
+/mob/living/simple_animal/hostile/abnormality/clown/AttackingTarget(atom/attacked_target)
 	. = ..()
 	if(.)
-		if(!ishuman(target))
+		if(!ishuman(attacked_target))
 			return
-		var/mob/living/carbon/human/TH = target
+		var/mob/living/carbon/human/TH = attacked_target
 		if(TH.health < 0)
 			finishing = TRUE
 			TH.Stun(4 SECONDS)

--- a/code/modules/mob/living/simple_animal/abnormality/waw/ebony_queen.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/ebony_queen.dm
@@ -205,15 +205,15 @@
 		OpenFire()
 		return
 
-	if(target) // You'd think this should be "attacked_target" but no this shit still uses target I hate it.
-		if(ismecha(target))
+	if(attacked_target) // You'd think this should be "attacked_target" but no this shit still uses target I hate it.
+		if(ismecha(attacked_target))
 			if(burst_cooldown <= world.time && prob(50))
 				thornBurst()
 			else
 				OpenFire()
 			return
-		else if(isliving(target))
-			var/mob/living/L = target
+		else if(isliving(attacked_target))
+			var/mob/living/L = attacked_target
 			if(L.stat != DEAD)
 				if(burst_cooldown <= world.time && prob(50))
 					thornBurst()

--- a/code/modules/mob/living/simple_animal/abnormality/waw/hatred_queen.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/hatred_queen.dm
@@ -233,8 +233,8 @@
 		wand.forceMove(get_turf(src)) //That way it will be behind her like in the game.
 	return ..()
 
-/mob/living/simple_animal/hostile/abnormality/hatred_queen/AttackingTarget()
-	return OpenFire(target)
+/mob/living/simple_animal/hostile/abnormality/hatred_queen/AttackingTarget(atom/attacked_target)
+	return OpenFire(attacked_target)
 
 /mob/living/simple_animal/hostile/abnormality/hatred_queen/OpenFire()
 	if(!can_act || IsContained())

--- a/code/modules/mob/living/simple_animal/abnormality/waw/judgement_bird.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/judgement_bird.dm
@@ -192,10 +192,10 @@
 	visible_message(span_danger("<b>[src]</b> taunts [A]!"))
 	ranged_cooldown = world.time + ranged_cooldown_time
 
-/mob/living/simple_animal/hostile/runawaybird/AttackingTarget()
+/mob/living/simple_animal/hostile/runawaybird/AttackingTarget(atom/attacked_target)
 	. = ..()
-	if(ishuman(target))
-		var/mob/living/carbon/human/L = target
+	if(ishuman(attacked_target))
+		var/mob/living/carbon/human/L = attacked_target
 		L.Knockdown(20)
 		var/obj/item/held = L.get_active_held_item()
 		L.dropItemToGround(held) //Drop weapon

--- a/code/modules/mob/living/simple_animal/abnormality/waw/naked_nest.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/naked_nest.dm
@@ -187,14 +187,14 @@
 		origin_nest = home_naked_nest
 	AddComponent(/datum/component/swarming)
 
-/mob/living/simple_animal/hostile/naked_nest_serpent/AttackingTarget()
-	if(iscarbon(target))
-		var/mob/living/carbon/human/C = target
+/mob/living/simple_animal/hostile/naked_nest_serpent/AttackingTarget(atom/attacked_target)
+	if(iscarbon(attacked_target))
+		var/mob/living/carbon/human/C = attacked_target
 		if(C.stat != DEAD && !C.NAKED_NESTED && a_intent == "harm")
 			EnterHost(C)
 			return
-	if(istype(target, /mob/living/simple_animal/hostile/abnormality/naked_nest))
-		var/mob/living/simple_animal/hostile/abnormality/naked_nest/nest = target
+	if(istype(attacked_target, /mob/living/simple_animal/hostile/abnormality/naked_nest))
+		var/mob/living/simple_animal/hostile/abnormality/naked_nest/nest = attacked_target
 		nest.RecoverSerpent(src)
 	return ..()
 

--- a/code/modules/mob/living/simple_animal/abnormality/waw/nosferatu.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/nosferatu.dm
@@ -188,15 +188,15 @@
 		Banquet()
 		return
 
-/mob/living/simple_animal/hostile/abnormality/nosferatu/AttackingTarget() //Combo for double attacks
-	if(!ishuman(target))
+/mob/living/simple_animal/hostile/abnormality/nosferatu/AttackingTarget(atom/attacked_target) //Combo for double attacks
+	if(!ishuman(attacked_target))
 		return ..()
-	var/mob/living/carbon/human/H = target
+	var/mob/living/carbon/human/H = attacked_target
 	if(bloodlust <= 0)
 		bloodlust = bloodlust_cooldown
 		H.deal_damage(45, BLACK_DAMAGE)
 		playsound(get_turf(src), 'sound/abnormalities/nosferatu/bat_attack.ogg', 50, 1)
-		to_chat(target, span_danger("The [src] attacks you savagely!"))
+		to_chat(attacked_target, span_danger("The [src] attacks you savagely!"))
 		AdjustThirst(40)
 	else
 		bloodlust -= 1
@@ -267,8 +267,8 @@
 	retreat_distance = 3
 	minimum_distance = 1
 
-/mob/living/simple_animal/hostile/nosferatu_mob/AttackingTarget() //they spawn blood on hit
-	if(ishuman(target))
+/mob/living/simple_animal/hostile/nosferatu_mob/AttackingTarget(atom/attacked_target) //they spawn blood on hit
+	if(ishuman(attacked_target))
 		var/obj/effect/decal/cleanable/blood/B = locate() in get_turf(src)
 		if(!B)
 			B = new /obj/effect/decal/cleanable/blood(get_turf(src))

--- a/code/modules/mob/living/simple_animal/abnormality/waw/queen_bee.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/queen_bee.dm
@@ -135,11 +135,11 @@
 	alpha = 25
 	animate(src, alpha = 255, transform = init_transform, time = 5)
 
-/mob/living/simple_animal/hostile/worker_bee/AttackingTarget()
+/mob/living/simple_animal/hostile/worker_bee/AttackingTarget(atom/attacked_target)
 	. = ..()
-	if(!ishuman(target))
+	if(!ishuman(attacked_target))
 		return
-	var/mob/living/carbon/human/H = target
+	var/mob/living/carbon/human/H = attacked_target
 	if(H.health <= 0)
 		var/turf/T = get_turf(H)
 		visible_message(span_danger("[src] bites hard on \the [H] as another bee appears!"))

--- a/code/modules/mob/living/simple_animal/abnormality/waw/screenwriter.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/screenwriter.dm
@@ -310,12 +310,12 @@ Defeating the murderer also surpresses the abnormality.
 	if(LAZYLEN(priority))
 		return pick(priority)
 
-/mob/living/simple_animal/hostile/actor/AttackingTarget()
+/mob/living/simple_animal/hostile/actor/AttackingTarget(atom/attacked_target)
 	. = ..()
-	if(!ishuman(target))
+	if(!ishuman(attacked_target))
 		return
 
-	var/mob/living/carbon/human/H = target
+	var/mob/living/carbon/human/H = attacked_target
 	if(!H.sanity_lost)
 		return
 

--- a/code/modules/mob/living/simple_animal/abnormality/waw/sphinx.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/sphinx.dm
@@ -279,12 +279,12 @@
 	if(LAZYLEN(priority))
 		return pick(priority)
 
-/mob/living/simple_animal/hostile/abnormality/sphinx/AttackingTarget()
+/mob/living/simple_animal/hostile/abnormality/sphinx/AttackingTarget(atom/attacked_target)
 	..()
-	if(!ishuman(target))
+	if(!ishuman(attacked_target))
 		return
 
-	var/mob/living/carbon/human/H = target
+	var/mob/living/carbon/human/H = attacked_target
 	if(!H.sanity_lost)
 		return
 

--- a/code/modules/mob/living/simple_animal/abnormality/waw/thunder_bird.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/thunder_bird.dm
@@ -369,13 +369,13 @@
 	var/mob/living/simple_animal/hostile/abnormality/thunder_bird/master
 
 //Zombie conversion from zombie kills
-/mob/living/simple_animal/hostile/thunder_zombie/AttackingTarget()
+/mob/living/simple_animal/hostile/thunder_zombie/AttackingTarget(atom/attacked_target)
 	. = ..()
 	if(!can_act)
 		return
-	if(!ishuman(target))
+	if(!ishuman(attacked_target))
 		return
-	var/mob/living/carbon/human/H = target
+	var/mob/living/carbon/human/H = attacked_target
 	if(H.stat >= SOFT_CRIT || H.health < 0)
 		Convert(H)
 

--- a/code/modules/mob/living/simple_animal/abnormality/waw/warden.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/warden.dm
@@ -78,14 +78,14 @@
 		|Soul Warden|: If you attack a corpse, you will dust it, heal and gain a stack of “Captured Soul”<br>\
 		For each stack of “Captured Soul”, you become faster, deal 10 less melee damage and take 50% more damage.</b>")
 
-/mob/living/simple_animal/hostile/abnormality/warden/AttackingTarget()
+/mob/living/simple_animal/hostile/abnormality/warden/AttackingTarget(atom/attacked_target)
 	. = ..()
 	if(.)
 		if(finishing)
 			return FALSE
-		if(!istype(target, /mob/living/carbon/human))
+		if(!istype(attacked_target, /mob/living/carbon/human))
 			return
-		var/mob/living/carbon/human/H = target
+		var/mob/living/carbon/human/H = attacked_target
 
 		if(H.health < 0)
 

--- a/code/modules/mob/living/simple_animal/abnormality/waw/wrath_servant.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/wrath_servant.dm
@@ -257,18 +257,18 @@
 		return
 	if(prob(5))
 		if(friendly)
-			new /obj/effect/gibspawner/generic/silent/wrath_acid(get_turf(target))
+			new /obj/effect/gibspawner/generic/silent/wrath_acid(get_turf(attacked_target))
 		else
-			new /obj/effect/gibspawner/generic/silent/wrath_acid/bad(get_turf(target))
+			new /obj/effect/gibspawner/generic/silent/wrath_acid/bad(get_turf(attacked_target))
 	. = ..()
 	attack_sound = pick('sound/abnormalities/wrath_servant/small_smash1.ogg','sound/abnormalities/wrath_servant/small_smash2.ogg')
-	if(!isliving(target) || (get_dist(target, src) > 1))
+	if(!isliving(attacked_target) || (get_dist(attacked_target, src) > 1))
 		return
-	var/mob/living/L = target
+	var/mob/living/L = attacked_target
 	L.deal_damage(rand(10, 15), BLACK_DAMAGE)
-	if(!istype(target, /mob/living/simple_animal/hostile/azure_hermit))
+	if(!istype(attacked_target, /mob/living/simple_animal/hostile/azure_hermit))
 		return
-	var/mob/living/simple_animal/hostile/azure_hermit/AZ = target
+	var/mob/living/simple_animal/hostile/azure_hermit/AZ = attacked_target
 	if(AZ.health > 120)
 		return
 	PerformEnding(AZ)
@@ -727,8 +727,8 @@
 /mob/living/simple_animal/hostile/azure_hermit/AttackingTarget(atom/attacked_target)
 	if(!can_act || (status_flags & GODMODE))
 		return
-	if(istype(target, /mob/living/simple_animal/hostile/abnormality/wrath_servant))
-		var/mob/living/simple_animal/hostile/abnormality/wrath_servant/SW = target
+	if(istype(attacked_target, /mob/living/simple_animal/hostile/abnormality/wrath_servant))
+		var/mob/living/simple_animal/hostile/abnormality/wrath_servant/SW = attacked_target
 		if(SW.stunned)
 			return
 		if(SW.health > 400)
@@ -757,8 +757,8 @@
 			SW.icon_state = "wrath_staff_stun"
 			SW.desc = "A large red monster with white bandages hanging from it. Its flesh oozes a bubble acid. A wooden staff is impaled in its chest, it can't seem to move!"
 		return
-	if(ishuman(target))
-		var/mob/living/carbon/human/H = target
+	if(ishuman(attacked_target))
+		var/mob/living/carbon/human/H = attacked_target
 		if(get_user_level(H) < 3)
 			say("Pardon me.")
 			var/turf/TT = get_turf(H)

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/bald.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/bald.dm
@@ -117,10 +117,10 @@
 		if(HAS_TRAIT(not_bald, TRAIT_BALD))
 			. -= not_bald
 
-/mob/living/simple_animal/hostile/abnormality/bald/AttackingTarget()
+/mob/living/simple_animal/hostile/abnormality/bald/AttackingTarget(atom/attacked_target)
 	. = ..()
-	if(ishuman(target))
-		var/mob/living/carbon/human/H = target
+	if(ishuman(attacked_target))
+		var/mob/living/carbon/human/H = attacked_target
 		do_bald(H)
 
 /mob/living/simple_animal/hostile/abnormality/bald/Login()

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/blubbering_toad.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/blubbering_toad.dm
@@ -229,14 +229,14 @@
 	update_icon_state() //prevents icons from getting stuck
 	..()
 
-/mob/living/simple_animal/hostile/abnormality/blubbering_toad/AttackingTarget()
-	if(!ishuman(target))
+/mob/living/simple_animal/hostile/abnormality/blubbering_toad/AttackingTarget(atom/attacked_target)
+	if(!ishuman(attacked_target))
 		return
-	if(target != idiot)
-		LoseTarget(target)
+	if(attacked_target != idiot)
+		LoseTarget(attacked_target)
 		return
 	..()
-	var/mob/living/carbon/human/H = target
+	var/mob/living/carbon/human/H = attacked_target
 	if(H.sanity_lost) //prevents hitting the same guy in an infinite loop
 		melee_damage_type = BLACK_DAMAGE
 	if(H.health < 0)

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/bottle.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/bottle.dm
@@ -230,8 +230,8 @@
 /mob/living/simple_animal/hostile/abnormality/bottle/AttackingTarget(atom/attacked_target)
 	if(eating)
 		return
-	if(isliving(target))
-		var/mob/living/L = target
+	if(isliving(attacked_target))
+		var/mob/living/L = attacked_target
 		if(faction_check_mob(L))
 			L.visible_message(span_danger("[src] feeds [L]... [L] seems heartier!"), span_nicegreen("[src] feeds you, you feel heartier!"))
 			L.adjustBruteLoss(-speak_damage/2)

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/fairy_festival.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/fairy_festival.dm
@@ -164,15 +164,15 @@
 	AddComponent(/datum/component/swarming)
 	summon_backup()
 
-/mob/living/simple_animal/hostile/mini_fairy/AttackingTarget()
+/mob/living/simple_animal/hostile/mini_fairy/AttackingTarget(atom/attacked_target)
 	. = ..()
 	var/friends = 0
 	for(var/mob/living/simple_animal/hostile/mini_fairy/fren in view(6, src))
 		friends++
 	if(friends < 3)
 		summon_backup()
-	if(ishuman(target))
-		var/mob/living/L = target
+	if(ishuman(attacked_target))
+		var/mob/living/L = attacked_target
 		if(L.health < 0 || L.stat == DEAD)
 			var/mob/living/simple_animal/hostile/mini_fairy/MF = new(get_turf(L))
 			MF.faction = src.faction

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/sleeping_beauty.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/sleeping_beauty.dm
@@ -159,9 +159,9 @@
 
 //pink midnight code
 
-/mob/living/simple_animal/hostile/abnormality/sleeping/AttackingTarget()
+/mob/living/simple_animal/hostile/abnormality/sleeping/AttackingTarget(atom/attacked_target)
 	if(grab_cooldown < world.time)
-		buckle_mob(target)
+		buckle_mob(attacked_target)
 		grab_cooldown = world.time + grab_cooldown_time
 	return ..()
 

--- a/code/modules/mob/living/simple_animal/animal_defense.dm
+++ b/code/modules/mob/living/simple_animal/animal_defense.dm
@@ -107,10 +107,9 @@
 		if(.)
 			L.amount_grown = min(L.amount_grown + damage, L.max_grown)
 
-/mob/living/simple_animal/attack_animal(mob/living/simple_animal/M)
+/mob/living/simple_animal/attack_animal(mob/living/simple_animal/M, damage)
 	. = ..()
 	if(.)
-		var/damage = rand(M.melee_damage_lower, M.melee_damage_upper)
 		return attack_threshold_check(damage, M.melee_damage_type)
 
 /mob/living/simple_animal/attack_slime(mob/living/simple_animal/slime/M)

--- a/code/modules/mob/living/simple_animal/distortion/legend/papa_bongy.dm
+++ b/code/modules/mob/living/simple_animal/distortion/legend/papa_bongy.dm
@@ -125,14 +125,14 @@
 				return FALSE
 	return ..()
 
-/mob/living/simple_animal/hostile/distortion/papa_bongy/AttackingTarget()
-	if(!can_act || !target)
+/mob/living/simple_animal/hostile/distortion/papa_bongy/AttackingTarget(atom/attacked_target)
+	if(!can_act || !attacked_target)
 		return FALSE
-	if(!isliving(target))
+	if(!isliving(attacked_target))
 		return ..()
-	var/mob/living/carbon/human/H = target
+	var/mob/living/carbon/human/H = attacked_target
 	if(ishuman(H))
-		if(istype(target.ai_controller, /datum/ai_controller/insane/murder/bongy))
+		if(istype(H.ai_controller, /datum/ai_controller/insane/murder/bongy))
 			LoseTarget()
 			return//need to test whether this is still needed
 		H.add_movespeed_modifier(/datum/movespeed_modifier/bongy)
@@ -141,7 +141,7 @@
 			BongyPanic(H)
 	..()
 	can_act = FALSE
-	return DingAttack(target)
+	return DingAttack(attacked_target)
 
 /mob/living/simple_animal/hostile/distortion/papa_bongy/proc/DingAttack(target)
 	var/turf/target_turf = get_turf(target)
@@ -241,10 +241,10 @@
 				return FALSE
 	return ..()
 
-/mob/living/simple_animal/hostile/bongy_hostile/AttackingTarget()
-	if(!target)
+/mob/living/simple_animal/hostile/bongy_hostile/AttackingTarget(atom/attacked_target)
+	if(!attacked_target)
 		return FALSE
-	var/mob/living/carbon/human/H = target
+	var/mob/living/carbon/human/H = attacked_target
 	..()
 	if(ishuman(H) && H.sanity_lost)
 		BongyPanic(H)

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -695,15 +695,17 @@
 		target and they suddenly or are currently something
 		we dont attack.*/
 	if(QDELETED(target))
-		if(approaching_target)
-			/* Approaching target means we are currently moving menacingly
-				towards something. Otherwise we are just moving and if we
-				are investigating a location we dont want to be told to stand still. */
-			LoseTarget()
-		return FALSE
+		if(!FindTarget(possible_targets, TRUE))
+			if(approaching_target)
+				/* Approaching target means we are currently moving menacingly
+					towards something. Otherwise we are just moving and if we
+					are investigating a location we dont want to be told to stand still. */
+				LoseTarget()
+			return FALSE
 	if(!CanAttack(target))
-		LoseTarget()
-		return FALSE
+		if(!FindTarget(possible_targets, TRUE))
+			LoseTarget()
+			return FALSE
 	// The target we currently have is in our view and we must decide if we move towards it more.
 	if(target in possible_targets)
 		var/turf/T = get_turf(src)

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -112,7 +112,7 @@
 		return
 	if(client)
 		return
-	if(lose_patience_timeout && patience_last_interaction + lose_patience_timeout < world.time)
+	if(lose_patience_timeout && !QDELETED(target) && AIStatus == AI_ON && patience_last_interaction + lose_patience_timeout < world.time)
 		LosePatience()
 	if(!can_patrol)
 		return

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
@@ -117,12 +117,12 @@
 	else
 		..()
 
-/mob/living/simple_animal/hostile/megafauna/AttackingTarget()
+/mob/living/simple_animal/hostile/megafauna/AttackingTarget(atom/attacked_target)
 	if(recovery_time >= world.time)
 		return
 	. = ..()
-	if(. && isliving(target))
-		var/mob/living/L = target
+	if(. && isliving(attacked_target))
+		var/mob/living/L = attacked_target
 		if(L.stat != DEAD)
 			if(!client && ranged && ranged_cooldown <= world.time)
 				OpenFire()

--- a/code/modules/mob/living/simple_animal/hostile/ordeal/amber.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/amber.dm
@@ -79,10 +79,12 @@
 	if(. && target) //reset burrow cooldown whenever in combat
 		burrow_cooldown = world.time + burrow_cooldown_time
 
-/mob/living/simple_animal/hostile/ordeal/amber_bug/AttackingTarget()
+/mob/living/simple_animal/hostile/ordeal/amber_bug/AttackingTarget(atom/attacked_target)
+	if(burrowing)
+		return
 	. = ..()
 	if(.)
-		var/dir_to_target = get_dir(get_turf(src), get_turf(target))
+		var/dir_to_target = get_dir(get_turf(src), get_turf(attacked_target))
 		animate(src, pixel_y = (base_pixel_y + 18), time = 2)
 		addtimer(CALLBACK(src, PROC_REF(AnimateBack)), 2)
 		for(var/i = 1 to 2)

--- a/code/modules/mob/living/simple_animal/hostile/ordeal/brown/dawn.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/brown/dawn.dm
@@ -184,10 +184,10 @@
 	guaranteed_butcher_results = list(/obj/item/food/meat/slab/human/mutant/plant = 1)
 	stat_attack = DEAD
 
-/mob/living/simple_animal/hostile/ordeal/sin_gluttony/AttackingTarget()
+/mob/living/simple_animal/hostile/ordeal/sin_gluttony/AttackingTarget(atom/attacked_target)
 	. = ..()
-	if(. && isliving(target) && SSmaptype.maptype != "limbus_labs")
-		var/mob/living/L = target
+	if(. && isliving(attacked_target) && SSmaptype.maptype != "limbus_labs")
+		var/mob/living/L = attacked_target
 		if(L.stat != DEAD)
 			if(L.health <= HEALTH_THRESHOLD_DEAD && HAS_TRAIT(L, TRAIT_NODEATH))
 				devour(L)
@@ -299,16 +299,16 @@
 		return FALSE
 	return ..()
 
-/mob/living/simple_animal/hostile/ordeal/sin_pride/AttackingTarget()
+/mob/living/simple_animal/hostile/ordeal/sin_pride/AttackingTarget(atom/attacked_target)
 	if(charging)
 		return
 	if(dash_cooldown <= world.time && prob(10) && !client)
-		PrepCharge(target)
+		PrepCharge(attacked_target)
 		return
 	. = ..()
-	if(!ishuman(target))
+	if(!ishuman(attacked_target))
 		return
-	var/mob/living/carbon/human/H = target
+	var/mob/living/carbon/human/H = attacked_target
 	if(H.health < 0)
 		if(SSmaptype.maptype != "limbus_labs")
 			H.gib()

--- a/code/modules/mob/living/simple_animal/hostile/ordeal/crimson.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/crimson.dm
@@ -36,9 +36,9 @@
 		return TRUE
 	return FALSE
 
-/mob/living/simple_animal/hostile/ordeal/crimson_clown/AttackingTarget()
-	if(istype(target, /obj/machinery/computer/abnormality))
-		var/obj/machinery/computer/abnormality/CA = target
+/mob/living/simple_animal/hostile/ordeal/crimson_clown/AttackingTarget(atom/attacked_target)
+	if(istype(attacked_target, /obj/machinery/computer/abnormality))
+		var/obj/machinery/computer/abnormality/CA = attacked_target
 		if(console_attack_counter < 12)
 			console_attack_counter += 1
 			visible_message(span_warning("[src] hits [CA]'s buttons at random!"))
@@ -382,10 +382,10 @@
 			L.apply_damage(700, RED_DAMAGE, null, L.run_armor_check(null, RED_DAMAGE))
 	gib()
 
-/mob/living/simple_animal/hostile/ordeal/crimson_tent/AttackingTarget()
+/mob/living/simple_animal/hostile/ordeal/crimson_tent/AttackingTarget(atom/attacked_target)
 	if(!can_act)
 		return FALSE
-	return Bite(target)
+	return Bite(attacked_target)
 
 /mob/living/simple_animal/hostile/ordeal/crimson_tent/proc/Bite(target)
 	if (get_dist(src, target) > 3)

--- a/code/modules/mob/living/simple_animal/hostile/ordeal/gold/dusk.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/gold/dusk.dm
@@ -191,19 +191,19 @@
 	recharge_cooldown = world.time + recharge_cooldown_time
 	current_beam = Beam(A, icon_state="lightning[rand(1,12)]", time = 3 SECONDS)
 
-/mob/living/simple_animal/hostile/ordeal/thunderbird_corrosion/AttackingTarget()
+/mob/living/simple_animal/hostile/ordeal/thunderbird_corrosion/AttackingTarget(atom/attacked_target)
 	. = ..()
-	if(!isliving(target))
+	if(!isliving(attacked_target))
 		return
-	var/mob/living/L = target
+	var/mob/living/L = attacked_target
 	if(charge_level) // We deal up to 20 more damage, 1 for every point of charge.
 		L.deal_damage(charge_level, BLACK_DAMAGE)
 		playsound(get_turf(src), 'sound/weapons/fixer/generic/energyfinisher1.ogg', 75, 1)
 		to_chat(L,span_danger("The [src] unleashes its charge!"))
 		AdjustCharge(-charge_level)
-	if(!ishuman(target))
+	if(!ishuman(attacked_target))
 		return
-	var/mob/living/carbon/human/H = target
+	var/mob/living/carbon/human/H = attacked_target
 	if(H.stat >= SOFT_CRIT || H.health < 0)
 		Convert(H)
 

--- a/code/modules/mob/living/simple_animal/hostile/ordeal/gold/noon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/gold/noon.dm
@@ -60,10 +60,10 @@
 		AreaAttack()
 		return
 
-/mob/living/simple_animal/hostile/ordeal/white_lake_corrosion/AttackingTarget()
+/mob/living/simple_animal/hostile/ordeal/white_lake_corrosion/AttackingTarget(atom/attacked_target)
 	if(!can_act)
 		return FALSE
-	return Slash(target)
+	return Slash(attacked_target)
 
 /mob/living/simple_animal/hostile/ordeal/white_lake_corrosion/proc/Slash(target)
 	if (get_dist(src, target) > 3)
@@ -293,14 +293,14 @@
 		return FALSE
 	return ..()
 
-/mob/living/simple_animal/hostile/ordeal/silentgirl_corrosion/AttackingTarget()
-	if(!vengeful && (target != current_target))
+/mob/living/simple_animal/hostile/ordeal/silentgirl_corrosion/AttackingTarget(atom/attacked_target)
+	if(!vengeful && (attacked_target != current_target))
 		return FALSE
 	. = ..()
 	if(.)
-		if(!ishuman(target))
+		if(!ishuman(attacked_target))
 			return
-		var/mob/living/carbon/human/TH = target
+		var/mob/living/carbon/human/TH = attacked_target
 		if(TH.health < 0 || TH.sanity_lost)
 			finishing = TRUE
 			TH.Stun(4 SECONDS)

--- a/code/modules/mob/living/simple_animal/hostile/ordeal/green.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/green.dm
@@ -38,6 +38,7 @@
 
 	/// Can't move/attack when it's TRUE
 	var/reloading = FALSE
+	var/firing_time = 0
 	/// When at 12 - it will start "reloading"
 	var/fire_count = 0
 
@@ -64,18 +65,23 @@
 /mob/living/simple_animal/hostile/ordeal/green_bot_big/OpenFire(atom/A)
 	if(reloading)
 		return FALSE
+	firing_time = world.time
 	fire_count += 1
 	if(fire_count >= 12)
 		StartReloading()
 		return FALSE
 	return ..()
 
-/mob/living/simple_animal/hostile/ordeal/green_bot_big/AttackingTarget()
+/mob/living/simple_animal/hostile/ordeal/green_bot_big/AttackingTarget(atom/attacked_target)
+	if(reloading)
+		return FALSE
+	if(world.time < firing_time + 1.2 SECONDS)
+		return FALSE
 	. = ..()
 	if(.)
-		if(!istype(target, /mob/living))
+		if(!istype(attacked_target, /mob/living))
 			return
-		var/turf/T = get_turf(target)
+		var/turf/T = get_turf(attacked_target)
 		if(!T)
 			return
 		for(var/i = 1 to 4)

--- a/code/modules/mob/living/simple_animal/hostile/ordeal/green/dawn.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/green/dawn.dm
@@ -47,14 +47,16 @@
 		return FALSE
 	return ..()
 
-/mob/living/simple_animal/hostile/ordeal/green_bot/AttackingTarget()
+/mob/living/simple_animal/hostile/ordeal/green_bot/AttackingTarget(atom/attacked_target)
+	if(finishing)
+		return
 	. = ..()
 	if(.)
-		if(!istype(target, /mob/living/carbon/human))
+		if(!istype(attacked_target, /mob/living/carbon/human))
 			return
 		if(SSmaptype.maptype in SSmaptype.citymaps)
 			return
-		var/mob/living/carbon/human/TH = target
+		var/mob/living/carbon/human/TH = attacked_target
 		if(TH.health < 0)
 			finishing = TRUE
 			TH.Stun(4 SECONDS)
@@ -103,12 +105,14 @@
 	melee_damage_lower = 14
 	melee_damage_upper = 16
 
-/mob/living/simple_animal/hostile/ordeal/green_bot/syringe/AttackingTarget()
+/mob/living/simple_animal/hostile/ordeal/green_bot/syringe/AttackingTarget(atom/attacked_target)
+	if(finishing)
+		return
 	. = ..()
 	if(.)
-		if(!istype(target, /mob/living/carbon/human))
+		if(!istype(attacked_target, /mob/living/carbon/human))
 			return
-		var/mob/living/carbon/human/H = target
+		var/mob/living/carbon/human/H = attacked_target
 		H.add_movespeed_modifier(/datum/movespeed_modifier/grab_slowdown/aggressive)
 		addtimer(CALLBACK(H, TYPE_PROC_REF(/mob, remove_movespeed_modifier), /datum/movespeed_modifier/grab_slowdown/aggressive), 4 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
 

--- a/code/modules/mob/living/simple_animal/hostile/ordeal/indigo.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/indigo.dm
@@ -38,10 +38,10 @@
 	. = ..()
 	a_intent_change(INTENT_HELP)
 
-/mob/living/simple_animal/hostile/ordeal/indigo_noon/AttackingTarget()
+/mob/living/simple_animal/hostile/ordeal/indigo_noon/AttackingTarget(atom/attacked_target)
 	. = ..()
-	if(. && isliving(target))
-		var/mob/living/L = target
+	if(. && isliving(attacked_target))
+		var/mob/living/L = attacked_target
 		if(L.stat != DEAD)
 			if(L.health <= HEALTH_THRESHOLD_DEAD && HAS_TRAIT(L, TRAIT_NODEATH))
 				devour(L)
@@ -196,10 +196,10 @@
 	. = ..()
 	a_intent_change(INTENT_HELP) //so that they dont get body blocked by their kin outside of combat
 
-/mob/living/simple_animal/hostile/ordeal/indigo_dusk/AttackingTarget()
+/mob/living/simple_animal/hostile/ordeal/indigo_dusk/AttackingTarget(atom/attacked_target)
 	. = ..()
-	if(. && isliving(target))
-		var/mob/living/L = target
+	if(. && isliving(attacked_target))
+		var/mob/living/L = attacked_target
 		if(L.stat != DEAD)
 			if(L.health <= HEALTH_THRESHOLD_DEAD && HAS_TRAIT(L, TRAIT_NODEATH))
 				devour(L)
@@ -361,10 +361,10 @@
 	patrol_reset()
 	return FALSE
 
-/mob/living/simple_animal/hostile/ordeal/indigo_midnight/AttackingTarget()
+/mob/living/simple_animal/hostile/ordeal/indigo_midnight/AttackingTarget(atom/attacked_target)
 	. = ..()
-	if(. && isliving(target))
-		var/mob/living/L = target
+	if(. && isliving(attacked_target))
+		var/mob/living/L = attacked_target
 		if(L.stat != DEAD)
 			if(L.health <= HEALTH_THRESHOLD_DEAD && HAS_TRAIT(L, TRAIT_NODEATH))
 				devour(L)

--- a/code/modules/mob/living/simple_animal/hostile/ordeal/indigo/dawn.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/indigo/dawn.dm
@@ -23,10 +23,10 @@
 	blood_volume = BLOOD_VOLUME_NORMAL
 	silk_results = list(/obj/item/stack/sheet/silk/indigo_simple = 1)
 
-/mob/living/simple_animal/hostile/ordeal/indigo_dawn/AttackingTarget()
+/mob/living/simple_animal/hostile/ordeal/indigo_dawn/AttackingTarget(atom/attacked_target)
 	. = ..()
-	if(. && isliving(target))
-		var/mob/living/L = target
+	if(. && isliving(attacked_target))
+		var/mob/living/L = attacked_target
 		if(L.stat != DEAD)
 			if(L.health <= HEALTH_THRESHOLD_DEAD && HAS_TRAIT(L, TRAIT_NODEATH))
 				devour(L)

--- a/code/modules/mob/living/simple_animal/hostile/ordeal/white.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/white.dm
@@ -59,12 +59,12 @@
 		current_pulse_range = max(6, current_pulse_range - min(round(amount * 0.1), 4)) // Being attacked will reduce the range temporarily
 	return ..()
 
-/mob/living/simple_animal/hostile/ordeal/black_fixer/AttackingTarget()
+/mob/living/simple_animal/hostile/ordeal/black_fixer/AttackingTarget(atom/attacked_target)
 	if(busy)
 		return
 	..()
 	if(hammer_cooldown < world.time)
-		HammerAttack(target)
+		HammerAttack(attacked_target)
 
 /mob/living/simple_animal/hostile/ordeal/black_fixer/OpenFire()
 	if(busy)
@@ -407,15 +407,15 @@
 		return FALSE
 	return ..()
 
-/mob/living/simple_animal/hostile/ordeal/red_fixer/AttackingTarget()
+/mob/living/simple_animal/hostile/ordeal/red_fixer/AttackingTarget(atom/attacked_target)
 	if(busy)
 		return
 	..()
 	if(multislash_cooldown < world.time)
-		MultiSlash(target)
+		MultiSlash(attacked_target)
 		return
 	if(prob(50) && beam_cooldown < world.time)
-		LaserBeam(target)
+		LaserBeam(attacked_target)
 		return
 
 /mob/living/simple_animal/hostile/ordeal/red_fixer/OpenFire()
@@ -565,14 +565,14 @@
 		return FALSE
 	return ..()
 
-/mob/living/simple_animal/hostile/ordeal/pale_fixer/AttackingTarget()
+/mob/living/simple_animal/hostile/ordeal/pale_fixer/AttackingTarget(atom/attacked_target)
 	if(!can_act)
 		return
 	if(prob(60) && multislash_cooldown < world.time)
-		MultiSlash(target)
+		MultiSlash(attacked_target)
 		return
 	if(prob(40) && tentacle_cooldown < world.time)
-		TentacleAttack(target)
+		TentacleAttack(attacked_target)
 		return
 	return ..()
 

--- a/code/modules/spells/ability_types/realized.dm
+++ b/code/modules/spells/ability_types/realized.dm
@@ -1106,10 +1106,10 @@
 	AddComponent(/datum/component/knockback, 1, FALSE, TRUE)
 	QDEL_IN(src, (90 SECONDS))
 
-/mob/living/simple_animal/hostile/shrimp/friendly/AttackingTarget()
+/mob/living/simple_animal/hostile/shrimp/friendly/AttackingTarget(atom/attacked_target)
 	. = ..()
 	if(.)
-		var/mob/living/L = target
+		var/mob/living/L = attacked_target
 		if(L.health < 0 || L.stat == DEAD)
 			L.gib() //Punch them so hard they explode
 /* Flesh Idol - Repentance */
@@ -1283,8 +1283,8 @@
 	AddComponent(/datum/component/swarming)
 	QDEL_IN(src, (20 SECONDS))
 
-/mob/living/simple_animal/hostile/naked_nest_serpent_friend/AttackingTarget()
-	var/mob/living/L = target
+/mob/living/simple_animal/hostile/naked_nest_serpent_friend/AttackingTarget(atom/attacked_target)
+	var/mob/living/L = attacked_target
 	var/datum/status_effect/stacking/infestation/INF = L.has_status_effect(/datum/status_effect/stacking/infestation)
 	if(!INF)
 		INF = L.apply_status_effect(/datum/status_effect/stacking/infestation)

--- a/code/modules/suppressions/extraction.dm
+++ b/code/modules/suppressions/extraction.dm
@@ -176,8 +176,8 @@
 
 /* Combat */
 
-/mob/living/simple_animal/hostile/megafauna/arbiter/AttackingTarget()
-	return OpenFire(target)
+/mob/living/simple_animal/hostile/megafauna/arbiter/AttackingTarget(atom/attacked_target)
+	return OpenFire(attacked_target)
 
 /mob/living/simple_animal/hostile/megafauna/arbiter/OpenFire(target)
 	if(charging)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes the mob ai more opportunistic about attacking other enemies while main target is out of reach.
Implements actual melee attack delay for ai (attack_cooldown in deciseconds), converts existing rapid_melee values.
AttackingTarget proc now actually uses the attacked_target parameter to allow attacking things other than the aggro holder.

https://github.com/vlggms/lobotomy-corp13/assets/23573057/f4f6d0e1-75da-461a-918e-d79c6ddbae7f


Optimised ListTargets.
Shortened patience loss time to 5 seconds, now mob has to lose target, lose patience or get enough aggro to overpower current target aggro + target_switch_resistance(about 15% maxhp worth of aggro) to switch targets instead of it being random upon taking damage. 
Simple animals now properly add aggro upon attacking, which fixes mobs always prioritizing attacking other mobs instead of humans.
Hostiles now gain patience upon being attacked by the target in melee, this lets mobs without melee attacks such as Arbiter keep the same target so long as you keep attacking them.
Added AGGRO_DAMAGE damage type for adding aggro without dealing damage.
Shield type ego now deal aggro damage, that scales with the average of fortitude and prudence, in a 3 tile radius on block(regardless of any attacks getting blocked)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Would make kiting strong enemies less effective.
Can customize mob attack cooldowns more precisely.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Mob ai will attack anyone in range while main target is too far
code: AttackingTarget now uses the attacked_target parameter, mob melee attack speed is now using attack_cooldown instead of rapid_melee
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
