### PR TITLE
Removes clothes igniting

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1979,12 +1979,17 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 /datum/species/proc/handle_fire(mob/living/carbon/human/H, no_protection = FALSE)
 	if(!CanIgniteMob(H))
 		return TRUE
+
+	////////////////////////////////////////
+	//Burning worn items has been disabled//
+	////////////////////////////////////////
+
 	if(H.on_fire)
 		//the fire tries to damage the exposed clothes and items
+/*
 		var/list/burning_items = list()
 		var/obscured = H.check_obscured_slots(TRUE)
 		//HEAD//
-
 		if(H.glasses && !(obscured & ITEM_SLOT_EYES))
 			burning_items += H.glasses
 		if(H.wear_mask && !(obscured & ITEM_SLOT_MASK))
@@ -2027,7 +2032,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 		for(var/X in burning_items)
 			var/obj/item/I = X
 			I.fire_act((H.fire_stacks * 50)) //damage taken is reduced to 2% of this value by fire_act()
-
+*/
 		var/thermal_protection = H.get_thermal_protection()
 
 		if(thermal_protection >= FIRE_IMMUNITY_MAX_TEMP_PROTECT && !no_protection)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes the ability for clothes to burn when a human wearing them is set on fire.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Now we can set people on fire without everyone becoming naked.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Removed fire damage from human ignition
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
