### PR TITLE
Apple Vines now can Grow On Floor Vents

### DIFF
--- a/ModularTegustation/lc13_structures.dm
+++ b/ModularTegustation/lc13_structures.dm
@@ -37,11 +37,15 @@
 		qdel(src)
 		return FALSE
 
-	var/list/spread_turfs = U.GetAtmosAdjacentTurfs()
+	var/list/spread_turfs = U.reachableAdjacentTurfs()
 	shuffle_inplace(spread_turfs)
 	for(var/turf/T in spread_turfs)
-		if(locate(/obj/structure/spreading) in T)
-			var/obj/structure/spreading/S = locate(/obj/structure/spreading) in T
+		var/obj/machinery/M = locate(/obj/machinery) in T
+		if(M)
+			if(M.density)
+				continue
+		var/obj/structure/spreading/S = locate(/obj/structure/spreading) in T
+		if(S)
 			if(S.type != type) //if it is not another of the same spreading structure.
 				S.take_damage(conflict_damage, BRUTE, "melee", 1)
 				break


### PR DESCRIPTION




<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Snow Whites apple couldnt grow vines on J-777's floor vents due to her checking atmos. So now it checks reachable turfs instead. I had to additionally add a check to see if there is a door since without that they grow under doors which i felt was unfair.

If there is any noticeable lag let me know.

## Changelog
:cl:
fix: snow whites apple vines.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
