### PR TITLE
Fixes a bug with player-controlled Faelantern

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/teth/faelantern.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/faelantern.dm
@@ -25,6 +25,7 @@
 	del_on_death = FALSE
 	death_message = "creaks and crumbles into its core."
 	ranged = TRUE
+	ranged_cooldown_time = 1.5 SECONDS
 
 	work_damage_amount = 5
 	work_damage_type = WHITE_DAMAGE
@@ -91,6 +92,7 @@
 /mob/living/simple_animal/hostile/abnormality/faelantern/OpenFire()
 	if(!can_act)
 		return
+	..()
 	if(lure_cooldown <= world.time)
 		if(fairy_enabled)
 			FairyLure()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes a bug with Faelantern where the ranged attack can be spammed without a cooldown, when controlled by a player. This may affect the hostile's attack speed slightly, but it is intentional.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixing bugs is generally good for the game.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixes faelantern's attack cooldown
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
