### PR TITLE
Adds city traits and stats to Torso Fabricator

### DIFF
--- a/ModularTegustation/lc13_machinery.dm
+++ b/ModularTegustation/lc13_machinery.dm
@@ -269,11 +269,15 @@
 	H.revive(full_heal = FALSE, admin_revive = FALSE)
 	H.emote("gasp")
 	H.Jitter(100)
+	ADD_TRAIT(H, TRAIT_COMBATFEAR_IMMUNE, JOB_TRAIT)
+	ADD_TRAIT(H, TRAIT_WORK_FORBIDDEN, JOB_TRAIT)
+	H.adjust_all_attribute_levels(45)
+	//45 stats with organic, 25 stats with robotic.
 
 	//YOU DIDNT PAY FOR PREMIUM SO WE ARE MAKING YOUR BODY WORSE
 	if(biotype == 2)
 		RoboticizeBody(H)
-		H.adjust_all_attribute_levels(-5)
+		H.adjust_all_attribute_levels(-20)
 	H.updateappearance()
 	DumpBody(H)
 


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Torso fabricator in the City map didnt provide stats or the combat fear immune trait. So i added it in.

Organic bodies give 45 stats while robotic give 25
Will make a rework of this when https://github.com/vlggms/lobotomy-corp13/pull/1843 is done.

## Why It's Good For The Game
Makes torso fabricator as a means to revive more viable.

## Changelog
:cl:
tweak: torso fabricator
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
