### PR TITLE
Implements a missing portrait

### DIFF
--- a/code/game/machinery/computer/abnormality_portraits.dm
+++ b/code/game/machinery/computer/abnormality_portraits.dm
@@ -78,6 +78,7 @@
 	'icons/UI_Icons/abnormality_portraits/nameless_fetus.png',
 	'icons/UI_Icons/abnormality_portraits/norinori.png',
 	'icons/UI_Icons/abnormality_portraits/nosferatu.png',
+	'icons/UI_Icons/abnormality_portraits/nothing_there.png',
 	'icons/UI_Icons/abnormality_portraits/nihil.png',
 	'icons/UI_Icons/abnormality_portraits/nobody_is.png',
 	'icons/UI_Icons/abnormality_portraits/old_lady.png',


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Implements the portrait for Nothing There. Nobody said anything about it until now, and I realized this while testing something completely unrelated.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Well, at least its fixed now.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Nothing There now has a proper portrait
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
