### PR TITLE
Add Syrup to Ordeal and Human Meat

### DIFF
--- a/code/game/objects/items/food/meat.dm
+++ b/code/game/objects/items/food/meat.dm
@@ -893,7 +893,7 @@
 	name = "meat slurry"
 	desc = "Cobalt metal holding the liquified remains of a human, it smells rancid. It has the taste and texture of Surströmming."
 	icon_state = "sweepermeat"
-	food_reagents = list(/datum/reagent/consumable/nutriment/protein = 4)
+	food_reagents = list(/datum/reagent/consumable/nutriment/protein = 4, /datum/reagent/abnormality/heartysyrup = 3)
 	tastes = list("tender meat" = 1, "metal" = 1)
 	foodtypes = MEAT | RAW | GROSS
 
@@ -901,7 +901,7 @@
 	name = "curious meat"
 	desc = "Wretched rubbery meat cut from a gigantic heart. It tastes of anxiety and has the texture of uncooked squid."
 	icon_state = "fruitmeat"
-	food_reagents = list(/datum/reagent/consumable/nutriment/protein = 4, /datum/reagent/consumable/sugar = 3)
+	food_reagents = list(/datum/reagent/consumable/nutriment/protein = 4, /datum/reagent/consumable/sugar = 3, /datum/reagent/abnormality/focussyrup = 3)
 	tastes = list("tender meat" = 1, "jelly" = 1, "slime" = 1)
 	foodtypes = MEAT | RAW | TOXIC | JUNKFOOD
 
@@ -912,7 +912,7 @@
 	name = "perfect meat"
 	desc = "An awful jiggling chunk of meat cut from the hide of a worm. It tastes foul and has the texture of spoiled jelly."
 	icon_state = "wormmeat"
-	food_reagents = list(/datum/reagent/consumable/nutriment/protein = 4, /datum/reagent/yuck = 5)
+	food_reagents = list(/datum/reagent/consumable/nutriment/protein = 4, /datum/reagent/yuck = 1, /datum/reagent/abnormality/heartysyrup = 3)
 	tastes = list("slime" = 1, "jelly" = 1)
 	foodtypes = MEAT | RAW | TOXIC | GROSS
 
@@ -923,7 +923,7 @@
 	name = "nihilist component"
 	desc = "Ancient metal, filaments and cogwheels, all absolutely ruined. It tastes of metal and has the texture of metal. Its metal."
 	icon_state = "robotmeat"
-	food_reagents = list(/datum/reagent/consumable/nutriment/protein = 4, /datum/reagent/iron = 3)
+	food_reagents = list(/datum/reagent/consumable/nutriment/protein = 4, /datum/reagent/iron = 3, /datum/reagent/abnormality/bittersyrup = 3)
 	tastes = list("metal" = 1)
 	foodtypes = MEAT | RAW | GROSS
 
@@ -931,7 +931,7 @@
 	name = "sweet meat"
 	desc = "Scraped together from what was left, the result smells sickly sweet. You should eat this as fast as possible, as it looks to be going bad very soon."
 	icon_state = "clownmeat"
-	food_reagents = list(/datum/reagent/consumable/nutriment/protein = 4)
+	food_reagents = list(/datum/reagent/consumable/nutriment/protein = 4, /datum/reagent/abnormality/tastesyrup = 3)
 	tastes = list("sugar" = 1, "nearly rotten flesh" = 1)
 	foodtypes = MEAT | RAW | TOXIC | GROSS
 
@@ -964,6 +964,7 @@
 	foodtypes = MEAT
 
 /obj/item/food/meat/steak/plain/human
+	food_reagents = list(/datum/reagent/consumable/nutriment/protein = 8, /datum/reagent/consumable/nutriment/vitamin = 1, /datum/reagent/abnormality/heartysyrup = 2)
 	tastes = list("tender meat" = 1)
 	foodtypes = MEAT | GROSS
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds stat increasing syrups to human and ordeal meats. Im putting them in the meats to make them unique but if it feels like syrup is kind of being shoehorned into everything i may abstain from putting it more than fish.

## Why It's Good For The Game
Makes ordeal meat nutritionally unique and stat boosting.

## Changelog
:cl:
tweak: ordeal meats
tweak: human meat
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
