### PR TITLE
Multi Tile Bosses [EXPERIMENTAL]

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -194,7 +194,7 @@
 				continue
 			closed[target] = TRUE
 			if(isturf(target) || isturf(target.loc) || (target in direct_access) || (ismovable(target) && target.flags_1 & IS_ONTOP_1)) //Directly accessible atoms
-				if(Adjacent(target) || (tool && CheckToolReach(src, target, tool.reach))) //Adjacent or reaching attacks
+				if(Adjacent(target) || (tool && CheckToolReach(src, target, tool.reach)) || bounds_dist(src, target) <= 0) //Adjacent or reaching attacks
 					return TRUE
 
 			if (!target.loc)

--- a/code/modules/mob/living/simple_animal/hostile/ordeal/amber.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/amber.dm
@@ -215,13 +215,17 @@
 
 	density = FALSE
 	alpha = 0
-	pixel_x = -96
-	base_pixel_x = -96
+	pixel_x = -64
+	base_pixel_x = -64
 	pixel_y = -16
 	base_pixel_y = -16
 
 	blood_volume = BLOOD_VOLUME_NORMAL
 	death_sound = 'sound/effects/ordeals/amber/midnight_dead.ogg'
+	//Causes entity center to be at the bottom of a 2by3 tile solid.
+	bound_width = 96
+	bound_height = 64
+	step_x = -32
 
 	var/burrowing = FALSE
 	var/burrow_cooldown

--- a/code/modules/mob/living/simple_animal/hostile/ordeal/green.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/green.dm
@@ -333,8 +333,8 @@
 	icon_living = "greenmidnight"
 	icon_dead = "greenmidnight_dead"
 	layer = LYING_MOB_LAYER
-	pixel_x = -96
-	base_pixel_x = -96
+	pixel_x = -64
+	base_pixel_x = -64
 	faction = list("green_ordeal")
 	gender = NEUTER
 	mob_biotypes = MOB_ROBOTIC
@@ -344,6 +344,10 @@
 	butcher_results = list(/obj/item/food/meat/slab/robot = 22)
 	guaranteed_butcher_results = list(/obj/item/food/meat/slab/robot = 16)
 	death_sound = 'sound/effects/ordeals/green/midnight_dead.ogg'
+	//Causes entity center to be at the bottom of a 2by3 tile solid.
+	bound_width = 96
+	bound_height = 64
+	step_x = -32
 
 	var/laser_cooldown
 	var/laser_cooldown_time = 20 SECONDS
@@ -421,13 +425,13 @@
 		INVOKE_ASYNC(src, PROC_REF(SetupLaser))
 
 /mob/living/simple_animal/hostile/ordeal/green_midnight/proc/OpenShell()
-	animate(left_shell, pixel_x = base_pixel_x - 24, time = 4 SECONDS, easing = QUAD_EASING)
-	animate(right_shell, pixel_x = base_pixel_x + 24, time = 4 SECONDS, easing = QUAD_EASING)
+	animate(left_shell, pixel_x = -96 - 24, time = 4 SECONDS, easing = QUAD_EASING)
+	animate(right_shell, pixel_x = -96 + 24, time = 4 SECONDS, easing = QUAD_EASING)
 	playsound(get_turf(src), 'sound/effects/ordeals/green/midnight_gears.ogg', 50, FALSE, 7)
 
 /mob/living/simple_animal/hostile/ordeal/green_midnight/proc/CloseShell()
-	animate(left_shell, pixel_x = base_pixel_x, time = 2 SECONDS, easing = QUAD_EASING)
-	animate(right_shell, pixel_x = base_pixel_x, time = 2 SECONDS, easing = QUAD_EASING)
+	animate(left_shell, pixel_x = -96, time = 2 SECONDS, easing = QUAD_EASING)
+	animate(right_shell, pixel_x = -96, time = 2 SECONDS, easing = QUAD_EASING)
 	playsound(get_turf(src), 'sound/effects/ordeals/green/midnight_gears_fast.ogg', 50, FALSE, 7)
 
 /mob/living/simple_animal/hostile/ordeal/green_midnight/proc/SetupLaser()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Increases the tile area that Amber and Green midnight take up to be 2by3.

Turns out that https://github.com/vlggms/lobotomy-corp13/pull/2210 figured out how to make the whole thing move. Which is very impressive.

closing PR but keeping it up incase the code is helpful.

## Why It's Good For The Game
Makes people not search for the special one tile where the core is.

## Changelog
:cl:
add: Multitile functionality to spears and other attacks.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
