### PR TITLE
Fixes, qdel failure fixes and effect optimisations

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -665,11 +665,8 @@ GLOBAL_LIST_EMPTY(species_list)
  * * hit_list - A list containing all things hit by this proc.
  */
 /mob/proc/HurtInTurf(turf/target, list/hit_list = list(), damage = 0, damage_type = RED_DAMAGE, def_zone = null, check_faction = FALSE, exact_faction_match = FALSE, hurt_mechs = FALSE, mech_damage = 0, hurt_hidden = FALSE, hurt_structure = FALSE, break_not_destroy = FALSE, attack_direction = null)
-	var/static/list/exclude
-	var/static/list/hiding_places
-	if(!exclude && !hiding_places)
-		exclude = typecacheof(list(/obj/structure/disposalpipe, /obj/structure/lattice, /obj/machinery/cryopod, /obj/structure/sign, /obj/machinery/button, /obj/machinery/light, /obj/structure/extinguisher_cabinet, /obj/machinery/containment_panel, /obj/machinery/computer/security/telescreen, /obj/machinery/facility_holomap)) // Types that should never be hit by HurtInTurf
-		hiding_places = typecacheof(list(/obj/structure/closet, /obj/structure/bodycontainer, /obj/machinery/disposal, /obj/machinery/cryopod, /obj/machinery/sleeper, /obj/machinery/fat_sucker))
+	var/static/list/exclude = typecacheof(list(/obj/machinery/navbeacon/wayfinding, /obj/structure/disposalpipe, /obj/structure/lattice, /obj/machinery/cryopod, /obj/structure/sign, /obj/machinery/button, /obj/machinery/light, /obj/structure/extinguisher_cabinet, /obj/machinery/containment_panel, /obj/machinery/computer/security/telescreen, /obj/machinery/facility_holomap)) // Types that should never be hit by HurtInTurf
+	var/static/list/hiding_places = typecacheof(list(/obj/structure/closet, /obj/structure/bodycontainer, /obj/machinery/disposal, /obj/machinery/cryopod, /obj/machinery/sleeper, /obj/machinery/fat_sucker))
 	. = list()
 	. += hit_list
 	target = isturf(target) ? target : get_turf(src)

--- a/code/datums/abnormality/datum/abnormality.dm
+++ b/code/datums/abnormality/datum/abnormality.dm
@@ -91,7 +91,7 @@
 	landmark = null
 	current = null
 	connected_structures = null
-	..()
+	return ..()
 
 /datum/abnormality/proc/RespawnAbno()
 	if(!ispath(abno_path))

--- a/code/datums/reusable_visual_pool.dm
+++ b/code/datums/reusable_visual_pool.dm
@@ -15,7 +15,7 @@
 		all_objects[i] = RV
 		++available_count
 		available_objects[available_count] = RV
-		stoplag()
+		CHECK_TICK
 
 /datum/reusable_visual_pool/Destroy()
 	available_objects.Cut()

--- a/code/game/objects/effects/spawners/abnormality_room.dm
+++ b/code/game/objects/effects/spawners/abnormality_room.dm
@@ -73,4 +73,4 @@ GLOBAL_LIST_EMPTY(abnormality_room_spawners)
 
 /obj/effect/spawner/abnormality_room/Destroy()
 	GLOB.abnormality_room_spawners -= src
-	..()
+	return ..()

--- a/code/game/objects/items/ego_weapons/aleph.dm
+++ b/code/game/objects/items/ego_weapons/aleph.dm
@@ -306,10 +306,10 @@
 /obj/item/ego_weapon/smile/attack(mob/living/target, mob/living/carbon/human/user)
 	if(!CanUseEgo(user))
 		return
-	..()
-	if((target.health<=target.maxHealth *0.1	|| target.stat == DEAD) && !(GODMODE in target.status_flags))	//Makes up for the lack of damage by automatically killing things under 10% HP
+	. = ..()
+	if((target.health <= target.maxHealth * 0.1 || target.stat == DEAD) && !(target.status_flags & GODMODE))	//Makes up for the lack of damage by automatically killing things under 10% HP
 		target.gib()
-		user.adjustBruteLoss(-user.maxHealth*0.15)	//Heal 15% HP. Moved here from the armor, because that's a nightmare to code
+		user.adjustBruteLoss(-user.maxHealth * 0.15)	//Heal 15% HP. Moved here from the armor, because that's a nightmare to code
 
 /obj/item/ego_weapon/smile/get_clamped_volume()
 	return 50

--- a/code/game/objects/items/ego_weapons/aleph.dm
+++ b/code/game/objects/items/ego_weapons/aleph.dm
@@ -453,7 +453,7 @@
 
 /obj/item/ego_weapon/soulmate/Initialize()
 	RegisterSignal(src, COMSIG_PROJECTILE_ON_HIT, PROC_REF(projectile_hit))
-	..()
+	. = ..()
 	AddElement(/datum/element/update_icon_updates_onmob)
 
 /obj/item/ego_weapon/soulmate/attack(mob/living/target, mob/living/user)
@@ -550,7 +550,7 @@
 	var/canaoe
 
 /obj/item/ego_weapon/space/Initialize()
-	..()
+	. = ..()
 	AddElement(/datum/element/update_icon_updates_onmob)
 
 /obj/item/ego_weapon/space/attack_self(mob/living/carbon/user)

--- a/code/game/objects/items/ego_weapons/he.dm
+++ b/code/game/objects/items/ego_weapons/he.dm
@@ -1096,7 +1096,7 @@
 
 /obj/effect/portal/warp/Initialize()
 	QDEL_IN(src, 3 SECONDS)
-	..()
+	return ..()
 
 /obj/item/ego_weapon/warp/knife		//knife subtype of the above. knife has to be the subtype because it fits in a belt
 	name = "dimension shredder"
@@ -1436,7 +1436,7 @@
 
 /obj/item/ego_weapon/lifestew/Initialize()
 	RegisterSignal(src, COMSIG_PROJECTILE_ON_HIT, PROC_REF(projectile_hit))
-	..()
+	return ..()
 
 /obj/item/ego_weapon/lifestew/attack(mob/living/target, mob/living/carbon/human/user)
 	if(!CanUseEgo(user))
@@ -1516,7 +1516,7 @@
 
 /obj/item/ego_weapon/faelantern/Initialize()
 	RegisterSignal(src, COMSIG_PROJECTILE_ON_HIT, PROC_REF(projectile_hit))
