### PR TITLE
Fluffy Tongue Removal

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -352,7 +352,6 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 //positive quirks
 #define TRAIT_RESISTANT      	"resistant"
 #define TRAIT_SKILLED    	    "skilled"
-#define TRAIT_FLUFFY_TONGUE     "fluffy_tongue" // technically not positive, but it costs points
 //neutral quirks
 #define TRAIT_NERD          	"nerd"
 #define TRAIT_BRAWLER    	    "brawler"

--- a/code/_globalvars/traits.dm
+++ b/code/_globalvars/traits.dm
@@ -186,7 +186,6 @@ GLOBAL_LIST_INIT(traits_by_type, list(
 		"TRAIT_ARTIST" = TRAIT_ARTIST,
 		"TRAIT_GUNS" = TRAIT_GUNS,               // used for the "no guns" challenge
 		"TRAIT_HEALING" = TRAIT_HEALING,          // used for the "no medipens" challenge
-		"TRAIT_FLUFFY_TONGUE" = TRAIT_FLUFFY_TONGUE,
 		"TRAIT_GRAB_IMMUNE" = TRAIT_GRAB_IMMUNE //used to prevent grab-related exploits
 	),
 	/obj/item/bodypart = list(

--- a/code/datums/quirks/good.dm
+++ b/code/datums/quirks/good.dm
@@ -31,29 +31,6 @@
 	H.adjust_attribute_buff(TEMPERANCE_ATTRIBUTE, 5)
 	H.adjust_attribute_buff(JUSTICE_ATTRIBUTE, 5)
 
-/datum/quirk/fluffy_tongue //not positive, but it costs points so we ball
-	name = "Fluffy Tongue"
-	desc = "You offended the wrong people and have been forced to undergo experimental surgery as punishment. You regret your existance."
-	value = 6
-	gain_text = "<span class='danger'>How can I bear to speak to my co-workers now?</span>"
-	medical_record_text = "Patient has gotten \"uwufication\" surgery by order of the Head. The condition is not to be treated."
-//	hardcore_value = -2 // un-comment to let hardcore random cause chaos, unrecommended
-
-/datum/quirk/fluffy_tongue/on_spawn()
-	RegisterSignal(quirk_holder, COMSIG_MOB_SAY, PROC_REF(handle_speech))
-
-/datum/quirk/fluffy_tongue/proc/handle_speech(datum/source, list/speech_args)
-	var/message = speech_args[SPEECH_MESSAGE]
-	if(message[1] != "*")
-		message = replacetext(message, "ne", "nye")
-		message = replacetext(message, "nu", "nyu")
-		message = replacetext(message, "na", "nya")
-		message = replacetext(message, "no", "nyo")
-		message = replacetext(message, "ove", "uv")
-		message = replacetext(message, "r", "w")
-		message = replacetext(message, "l", "w")
-	speech_args[SPEECH_MESSAGE] = message
-
 // Special quirks end
 
 /datum/quirk/musician


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes all the Fluffy Tongue related code.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It isn't exactly a good thing when almost every person who uses it doesn't play the quirk's lore correctly, and the fact some fluffy tongues take this role yet use a command role or other role with loud speak just isn't healthy enough, and would cause WAY less conflicts between players if it was outright removed instead....
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Removed old things
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
