### PR TITLE
Slightly more accurate Shi Asso knoife translation

### DIFF
--- a/code/game/objects/items/ego_weapons/non_abnormality/shi.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/shi.dm
@@ -29,7 +29,7 @@
 			return
 		user.death()
 		for(var/mob/M in GLOB.player_list)
-			to_chat(M, span_userdanger("[uppertext(user.real_name)] has gone out with honor. 灰から灰へ"))
+			to_chat(M, span_userdanger("[uppertext(user.real_name)] has gone out with honor. 灰は灰に "))
 		new /obj/effect/temp_visual/BoD(get_turf(target))
 		suicide_used |= user.ckey
 	if(!CanUseEgo(user))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Increases the translation accuracy of the shi asso knife.
It's changed from  灰から灰へ (from ashes into ashes)
To what is used in the bible translations 灰は灰に
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This is a more accurate translation to what is used in the bible, which is what the phrase comes from.

No this is not a shitpost pr.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
spellcheck: Fixed a typo with the Shi asso knife. It is now changed from what is like slightly more accurate to what is used in the japanese bible.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