-	..()
+	return ..()
 
 /obj/item/ego_weapon/faelantern/afterattack(atom/target, mob/living/user, proximity_flag, clickparams)
 	if(!CanUseEgo(user))

--- a/code/game/objects/items/ego_weapons/non_abnormality/black_silence.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/black_silence.dm
@@ -493,7 +493,7 @@
 
 /obj/item/ego_weapon/black_silence_gloves/logic/Initialize()
 	RegisterSignal(src, COMSIG_PROJECTILE_ON_HIT, PROC_REF(projectile_hit))
-	..()
+	return ..()
 
 /obj/item/ego_weapon/black_silence_gloves/logic/Special(mob/living/user, atom/target)
 	special_cooldown = world.time + special_cooldown_time

--- a/code/game/objects/items/ego_weapons/non_abnormality/limbus_sinner.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/limbus_sinner.dm
@@ -241,7 +241,7 @@
 
 /obj/item/ego_weapon/nobody/Initialize()
 	RegisterSignal(src, COMSIG_PROJECTILE_ON_HIT, PROC_REF(projectile_hit))
-	..()
+	return ..()
 
 /obj/item/ego_weapon/nobody/afterattack(atom/target, mob/living/user, proximity_flag, clickparams)
 	if(!CanUseEgo(user))

--- a/code/game/objects/items/ego_weapons/non_abnormality/sweeper.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/sweeper.dm
@@ -21,9 +21,9 @@
 	if(!CanUseEgo(user))
 		return
 	..()
-	if((target.stat == DEAD) && !(GODMODE in target.status_flags))
+	if((target.stat == DEAD) && !(target.status_flags & GODMODE))
 		target.gib()
-		user.adjustBruteLoss(-user.maxHealth*0.10)	//Heal 10% HP
+		user.adjustBruteLoss(-user.maxHealth * 0.1)	//Heal 10% HP
 
 /obj/item/ego_weapon/city/sweeper/sickle
 	name = "sweeper_sickle"

--- a/code/game/objects/items/ego_weapons/special.dm
+++ b/code/game/objects/items/ego_weapons/special.dm
@@ -140,7 +140,7 @@
 	var/ramping_damage = 0 //no maximum, will stack as long as people are attacking with it.
 
 /obj/item/ego_weapon/iron_maiden/Initialize()
-	..()
+	. = ..()
 	AddElement(/datum/element/update_icon_updates_onmob)
 
 /obj/item/ego_weapon/iron_maiden/proc/Multihit(mob/living/target, mob/living/user, attack_amount)

--- a/code/game/objects/items/ego_weapons/teth.dm
+++ b/code/game/objects/items/ego_weapons/teth.dm
@@ -351,7 +351,7 @@
 		res.traps -= src
 		res = null
 	creator = null
-	. = ..()
+	return ..()
 
 /obj/effect/temp_visual/lanterntrap/proc/burst_check()
 	for(var/mob/living/L in get_turf(src))
@@ -489,7 +489,7 @@
 
 /obj/item/ego_weapon/zauberhorn/Initialize()
 	RegisterSignal(src, COMSIG_PROJECTILE_ON_HIT, PROC_REF(projectile_hit))
-	..()
+	return ..()
 
 /obj/item/ego_weapon/zauberhorn/afterattack(atom/target, mob/living/user, proximity_flag, clickparams)
 	if(!CanUseEgo(user))

--- a/code/game/objects/items/ego_weapons/waw.dm
+++ b/code/game/objects/items/ego_weapons/waw.dm
@@ -376,7 +376,7 @@
 	var/vine_cooldown
 
 /obj/item/ego_weapon/stem/Initialize(mob/user)
-	.=..()
+	. = ..()
 	vine_cooldown = world.time
 
 /obj/item/ego_weapon/stem/attack_self(mob/living/user)
@@ -848,7 +848,7 @@
 
 /obj/item/ego_weapon/shield/swan/Initialize()
 	RegisterSignal(src, COMSIG_PROJECTILE_ON_HIT, PROC_REF(projectile_hit))
-	..()
+	return ..()
 
 /obj/item/ego_weapon/shield/swan/proc/projectile_hit(atom/fired_from, atom/movable/firer, atom/target, Angle)
 	SIGNAL_HANDLER
@@ -997,11 +997,11 @@
 							)
 
 /obj/item/ego_weapon/shield/pharaoh/pre_attack(atom/A, mob/living/user, params)
-	if(istype(A,/obj/structure/statue/petrified) && CanUseEgo(user))
-		playsound(A, 'sound/effects/break_stone.ogg', rand(10,50), TRUE)
+	if(istype(A, /obj/structure/statue/petrified) && CanUseEgo(user))
+		playsound(A, 'sound/effects/break_stone.ogg', rand(10, 50), TRUE)
 		A.visible_message(span_danger("[A] returns to normal!"), span_userdanger("You break free of the stone!"))
-		A.Destroy()
-		return
+		qdel(A)
+		return TRUE
 	..()
 
 /obj/item/ego_weapon/blind_rage
@@ -1107,8 +1107,8 @@
 	attribute_requirements = list(FORTITUDE_ATTRIBUTE = 80)
 
 /obj/item/ego_weapon/diffraction/attack(mob/living/target, mob/living/user)
-	if((target.health<=target.maxHealth *0.2) && !(GODMODE in target.status_flags))
-		force*=2
+	if((target.health <= target.maxHealth * 0.2) && !(target.status_flags & GODMODE))
+		force *= 2
 	..()
 	force = initial(force)
 
@@ -1679,7 +1679,7 @@
 	successfull_activation = "You release your charge!"
 
 /obj/item/ego_weapon/warring/Initialize()
-	..()
+	. = ..()
 	AddElement(/datum/element/update_icon_updates_onmob)
 
 /obj/item/ego_weapon/warring/attack(mob/living/target, mob/living/user)
@@ -1748,7 +1748,7 @@
 	var/transformed = FALSE
 
 /obj/item/ego_weapon/hyde/Initialize()
-	..()
+	. = ..()
 	AddElement(/datum/element/update_icon_updates_onmob)
 
 /obj/item/ego_weapon/hyde/attack_self(mob/living/carbon/human/user)

