### PR TITLE
Fix Memories 0 Qliphoth

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/he/better_memories.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/better_memories.dm
@@ -63,6 +63,7 @@
 	if(!IsCombatMap())
 		var/turf/W = pick(GLOB.department_centers)
 		breaching_minion = SpawnMinion(get_turf(W))
+		datum_reference.qliphoth_change(2)
 
 	//--Side Gamemodes stuff--
 	else


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Memories of a better time had 0 qliphoth due to me not putting in the code to restore their qliphoth after spawning a minion.

## Changelog
:cl:
fix: better memories
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
