### PR TITLE
Item middle click actions

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -1043,6 +1043,10 @@
 #define COMSIG_ITEM_AFTERATTACK "item_afterattack"
 ///from base of obj/item/attack_qdeleted(): (atom/target, mob/user, params)
 #define COMSIG_ITEM_ATTACK_QDELETED "item_attack_qdeleted"
+///from base of obj/item/MiddleClickAction(): (atom/target, mob/living/user, params)
+#define COMSIG_ITEM_MIDDLE_CLICK_ACTION "item_middle_click_action"
+	///cancels middle click action
+	#define COMPONENT_CANCEL_MIDDLE_CLICK_ACTION (1<<0)
 ///from base of atom/attack_hand(): (mob/user)
 #define COMSIG_MOB_ATTACK_HAND "mob_attack_hand"
 ///from base of /obj/item/attack(): (mob/M, mob/user)

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -285,7 +285,29 @@
 	. = SEND_SIGNAL(src, COMSIG_MOB_MIDDLECLICKON, A, params)
 	if(. & COMSIG_MOB_CANCEL_CLICKON)
 		return
-	swap_hand()
+
+	var/list/modifiers = params2list(params)
+	if(incapacitated(ignore_restraints = TRUE, ignore_stasis = TRUE))
+		return
+
+	face_atom(A)
+
+	if(next_move > world.time)
+		return
+
+	if(!LAZYACCESS(modifiers, "catcher") && A.IsObscured())
+		return
+
+	var/obj/item/W = get_active_held_item()
+
+	if(!W || W == A)
+		return
+
+	//Can't reach anything else in lockers or other weirdness
+	if(!loc.AllowClick())
+		return
+
+	W.MiddleClickAction(A, src)
 
 /**
  * Shift click
@@ -443,14 +465,10 @@
 
 /atom/movable/screen/click_catcher/Click(location, control, params)
 	var/list/modifiers = params2list(params)
-	if(LAZYACCESS(modifiers, MIDDLE_CLICK) && iscarbon(usr))
-		var/mob/living/carbon/C = usr
-		C.swap_hand()
-	else
-		var/turf/T = params2turf(LAZYACCESS(modifiers, SCREEN_LOC), get_turf(usr.client ? usr.client.eye : usr), usr.client)
-		params += "&catcher=1"
-		if(T)
-			T.Click(location, control, params)
+	var/turf/T = params2turf(LAZYACCESS(modifiers, SCREEN_LOC), get_turf(usr.client ? usr.client.eye : usr), usr.client)
+	params += "&catcher=1"
+	if(T)
+		T.Click(location, control, params)
 	. = 1
 
 /// MouseWheelOn

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -92,7 +92,7 @@
 		MiddleClickOn(A, params)
 		return
 	if(LAZYACCESS(modifiers, ALT_CLICK)) // alt and alt-gr (rightalt)
-		AltClickOn(A)
+		AltClickOn(A, params)
 		return
 	if(LAZYACCESS(modifiers, CTRL_CLICK))
 		CtrlClickOn(A)
@@ -300,7 +300,7 @@
 
 	var/obj/item/W = get_active_held_item()
 
-	if(!W || W == A)
+	if(!W || ismovable(A.loc))
 		return
 
 	//Can't reach anything else in lockers or other weirdness
@@ -355,11 +355,38 @@
  * Alt click
  * Unused except for AI
  */
-/mob/proc/AltClickOn(atom/A)
+/mob/proc/AltClickOn(atom/A, params)
 	. = SEND_SIGNAL(src, COMSIG_MOB_ALTCLICKON, A)
 	if(. & COMSIG_MOB_CANCEL_CLICKON)
 		return
 	A.AltClick(src)
