### PR TITLE
No skip crimson ordeal

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/ordeal/crimson.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/crimson.dm
@@ -120,12 +120,23 @@
 	/// How many mobs we spawn on death
 	var/mob_spawn_amount = 3
 
+	var/can_be_gibbed = TRUE
+
 /mob/living/simple_animal/hostile/ordeal/crimson_noon/death(gibbed)
-	animate(src, transform = matrix()*1.25, color = "#FF0000", time = 5)
-	addtimer(CALLBACK(src, PROC_REF(DeathExplosion)), 5)
+	if(gibbed)
+		DeathExplosion(TRUE)
+	else
+		can_be_gibbed = FALSE
+		animate(src, transform = matrix()*1.25, color = "#FF0000", time = 5)
+		addtimer(CALLBACK(src, PROC_REF(DeathExplosion)), 5)
 	..()
 
-/mob/living/simple_animal/hostile/ordeal/crimson_noon/proc/DeathExplosion()
+/mob/living/simple_animal/hostile/ordeal/crimson_noon/gib()
+	if(!can_be_gibbed)
+		return
+	return ..()
+
+/mob/living/simple_animal/hostile/ordeal/crimson_noon/proc/DeathExplosion(gibbed = FALSE)
 	if(QDELETED(src))
 		return
 	visible_message(span_danger("[src] suddenly explodes!"))
@@ -146,7 +157,9 @@
 	if(ordeal_reference)
 		ordeal_reference.OnMobDeath(src)
 		ordeal_reference = null
-	gib()
+	if(!gibbed)
+		can_be_gibbed = TRUE
+		gib()
 
 // Crimson dusk
 /mob/living/simple_animal/hostile/ordeal/crimson_noon/crimson_dusk
@@ -187,7 +200,7 @@
 		return FALSE
 	return ..()
 
-/mob/living/simple_animal/hostile/ordeal/crimson_noon/crimson_dusk/DeathExplosion()
+/mob/living/simple_animal/hostile/ordeal/crimson_noon/crimson_dusk/DeathExplosion(gibbed = FALSE)
 	if(QDELETED(src))
 		return
 	visible_message(span_danger("[src] suddenly explodes!"))
@@ -208,7 +221,9 @@
 	if(ordeal_reference)
 		ordeal_reference.OnMobDeath(src)
 		ordeal_reference = null
-	gib()
+	if(!gibbed)
+		can_be_gibbed = TRUE
+		gib()
 
 /mob/living/simple_animal/hostile/ordeal/crimson_noon/crimson_dusk/OpenFire()
 	if(client)
@@ -503,7 +518,7 @@
 	animate(src, transform = matrix()*1.3, time = 0 SECONDS)
 	AddComponent(/datum/component/knockback, 3, FALSE, TRUE) //1 is distance thrown, False is if it can throw anchored objects, True if doesnt apply damage or stun when hits a wall.
 
-/mob/living/simple_animal/hostile/ordeal/crimson_noon/crimson_midnight/DeathExplosion()
+/mob/living/simple_animal/hostile/ordeal/crimson_noon/crimson_midnight/DeathExplosion(gibbed = FALSE)
 	if(QDELETED(src))
 		return
 	visible_message(span_danger("[src] suddenly explodes!"))
@@ -524,7 +539,9 @@
 	if(ordeal_reference)
 		ordeal_reference.OnMobDeath(src)
 		ordeal_reference = null
-	gib()
+	if(!gibbed)
+		can_be_gibbed = TRUE
+		gib()
 
 // Tent spawned variants
 // Dawn
@@ -558,15 +575,16 @@
 /mob/living/simple_animal/hostile/ordeal/crimson_noon/spawned/Initialize()
 	. = ..()
 	animate(src, transform = matrix()*1.2, color = "#FF0000", time = 45 SECONDS)
-	addtimer(CALLBACK(src, PROC_REF(DeathExplosion), ordeal_reference), 45 SECONDS)
+	addtimer(CALLBACK(src, PROC_REF(DeathExplosion), FALSE, ordeal_reference), 45 SECONDS)
 
 /mob/living/simple_animal/hostile/ordeal/crimson_noon/spawned/death(gibbed)
 	. = ..()
 	if(!gibbed)
+		can_be_gibbed = TRUE
 		gib()
 
-/mob/living/simple_animal/hostile/ordeal/crimson_noon/spawned/DeathExplosion()
-	if(QDELETED(src))
+/mob/living/simple_animal/hostile/ordeal/crimson_noon/spawned/DeathExplosion(gibbed = FALSE)
+	if(QDELETED(src) || gibbed)
 		return
 	visible_message(span_danger("[src] suddenly explodes!"))
 	var/valid_directions = list(0) // 0 is used by get_turf to find the turf a target, so it'll at the very least be able to spawn on itself.
@@ -597,15 +615,16 @@
 /mob/living/simple_animal/hostile/ordeal/crimson_noon/crimson_dusk/spawned/Initialize()
 	. = ..()
 	animate(src, transform = matrix()*1.2, color = "#FF0000", time = 60 SECONDS)
-	addtimer(CALLBACK(src, PROC_REF(DeathExplosion), ordeal_reference), 60 SECONDS)
+	addtimer(CALLBACK(src, PROC_REF(DeathExplosion), FALSE, ordeal_reference), 60 SECONDS)
 
 /mob/living/simple_animal/hostile/ordeal/crimson_noon/crimson_dusk/spawned/death(gibbed)
 	. = ..()
 	if(!gibbed)
+		can_be_gibbed = TRUE
 		gib()
 
-/mob/living/simple_animal/hostile/ordeal/crimson_noon/crimson_dusk/spawned/DeathExplosion()
-	if(QDELETED(src))
+/mob/living/simple_animal/hostile/ordeal/crimson_noon/crimson_dusk/spawned/DeathExplosion(gibbed = FALSE)
+	if(QDELETED(src) || gibbed)
 		return
 	visible_message(span_danger("[src] suddenly explodes!"))
 	playsound(get_turf(src), 'sound/effects/ordeals/crimson/dusk_dead.ogg', 50, 1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Normal crimson ordeals will split properly even when gibbed, timed spawn variants work the same as before.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Theres no reason why gibbing would prevent them from splitting, and it creates a weird over reliance on very particular ego to trivialise the ordeal.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: normal crimson ordeal mobs split when gibbed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
