### PR TITLE
Crit health fixes and adjustment

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -81,8 +81,8 @@
 
 //Health Defines
 #define HEALTH_THRESHOLD_CRIT 0
-#define HEALTH_THRESHOLD_FULLCRIT -10		//increased later.
-#define HEALTH_THRESHOLD_DEAD -20
+#define HEALTH_THRESHOLD_FULLCRIT -15		//increased later.
+#define HEALTH_THRESHOLD_DEAD -30
 
 #define HEALTH_THRESHOLD_NEARDEATH -30 //Not used mechanically, but to determine if someone is so close to death they hear the other side
 

--- a/code/datums/attributes/fortitude.dm
+++ b/code/datums/attributes/fortitude.dm
@@ -10,6 +10,6 @@
 /datum/attribute/fortitude/on_update(mob/living/carbon/user)
 	if(!istype(user))
 		return FALSE
-	user.death_threshold = HEALTH_THRESHOLD_DEAD - (level + level_buff) * 0.5
-	user.hardcrit_threshold = HEALTH_THRESHOLD_FULLCRIT - (level + level_buff) * 0.25
+	user.death_threshold = HEALTH_THRESHOLD_DEAD - round((level + level_buff) * 0.5)
+	user.hardcrit_threshold = HEALTH_THRESHOLD_FULLCRIT - round((level + level_buff) * 0.25)
 	return TRUE

--- a/code/datums/attributes/fortitude.dm
+++ b/code/datums/attributes/fortitude.dm
@@ -6,3 +6,10 @@
 
 /datum/attribute/fortitude/get_printed_level_bonus()
 	return round(level * FORTITUDE_MOD) + initial_stat_value
+
+/datum/attribute/fortitude/on_update(mob/living/carbon/user)
+	if(!istype(user))
+		return FALSE
+	user.death_threshold = HEALTH_THRESHOLD_DEAD - (level + level_buff) * 0.5
+	user.hardcrit_threshold = HEALTH_THRESHOLD_FULLCRIT - (level + level_buff) * 0.25
+	return TRUE

--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -109,7 +109,7 @@ Medical HUD! Basic mode needs suit sensors on.
 		return "health-100" //what's our health? it doesn't matter, we're dead, or faking
 	var/maxi_health = M.maxHealth
 	if(iscarbon(M) && M.health < 0)
-		maxi_health = 100 //so crit shows up right for aliens and other high-health carbon mobs; noncarbons don't have crit.
+		maxi_health = -M.death_threshold //so crit shows up right for aliens and other high-health carbon mobs; noncarbons don't have crit.
 	var/resulthealth = (M.health / maxi_health) * 100
 	switch(resulthealth)
 		if(100 to INFINITY)

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -197,7 +197,7 @@
 				data["occupant"]["statstate"] = "bad"
 		data["occupant"]["health"] = mob_occupant.health
 		data["occupant"]["maxHealth"] = mob_occupant.maxHealth
-		data["occupant"]["minHealth"] = HEALTH_THRESHOLD_DEAD
+		data["occupant"]["minHealth"] = mob_occupant.death_threshold
 		data["occupant"]["bruteLoss"] = mob_occupant.getBruteLoss()
 		data["occupant"]["sanityLoss"] = mob_occupant.getSanityLoss()
 		data["occupant"]["oxyLoss"] = mob_occupant.getOxyLoss()

--- a/code/game/machinery/computer/Operating.dm
+++ b/code/game/machinery/computer/Operating.dm
@@ -113,7 +113,7 @@
 	data["patient"]["health"] = patient.health
 	data["patient"]["blood_type"] = patient.dna.blood_type
 	data["patient"]["maxHealth"] = patient.maxHealth
-	data["patient"]["minHealth"] = HEALTH_THRESHOLD_DEAD
+	data["patient"]["minHealth"] = patient.death_threshold
 	data["patient"]["bruteLoss"] = patient.getBruteLoss()
 	data["patient"]["sanityLoss"] = patient.getSanityLoss()
 	data["patient"]["fireLoss"] = patient.getFireLoss()