+
+/mob/living/carbon/AltClickOn(atom/A, params)
+	. = ..()
+	if(. & COMSIG_MOB_CANCEL_CLICKON)
+		return
+	var/list/modifiers = params2list(params)
+	if(incapacitated(ignore_restraints = TRUE, ignore_stasis = TRUE))
+		return
+
+	face_atom(A)
+
+	if(next_move > world.time)
+		return
+
+	if(!LAZYACCESS(modifiers, "catcher") && A.IsObscured())
+		return
+
+	var/obj/item/W = get_active_held_item()
+
+	if(!W || ismovable(A.loc))
+		return
+
+	//Can't reach anything else in lockers or other weirdness
+	if(!loc.AllowClick())
+		return
+
+	W.MiddleClickAction(A, src)
 
 /atom/proc/AltClick(mob/user)
 	SEND_SIGNAL(src, COMSIG_CLICK_ALT, user)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1155,3 +1155,8 @@ GLOBAL_VAR_INIT(embedpocalypse, FALSE) // if true, all items will be able to emb
 /obj/item/proc/on_offer_taken(mob/living/carbon/offerer, mob/living/carbon/taker)
 	if(SEND_SIGNAL(src, COMSIG_ITEM_OFFER_TAKEN, offerer, taker) & COMPONENT_OFFER_INTERRUPT)
 		return TRUE
+
+/obj/item/proc/MiddleClickAction(atom/target, mob/living/user)
+	SHOULD_CALL_PARENT(TRUE)
+	if(SEND_SIGNAL(src, COMSIG_ITEM_MIDDLE_CLICK_ACTION, target, user) & COMPONENT_CANCEL_MIDDLE_CLICK_ACTION)
+		return TRUE

--- a/code/game/objects/items/ego_weapons/_ego_weapon.dm
+++ b/code/game/objects/items/ego_weapons/_ego_weapon.dm
@@ -202,3 +202,8 @@
 	icon_state = "stun"
 	layer = ABOVE_ALL_MOB_LAYER
 	duration = 9
+
+/obj/item/ego_weapon/MiddleClickAction(atom/target, mob/living/user)
+	. = ..()
+	if(. || !CanUseEgo(user))
+		return TRUE

--- a/code/game/objects/items/ego_weapons/he.dm
+++ b/code/game/objects/items/ego_weapons/he.dm
@@ -845,7 +845,7 @@
 /obj/item/ego_weapon/fluid_sac
 	name = "fluid sac"
 	desc = "Crush them, even if you must disgorge everything."
-	special = "This weapon can be used to perform a jump attack after a short wind-up."
+	special = "This weapon can be used to perform a jump attack after a short wind-up (Middle mouse button click an enemy)."
 	icon_state = "fluid_sac"
 	force = 55
 	attack_speed = 2
@@ -872,17 +872,20 @@
 /obj/item/ego_weapon/fluid_sac/proc/JumpReset()
 	can_attack = TRUE
 
-/obj/item/ego_weapon/fluid_sac/afterattack(atom/A, mob/living/user, proximity_flag, params)
-	if(!CanUseEgo(user) || !can_attack)
+/obj/item/ego_weapon/fluid_sac/MiddleClickAction(atom/target, mob/living/user)
+	. = ..()
+	if(.)
 		return
-	if(!isliving(A))
+	if(!can_attack)
 		return
+	if(!isliving(target))
+		return
+	var/mob/living/A = target
 	if(dash_cooldown > world.time)
 		to_chat(user, span_warning("Your dash is still recharging!"))
 		return
 	if((get_dist(user, A) < 2) || (!(can_see(user, A, dash_range))))
 		return
-	..()
 	if(do_after(user, 5, src))
 		dash_cooldown = world.time + dash_cooldown_time
 		playsound(src, 'sound/abnormalities/ichthys/jump.ogg', 50, FALSE, -1)

--- a/code/game/objects/items/ego_weapons/he.dm
+++ b/code/game/objects/items/ego_weapons/he.dm
@@ -845,7 +845,7 @@
 /obj/item/ego_weapon/fluid_sac
 	name = "fluid sac"
 	desc = "Crush them, even if you must disgorge everything."
