### PR TITLE
Rhino pilots unequip armor on entry

### DIFF
--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -1117,6 +1117,10 @@
 	update_icon()
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
+		var/obj/item/suit = H.get_item_by_slot(ITEM_SLOT_OCLOTHING)
+		if(suit)
+			H.dropItemToGround(suit, TRUE)
+			to_chat(H, span_interface("You remove your armor to put on the exosuit"))
 		H.physiology.red_mod *= 1 - clamp(armor[RED_DAMAGE], 0, 99) / 100
 		H.physiology.white_mod *= 1 - clamp(armor[WHITE_DAMAGE], 0, 99) / 100
 		H.physiology.black_mod *= 1 - clamp(armor[BLACK_DAMAGE], 0, 99) / 100


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Since rhino pilots now get armor from the rhino mech, the armor that they can pillage from dead rabbits is overkill so now they will drop equipped armor upon mech entry.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Rhino pilots wont be too tanky to piercing abilities anymore.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Rhino pilots drop armor when entering mech
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
