### PR TITLE
LOB points research for Main Office Representative

### DIFF
--- a/ModularTegustation/tegu_items/representative/research/lcorp.dm
+++ b/ModularTegustation/tegu_items/representative/research/lcorp.dm
@@ -243,7 +243,7 @@ GLOBAL_LIST_EMPTY(lcorp_upgrades)
 	minor_announce("HQ has improved your LOB points budget.", "HQ Alert:", TRUE)
 	for(var/obj/machinery/computer/abnormality_auxiliary/A in GLOB.lobotomy_devices)
 		SSlobotomy_corp.lob_points +=2
-		A.audible_message("<span class='notice'>5 LOB points deposited! Reason: Improved budget from HQ.</span>")
+		A.audible_message(span_notice("5 LOB points deposited! Reason: Improved budget from HQ."))
 		playsound(get_turf(A), 'sound/machines/twobeep_high.ogg', 20, TRUE)
 		A.updateUsrDialog()
 	..()

--- a/ModularTegustation/tegu_items/representative/research/lcorp.dm
+++ b/ModularTegustation/tegu_items/representative/research/lcorp.dm
@@ -231,3 +231,35 @@ GLOBAL_LIST_EMPTY(lcorp_upgrades)
 	cost = AVERAGE_RESEARCH_PRICE
 	corp = L_CORP_REP
 	required_research = /datum/data/lc13research/salesspeed/lvl7
+
+//LOB points
+/datum/data/lc13research/lob/lvl1
+	research_name = "LOB points grant"
+	research_desc = "HQ is allowing you more LOB points budget in exchange for PE."
+	cost = HIGH_RESEARCH_PRICE
+	corp = L_CORP_REP
+
+/datum/data/lc13research/lob/lvl1/ResearchEffect(obj/structure/representative_console/caller, amount = 5)
+	minor_announce("HQ has improved your LOB points budget.", "HQ Alert:", TRUE)
+	for(var/obj/machinery/computer/abnormality_auxiliary/A in GLOB.lobotomy_devices)
+		SSlobotomy_corp.lob_points += amount
+		A.audible_message("<span class='notice'>5 LOB points deposited! Reason: Improved budget from HQ.</span>")
+		playsound(get_turf(A), 'sound/machines/twobeep_high.ogg', 20, TRUE)
+		A.updateUsrDialog()
+	..()
+
+/datum/data/lc13research/lob/lvl2
+	research_name = "LOB points grant"
+	research_desc = "HQ is impressed by your production and is allowing you even more LOB points budget in exchange for PE."
+	cost = HIGH_RESEARCH_PRICE+25
+	corp = L_CORP_REP
+	required_research = /datum/data/lc13research/lob/lvl1
+
+/datum/data/lc13research/lob/lvl2/ResearchEffect(obj/structure/representative_console/caller, amount = 10)
+	minor_announce("HQ has further improved your LOB points budget.", "HQ Alert:", TRUE)
+	for(var/obj/machinery/computer/abnormality_auxiliary/A in GLOB.lobotomy_devices)
+		SSlobotomy_corp.lob_points += amount
+		A.audible_message("<span class='notice'>10 LOB points deposited! Reason: Improved budget from HQ.</span>")
+		playsound(get_turf(A), 'sound/machines/twobeep_high.ogg', 20, TRUE)
+		A.updateUsrDialog()
+	..()

--- a/ModularTegustation/tegu_items/representative/research/lcorp.dm
+++ b/ModularTegustation/tegu_items/representative/research/lcorp.dm
@@ -259,7 +259,7 @@ GLOBAL_LIST_EMPTY(lcorp_upgrades)
 	minor_announce("HQ has further improved your LOB points budget.", "HQ Alert:", TRUE)
 	for(var/obj/machinery/computer/abnormality_auxiliary/A in GLOB.lobotomy_devices)
 		SSlobotomy_corp.lob_points +=2
-		A.audible_message("<span class='notice'>10 LOB points deposited! Reason: Improved budget from HQ.</span>")
+		A.audible_message(span_notice("10 LOB points deposited! Reason: Improved budget from HQ."))
 		playsound(get_turf(A), 'sound/machines/twobeep_high.ogg', 20, TRUE)
 		A.updateUsrDialog()
 	..()

--- a/ModularTegustation/tegu_items/representative/research/lcorp.dm
+++ b/ModularTegustation/tegu_items/representative/research/lcorp.dm
@@ -239,10 +239,10 @@ GLOBAL_LIST_EMPTY(lcorp_upgrades)
 	cost = HIGH_RESEARCH_PRICE
 	corp = L_CORP_REP
 
-/datum/data/lc13research/lob/lvl1/ResearchEffect(obj/structure/representative_console/caller, amount = 5)
+/datum/data/lc13research/lob/lvl1/ResearchEffect(obj/structure/representative_console/caller)
 	minor_announce("HQ has improved your LOB points budget.", "HQ Alert:", TRUE)
 	for(var/obj/machinery/computer/abnormality_auxiliary/A in GLOB.lobotomy_devices)
-		SSlobotomy_corp.lob_points += amount
+		SSlobotomy_corp.lob_points +=2
 		A.audible_message("<span class='notice'>5 LOB points deposited! Reason: Improved budget from HQ.</span>")
 		playsound(get_turf(A), 'sound/machines/twobeep_high.ogg', 20, TRUE)
 		A.updateUsrDialog()
@@ -255,10 +255,10 @@ GLOBAL_LIST_EMPTY(lcorp_upgrades)
 	corp = L_CORP_REP
 	required_research = /datum/data/lc13research/lob/lvl1
 
-/datum/data/lc13research/lob/lvl2/ResearchEffect(obj/structure/representative_console/caller, amount = 10)
+/datum/data/lc13research/lob/lvl2/ResearchEffect(obj/structure/representative_console/caller)
 	minor_announce("HQ has further improved your LOB points budget.", "HQ Alert:", TRUE)
 	for(var/obj/machinery/computer/abnormality_auxiliary/A in GLOB.lobotomy_devices)
-		SSlobotomy_corp.lob_points += amount
+		SSlobotomy_corp.lob_points +=2
 		A.audible_message("<span class='notice'>10 LOB points deposited! Reason: Improved budget from HQ.</span>")
 		playsound(get_turf(A), 'sound/machines/twobeep_high.ogg', 20, TRUE)
 		A.updateUsrDialog()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Allows the Main Office Representative to trade PE for LOB point through two researches :
- 25 PE for 2 LOB points (non-repeatable, unlocks he next trade)
- 50 PE for 2 more LOB points (non-repeatable)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Gives the manager a source of LOB points so they doesn't relies exclusively on Understandings and Ordeals.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: 2 Main Office Representative researches that trades PE for LOB points.
:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