-	special = "This weapon can be used to perform a jump attack after a short wind-up (Middle mouse button click an enemy)."
+	special = "This weapon can be used to perform a jump attack after a short wind-up (Middle mouse button click/alt click an enemy)."
 	icon_state = "fluid_sac"
 	force = 55
 	attack_speed = 2

--- a/code/modules/projectiles/guns/ego_gun/aleph.dm
+++ b/code/modules/projectiles/guns/ego_gun/aleph.dm
@@ -144,7 +144,7 @@
 			Can guns really bring peace and love?"
 	icon_state = "pink"
 	inhand_icon_state = "pink"
-	special = "This weapon has a scope, and fires projectiles with zero travel time. Damage dealt is increased when hitting targets further away. Middle mouse button click to zoom in that direction."
+	special = "This weapon has a scope, and fires projectiles with zero travel time. Damage dealt is increased when hitting targets further away. Middle mouse button click/alt click to zoom in that direction."
 	ammo_type = /obj/item/ammo_casing/caseless/pink
 	weapon_weight = WEAPON_HEAVY
 	fire_sound = 'sound/abnormalities/armyinblack/pink.ogg'

--- a/code/modules/projectiles/guns/ego_gun/aleph.dm
+++ b/code/modules/projectiles/guns/ego_gun/aleph.dm
@@ -144,14 +144,16 @@
 			Can guns really bring peace and love?"
 	icon_state = "pink"
 	inhand_icon_state = "pink"
-	special = "This weapon has a scope, and fires projectiles with zero travel time. Damage dealt is increased when hitting targets further away."
+	special = "This weapon has a scope, and fires projectiles with zero travel time. Damage dealt is increased when hitting targets further away. Middle mouse button click to zoom in that direction."
 	ammo_type = /obj/item/ammo_casing/caseless/pink
 	weapon_weight = WEAPON_HEAVY
 	fire_sound = 'sound/abnormalities/armyinblack/pink.ogg'
-	fire_delay = 18
+	fire_delay = 9
 	zoomable = TRUE
 	zoom_amt = 10
 	zoom_out_amt = 13
+	shotsleft = 5
+	reloadtime = 2.1 SECONDS
 	attribute_requirements = list(
 							FORTITUDE_ATTRIBUTE = 80,
 							PRUDENCE_ATTRIBUTE = 100,
@@ -160,9 +162,11 @@
 							)
 	var/mob/current_holder
 
-/obj/item/gun/ego_gun/pink/attack_self(mob/user)
-	zoom(user, user.dir)
-	..()
+/obj/item/gun/ego_gun/pink/MiddleClickAction(atom/target, mob/living/user)
+	. = ..()
+	if(.)
+		return
+	zoom(user, get_cardinal_dir(user, target))
 
 /obj/item/gun/ego_gun/pink/zoom(mob/living/user, direc, forced_zoom)
 	if(!CanUseEgo(user))
@@ -191,7 +195,7 @@
 
 /obj/item/gun/ego_gun/pink/proc/UserMoved(mob/living/user, direc)
 	SIGNAL_HANDLER
-	attack_self(user)//disengage
+	zoom(user)//disengage
 
 /obj/item/gun/ego_gun/pink/Destroy(mob/user)//FIXME: causes component runtimes
 	if(!user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Replaces the middle mouse click action from hand swapping to calling an active item's MiddleClickAction proc.
Allows to put various special abilities on its own button.
As a proof of concept put fluid sac jump ability and pink rifle zoom on middle click. Im not sure about the reload related rebalancing pink needs but i just cut its fire delay by half with 5 shot magazine and 2.1 second reload for now.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Gives another button that can be used for cool things. Lets guns have abilities at the same time as reloading.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: added reloading to pink gun: 5 shot magazine, 2.1 second reload, and halved fire delay
code: added MiddleClickAction proc for all items, changed middle click action from swap hands to calling this proc.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