--- a/code/game/objects/items/defib.dm
+++ b/code/game/objects/items/defib.dm
@@ -1,5 +1,5 @@
 //backpack item
-#define HALFWAYCRITDEATH ((HEALTH_THRESHOLD_CRIT + HEALTH_THRESHOLD_DEAD) * 0.5)
+#define HALFWAYCRITDEATH(THE_MOB) ((THE_MOB.crit_threshold + THE_MOB.death_threshold) * 0.5)
 
 /obj/item/defibrillator
 	name = "defibrillator"
@@ -597,15 +597,15 @@
 					var/total_burn = H.getFireLoss()
 
 					//If the body has been fixed so that they would not be in crit when defibbed, give them oxyloss to put them back into crit
-					if (H.health > HALFWAYCRITDEATH)
-						H.adjustOxyLoss(H.health - HALFWAYCRITDEATH, 0)
+					if (H.health > HALFWAYCRITDEATH(H))
+						H.adjustOxyLoss(H.health - HALFWAYCRITDEATH(H), 0)
 					else
 						var/overall_damage = total_brute + total_burn + H.getToxLoss() + H.getOxyLoss()
 						var/mobhealth = H.health
-						H.adjustOxyLoss((mobhealth - HALFWAYCRITDEATH) * (H.getOxyLoss() / overall_damage), 0)
-						H.adjustToxLoss((mobhealth - HALFWAYCRITDEATH) * (H.getToxLoss() / overall_damage), 0)
-						H.adjustFireLoss((mobhealth - HALFWAYCRITDEATH) * (total_burn / overall_damage), 0)
-						H.adjustBruteLoss((mobhealth - HALFWAYCRITDEATH) * (total_brute / overall_damage), 0)
+						H.adjustOxyLoss((mobhealth - HALFWAYCRITDEATH(H)) * (H.getOxyLoss() / overall_damage), 0)
+						H.adjustToxLoss((mobhealth - HALFWAYCRITDEATH(H)) * (H.getToxLoss() / overall_damage), 0)
+						H.adjustFireLoss((mobhealth - HALFWAYCRITDEATH(H)) * (total_burn / overall_damage), 0)
+						H.adjustBruteLoss((mobhealth - HALFWAYCRITDEATH(H)) * (total_brute / overall_damage), 0)
 					H.updatehealth() // Previous "adjust" procs don't update health, so we do it manually.
 					user.visible_message("<span class='notice'>[req_defib ? "[defib]" : "[src]"] pings: Resuscitation successful.</span>")
 					playsound(src, 'sound/machines/defib_success.ogg', 50, FALSE)

--- a/code/modules/mob/living/brain/brain.dm
+++ b/code/modules/mob/living/brain/brain.dm
@@ -54,7 +54,7 @@
 	return // no eyes, no flashing
 
 /mob/living/brain/can_be_revived()
-	if(!container || health <= HEALTH_THRESHOLD_DEAD)
+	if(!container || health <= death_threshold)
 		return FALSE
 	return TRUE
 

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -121,7 +121,7 @@
 
 	if((organ_flags & ORGAN_FAILING) && O.is_drainable() && O.reagents.has_reagent(/datum/reagent/medicine/mannitol)) //attempt to heal the brain
 		. = TRUE //don't do attack animation.
-		if(brainmob?.health <= HEALTH_THRESHOLD_DEAD) //if the brain is fucked anyway, do nothing
+		if(brainmob?.health <= brainmob.death_threshold) //if the brain is fucked anyway, do nothing
 			to_chat(user, span_warning("[src] is far too damaged, there's nothing else we can do for it!"))
 			return
 

--- a/code/modules/mob/living/brain/life.dm
+++ b/code/modules/mob/living/brain/life.dm
@@ -10,7 +10,7 @@
 /mob/living/brain/update_stat()
 	if(status_flags & GODMODE)
 		return