--- a/code/modules/mob/living/simple_animal/abnormality/_abnormality.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_abnormality.dm
@@ -178,7 +178,7 @@
 		addtimer(CALLBACK (datum_reference, TYPE_PROC_REF(/datum/abnormality, RespawnAbno)), 30 SECONDS)
 	else if(core_enabled)//Abnormality Cores are spawned if there is no console tied to the abnormality
 		CreateAbnoCore(name, core_icon)//If cores are manually disabled for any reason, they won't generate.
-	..()
+	. = ..()
 	if(loc)
 		if(isarea(loc))
 			var/area/a = loc
@@ -258,7 +258,7 @@
 /mob/living/simple_animal/hostile/abnormality/proc/FearEffect()
 	if(fear_level <= 0)
 		return
-	for(var/mob/living/carbon/human/H in view(7, src))
+	for(var/mob/living/carbon/human/H in ohearers(7, src))
 		if(H in breach_affected)
 			continue
 		if(H.stat == DEAD)
@@ -515,6 +515,10 @@
 	var/mob/living/simple_animal/hostile/abnormality/A
 	var/chosen_message
 	var/chosen_attack_num = 0
+
+/datum/action/innate/abnormality_attack/Destroy()
+	A = null
+	return ..()
 
 /datum/action/innate/abnormality_attack/Grant(mob/living/L)
 	if(istype(L, /mob/living/simple_animal/hostile/abnormality))

--- a/code/modules/mob/living/simple_animal/abnormality/_auxiliary_modes/joke/ego_weapons.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_auxiliary_modes/joke/ego_weapons.dm
@@ -46,7 +46,7 @@
 	)
 
 /obj/item/ego_weapon/chaosdunk/Initialize()
-	..()
+	. = ..()
 	AddElement(/datum/element/update_icon_updates_onmob)
 	addtimer(CALLBACK(src, PROC_REF(ChangeColors)), 5) //Call ourselves every 0.5 seconds to change color
 	set_light(4, 3, "#FFFF00") //Range of 4, brightness of 3 - Same range as a flashlight
@@ -129,7 +129,7 @@
 	var/aoe_damage = 400
 
 /obj/item/ego_weapon/violet_curse/Initialize()
-	..()
+	. = ..()
 	AddElement(/datum/element/update_icon_updates_onmob)
 
 /obj/item/ego_weapon/violet_curse/attack(mob/living/target, mob/living/user)
@@ -143,7 +143,7 @@
 		inhand_icon_state = "violet_curse_c"
 		update_icon_state()
 
-	if(target.stat == DEAD && !(GODMODE in target.status_flags))
+	if(target.stat == DEAD && !(target.status_flags & GODMODE))
 		target.gib()
 
 /obj/item/ego_weapon/violet_curse/afterattack(atom/A, mob/living/user, proximity_flag, params)

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/army_in_black.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/army_in_black.dm
@@ -233,7 +233,7 @@ GLOBAL_LIST_EMPTY(army)
 	return
 
 /mob/living/simple_animal/hostile/army_enemy/Initialize()
-	..()
+	. = ..()
 	addtimer(CALLBACK(src, PROC_REF(Explode)), 120 SECONDS)
 	var/list/depts = shuffle(GLOB.department_centers)
 	var/list/depts_far = list()
@@ -404,11 +404,11 @@ GLOBAL_LIST_EMPTY(army)
 	var/targetted_army
 
 /obj/effect/pink_beacon/Initialize()
-	..()
+	. = ..()
 	QDEL_IN(src, 130 SECONDS)
 
 /obj/effect/pink_beacon/Crossed(atom/movable/AM)//this atom eventually qdeletes itself, no need to worry about cleanup
-	..()
+	. = ..()
 	var/mob/living/simple_animal/hostile/army_enemy/E = targetted_army
 	if(AM == E)
 		E.Explode()
@@ -424,7 +424,7 @@ GLOBAL_LIST_EMPTY(army)
 	pixel_y = 0
 
 /obj/effect/temp_visual/pink_explosion/Initialize()
-	..()
+	. = ..()
 	animate(src, transform = matrix()*1.8, alpha = 0, time = duration)
 
 /obj/effect/temp_visual/black_explosion
@@ -436,7 +436,7 @@ GLOBAL_LIST_EMPTY(army)
 	pixel_y = 0
 
 /obj/effect/temp_visual/black_explosion/Initialize()
-	..()
+	. = ..()
 	animate(src, transform = matrix()*1.8, alpha = 0, time = duration)
 
 /obj/effect/temp_visual/army_hearts
@@ -446,7 +446,7 @@ GLOBAL_LIST_EMPTY(army)
 	duration = 10
 
 /obj/effect/temp_visual/army_hearts/Initialize()
-	..()
+	. = ..()
 	animate(src, alpha = 0, time = duration)
 
 /obj/effect/temp_visual/friend_hearts
@@ -456,7 +456,7 @@ GLOBAL_LIST_EMPTY(army)
 	duration = 10
 
 /obj/effect/temp_visual/friend_hearts/Initialize()
-	..()
+	. = ..()
 	animate(src, alpha = 0, time = duration)
 
 /obj/effect/army_friend

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/blue_star.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/blue_star.dm
@@ -54,7 +54,7 @@
 
 /mob/living/simple_animal/hostile/abnormality/bluestar/Destroy()
 	QDEL_NULL(soundloop)
-	..()
+	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/bluestar/death(gibbed)
 	QDEL_NULL(soundloop)

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/white_night.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/white_night.dm
@@ -125,14 +125,19 @@ GLOBAL_LIST_EMPTY(apostles)
 	var/turf/target_c = get_turf(src)
 	var/list/turf_list = list()
 	for(var/i = 1 to range_override)
-		turf_list = spiral_range_turfs(i, target_c) - spiral_range_turfs(i-1, target_c)
+		turf_list = (target_c.y - i > 0 			? getline(locate(max(target_c.x - i, 1), target_c.y - i, target_c.z), locate(min(target_c.x + i - 1, world.maxx), target_c.y - i, target_c.z)) : list()) +\
+					(target_c.x + i <= world.maxx ? getline(locate(target_c.x + i, max(target_c.y - i, 1), target_c.z), locate(target_c.x + i, min(target_c.y + i - 1, world.maxy), target_c.z)) : list()) +\
+					(target_c.y + i <= world.maxy ? getline(locate(min(target_c.x + i, world.maxx), target_c.y + i, target_c.z), locate(max(target_c.x - i + 1, 1), target_c.y + i, target_c.z)) : list()) +\
+					(target_c.x - i > 0 			? getline(locate(target_c.x - i, min(target_c.y + i, world.maxy), target_c.z), locate(target_c.x - i, max(target_c.y - i + 1, 1), target_c.z)) : list())
 		for(var/turf/open/T in turf_list)
