### PR TITLE
Events now have Custom Battle Coin Rewards

### DIFF
--- a/ModularTegustation/_adventure_console/adventure_events/_event.dm
+++ b/ModularTegustation/_adventure_console/adventure_events/_event.dm
@@ -102,12 +102,23 @@
 		/*-----------------\
 		|Event Effect Procs|
 		\-----------------*/
-/datum/adventure_event/proc/CauseBattle(new_desc = "ERROR", new_damage = "1d6", new_hp = 50)
+/datum/adventure_event/proc/CauseBattle(new_desc = "ERROR", new_damage = MON_DAMAGE_EASY, new_hp = 50, new_coin)
 	gamer.travel_mode = ADVENTURE_MODE_EVENT_BATTLE
 	gamer.enemy_desc = new_desc
 	gamer.enemy_integrity = new_hp
 	gamer.enemy_damage = new_damage
+	if(!new_coin)
+		gamer.enemy_coin = round(MaxDiceDam(new_damage)/5)
+	else
+		gamer.enemy_coin = new_coin
 	temp_text += "ENEMY INITIALIZATION COMPLETE<br>"
+
+//This may be too intensive but it will only happen once in a while.
+/datum/adventure_event/proc/MaxDiceDam(dice_text)
+	var/list/numbers = splittext(dice_text,"d")
+	var/sides = text2num(numbers[1])
+	var/dice = text2num(numbers[2])
+	return sides * dice
 
 /**
  * This is inconviently weird/simple? meaning if you want it to be more complext you need to override it.

--- a/ModularTegustation/_adventure_console/adventure_events/general/quiz.dm
+++ b/ModularTegustation/_adventure_console/adventure_events/general/quiz.dm
@@ -40,7 +40,7 @@
 		if(5)
 			CauseBattle(
 				"Speculative Amalagam Error:Some imperfect mix of a fixer and a sweeper. The differing physiology of a sweeper and a human causes them to violently ooze red fluid from where the sweeper parts end and the human parts begin.",
-				"1d10",
+				"1d8",
 				MON_HP_RAND_EASY,
 			)
 	return ..()

--- a/code/__DEFINES/~lobotomy_defines/adventure.dm
+++ b/code/__DEFINES/~lobotomy_defines/adventure.dm
@@ -24,6 +24,13 @@
 #define MON_HP_RAND_EASY rand(10,50)
 #define MON_HP_RAND_NORMAL rand(75,100)
 
+/*
+* DEFAULT COIN REWARDS
+* Easy grants 1
+* Normal grants 3
+* Hard grants 5
+* 5 Coins is the cost of 15% chance increase on ability challenges
+*/
 #define MON_DAMAGE_EASY "1d6"
 #define MON_DAMAGE_NORMAL "2d7"
 #define MON_DAMAGE_HARD "2d12"

--- a/lobotomy-corp13.dme
+++ b/lobotomy-corp13.dme
@@ -3943,6 +3943,7 @@
 #include "ModularTegustation\_adventure_console\adventure_events\abnormality\teth\forsaken_murderer.dm"
 #include "ModularTegustation\_adventure_console\adventure_events\abnormality\teth\old_lady.dm"
 #include "ModularTegustation\_adventure_console\adventure_events\abnormality\teth\scorched_girl.dm"
+#include "ModularTegustation\_adventure_console\adventure_events\general\jazz_end.dm"
 #include "ModularTegustation\_adventure_console\adventure_events\general\legacy.dm"
 #include "ModularTegustation\_adventure_console\adventure_events\general\quiz.dm"
 #include "ModularTegustation\_adventure_console\adventure_events\general\sinking_bell.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Gives event battles coin rewards that can be defined beforehand or calculated from damage.
tweaks quiz event enemy damage from 1d10 to 1d8 so it gives 1 coin instead of 2
Also turns on the jazz adventure event because it was turned off.

## Why It's Good For The Game
Allows event battles to have custom or scaling coin rewards
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: adventure console
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
