### PR TITLE
Fire damage runtime fix

### DIFF
--- a/code/modules/mob/living/simple_animal/_damage_coeff.dm
+++ b/code/modules/mob/living/simple_animal/_damage_coeff.dm
@@ -1,9 +1,9 @@
-#define DAMCOEFFID "damage_coeff-[red]-[white]-[black]-[pale]-[brute]-[burn]-[tox]-[clone]-[stamina]-[oxy]"
+#define DAMCOEFFID "damage_coeff-[red]-[white]-[black]-[pale]-[brute]-[fire]-[tox]-[clone]-[stamina]-[oxy]"
 
-/proc/getDamCoeff(red = 1, white = 1, black = 1, pale = 1, brute = 1, burn = 1, tox = 1, clone = 1, stamina = 1, oxy = 1)
+/proc/getDamCoeff(red = 1, white = 1, black = 1, pale = 1, brute = 1, fire = 1, tox = 1, clone = 1, stamina = 1, oxy = 1)
 	. = locate(DAMCOEFFID)
 	if(!.)
-		. = new /datum/dam_coeff(red, white, black, pale, brute, burn, tox, clone, stamina, oxy)
+		. = new /datum/dam_coeff(red, white, black, pale, brute, fire, tox, clone, stamina, oxy)
 
 /proc/makeDamCoeff(list/dc = list())
 	var/list/coeffs = list(RED_DAMAGE = 1, WHITE_DAMAGE = 1, BLACK_DAMAGE = 1, PALE_DAMAGE = 1, BRUTE = 1, BURN = 1, TOX = 1, CLONE = 1, STAMINA = 1, OXY = 1)
@@ -14,7 +14,7 @@
 /datum/dam_coeff
 	datum_flags = DF_USE_TAG
 	var/brute
-	var/burn
+	var/fire
 	var/tox
 	var/clone
 	var/stamina
@@ -24,29 +24,29 @@
 	var/black
 	var/pale
 
-/datum/dam_coeff/New(red = 1, white = 1, black = 1, pale = 1, brute = 1, burn = 1, tox = 1, clone = 1, stamina = 1, oxy = 1)
+/datum/dam_coeff/New(red = 1, white = 1, black = 1, pale = 1, brute = 1, fire = 1, tox = 1, clone = 1, stamina = 1, oxy = 1)
 	src.red = red
 	src.white = white
 	src.black = black
 	src.pale = pale
 	src.brute = brute
-	src.burn = burn
+	src.fire = fire
 	src.tox = tox
 	src.clone = clone
 	src.stamina = stamina
 	src.oxy = oxy
 	tag = DAMCOEFFID
 
-/datum/dam_coeff/proc/modifyCoeff(red = 0, white = 0, black = 0, pale = 0, brute = 0, burn = 0, tox = 0, clone = 0, stamina = 0, oxy = 0)
-	return getDamCoeff(src.red+red, src.white+white, src.black+black, src.pale+pale, src.brute+brute, src.burn+burn, src.tox+tox, src.clone+clone, src.stamina+stamina, src.oxy+oxy)
+/datum/dam_coeff/proc/modifyCoeff(red = 0, white = 0, black = 0, pale = 0, brute = 0, fire = 0, tox = 0, clone = 0, stamina = 0, oxy = 0)
+	return getDamCoeff(src.red+red, src.white+white, src.black+black, src.pale+pale, src.brute+brute, src.fire+fire, src.tox+tox, src.clone+clone, src.stamina+stamina, src.oxy+oxy)
 
-/datum/dam_coeff/proc/setCoeff(red, white, black, pale, brute, burn, tox, clone, stamina, oxy)
+/datum/dam_coeff/proc/setCoeff(red, white, black, pale, brute, fire, tox, clone, stamina, oxy)
 	return getDamCoeff((isnull(red) ? src.red : red),\
 					(isnull(white) ? src.white : white),\
 					(isnull(black) ? src.black : black),\
 					(isnull(pale) ? src.pale : pale),\
 					(isnull(brute) ? src.brute : brute),\
-					(isnull(burn) ? src.burn : burn),\
+					(isnull(fire) ? src.fire : fire),\
 					(isnull(tox) ? src.tox : clone),\
 					(isnull(clone) ? src.clone : clone),\
 					(isnull(stamina) ? src.stamina : stamina),\
@@ -56,7 +56,7 @@
 	return vars[coeff]
 
 /datum/dam_coeff/proc/getList()
-	return list(RED_DAMAGE = red, WHITE_DAMAGE = white, BLACK_DAMAGE = black, PALE_DAMAGE = pale, BRUTE = brute, BURN = burn, TOX = tox, CLONE = clone, STAMINA = stamina, OXY = oxy)
+	return list(RED_DAMAGE = red, WHITE_DAMAGE = white, BLACK_DAMAGE = black, PALE_DAMAGE = pale, BRUTE = brute, BURN = fire, TOX = tox, CLONE = clone, STAMINA = stamina, OXY = oxy)
 
 /datum/dam_coeff/vv_edit_var(var_name, var_value)
 	if (var_name == NAMEOF(src, tag))

--- a/code/modules/mob/living/simple_animal/damage_coeff_helper.dm
+++ b/code/modules/mob/living/simple_animal/damage_coeff_helper.dm
@@ -90,7 +90,7 @@
 		if(BRUTE)
 			unmodified_damage_coeff_datum = unmodified_damage_coeff_datum.setCoeff(brute = value)
 		if(BURN)
-			unmodified_damage_coeff_datum = unmodified_damage_coeff_datum.setCoeff(burn = value)
+			unmodified_damage_coeff_datum = unmodified_damage_coeff_datum.setCoeff(fire = value)
 		if(TOX)
 			unmodified_damage_coeff_datum = unmodified_damage_coeff_datum.setCoeff(tox = value)
 		if(CLONE)

--- a/code/modules/mob/living/simple_animal/damage_procs.dm
+++ b/code/modules/mob/living/simple_animal/damage_procs.dm
@@ -29,7 +29,7 @@
 	if(forced)
 		. = adjustHealth(amount * CONFIG_GET(number/damage_multiplier), updating_health, forced)
 	else
-		. = adjustHealth(amount * damage_coeff.burn * CONFIG_GET(number/damage_multiplier), updating_health, forced)
+		. = adjustHealth(amount * damage_coeff.fire * CONFIG_GET(number/damage_multiplier), updating_health, forced)
 
 /mob/living/simple_animal/adjustOxyLoss(amount, updating_health = TRUE, forced = FALSE)
 	if(forced)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
At some point BURN define got changed to "fire" but Simplemob armor check was trying to access armor var by name which was still burn.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fire damage doesnt runtime on simplemobs.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fire damage now checks the correct armor var on simplemobs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
