### PR TITLE
Fairy and Steel Runtime Fixes

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/aleph/titania.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/titania.dm
@@ -78,12 +78,18 @@
 	//Kills the weak immediately.
 	if(get_user_level(H) < 4 && (ishuman(H)))
 		say("I rid you of your pain, mere human.")
-		H.gib()
-		for(var/i=fairy_spawn_number*2, i>=1, i--)	//This counts down.
-			var/mob/living/simple_animal/hostile/fairyswarm/V = new(get_turf(target))
-			V.faction = faction
-			spawned_mobs+=V
-		return
+		//Double Check
+		if(H)
+			var/turf/fairy_spawn = get_turf(H)
+			//Just to be extra safe.
+			if(!fairy_spawn)
+				fairy_spawn = get_turf(src)
+			H.gib()
+			for(var/i=fairy_spawn_number*2, i>=1, i--)	//This counts down.
+				var/mob/living/simple_animal/hostile/fairyswarm/V = new(fairy_spawn)
+				V.faction = faction
+				spawned_mobs+=V
+			return
 
 	if(target == nemesis)	//Deals pale damage to Oberon, fuck you.
 		melee_damage_type = PALE_DAMAGE

--- a/code/modules/mob/living/simple_animal/hostile/ordeal/steel.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/steel.dm
@@ -187,15 +187,17 @@
 	sweeptarget.apply_damage(30, RED_DAMAGE, null, run_armor_check(null, RED_DAMAGE))
 	playsound(get_turf(src), 'sound/effects/meteorimpact.ogg', 50, TRUE)
 	if(sweeptarget.mob_size <= MOB_SIZE_HUMAN)
-		do_knockback(sweeptarget, src, get_dir(src, sweeptarget))
+		DoKnockback(sweeptarget, src, get_dir(src, sweeptarget))
 		shake_camera(sweeptarget, 4, 3)
 		shake_camera(src, 2, 3)
 
-/mob/living/simple_animal/hostile/ordeal/steel_dawn/steel_noon/flying/proc/do_knockback(atom/target, mob/thrower, throw_dir) //stolen from the knockback component since this happens only once
+/mob/living/simple_animal/hostile/ordeal/steel_dawn/steel_noon/flying/proc/DoKnockback(atom/target, mob/thrower, throw_dir) //stolen from the knockback component since this happens only once
 	if(!ismovable(target) || throw_dir == null)
 		return
 	var/atom/movable/throwee = target
 	if(throwee.anchored)
+		return
+	if(QDELETED(throwee))
 		return
 	var/atom/throw_target = get_edge_target_turf(throwee, throw_dir)
 	throwee.safe_throw_at(throw_target, 1, 1, thrower, gentle = TRUE)


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes a runtime with Titanias fairies which are being spawned ontop of a gibbed corpse after it has been gibbed. Now they register the location of the body before it is gibbed then gib it then spawn.

Steel flying knockback has been given a return condition if the thing being thrown has been qdeleted.

## Changelog
:cl:
fix: Titania fairy spawn runtime
fix: Steel knockback runtime.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