-	if(health <= HEALTH_THRESHOLD_DEAD)
+	if(health <= death_threshold)
 		if(stat != DEAD)
 			death()
 		var/obj/item/organ/brain/BR

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -562,7 +562,7 @@
 	set_health(round(maxHealth - getOxyLoss() - getToxLoss() - getCloneLoss() - total_burn - total_brute, DAMAGE_PRECISION))
 	staminaloss = round(total_stamina, DAMAGE_PRECISION)
 	update_stat()
-	if(((maxHealth - total_burn) < HEALTH_THRESHOLD_DEAD*2) && stat == DEAD )
+	if(((maxHealth - total_burn) < death_threshold*2) && stat == DEAD )
 		become_husk(BURN)
 
 	med_hud_set_health()
@@ -822,7 +822,7 @@
 	if(status_flags & GODMODE)
 		return
 	if(stat != DEAD)
-		if(health <= HEALTH_THRESHOLD_DEAD && !HAS_TRAIT(src, TRAIT_NODEATH))
+		if(health <= death_threshold && !HAS_TRAIT(src, TRAIT_NODEATH))
 			death()
 			return
 		if(health <= hardcrit_threshold && !HAS_TRAIT(src, TRAIT_NOHARDCRIT))

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -33,10 +33,6 @@
 	AddElement(/datum/element/ridable, /datum/component/riding/creature/human)
 	GLOB.human_list += src
 
-	//Crit stuff. Each Fort gets you 0.5 more soft crit health, and 0.5 more hard crit health
-	crit_threshold -= get_attribute_level(src, FORTITUDE_ATTRIBUTE)/2
-	hardcrit_threshold -= get_attribute_level(src, FORTITUDE_ATTRIBUTE)
-
 /mob/living/carbon/human/proc/init_attributes()
 	for(var/type in GLOB.attribute_types)
 		if(ispath(type, /datum/attribute))

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -394,7 +394,7 @@
 		to_chat(src, text="You are unable to succumb to death! This life continues.", type=MESSAGE_TYPE_INFO)
 		return
 	log_message("Has [whispered ? "whispered his final words" : "succumbed to death"] with [round(health, 0.1)] points of health!", LOG_ATTACK)
-	adjustOxyLoss(health - HEALTH_THRESHOLD_DEAD)
+	adjustOxyLoss(health - death_threshold)
 	updatehealth()
 	if(!whispered)
 		to_chat(src, "<span class='notice'>You have given up life and succumbed to death.</span>")
@@ -734,7 +734,7 @@
 //proc called by revive(), to check if we can actually ressuscitate the mob (we don't want to revive him and have him instantly die again)
 /mob/living/proc/can_be_revived()
 	. = TRUE
-	if(health <= HEALTH_THRESHOLD_DEAD)
+	if(health <= death_threshold)
 		return FALSE
 
 /mob/living/proc/update_damage_overlays()

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -30,6 +30,7 @@
 	var/maxSanity = 100
 	///When the mob enters hard critical state and is fully incapacitated.
 	var/hardcrit_threshold = HEALTH_THRESHOLD_FULLCRIT
+	var/death_threshold = HEALTH_THRESHOLD_DEAD
 
 	//Damage dealing vars! These are meaningless outside of specific instances where it's checked and defined.
 	// Lower bound of damage done by unarmed melee attacks. Mob code is a mess, only works where this is checked for.

--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -176,7 +176,7 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 		message_range = 1
 		log_talk(message, LOG_WHISPER)
 		if(stat == HARD_CRIT)
-			var/health_diff = round(-HEALTH_THRESHOLD_DEAD + health)
+			var/health_diff = round(-death_threshold + health)
 			// If we cut our message short, abruptly end it with a-..
 			var/message_len = length_char(message)
 			message = copytext_char(message, 1, health_diff) + "[message_len > health_diff ? "-.." : "..."]"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Replaces the death threshold constant with a variable in various places.
Fort scaling for crit health: 0 fort - 15 soft crit hp/15 hard crit hp will die at -30 hp; 130 fort - 47.5 soft crit hp/47.5 hard crit hp will die at -95 hp
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Should work properly now.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixed crit health scaling
balance: total crit hp starts at 30 and adds 0.5 per fort
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
