### PR TITLE
rewrites the TSA in the woods adventure

### DIFF
--- a/ModularTegustation/_adventure_console/adventure_events/abnormality/he/tsa_woods.dm
+++ b/ModularTegustation/_adventure_console/adventure_events/abnormality/he/tsa_woods.dm
@@ -16,10 +16,14 @@
 		an hour to reach the end of the line. <br> \
 		At the end, you see people tearing their own skins and placing them into bins.",
 
-		"You conform to the rules, as everyone else has.<br> \
-		No matter how painful or unusual it may be.<br> \
-		After the traumatic ordeal, you are instructed to wear your skin as if it were any article of clothing.<br> \
-		However, the mental scars remain.",
+		"The now-skinless people pack their organs as if they were luggage.<br> \
+		You must conform to the rules, as everyone else has.<br> \
+		No matter how painful or uncomfortable it may be.<br> \
+		Following the excruciating ordeal, you wear your eyes as if they were glasses.<br> \
+		Your lungs, as if they were a bra.<br> \
+		Your intestines, a tie below the waist.<br> \
+		The final accoutrement, your button heart.<br> \
+		At last, you are ushered out, horrified and indignant.",
 
 		"The building is so crowded, you can't escape by conventional means. \
 		You need to think of a way to get out of here.",
@@ -46,7 +50,7 @@
 			BUTTON_FORMAT(7, "WALK AWAY", M)
 			return
 		if(2)
-			BUTTON_FORMAT(3, "TEAR OFF YOUR SKIN", M)
+			BUTTON_FORMAT(3, "CONTINUE", M)
 			BUTTON_FORMAT(4, "ATTEMPT ESCAPE", M)
 			return
 		if(3)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

What it says on the tin
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Tempy(temperancetempy) had mentioned that this event was very similar to the Laundry of Dreams from Distortion Detective, and I agree. This PR re-writes the lines for the failure event.

## Why It's Good For The Game

This abnormality and event was based on a dream I once had, of which this outcome was not explored. When writing this event, I simply wrote the details that came to mind at the moment, and I believe this would be an improvement.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: EO adventure writing TSA_woods
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
