### PR TITLE
Vermillion no longer gains damage and healing from corpses and friendly naked nest serpents

### DIFF
--- a/code/game/objects/items/ego_weapons/non_abnormality/color_fixer.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/color_fixer.dm
@@ -20,7 +20,11 @@
 		TEMPERANCE_ATTRIBUTE = 120,
 		JUSTICE_ATTRIBUTE = 120,
 	)
-	var/ready = TRUE
+	/// Are we currently using our ability?
+	var/using_ability = FALSE
+
+	/// The mobs we dont want to scale damage to
+	var/list/mob_blacklist = list(/mob/living/simple_animal/hostile/naked_nest_serpent_friend)
 
 
 /obj/item/ego_weapon/city/vermillion/attack_self(mob/living/carbon/human/user)
@@ -28,32 +32,40 @@
 	if(!CanUseEgo(user))
 		return
 
-	if(!ready)
+	if(using_ability)
 		return
-	ready = FALSE
+
+	using_ability = TRUE
 	to_chat(user, span_userdanger("READY."))
-	force*=1.5
+	force *= 1.5
 	user.adjustBruteLoss(user.maxHealth*0.5)
 	addtimer(CALLBACK(src, PROC_REF(Return), user), 15 SECONDS)
 
 
 /obj/item/ego_weapon/city/vermillion/attack(mob/living/target, mob/living/carbon/human/user)
-	var/living
-	if(target.stat != DEAD)
-		living = TRUE
-	..()
-	if(target.stat == DEAD && living)
-		user.adjustSanityLoss(-30)
-		living = FALSE
+	if(!using_ability)
+		return ..()
 
-	if(force != initial(force) && !living)
-		to_chat(user, span_userdanger("ANOTHER."))
-		force*=1.5
-		user.adjustBruteLoss(-user.maxHealth*0.1)
+	for(var/mob/living/alive_mob in mob_blacklist)
+		if(target == alive_mob)
+			return ..()
+
+	if(target.stat == DEAD)
+		return ..()
+
+	. = ..()
+	if(target.stat != DEAD)
+		return
+
+	user.adjustSanityLoss(-30)
+	user.adjustBruteLoss(-user.maxHealth*0.1)
+
+	to_chat(user, span_userdanger("ANOTHER."))
+	force*=1.5
 
 /obj/item/ego_weapon/city/vermillion/proc/Return(mob/living/carbon/human/user)
 	force = initial(force)
-	ready = TRUE
+	using_ability = FALSE
 	to_chat(user, span_notice("I AM NOT SATED."))
 
 /obj/item/ego_weapon/mimicry/kali

--- a/code/game/objects/items/ego_weapons/non_abnormality/color_fixer.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/color_fixer.dm
@@ -43,25 +43,26 @@
 
 
 /obj/item/ego_weapon/city/vermillion/attack(mob/living/target, mob/living/carbon/human/user)
-	if(!using_ability)
+	if(target.stat == DEAD)
 		return ..()
 
 	for(var/mob/living/alive_mob in mob_blacklist)
 		if(target == alive_mob)
 			return ..()
 
-	if(target.stat == DEAD)
-		return ..()
-
 	. = ..()
+
 	if(target.stat != DEAD)
 		return
 
 	user.adjustSanityLoss(-30)
-	user.adjustBruteLoss(-user.maxHealth*0.1)
 
+	if(!using_ability)
+		return
+
+	user.adjustBruteLoss(-user.maxHealth*0.1)
 	to_chat(user, span_userdanger("ANOTHER."))
-	force*=1.5
+	force *= 1.5
 
 /obj/item/ego_weapon/city/vermillion/proc/Return(mob/living/carbon/human/user)
 	force = initial(force)


### PR DESCRIPTION

## About The Pull Request

Fixes the vermillion cross gaining damage from corpses
And balances it to no longer gain damage from friendly naked nest serpents

It was always meant to be a good crowd control weapon, so everything else is fair game

## Why It's Good For The Game

Because its superior to all other weapons, a verbillion damage and healing is probably not good

## Changelog
:cl:
fix: Vermillion cross no longer gets its abilities triggered by dead corpses
balance: Vermillion cross no longer gets its abilities triggered by friendly naked nest serpents
/:cl:
