### PR TITLE
Aoe Weapon Fix

### DIFF
--- a/code/game/objects/items/ego_weapons/he.dm
+++ b/code/game/objects/items/ego_weapons/he.dm
@@ -14,15 +14,16 @@
 							)
 
 /obj/item/ego_weapon/grinder/attack(mob/living/target, mob/living/user)
-	if(!..())
-		return FALSE
 	var/turf/T = get_turf(target)
+	. = ..()
+	if(!.)
+		return FALSE
 	//damage calculations
 	var/userjust = (get_modified_attribute_level(user, JUSTICE_ATTRIBUTE))
-	var/justicemod = 1 + userjust/100
-	force*=justicemod
-	user.HurtInTurf(T, list(target), (force*force_multiplier), RED_DAMAGE, hurt_mechs = TRUE, hurt_structure = TRUE)
-	force = 26
+	var/justicemod = 1 + userjust / 100
+	var/damage_dealt = force * justicemod * force_multiplier
+	var/list/been_hit = QDELETED(target) ? list() : list(target)
+	user.HurtInTurf(T, been_hit, damage_dealt, RED_DAMAGE, hurt_mechs = TRUE, hurt_structure = TRUE)
 
 /obj/item/ego_weapon/grinder/get_clamped_volume()
 	return 40

--- a/code/game/objects/items/ego_weapons/waw.dm
+++ b/code/game/objects/items/ego_weapons/waw.dm
@@ -17,15 +17,16 @@
 	)
 
 /obj/item/ego_weapon/lamp/attack(mob/living/M, mob/living/user)
+	var/turf/target_turf = get_turf(M)
 	. = ..()
 	if(!.)
 		return FALSE
-	for(var/mob/living/L in view(1, M))
+	for(var/mob/living/L in hearers(1, target_turf))
 		var/aoe = 25
 		var/userjust = (get_modified_attribute_level(user, JUSTICE_ATTRIBUTE))
-		var/justicemod = 1 + userjust/100
-		aoe*=justicemod
-		aoe*=force_multiplier
+		var/justicemod = 1 + userjust / 100
+		aoe *= justicemod
+		aoe *= force_multiplier
 		if(L == user || ishuman(L))
 			continue
 		L.apply_damage(aoe, BLACK_DAMAGE, null, L.run_armor_check(null, BLACK_DAMAGE), spread_damage = TRUE)
@@ -1028,6 +1029,7 @@
 	return 30
 
 /obj/item/ego_weapon/blind_rage/attack(mob/living/M, mob/living/carbon/human/user)
+	var/turf/target_turf = get_turf(M)
 	. = ..()
 	if(!.)
 		return FALSE
@@ -1046,41 +1048,19 @@
 		damage *= 3
 	if(user.sanity_lost)
 		damage *= 1.2
-	for(var/turf/open/T in range(aoe_range, M))
+	for(var/turf/open/T in RANGE_TURFS(aoe_range, target_turf))
 		var/obj/effect/temp_visual/small_smoke/halfsecond/smonk = new(T)
 		smonk.color = COLOR_GREEN
-		user.HurtInTurf(T, list(M), damage, damtype, hurt_mechs = TRUE, hurt_structure = TRUE, break_not_destroy = TRUE)
+		var/list/been_hit = QDELETED(M) ? list() : list(M)
+		user.HurtInTurf(T, been_hit, damage, damtype, hurt_mechs = TRUE, hurt_structure = TRUE, break_not_destroy = TRUE)
 		user.HurtInTurf(T, list(), damage, aoe_damage_type, hurt_mechs = TRUE, hurt_structure = TRUE, break_not_destroy = TRUE)
 		if(prob(5))
 			new /obj/effect/gibspawner/generic/silent/wrath_acid(T) // The non-damaging one
-	var/combo = FALSE
 	var/mob/living/carbon/human/myman = user
 	var/obj/item/ego_weapon/blind_rage/Y = myman.get_inactive_held_item()
 	var/obj/item/clothing/suit/armor/ego_gear/realization/woundedcourage/Z = myman.get_item_by_slot(ITEM_SLOT_OCLOTHING)
-	if((istype(Y)) & (istype(Z))) //dual wielding and wearing Wounded Courage? if so...
-		combo = TRUE //hits twice
-	else
-		combo = FALSE
-	if(combo)
-		if(M in view(reach,user))
-			Y.attacks++
-			Y.attacks %=3
-			switch(attacks)
-				if(0)
-					hitsound = 'sound/abnormalities/wrath_servant/big_smash1.ogg'
-				if(1)
-					hitsound = 'sound/abnormalities/wrath_servant/big_smash2.ogg'
-				if(2)
-					hitsound = 'sound/abnormalities/wrath_servant/big_smash3.ogg'
-			M.attacked_by(src, user)
-			M.send_item_attack_message(src, user,M)
-			user.do_attack_animation(M)
-			playsound(loc, hitsound, get_clamped_volume(), TRUE, extrarange = stealthy_audio ? SILENCED_SOUND_EXTRARANGE : -1, falloff_distance = 0)
-			for(var/turf/open/T in range(aoe_range, M))
-				var/obj/effect/temp_visual/small_smoke/halfsecond/smonk = new(T)
-				smonk.color = COLOR_GREEN
-				user.HurtInTurf(T, list(M), damage, damtype, hurt_mechs = TRUE, hurt_structure = TRUE, break_not_destroy = TRUE)
-				user.HurtInTurf(T, list(), damage, aoe_damage_type, hurt_mechs = TRUE, hurt_structure = TRUE, break_not_destroy = TRUE)
+	if(istype(Y) && Y != src && istype(Z) && !QDELETED(M)) //dual wielding and wearing Wounded Courage? if so...
+		Y.melee_attack_chain(user, M)
 
 /obj/item/ego_weapon/blind_rage/attackby(obj/item/I, mob/living/user, params)
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes aoe melee weapons do the aoe effect even when target dies from the base attack damage.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes blind rage work on titania fairies, and other aoe weapons wont lose the aoe damage on the last hit on qdeleting enemy.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Aoe weapons do aoe effect when target is deleted by initial weapon damage.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
