### PR TITLE
Removes the corpses inside of lockers and crates breathing

### DIFF
--- a/ModularTegustation/hiding/closet.dm
+++ b/ModularTegustation/hiding/closet.dm
@@ -24,16 +24,30 @@
 
 /obj/structure/closet/take_contents()
 	. = ..()
-	if(locate(/mob/living) in src.contents)
+	for(var/object as anything in src.contents)
+		if(!istype(object, /mob/living))
+			continue
+		var/mob/living/beast = object
+		if(beast.stat == DEAD)
+			continue
+
 		anchorable = FALSE // dont let them move it
 		set_anchored(TRUE)
 		toggle_breathing(FALSE)
 
 /obj/structure/closet/dump_contents()
-	if(locate(/mob/living) in src.contents)
-		anchorable = TRUE
-		set_anchored(FALSE)
-		toggle_breathing(TRUE)
+	for(var/object as anything in src.contents)
+		if(!istype(object, /mob/living))
+			continue
+		var/mob/living/beast = object
+		var/turf/open/floor/corpse_dirt = get_turf(src)
+		for(var/person as anything in corpse_dirt.possible_hiding_players)
+			if(beast != person)
+				continue
+
+			anchorable = TRUE
+			set_anchored(FALSE)
+			toggle_breathing(TRUE)
 
 	return ..()
 


### PR DESCRIPTION
## About The Pull Request

Makes it so the closets now do not lock themselfes down if the person put inside of them is a corpse
This allows trash carts to again be used to transport corpses... althrough i will say you could just use a body bag for dat

## Why It's Good For The Game

Its what people have come to expect, and tbh its probably better
It does allow people to now again hide corpses from corpse loving abnormalities in lockers and such, but a lot of abnos don't benefit from interacting with them anyways

## Changelog
:cl:
fix: Trash carts now can again transport corpses
/:cl:
