### PR TITLE
Dosage Estimator

### DIFF
--- a/ModularTegustation/tegu_items/gadgets/unpowered.dm
+++ b/ModularTegustation/tegu_items/gadgets/unpowered.dm
@@ -36,6 +36,39 @@
 			else
 				walk_to(SA, 0)
 
+	//Dosage Estimator
+/obj/item/dosage_est
+	name = "Dosage Estimator"
+	desc = "A modified reagent scanner that estimates how long a reagent will last in a regular human body. \
+		Its uncommon to see one of these outside of well funded laboratory. Use this on a container."
+	icon = 'ModularTegustation/Teguicons/teguitems.dmi'
+	icon_state = "gadget3"
+
+/obj/item/dosage_est/afterattack(atom/target, mob/user, proximity_flag)
+	. = ..()
+	if(istype(target, /obj/item/reagent_containers))
+		var/obj/item/reagent_containers/C = target
+		var/datum/reagents/reagent_container = C.reagents
+		var/list/chemical_list = reagent_container.reagent_list
+		var/datum/reagent/gloop
+		if(chemical_list.len)
+			var/render_list = "Chemicals Detected:"
+			for(var/r in chemical_list)
+				gloop = r
+				/*
+				* These calculations are sort of correct. In testing
+				* the time tended to be 1-2 seconds less than predicted.
+				* Inverting this equation would be
+				* volume = (seconds/2) * metabolization_rate
+				* -IP
+				*/
+				var/reagent_vol = round(gloop.volume, 0.001)
+				var/reagent_cycle = reagent_vol / gloop.metabolization_rate
+				render_list += "<br>[reagent_vol] units of [gloop.name] will metabolize [reagent_cycle] cycles for a total of [reagent_cycle*2] seconds."
+			to_chat(user, render_list)
+		else
+			to_chat(user, span_notice("No reagents detected."))
+
 	//abnos spawn slower, for maps that suck lol
 /obj/item/lc13_abnospawn
 	name = "Lobotomy Corporation Radio"

--- a/code/modules/clothing/outfits/standard.dm
+++ b/code/modules/clothing/outfits/standard.dm
@@ -481,7 +481,9 @@
 		/obj/item/gun/magic/wand/death/debug=1,\
 		/obj/item/debug/human_spawner=1,\
 		/obj/item/debug/omnitool=1,\
-		/obj/item/storage/box/stabilized=1
+		/obj/item/storage/box/stabilized=1,\
+		/obj/item/dosage_est=1,\
+		/obj/item/storage/box/lc_debugtools=1\
 		)
 
 /datum/outfit/admin/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
A tool for measuring how long the dosage of a substance will last in the human body. The margin of error between the calculated time and the actual time it took to metabolize the reagent is mostly unnoticable.

ADDITIONALLY ADDS DOSAGE ESTIMATOR AND LC13 DEBUG TOOL BOX TO ADMIN OUTFIT

Formula:
(volume / metabolization_rate) * 2 = seconds
(seconds/2) * metabolization_rate = volume

## Why It's Good For The Game
Reagents are kind of difficult to balance due to the vagueness of how they work and how long they work. Creating a goop that heals 1 health in a 1.1 metabolism thing is faster than a 0.6 metabolism, but how much faster is it? Im hoping this gadget can solve that issue for coders.

## Changelog
:cl:
add: dosage_estimator tool
tweak: admin outfit
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
