### PR TITLE
HurtInTurf improvements

### DIFF
--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -22,6 +22,9 @@
 	. = ..()
 	. += deconstruction_hints(user)
 
+/obj/structure/lattice/attack_animal(mob/living/simple_animal/M)
+	return FALSE
+
 /obj/structure/lattice/proc/deconstruction_hints(mob/user)
 	return span_notice("The rods look like they could be <b>cut</b>. There's space for more <i>rods</i> or a <i>tile</i>.")
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds some more stuff including lattices into hurtinturf blacklist.
Allows hurtinturf to damage machinery.
Adds more potential hiding spots to check.
Adds attack direction parameter for mecha directional armor.
Additionally made simplemobs unable to attack lattices.
Also seems to be faster now
![2024-04-29 04_59_39-Lobotomy Corporation 13 (Unofficial)_ Matzah No-Moon XI](https://github.com/vlggms/lobotomy-corp13/assets/23573057/7e6bf9aa-5341-4122-b87c-71977972ba8c)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Abnormalities and hostiles shouldnt be able to break lattice floors anymore with direct attacks or abilities.
Better hurtinturf proc.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: simplemobs cant attack lattices anymore
code: HurtInTurf for various abilities now ignores lattices and is better.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
