### PR TITLE
Fixes oversight in non-standard weapon charging and wayward having a useless attack_speed variable

### DIFF
--- a/code/game/objects/items/ego_weapons/_ego_weapon.dm
+++ b/code/game/objects/items/ego_weapons/_ego_weapon.dm
@@ -29,7 +29,7 @@
 	if(attack_speed)
 		user.changeNext_move(CLICK_CD_MELEE * attack_speed)
 
-	if(charge)
+	if(charge && attack_charge_gain)
 		HandleCharge(1, target)
 
 	if(target.anchored || !knockback) // lets not throw machines around

--- a/code/game/objects/items/ego_weapons/he.dm
+++ b/code/game/objects/items/ego_weapons/he.dm
@@ -1015,7 +1015,6 @@
 	righthand_file = 'icons/mob/inhands/weapons/ego_righthand.dmi'
 	inhand_x_dimension = 32
 	inhand_y_dimension = 32
-	attack_speed = 1
 	hitsound = 'sound/abnormalities/wayward_passenger/attack1.ogg'
 	reach = 2
 	damtype = RED_DAMAGE

--- a/code/game/objects/items/ego_weapons/subtype/charge.dm
+++ b/code/game/objects/items/ego_weapons/subtype/charge.dm
@@ -91,7 +91,7 @@
 		charge_amount = initial(charge_amount)
 		CRASH("[src] has somehow aquired a negative charge amount, automatically reset it to the initial charge amount")
 
-	if(attack_charge_gain && charge_amount < charge_cap)
+	if(charge_amount < charge_cap)
 		charge_amount += added_charge
 
 /// Lets people refund their charge if the allow_ability_cancel var is set to TRUE


### PR DESCRIPTION

## About The Pull Request

HandleCharge is supposed to universally handle charging, but it was checking specifically if it could charge via attacking and if not denying any charging at all.
My bad on the oversight

Also removes the waywards default attack speed because i just noticed it was like dat

## Why It's Good For The Game

Weapons working is gud

## Changelog
:cl:
fix: wayward passenger EGO now again charges when you move
/:cl:
