### PR TITLE
I got pissed at inconsistent tool behavior, so i decided to make the warnings more visible -- A salt PR

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/_tools/he/researcher.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_tools/he/researcher.dm
@@ -67,7 +67,7 @@
 		addtimer(CALLBACK(src, PROC_REF(Explode), owner), 1) //Gives damage procs time to process
 		return
 	if(damage_counter >= (damage_max * 0.8))
-		to_chat(owner, span_userdanger("You need to return the research notes immediately!"))
+		to_chat(owner, span_hypnophrase("You need to return the research notes immediately!"))
 		return
 	if(damage_counter >= (damage_max * 0.6))
 		to_chat(owner, span_userdanger("You feel like you should avoid taking any more damage!"))

--- a/code/modules/mob/living/simple_animal/abnormality/_tools/teth/bracelet.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_tools/teth/bracelet.dm
@@ -50,6 +50,7 @@
 	if(healthtracker>=300)
 		if(warningtracker == 0)
 			to_chat(H, span_hypnophrase("You have been wearing the luminous bracelet for a long time. Any longer could be dangerous!"))
+			H.playsound_local(get_turf(H), 'sound/abnormalities/nothingthere/heartbeat.ogg', 50, 0, 3)
 		warningtracker+=1
 	if(warningtracker >= 150)
 		H.gib()

--- a/code/modules/mob/living/simple_animal/abnormality/_tools/teth/bracelet.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_tools/teth/bracelet.dm
@@ -49,6 +49,7 @@
 	//Count down to 5 minutes of wearing
 	if(healthtracker>=300)
 		if(warningtracker == 0)
+			to_chat(H, span_narsie("!"))
 			to_chat(H, span_hypnophrase("You have been wearing the luminous bracelet for a long time. Any longer could be dangerous!"))
 			H.playsound_local(get_turf(H), 'sound/abnormalities/nothingthere/heartbeat.ogg', 50, 0, 3)
 		warningtracker+=1

--- a/code/modules/mob/living/simple_animal/abnormality/_tools/teth/bracelet.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_tools/teth/bracelet.dm
@@ -49,7 +49,6 @@
 	//Count down to 5 minutes of wearing
 	if(healthtracker>=300)
 		if(warningtracker == 0)
-			to_chat(H, span_narsie("!"))
 			to_chat(H, span_hypnophrase("You have been wearing the luminous bracelet for a long time. Any longer could be dangerous!"))
 			H.playsound_local(get_turf(H), 'sound/abnormalities/nothingthere/heartbeat.ogg', 50, 0, 3)
 		warningtracker+=1

--- a/code/modules/mob/living/simple_animal/abnormality/_tools/teth/bracelet.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_tools/teth/bracelet.dm
@@ -49,7 +49,7 @@
 	//Count down to 5 minutes of wearing
 	if(healthtracker>=300)
 		if(warningtracker == 0)
-			to_chat(H, span_danger("You have been wearing the luminous bracelet for a long time. Any longer could be dangerous!"))
+			to_chat(H, span_hypnophrase("You have been wearing the luminous bracelet for a long time. Any longer could be dangerous!"))
 		warningtracker+=1
 	if(warningtracker >= 150)
 		H.gib()

--- a/code/modules/mob/living/simple_animal/abnormality/_tools/teth/heart.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_tools/teth/heart.dm
@@ -67,14 +67,17 @@
 	if(H.health < H.maxHealth * 0.25)
 		if(!raging)
 			SuperRageEnable()
-	if(H.stat == DEAD)
-		var/obj/item/organ/heart/heart = H.getorganslot(ORGAN_SLOT_HEART)
-		if(istype(heart))
-			QDEL_NULL(heart)
-			return
-		H.visible_message(span_danger("[H]'s heart explodes!"))
-		new /obj/effect/gibspawner/generic(get_turf(H))
-		H.remove_status_effect(src)
+	if(H.stat != DEAD)
+		return
+
+	var/obj/item/organ/heart/heart = H.getorganslot(ORGAN_SLOT_HEART)
+	if(istype(heart))
+		QDEL_NULL(heart)
+		return
+
+	H.visible_message(span_danger("[H]'s heart explodes!"))
+	new /obj/effect/gibspawner/generic(get_turf(H))
+	H.remove_status_effect(src)
 
 /datum/status_effect/display/aspiration/proc/RageEnable()
 	var/mob/living/carbon/human/H = owner

--- a/code/modules/mob/living/simple_animal/abnormality/_tools/waw/clock.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_tools/waw/clock.dm
@@ -16,10 +16,10 @@
 	var/clock_cooldown //prevents an exploit
 
 	var/list/exceptions = list( //It only affects abnormalities and ordeals, so claw and arbiter are not even included.
-	/mob/living/simple_animal/hostile/abnormality/white_night,
-	/mob/living/simple_animal/hostile/abnormality/distortedform,
-	/mob/living/simple_animal/hostile/abnormality/nihil,
-	/mob/living/simple_animal/hostile/abnormality/sukuna,
+		/mob/living/simple_animal/hostile/abnormality/white_night,
+		/mob/living/simple_animal/hostile/abnormality/distortedform,
+		/mob/living/simple_animal/hostile/abnormality/nihil,
+		/mob/living/simple_animal/hostile/abnormality/sukuna,
 	)
 
 	ego_list = list(

--- a/code/modules/mob/living/simple_animal/abnormality/_tools/waw/dr_jekyll.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_tools/waw/dr_jekyll.dm
@@ -88,14 +88,14 @@
 	var/message_cooldown
 	var/message_cooldown_time = 30 SECONDS
 	var/list/message_list = list(
-	"Are you ready?",
-	"Mankind is not truly one, but truly two.",
-	"The blood quickens, the soul sickens.",
-	"I am a part of you now. Just as you are a part of me.",
-	"Drink.",
-	"Don't concern yourself with good and evil.",
-	"You could be so much more than those panting hypocrites.",
-	"Take back what they took from you. Trample on their dead bodies.",
+		"Are you ready?",
+		"Mankind is not truly one, but truly two.",
+		"The blood quickens, the soul sickens.",
+		"I am a part of you now. Just as you are a part of me.",
+		"Drink.",
+		"Don't concern yourself with good and evil.",
+		"You could be so much more than those panting hypocrites.",
+		"Take back what they took from you. Trample on their dead bodies.",
 	)
 
 /atom/movable/screen/alert/status_effect/hyde

--- a/code/modules/mob/living/simple_animal/abnormality/_tools/zayin/wishwell.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_tools/zayin/wishwell.dm
@@ -181,9 +181,9 @@
 
 //This proc removes the need to copypaste every single armor and weapon into a list.
 /obj/structure/toolabnormality/wishwell/Initialize()
-	return ..()
+	. = ..()
 
-//Sorts them into their lists
+	//Sorts them into their lists
 	for(var/path in subtypesof(/datum/ego_datum))
 		var/datum/ego_datum/ego = path
 		switch(initial(ego.cost))

--- a/code/modules/mob/living/simple_animal/abnormality/_tools/zayin/wishwell.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_tools/zayin/wishwell.dm
@@ -8,16 +8,17 @@
 
 	ego_list = list(
 		/datum/ego_datum/weapon/bucket,
-		/datum/ego_datum/armor/bucket
-		)
+		/datum/ego_datum/armor/bucket,
+	)
 
 //loot lists
 	var/list/superEGO = list( //do NOT put this in the loot lists ever. SuperEGO is for inputs only so people can throw away twilight for no good reason.
 		/obj/item/ego_weapon/paradise,
 		/obj/item/clothing/suit/armor/ego_gear/aleph/twilight,
 		/obj/item/ego_weapon/twilight,
-		/obj/item/ego_weapon/shield/distortion
-		)
+		/obj/item/ego_weapon/shield/distortion,
+	)
+
 	var/list/strongaleph = list( //items that can be bought with PE with costs over 100 and other goodies
 		/obj/item/nihil/heart,
 		/obj/item/nihil/spade,
@@ -27,13 +28,15 @@
 		/obj/item/clothing/suit/armor/ego_gear/aleph/distortion,
 		/obj/item/ego_weapon/iron_maiden,
 		/obj/item/clothing/suit/armor/ego_gear/aleph/flowering,
-		/obj/item/toy/plush/bongbong
-		)
+		/obj/item/toy/plush/bongbong,
+	)
+
 	var/list/alephitem = list(//less junk items at higher risk levels
 		/obj/item/clothing/suit/armor/ego_gear/aleph/praetorian,
 		/obj/item/toy/plush/mosb,
-		/obj/item/toy/plush/melt
-		)
+		/obj/item/toy/plush/melt,
+	)
+
 	var/list/wawitem = list(
 		/obj/item/clothing/suit/armor/ego_gear/limbus/durante,
 		/obj/item/ego_weapon/lance/sangre,
@@ -45,8 +48,9 @@
 		/obj/item/toy/plush/bigbird,
 		/obj/item/toy/plush/rabbit,
 		/obj/item/grenade/spawnergrenade/shrimp/super,
-		/obj/item/ego_weapon/flower_waltz
-		)
+		/obj/item/ego_weapon/flower_waltz,
+	)
+
 	var/list/heitem = list(
 		/obj/item/gun/ego_gun/sodashotty,
 		/obj/item/gun/ego_gun/sodarifle,
@@ -57,7 +61,8 @@
 		/obj/item/clothing/glasses/sunglasses/reagent,
 		/obj/item/clothing/suit/hawaiian,
 		/obj/item/clothing/neck/necklace/dope,
-		)
+	)
+
 	var/list/tethitem = list(
 		/obj/item/clothing/suit/armor/ego_gear/teth/training,
 		/obj/item/ego_weapon/training,
@@ -69,16 +74,18 @@
 		/obj/item/clothing/under/suit/lobotomy/architecture,
 		/obj/item/clothing/under/suit/lobotomy/rabbit,
 		/obj/item/clothing/under/color/rainbow,
-		/obj/item/toy/plush/yuri
-		)
+		/obj/item/toy/plush/yuri,
+	)
+
 	var/list/zayinitem = list(
 		/obj/item/reagent_containers/food/drinks/soda_cans/wellcheers_red,
 		/obj/item/reagent_containers/food/drinks/soda_cans/wellcheers_white,
 		/obj/item/food/bread/bongbread,
 		/obj/item/clothing/neck/tie/horrible,
 		/obj/item/clothing/mask/cigarette/cigar/havana,
-		/mob/living/carbon/human/species/shrimp
-		)
+		/mob/living/carbon/human/species/shrimp,
+	)
+
 	var/list/normalitem = list(
 		/obj/item/reagent_containers/hypospray/medipen/salacid,
 		/obj/item/reagent_containers/hypospray/medipen/mental,
@@ -99,7 +106,8 @@
 		/obj/item/clothing/under/suit/lobotomy/welfare,
 		/obj/item/clothing/under/suit/lobotomy/extraction,
 		/obj/item/clothing/under/suit/lobotomy/records,
-		)
+	)
+
 	var/list/baditem = list(
 		/obj/item/toy/plush/yisang,
 		/obj/item/toy/plush/faust,
@@ -122,8 +130,9 @@
 		/obj/item/toy/eightball,
 		/obj/item/rack_parts,
 		/obj/item/clothing/under/color/rainbow,
-		/obj/item/coin/silver
-		)
+		/obj/item/coin/silver,
+	)
+
 	var/list/trash = list(
 		/obj/item/toy/plush/fumo, //Needs no explanation
 		/obj/item/toy/plush/blank,
@@ -139,8 +148,8 @@
 		/obj/effect/decal/cleanable/ash,
 		/obj/item/cigbutt,
 		/obj/item/food/urinalcake,
-		/obj/item/shard
-		)
+		/obj/item/shard,
+	)
 
 //Potential threats
 	var/list/dawn = list(
@@ -149,27 +158,30 @@
 		/obj/item/clothing/mask/facehugger/bongy,
 		/mob/living/simple_animal/hostile/ordeal/violet_fruit,
 		/mob/living/simple_animal/hostile/ordeal/sin_sloth,
-		/mob/living/simple_animal/hostile/ordeal/sin_gluttony
-		)
+		/mob/living/simple_animal/hostile/ordeal/sin_gluttony,
+	)
+
 	var/list/noon = list(
 		/mob/living/simple_animal/hostile/ordeal/green_bot_big,
 		/mob/living/simple_animal/hostile/ordeal/indigo_noon,
-		/mob/living/simple_animal/hostile/ordeal/sin_gloom
-		)
+		/mob/living/simple_animal/hostile/ordeal/sin_gloom,
+	)
+
 	var/list/dusk = list(
 		/mob/living/simple_animal/hostile/ordeal/sin_pride,
 		/mob/living/simple_animal/hostile/ordeal/KHz_corrosion,
 		/mob/living/simple_animal/hostile/mini_censored,
-		/mob/living/simple_animal/hostile/slime
-		)
+		/mob/living/simple_animal/hostile/slime,
+	)
+
 	var/list/midnight = list(//TODO: Add more somewhat reasonable threats
 		/mob/living/simple_animal/hostile/slime/big,
 		/mob/living/simple_animal/hostile/ordeal/sin_wrath,
-		)
+	)
 
 //This proc removes the need to copypaste every single armor and weapon into a list.
 /obj/structure/toolabnormality/wishwell/Initialize()
-	. = ..()
+	return ..()
 
 //Sorts them into their lists
 	for(var/path in subtypesof(/datum/ego_datum))
@@ -297,41 +309,44 @@
 	if(gift)
 		Dispense(gift)
 
-/obj/structure/toolabnormality/wishwell/proc/Dispense(atom/dispenseobject)
+/obj/structure/toolabnormality/wishwell/proc/Dispense(atom/output_object)
 	playsound(src, 'sound/abnormalities/bloodbath/Bloodbath_EyeOn.ogg', 80, FALSE, -3)
 	var/turf/dispense_turf = get_step(src, pick(1,2,4,5,6,8,9,10))
 	if(!isopenturf(dispense_turf))
 		dispense_turf = get_turf(src)
-	new dispenseobject(dispense_turf)
+
+	new output_object(dispense_turf)
 	var/list/water_area = range(1, dispense_turf)
 	for(var/turf/open/O in water_area)
 		new /obj/effect/particle_effect/water(O)
+
 	visible_message(span_notice("Something comes out of the well!"))
 
 //Throw yourself into the well : The Code
 /obj/structure/toolabnormality/wishwell/user_buckle_mob(mob/living/M, mob/user, check_loc = TRUE)
-	if (!istype(M, /mob/living/carbon/human))
+	if(!istype(M, /mob/living/carbon/human))
 		to_chat(usr, span_warning("It doesn't look like I can't quite fit in."))
 		return FALSE // Can only extract from humans.
 
-	if(M != user)
-		to_chat(user, span_warning("You start pulling [M] into the well."))
-		if(do_after(user, 7 SECONDS, target = M)) //If you're going to throw someone else, they have to be dead first.
-			if(M.stat == DEAD)
-				to_chat(user, span_notice("You throw [M] in the well!"))
-				buckle_mob(M, check_loc = check_loc)
-			else
-				to_chat(user, span_warning("How could you be so cruel? [M] is still alive!"))
+	if(M == user)
+		to_chat(user, span_warning("You start climbing into the well."))
+		if(!do_after(user, 7 SECONDS, target = M))
+			to_chat(user, span_notice("You decide that might be a bad idea."))
+			return FALSE
+
+		to_chat(user, span_userdanger("You fall into the well!"))
+
+		return ..(M, user, check_loc = FALSE) //it just works
+
+	if(M.stat != DEAD)
+		to_chat(user, span_warning("How could you be so cruel? [M] is still alive!"))
 		return
 
-	to_chat(user, span_warning("You start climbing into the well."))
-	if(!do_after(user, 7 SECONDS, target = M))
-		to_chat(user, span_notice("You decide that might be a bad idea."))
-		return FALSE
+	to_chat(user, span_warning("You start pulling [M] into the well."))
 
-	to_chat(user, span_userdanger("You fall into the well!"))
-	return ..(M, user, check_loc = FALSE) //it just works
-
+	if(do_after(user, 7 SECONDS, target = M)) //If you're going to throw someone else, they have to be dead first.
+		to_chat(user, span_notice("You throw [M] in the well!"))
+		buckle_mob(M, check_loc = check_loc)
 
 /obj/structure/toolabnormality/wishwell/post_buckle_mob(mob/living/carbon/human/M)
 	if(!ishuman(M))
@@ -361,6 +376,6 @@
 		deathgift = pick(trash)
 
 	bastards += M.ckey
-	sleep(10)
+	sleep(1 SECONDS)
 	Dispense(deathgift)
 	..()


### PR DESCRIPTION
## About The Pull Request

This is a salt PR technically
It does the following:
- All tools (bracelet and researchers notes) now use the span "hypnophrase" for their near-death warnings, making them much easier to notice, heart specifically also had another message added thats an exclamation mark with span_narsie
- Bracelet now gives a heart sound effect when you are nearly dead, as while researchers note spams you, heart does not.
- Made lists on tools more consistent, and in-line with the list standards
- Removed some unnecessary indentation

## Why It's Good For The Game

> All tools (bracelet and researchers notes) now use the span "hypnophrase" for their near-death warnings, making them much easier to notice
- The warnings are supposed to be VISIBLE, yet they (specifically bracelet) are basically impossible to differentiate from combat messages when you are fighting abnormalities. That is not gud

> Made lists on tools more consistent, and in-line with the list standards
- They already should be up to standards

> Removed some unnecessary indentation
- Its easier to read the code that way, really

## Changelog
:cl:
tweak: Tool near-death warnings are now more visible to the user
tweak: The heart of aspiration will no longer damage you if you are in hard-crit for 30 seconds
/:cl:
