### PR TITLE
Returns Braincake to the Hungry Masses

### DIFF
--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -426,7 +426,6 @@
 		/datum/crafting_recipe/food/bscvcake,
 		/datum/crafting_recipe/food/berrytart,
 		/datum/crafting_recipe/food/clowncake,
-		/datum/crafting_recipe/food/braincake,
 		/datum/crafting_recipe/food/birthdaycake,
 		/datum/crafting_recipe/food/chocolatecake,
 		/datum/crafting_recipe/food/lemoncake,

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_pastry.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_pastry.dm
@@ -19,6 +19,15 @@
 	result = /obj/item/food/cake/vanilla_cake
 	subcategory = CAT_PASTRY
 
+/datum/crafting_recipe/food/braincake
+	name = "Brain cake"
+	reqs = list(
+		/obj/item/organ/brain = 1,
+		/obj/item/food/cake/plain = 1
+	)
+	result = /obj/item/food/cake/brain
+	subcategory = CAT_PASTRY
+
 /datum/crafting_recipe/food/bscccake
 	name = "blackberry and strawberry chocolate cake"
 	reqs = list(
@@ -130,16 +139,6 @@
 		/datum/reagent/consumable/caramel = 2
 	)
 	result = /obj/item/food/cake/birthday
-	subcategory = CAT_PASTRY
-	always_available = FALSE
-
-/datum/crafting_recipe/food/braincake
-	name = "Brain cake"
-	reqs = list(
-		/obj/item/organ/brain = 1,
-		/obj/item/food/cake/plain = 1
-	)
-	result = /obj/item/food/cake/brain
 	subcategory = CAT_PASTRY
 	always_available = FALSE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
When i was tweaking crafting catagories i put alot of cakes inside book granters so people could choose to make their crafting menu a nightmarish mess. But the hunger for braincake always endures. Humanities march towards braincake being avaliable to every man, woman, and child is too strong for any book.
Makes Braincake always avaliable for crafting.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Changelog
:cl:
tweak: braincake
tweak: cooking deserts 101 granter
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
