### PR TITLE
Apex predator can recloak

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/waw/apex_predator.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/apex_predator.dm
@@ -57,6 +57,8 @@
 	var/jump_cooldown_time = 5 SECONDS
 	var/jump_damage = 60
 
+	var/recloak_time = 0
+	var/recloak_time_cooldown = 30 SECONDS
 
 
 /mob/living/simple_animal/hostile/abnormality/apex_predator/Move()
@@ -66,6 +68,10 @@
 		return FALSE
 	..()
 
+/mob/living/simple_animal/hostile/abnormality/apex_predator/Life()
+	. = ..()
+	if(. && !(status_flags & GODMODE) && revealed && recloak_time < world.time)
+		Cloak()
 
 /mob/living/simple_animal/hostile/abnormality/apex_predator/NeutralEffect(mob/living/carbon/human/user, work_type, pe)
 	. = ..()
@@ -152,6 +158,7 @@
 	density = FALSE
 
 /mob/living/simple_animal/hostile/abnormality/apex_predator/proc/Decloak()
+	recloak_time = world.time + recloak_time_cooldown
 	alpha = 255
 	revealed = TRUE
 	density = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Allows apex predator to recloak after 30 seconds of not taking damage. Taking damage refreshes the timer.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The abnormality wont lose its fun gimmick for the rest of its life after taking any bit of damage anymore. Will make it more fun in RCA mode.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Apex Predator can recloak after 30 seconds of not taking damage.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