-			var/obj/effect/reusable_visual/S = RVP.NewCultSparks(T, 10)
 			if(faction_check != "apostle")
-				S.color = "#AAFFAA" // Indicating that it's a good thing
+				RVP.NewSparkles(T, 10, "#AAFFAA") // Indicating that it's a good thing
+			else
+				RVP.NewCultSparks(T, 10)
 			for(var/mob/living/L in T)
 				RVP.NewCultIn(T, L.dir)
 				addtimer(CALLBACK(src, PROC_REF(revive_target), L, i, faction_check))
+			CHECK_TICK
 		SLEEP_CHECK_DEATH(1.5)
 
 /mob/living/simple_animal/hostile/abnormality/white_night/proc/revive_target(mob/living/L, attack_range = 1, faction_check = "apostle")

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/white_night.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/white_night.dm
@@ -63,6 +63,8 @@ GLOBAL_LIST_EMPTY(apostles)
 	/// List of Living People on Breach
 	var/list/heretics = list()
 
+	var/datum/reusable_visual_pool/RVP = new(487)
+
 /mob/living/simple_animal/hostile/abnormality/white_night/FearEffectText(mob/affected_mob, level = 0)
 	level = num2text(clamp(level, 1, 5))
 	var/list/result_text_list = list(
@@ -87,7 +89,7 @@ GLOBAL_LIST_EMPTY(apostles)
 	if(!(status_flags & GODMODE))
 		if(holy_revival_cooldown < world.time)
 			for(var/mob/living/simple_animal/hostile/apostle/scythe/guardian/G in apostles)
-				if(G in view(10, src)) // Only teleport them if they are not in view.
+				if(G in ohearers(10, src)) // Only teleport them if they are not in view.
 					continue
 				var/turf/T = get_step(src, pick(NORTH,SOUTH,WEST,EAST))
 				G.forceMove(T)
@@ -109,6 +111,7 @@ GLOBAL_LIST_EMPTY(apostles)
 	apostles = null
 	QDEL_NULL(particles)
 	particles = null
+	QDEL_NULL(RVP)
 	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/white_night/proc/revive_humans(range_override = null, faction_check = "apostle")
@@ -124,11 +127,11 @@ GLOBAL_LIST_EMPTY(apostles)
 	for(var/i = 1 to range_override)
 		turf_list = spiral_range_turfs(i, target_c) - spiral_range_turfs(i-1, target_c)
 		for(var/turf/open/T in turf_list)
-			var/obj/effect/temp_visual/cult/sparks/S = new(T)
+			var/obj/effect/reusable_visual/S = RVP.NewCultSparks(T, 10)
 			if(faction_check != "apostle")
 				S.color = "#AAFFAA" // Indicating that it's a good thing
 			for(var/mob/living/L in T)
-				new /obj/effect/temp_visual/dir_setting/cult/phase(T, L.dir)
+				RVP.NewCultIn(T, L.dir)
 				addtimer(CALLBACK(src, PROC_REF(revive_target), L, i, faction_check))
 		SLEEP_CHECK_DEATH(1.5)
 
@@ -349,7 +352,7 @@ GLOBAL_LIST_EMPTY(apostles)
 	scythe_damage = 150 // It's a big AoE unlike base game where it's smaller and as it is you straight up die unless you have 7+ Pale resist. You also have TWO of these AND WN hitting you for ~80 Pale at this range.
 
 /mob/living/simple_animal/hostile/apostle/scythe/guardian/CanStartPatrol()
-	if(locate(/mob/living/simple_animal/hostile/abnormality/white_night) in view(9, src))
+	if(locate(/mob/living/simple_animal/hostile/abnormality/white_night) in ohearers(9, src))
 		return FALSE
 	return ..()
 
@@ -491,7 +494,7 @@ GLOBAL_LIST_EMPTY(apostles)
 
 /mob/living/simple_animal/hostile/apostle/staff/Destroy()
 	QDEL_NULL(beamloop)
-	..()
+	return ..()
 
 /mob/living/simple_animal/hostile/apostle/staff/death(gibbed)
 	beamloop.stop()

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/white_night.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/white_night.dm
@@ -55,7 +55,7 @@ GLOBAL_LIST_EMPTY(apostles)
 	var/holy_revival_cooldown
 	var/holy_revival_cooldown_base = 75 SECONDS
 	var/holy_revival_damage = 80 // Pale damage, scales with distance
-	var/holy_revival_range = 48
+	var/holy_revival_range = 80
 	/// List of mobs that have been hit by the revival field to avoid double effect
 	var/list/been_hit = list()
 	/// Currently spawned apostles by this mob
@@ -63,7 +63,7 @@ GLOBAL_LIST_EMPTY(apostles)
 	/// List of Living People on Breach
 	var/list/heretics = list()
 
-	var/datum/reusable_visual_pool/RVP = new(487)
+	var/datum/reusable_visual_pool/RVP = new(500)
 
 /mob/living/simple_animal/hostile/abnormality/white_night/FearEffectText(mob/affected_mob, level = 0)
 	level = num2text(clamp(level, 1, 5))

--- a/code/modules/mob/living/simple_animal/abnormality/he/KQE.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/KQE.dm
@@ -260,7 +260,7 @@
 	layer = POINT_LAYER//Sprite should always be visible
 
 /obj/effect/kqe_claw/Initialize()
-	..()
+	. = ..()
 	addtimer(CALLBACK(src, PROC_REF(GrabAttack)), 3 SECONDS)
 
 /obj/effect/kqe_claw/proc/GrabAttack()

--- a/code/modules/mob/living/simple_animal/abnormality/he/doomsday_calendar.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/doomsday_calendar.dm
@@ -201,7 +201,7 @@
 
 /obj/effect/temp_visual/doomsday/Initialize()
 	add_overlay(mutable_appearance('icons/effects/effects.dmi', "empdisable", -ABOVE_OBJ_LAYER))
-	return..()
+	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/doomsday_calendar/proc/CheckCountdown()//grabbed from TSO
 	if(world.time >= next_phase_time) // Next phase

--- a/code/modules/mob/living/simple_animal/abnormality/he/golden_false_apple.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/golden_false_apple.dm
@@ -133,7 +133,7 @@
 		pulse_cooldown_time = 130 SECONDS//The duraction of the buff is 60 seconds; you can't build stacks at this rate.
 	maggot_attack = new /datum/action/innate/abnormality_attack/maggot_spread
 	maggot_attack2 = new /datum/action/innate/abnormality_attack/maggot_spread2
-	..()
+	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/golden_apple/Life()
 	. = ..()

--- a/code/modules/mob/living/simple_animal/abnormality/he/jangsan.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/jangsan.dm
@@ -325,7 +325,7 @@
 		visible_message(span_userdanger("[P] is caught in [src]'s thick fur!"))
 		P.Destroy()
 		return
-	..()
+	return ..()
 
 //on-kill effect
 /obj/effect/halo

--- a/code/modules/mob/living/simple_animal/abnormality/he/norinori.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/norinori.dm
@@ -205,7 +205,7 @@
 		visible_message(span_userdanger("[src] swiftly dodges [P]!"))
 		P.Destroy()
 		return
-	..()
+	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/norinori/LoseTarget()
 	. = ..()

--- a/code/modules/mob/living/simple_animal/abnormality/he/pinocchio.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/pinocchio.dm
@@ -295,7 +295,7 @@
 	var/core_enabled = FALSE
 
 /mob/living/carbon/human/species/pinocchio/Initialize(mapload, cubespawned=FALSE, mob/spawner) //There is basically no documentation for bodyparts and hair, so this was the next best thing.
-	..()
+	. = ..()
 	var/strings = icon('icons/mob/mutant_bodyparts.dmi', "strings_pinnochio_ADJ")
 	src.add_overlay(strings)
 

--- a/code/modules/mob/living/simple_animal/abnormality/he/red_shoes.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/red_shoes.dm
@@ -86,7 +86,12 @@
 	alpha = 255
 	QDEL_IN(src, 10 SECONDS)
 	QDEL_NULL(soundloop)
-	..()
+	return ..()
+
+/mob/living/simple_animal/hostile/abnormality/red_shoes/Destroy()
+	if(soundloop)
+		QDEL_NULL(soundloop)
+	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/red_shoes/Initialize()
 	. = ..()

--- a/code/modules/mob/living/simple_animal/abnormality/he/road_home.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/road_home.dm
@@ -145,7 +145,7 @@
 	for(var/mob/living/carbon/human/H in agent_friends)
 		H.remove_status_effect(/datum/status_effect/stay_home)
 	agent_friends = null
-	..()
+	return ..()
 
 ///Flips and gives everyone the stay home status effect.
 /mob/living/simple_animal/hostile/abnormality/road_home/proc/FlipAttack()

--- a/code/modules/mob/living/simple_animal/abnormality/he/wayward_passenger.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/wayward_passenger.dm
@@ -282,4 +282,4 @@
 
 /obj/effect/portal/abno_warp/Initialize()
 	QDEL_IN(src, 3 SECONDS)
-	..()
+	return ..()

--- a/code/modules/mob/living/simple_animal/abnormality/he/woodsman.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/woodsman.dm
@@ -104,7 +104,7 @@
 
 /mob/living/simple_animal/hostile/abnormality/woodsman/Destroy()
 	QDEL_NULL(soundloop)
-	..()
+	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/woodsman/Life()
 	. = ..()

--- a/code/modules/mob/living/simple_animal/abnormality/waw/dreaming_current.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/dreaming_current.dm
@@ -68,7 +68,7 @@
 
 /mob/living/simple_animal/hostile/abnormality/dreaming_current/Destroy()
 	QDEL_NULL(soundloop)
-	..()
+	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/dreaming_current/AttackingTarget()
 	return OpenFire()

--- a/code/modules/mob/living/simple_animal/abnormality/waw/orange_tree.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/orange_tree.dm
@@ -45,7 +45,7 @@
 
 /mob/living/simple_animal/hostile/abnormality/orange_tree/Destroy()
 	QDEL_NULL(soundloop)
-	..()
+	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/orange_tree/PostSpawn()
 	..()
@@ -193,7 +193,7 @@
 	duration = 50
 
 /obj/effect/temp_visual/dancing_lights/Initialize()
-	..()
+	. = ..()
 	animate(src, alpha = rand(125,200), time = 5)
 	addtimer(CALLBACK(src, PROC_REF(fade_out)), 5)
 

--- a/code/modules/mob/living/simple_animal/abnormality/waw/parasite_tree.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/parasite_tree.dm
@@ -163,7 +163,7 @@
 	var/mob/living/simple_animal/hostile/abnormality/parasite_tree/connected_abno
 
 /mob/living/simple_animal/hostile/parasite_tree_sapling/Initialize()
-	..()
+	. = ..()
 	icon_living = "sapling[pick(1,2)]"
 	icon_state = icon_living
 	connected_abno = locate(/mob/living/simple_animal/hostile/abnormality/parasite_tree) in GLOB.abnormality_mob_list

--- a/code/modules/mob/living/simple_animal/abnormality/waw/queen_bee.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/queen_bee.dm
@@ -43,7 +43,7 @@
 
 /mob/living/simple_animal/hostile/abnormality/queen_bee/Destroy()
 	QDEL_NULL(soundloop)
-	..()
+	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/queen_bee/proc/emit_spores()
 	var/turf/target_c = get_turf(src)

--- a/code/modules/mob/living/simple_animal/abnormality/waw/rose_sign.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/rose_sign.dm
@@ -293,7 +293,7 @@
 	pixel_y = 0
 
 /obj/effect/rose_target/Initialize()
-	..()
+	. = ..()
 	addtimer(CALLBACK(src, PROC_REF(GrabAttack)), 3 SECONDS)
 
 /obj/effect/rose_target/proc/GrabAttack()
@@ -412,7 +412,7 @@
 	var/mob/living/simple_animal/hostile/abnormality/rose_sign/master
 
 /obj/structure/rose_work/Initialize()
-	..()
+	. = ..()
 	picked_color = pick(RED_DAMAGE, WHITE_DAMAGE, BLACK_DAMAGE, PALE_DAMAGE)
 	icon_state = "rose_" + picked_color
 	desc = "The heavier your sins, the deeper the color of petals will be."
@@ -455,7 +455,7 @@
 	if(killed)
 		master.datum_reference.qliphoth_change(-1)
 	master.work_roses -= src
-	..()
+	return ..()
 
 //debuff definition
 /datum/status_effect/stacking/crownthorns
@@ -526,7 +526,7 @@
 	layer = ABOVE_MOB_LAYER
 
 /obj/structure/rose_crucifix/Initialize()
-	..()
+	. = ..()
 	if(prob(25))//TODO: make this from a white rose
 		add_overlay(mutable_appearance('ModularTegustation/Teguicons/32x32.dmi', "crucify_white", -ABOVE_MOB_LAYER))
 	else

--- a/code/modules/mob/living/simple_animal/abnormality/waw/silence.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/silence.dm
@@ -37,7 +37,7 @@
 
 /mob/living/simple_animal/hostile/abnormality/silence/Destroy()
 	QDEL_NULL(soundloop)
-	..()
+	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/silence/SuccessEffect(mob/living/carbon/human/user, work_type, pe)
 	. = ..()

--- a/code/modules/mob/living/simple_animal/abnormality/waw/thunder_bird.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/thunder_bird.dm
@@ -146,7 +146,7 @@
 
 //delete the zombies on death
 /mob/living/simple_animal/hostile/abnormality/thunder_bird/Destroy()
-	..()
+	. = ..()
 	for(var/mob/living/simple_animal/hostile/thunder_zombie/Z in spawned_mobs)
 		QDEL_IN(Z, rand(3) SECONDS)
 		spawned_mobs -= Z

--- a/code/modules/mob/living/simple_animal/abnormality/waw/wrath_servant.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/wrath_servant.dm
@@ -859,7 +859,7 @@
 	icon = 'ModularTegustation/Teguicons/tegu_effects.dmi'
 	icon_state = "wrath_acid"
 	random_icon_states = list("wrath_acid")
-	mergeable_decal = TRUE
+	mergeable_decal = FALSE
 	var/duration = 2 MINUTES
 	var/delling = FALSE
 
@@ -868,11 +868,17 @@
 	START_PROCESSING(SSobj, src)
 	duration += world.time
 
+/obj/effect/decal/cleanable/wrath_acid/Destroy()
+	if(!delling)
+		STOP_PROCESSING(SSobj, src)
+	return ..()
+
 /obj/effect/decal/cleanable/wrath_acid/process(delta_time)
 	if(world.time > duration)
 		Remove()
 
 /obj/effect/decal/cleanable/wrath_acid/proc/Remove()
+	delling = TRUE
 	STOP_PROCESSING(SSobj, src)
 	animate(src, time = (5 SECONDS), alpha = 0)
 	QDEL_IN(src, 5 SECONDS)
@@ -885,6 +891,10 @@
 			sleep(2)
 		if(!step_to(src, get_step(src, direction), 0))
 			break
+	var/turf/T = get_turf(src)
+	for(var/obj/effect/decal/cleanable/wrath_acid/w in T)
+		if(w != src && !QDELETED(w))
+			qdel(w)
 
 /obj/effect/decal/cleanable/wrath_acid/Crossed(atom/movable/AM)
 	. = ..()
@@ -910,7 +920,7 @@
 
 /obj/effect/gibspawner/generic/silent/wrath_acid
 	gibtypes = list(/obj/effect/decal/cleanable/wrath_acid)
-	gibamounts = list(3)
+	gibamounts = list(1)
 
 /obj/effect/gibspawner/generic/silent/wrath_acid/bad
 	gibtypes = list(/obj/effect/decal/cleanable/wrath_acid/bad)

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/pile_of_mail.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/pile_of_mail.dm
@@ -36,10 +36,9 @@
 	var/spawned_effects = list()
 
 /mob/living/simple_animal/hostile/abnormality/mailpile/Destroy()
-	..()
 	for(var/obj/effect/VFX in spawned_effects)
-		VFX.Destroy()
-	return
+		qdel(VFX)
+	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/mailpile/Initialize(mapload)
 	. = ..()

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/quiet_day.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/quiet_day.dm
@@ -282,4 +282,4 @@
 
 /mob/living/simple_animal/hostile/abnormality/quiet_day/Destroy()
 	QDEL_NULL(soundloop)
-	..()
+	return ..()

--- a/code/modules/mob/living/simple_animal/hostile/ordeal/_ordeal.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/_ordeal.dm
@@ -22,16 +22,16 @@
 	if(ordeal_reference && ordeal_remove_ondeath)
 		ordeal_reference.OnMobDeath(src)
 		ordeal_reference = null
-	..()
+	return ..()
 
 /mob/living/simple_animal/hostile/ordeal/Destroy()
 	if(ordeal_reference)
 		ordeal_reference.OnMobDeath(src)
 		ordeal_reference = null
-	..()
+	return ..()
 
 //You should let these gib on Citymap
 /mob/living/simple_animal/hostile/ordeal/Initialize()
-	..()
+	. = ..()
 	if(SSmaptype.maptype in SSmaptype.citymaps)
 		stat_attack = HARD_CRIT	//Guarantee this

--- a/code/modules/mob/living/simple_animal/hostile/ordeal/amber.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/amber.dm
@@ -218,7 +218,7 @@
 
 /mob/living/simple_animal/hostile/ordeal/amber_dusk/Destroy()
 	QDEL_NULL(soundloop)
-	..()
+	return ..()
 
 /mob/living/simple_animal/hostile/ordeal/amber_dusk/Life()
 	. = ..()
@@ -354,7 +354,7 @@
 
 /mob/living/simple_animal/hostile/ordeal/amber_midnight/Destroy()
 	QDEL_NULL(soundloop)
-	..()
+	return ..()
 
 /mob/living/simple_animal/hostile/ordeal/amber_midnight/death(gibbed)
 	alpha = 255

--- a/code/modules/mob/living/simple_animal/hostile/ordeal/crimson.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/crimson.dm
@@ -514,7 +514,7 @@
 	mob_spawn_amount = 2
 
 /mob/living/simple_animal/hostile/ordeal/crimson_noon/crimson_midnight/Initialize()
-	..()
+	. = ..()
 	animate(src, transform = matrix()*1.3, time = 0 SECONDS)
 	AddComponent(/datum/component/knockback, 3, FALSE, TRUE) //1 is distance thrown, False is if it can throw anchored objects, True if doesnt apply damage or stun when hits a wall.
 

--- a/code/modules/mob/living/simple_animal/hostile/ordeal/gold.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/gold.dm
@@ -1364,7 +1364,7 @@
 	var/smash_damage = 45
 
 /mob/living/simple_animal/hostile/ordeal/sin_lust/Initialize()
-	..()
+	. = ..()
 	AddComponent(/datum/component/knockback, 2, FALSE, TRUE)
 
 /mob/living/simple_animal/hostile/ordeal/sin_lust/bullet_act(obj/projectile/P)

--- a/code/modules/mob/living/simple_animal/hostile/ordeal/indigo.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/indigo.dm
@@ -157,7 +157,7 @@
 	damage_coeff = list(RED_DAMAGE = 1.5, WHITE_DAMAGE = 0.7, BLACK_DAMAGE = 0.7, PALE_DAMAGE = 0.5)
 
 /mob/living/simple_animal/hostile/ordeal/indigo_dusk/Initialize(mapload)
-	..()
+	. = ..()
 	var/units_to_add = list(
 		/mob/living/simple_animal/hostile/ordeal/indigo_noon = 1,
 		)

--- a/code/modules/mob/living/simple_animal/hostile/ordeal/shrimps.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/shrimps.dm
@@ -49,5 +49,5 @@
 	speak_emote = list("burbles")
 
 /mob/living/simple_animal/hostile/senior_shrimp/ComponentInitialize()
-	..()
+	. = ..()
 	AddComponent(/datum/component/knockback, 3, FALSE, FALSE)

--- a/code/modules/mob/living/simple_animal/hostile/ordeal/steel.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/steel.dm
@@ -28,7 +28,7 @@
 	silk_results = list(/obj/item/stack/sheet/silk/steel_simple = 1)
 
 /mob/living/simple_animal/hostile/ordeal/steel_dawn/Initialize()
-	..()
+	. = ..()
 	attack_sound = "sound/effects/ordeals/steel/gcorp_attack[pick(1,2,3)].ogg"
 	if(!istype(src, /mob/living/simple_animal/hostile/ordeal/steel_dawn/steel_noon)) //due to being a root of noon
 		icon_living = "gcorp[pick(1,2,3,4)]"
@@ -242,7 +242,7 @@
 	var/can_act = TRUE
 
 /mob/living/simple_animal/hostile/ordeal/steel_dusk/Initialize(mapload)
-	..()
+	. = ..()
 	var/list/units_to_add = list(
 		/mob/living/simple_animal/hostile/ordeal/steel_dawn = 6,
 		/mob/living/simple_animal/hostile/ordeal/steel_dawn/steel_noon = 2,

--- a/code/modules/mob/living/simple_animal/hostile/ordeal/violet.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/violet.dm
@@ -207,6 +207,8 @@
 	/// List of datums and objects that will be deleted on death/destruction
 	var/list/created_objects = list()
 
+	var/datum/reusable_visual_pool/RVP
+
 /mob/living/simple_animal/hostile/ordeal/violet_midnight/Initialize()
 	. = ..()
 	ability_cooldown = world.time + rand(5 SECONDS, ability_cooldown_time)
@@ -215,6 +217,7 @@
 /mob/living/simple_animal/hostile/ordeal/violet_midnight/Destroy()
 	for(var/T in created_objects)
 		QDEL_NULL(T)
+	QDEL_NULL(RVP)
 	return ..()
 
 /mob/living/simple_animal/hostile/ordeal/violet_midnight/death()
@@ -290,6 +293,7 @@
 
 	var/attack_damage = 220 // Dealt once if hit
 	var/list/been_hit = list()
+	RVP = new(1865)
 
 /mob/living/simple_animal/hostile/ordeal/violet_midnight/red/Retaliation()
 	PerformAbility(src)
@@ -347,15 +351,15 @@
 
 /mob/living/simple_animal/hostile/ordeal/violet_midnight/red/proc/DoLineAttack(list/line)
 	for(var/turf/T in line)
-		for(var/turf/TT in range(3, T))
-			new /obj/effect/temp_visual/sparkles/red(TT)
-		for(var/mob/living/L in range(3, T))
-			if(L in been_hit)
-				continue
-			if(!CanAttack(L))
-				continue
-			been_hit += L
-			L.apply_damage(attack_damage, RED_DAMAGE, null, L.run_armor_check(null, RED_DAMAGE))
+		for(var/turf/TT in RANGE_TURFS(3, T))
+			RVP.NewSparkles(TT, color = COLOR_RED)
+			for(var/mob/living/L in TT)
+				if(L in been_hit)
+					continue
+				if(!CanAttack(L))
+					continue
+				been_hit += L
+				L.apply_damage(attack_damage, RED_DAMAGE, null, L.run_armor_check(null, RED_DAMAGE))
 		SLEEP_CHECK_DEATH(0.1)
 
 /mob/living/simple_animal/hostile/ordeal/violet_midnight/white
@@ -366,6 +370,7 @@
 
 	var/attack_damage = 150
 	var/list/been_hit = list()
+	RVP = new(1400)
 
 /mob/living/simple_animal/hostile/ordeal/violet_midnight/white/Retaliation()
 	PerformAbility(src)
@@ -429,18 +434,23 @@
 
 /mob/living/simple_animal/hostile/ordeal/violet_midnight/white/proc/DoLineAttack(list/line)
 	for(var/turf/T in line)
-		for(var/turf/TT in range(3, T))
-			if(locate(/obj/effect/temp_visual/small_smoke/second) in TT)
+		for(var/turf/TT in RANGE_TURFS(3, T))
+			var/skip = FALSE
+			for(var/obj/effect/reusable_visual/RV in TT)
+				if(RV.name == "smoke")
+					skip = TRUE
+					break
+			if(skip)
 				continue
-			new /obj/effect/temp_visual/sparkles(TT)
-			new /obj/effect/temp_visual/small_smoke/second(TT)
-		for(var/mob/living/L in range(2, T))
-			if(L in been_hit)
-				continue
-			if(!CanAttack(L))
-				continue
-			been_hit += L
-			L.apply_damage(attack_damage, WHITE_DAMAGE, null, L.run_armor_check(null, WHITE_DAMAGE))
+			RVP.NewSparkles(TT)
+			RVP.NewSmoke(TT)
+			for(var/mob/living/L in TT)
+				if(L in been_hit)
+					continue
+				if(!CanAttack(L))
+					continue
+				been_hit += L
+				L.apply_damage(attack_damage, WHITE_DAMAGE, null, L.run_armor_check(null, WHITE_DAMAGE))
 
 /mob/living/simple_animal/hostile/ordeal/violet_midnight/black
 	icon_state = "violet_midnightb"
@@ -450,6 +460,7 @@
 
 	var/attack_damage = 220
 	var/list/been_hit = list()
+	RVP = new(1000)
 
 /mob/living/simple_animal/hostile/ordeal/violet_midnight/black/Retaliation()
 	PerformAbility(src)
@@ -479,6 +490,8 @@
 	var/turf/T2 = get_turf_in_angle(angle2, T, 9)
 	var/obj/effect/violet_portal/black/P1 = new(T1)
 	var/obj/effect/violet_portal/black/P2 = new(T2)
+	created_objects += P1
+	created_objects += P2
 	P1.transform = turn(matrix(), angle1)
 	P2.transform = turn(matrix(), angle2)
 	var/datum/beam/B = T1.Beam(T2, "beam", time = (3.5 SECONDS))
@@ -503,18 +516,20 @@
 	animate(P2, alpha = 0, time = (1 SECONDS))
 	QDEL_IN(P1, (1 SECONDS))
 	QDEL_IN(P2, (1 SECONDS))
+	created_objects -= P1
+	created_objects -= P2
 
 /mob/living/simple_animal/hostile/ordeal/violet_midnight/black/proc/DoLineAttack(list/line)
 	for(var/turf/T in line)
-		for(var/turf/TT in range(2, T))
-			new /obj/effect/temp_visual/sparkles/purple(TT)
-		for(var/mob/living/L in range(2, T))
-			if(L in been_hit)
-				continue
-			if(!CanAttack(L))
-				continue
-			been_hit += L
-			L.apply_damage(attack_damage, BLACK_DAMAGE, null, L.run_armor_check(null, BLACK_DAMAGE))
+		for(var/turf/TT in RANGE_TURFS(2, T))
+			RVP.NewSparkles(TT, color = COLOR_PURPLE)
+			for(var/mob/living/L in TT)
+				if(L in been_hit)
+					continue
+				if(!CanAttack(L))
+					continue
+				been_hit += L
+				L.apply_damage(attack_damage, BLACK_DAMAGE, null, L.run_armor_check(null, BLACK_DAMAGE))
 		SLEEP_CHECK_DEATH(0.05)
 
 /obj/effect/black_portal
@@ -540,6 +555,7 @@
 	var/pulse_range = 5
 	/// How often it deals damage at the eye's location
 	var/pulse_delay = 1 SECONDS
+	RVP = new(121)
 
 /mob/living/simple_animal/hostile/ordeal/violet_midnight/pale/Initialize()
 	. = ..()
@@ -600,18 +616,29 @@
 		pulsating = FALSE
 		return
 	var/has_targets = FALSE
-	for(var/turf/T in range(pulse_range, eye))
-		new /obj/effect/temp_visual/pale_eye_attack(T)
-	for(var/mob/living/L in range(pulse_range, eye))
-		if(!CanAttack(L))
-			continue
-		L.apply_damage(pulse_damage, PALE_DAMAGE, null, L.run_armor_check(null, PALE_DAMAGE))
-		has_targets = TRUE
+	for(var/turf/T in RANGE_TURFS(pulse_range, eye))
+		RVP.NewPaleEyeAttack(T)
+		for(var/mob/living/L in T)
+			if(!CanAttack(L))
+				continue
+			L.apply_damage(pulse_damage, PALE_DAMAGE, null, L.run_armor_check(null, PALE_DAMAGE))
+			has_targets = TRUE
 	var/obj/effect/temp_visual/decoy/D = new /obj/effect/temp_visual/decoy(get_turf(eye), eye)
 	animate(D, alpha = 0, transform = matrix()*1.25, time = 4)
 	if(has_targets)
 		playsound(get_turf(eye), 'sound/effects/ordeals/violet/midnight_pale_attack.ogg', 75, TRUE, 8)
 	addtimer(CALLBACK(src, PROC_REF(Pulsate)), pulse_delay)
+
+/datum/reusable_visual_pool/proc/NewPaleEyeAttack(turf/location, duration = 5)
+	var/obj/effect/reusable_visual/RV = TakePoolElement()
+	SET_RV_RETURN_TIMER(RV, duration)
+	RV.name = "pale particles"
+	RV.icon = 'icons/effects/effects.dmi'
+	RV.icon_state = "ion_fade_flight"
+	RV.dir = pick(GLOB.cardinals)
+	RV.loc = location
+	animate(RV, alpha = 0, time = duration)
+	return RV
 
 /obj/effect/pale_eye
 	name = "pale eye"

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -37,6 +37,7 @@
 	qdel(hud_used)
 	QDEL_LIST(client_colours)
 	ghostize()
+	QDEL_LIST(actions)
 	return ..()
 
 

--- a/code/modules/spells/ability_types/realized.dm
+++ b/code/modules/spells/ability_types/realized.dm
@@ -500,6 +500,7 @@
 		return
 	if(stacks <= 0 && stacks_added < 0)
 		qdel(src)
+		return
 	var/mob/living/carbon/human/H = owner
 	H.adjust_attribute_buff(JUSTICE_ATTRIBUTE, stacks_added)
 	stacks += stacks_added


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes pretty much all abnormalities return hints on initialize and destroy, fixes qdel failures on abnormalities and wrath acid, optimises violet midnight, wn pulse, and white fixer; adds navbeacons to hurtinturf exclude.
Whitenight pulse doesnt cause lag spikes now, healing pulse is colored green as was originally intended supposedly, pulse range is extended.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Should reduce qdel issues and reduce tick drift on effect spamming mobs.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixed wrath acid and abnormalities failing to qdel, white fixer cant act anymore during reflection if it starts mid attack, and can reflect punch damage now.
code: most abnos return stuff on initialize and destroy
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
