### PR TITLE
Removes sloth from LCL asset protection spawns

### DIFF
--- a/code/modules/jobs/job_types/labs/command/assetprot.dm
+++ b/code/modules/jobs/job_types/labs/command/assetprot.dm
@@ -42,7 +42,6 @@
 	set category = "Gamemaster"
 
 	var/list/peccetulum = list(
-		/mob/living/simple_animal/hostile/ordeal/sin_sloth,
 		/mob/living/simple_animal/hostile/ordeal/sin_gloom,
 		/mob/living/simple_animal/hostile/ordeal/sin_gluttony,
 	)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Refer to title
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Sloth did not grant an opportunity for RP, the ap ability grants players permanently dead the ability to re-enter the game and RP. Sloth would instead knockdown some folks, maybe kill 1 person and do nothing. Sloth is not a controllable mob as it moves on its own so the player would simply say a few lines then die..
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Removed Sloth from asset protection Pecca spawn
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
