### PR TITLE
Add Visual Flash to Better Memories

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/he/better_memories.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/better_memories.dm
@@ -469,6 +469,7 @@
 	///This proc deterimines how the spell will affect mobs.
 /mob/living/simple_animal/hostile/better_memories_minion/proc/DoConeMobEffect(mob/living/target_mob)
 	if(ishuman(target_mob))
+		target_mob.flash_act()
 		target_mob.apply_status_effect(MEMORY_DEBUFF)
 
 	///This proc adjusts the cones width depending on the level.


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Better Memories now camera flashes your screen when they snap a picture of you. This is a purely visual flash that is intended to give memories a chance to escape while also temporarily blinding people.

If this is a good feature or not is yet to be seen so i will atomize this into a compact PR.

## Why It's Good For The Game
Unique effect connected to a camera flash. Possibly a intresting use of immersive mechanics unless these immersive mechanics are too much.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Better Memories
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
