### PR TITLE
All-around Helper is now all-around weaker

### DIFF
--- a/code/game/objects/items/ego_weapons/he.dm
+++ b/code/game/objects/items/ego_weapons/he.dm
@@ -4,7 +4,7 @@
 	Its operation is simple and straightforward, but that doesn't necessarily make it easy to wield."
 	special = "This weapon pierces to hit everything on the target's tile."
 	icon_state = "grinder"
-	force = 30
+	force = 26
 	damtype = RED_DAMAGE
 	attack_verb_continuous = list("slices", "saws", "rips")
 	attack_verb_simple = list("slice", "saw", "rip")
@@ -22,7 +22,7 @@
 	var/justicemod = 1 + userjust/100
 	force*=justicemod
 	user.HurtInTurf(T, list(target), (force*force_multiplier), RED_DAMAGE, hurt_mechs = TRUE, hurt_structure = TRUE)
-	force = 30
+	force = 26
 
 /obj/item/ego_weapon/grinder/get_clamped_volume()
 	return 40

--- a/code/modules/clothing/suits/ego_gear/he.dm
+++ b/code/modules/clothing/suits/ego_gear/he.dm
@@ -12,7 +12,7 @@ Any attempt to code risk class armor will result in a 10 day Github ban.*/
 	name = "grinder MK4"
 	desc = "A sleek coat covered with bloodstains of an unknown origin."
 	icon_state = "grinder"
-	armor = list(RED_DAMAGE = 50, WHITE_DAMAGE = -20, BLACK_DAMAGE = 20, PALE_DAMAGE = 20) // 70
+	armor = list(RED_DAMAGE = 40, WHITE_DAMAGE = -10, BLACK_DAMAGE = 20, PALE_DAMAGE = 20) // 70
 	attribute_requirements = list(
 							PRUDENCE_ATTRIBUTE = 40
 							)

--- a/code/modules/mob/living/simple_animal/abnormality/he/helper.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/helper.dm
@@ -49,7 +49,7 @@
 	var/dash_cooldown = 0
 	var/dash_cooldown_time = 8 SECONDS
 	var/list/been_hit = list() // Don't get hit twice.
-	var/stuntime = 5 SECONDS
+	var/stuntime = 3 SECONDS
 
 	//PLAYABLES ATTACKS
 	attack_action_types = list(/datum/action/innate/abnormality_attack/toggle/helper_dash_toggle)
@@ -118,7 +118,7 @@
 	if(dir_to_target in list(WEST, NORTHWEST, SOUTHWEST))
 		para = FALSE
 	been_hit = list()
-	SpinAnimation(1.8 SECONDS, 1, para)
+	SpinAnimation(1.3 SECONDS, 1, para)
 	addtimer(CALLBACK(src, PROC_REF(do_dash), dir_to_target, 0), 1.5 SECONDS)
 	playsound(src, 'sound/abnormalities/helper/rise.ogg', 100, 1)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
- Grinder MK4's damage was reduced from 30 to 26.
- Grinder MK4's armor was changed from 5/-2/2/2 to 4/-1/2/2.
- Helper starts the spin attack 0.5 seconds faster
- Helper is now stunned for 3 seconds instead of 5.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Helper gives you way, way too much for what it is.
I want to curb it very slightly, without totally gutting everything.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Helper and it's EGO are now less desirable.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
