### PR TITLE
Healing block status effect

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -373,6 +373,8 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define TRAIT_HEALING          	"healing"    // used for the "no medipens" challenge
 #define TRAIT_GRAB_IMMUNE 		"grab_immune"// used to prevent grabs
 //lobotomy quirk traits end
+#define TRAIT_PHYSICAL_HEALING_BLOCKED "physical_healing_blocked"
+#define TRAIT_SANITY_HEALING_BLOCKED "sanity_healing_blocked"
 #define TRAIT_ALCOHOL_TOLERANCE	"alcohol_tolerance"
 #define TRAIT_AGEUSIA			"ageusia"
 #define TRAIT_HEAVY_SLEEPER		"heavy_sleeper"

--- a/code/_globalvars/traits.dm
+++ b/code/_globalvars/traits.dm
@@ -186,7 +186,9 @@ GLOBAL_LIST_INIT(traits_by_type, list(
 		"TRAIT_ARTIST" = TRAIT_ARTIST,
 		"TRAIT_GUNS" = TRAIT_GUNS,               // used for the "no guns" challenge
 		"TRAIT_HEALING" = TRAIT_HEALING,          // used for the "no medipens" challenge
-		"TRAIT_GRAB_IMMUNE" = TRAIT_GRAB_IMMUNE //used to prevent grab-related exploits
+		"TRAIT_GRAB_IMMUNE" = TRAIT_GRAB_IMMUNE, //used to prevent grab-related exploits
+		"TRAIT_PHYSICAL_HEALING_BLOCKED" = TRAIT_PHYSICAL_HEALING_BLOCKED,
+		"TRAIT_SANITY_HEALING_BLOCKED" = TRAIT_SANITY_HEALING_BLOCKED
 	),
 	/obj/item/bodypart = list(
 		"TRAIT_PARALYSIS" = TRAIT_PARALYSIS

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -1208,3 +1208,22 @@
 		return
 	var/mob/living/carbon/human/status_holder = owner
 	status_holder.adjustSanityLoss(stacks * stacks)//sanity damage is the # of stacks squared
+
+/datum/status_effect/healing_block
+	id = "healing_block_base"
+	status_type = STATUS_EFFECT_REFRESH
+	alert_type = null
+
+/datum/status_effect/healing_block/on_apply()
+	if(!HAS_TRAIT(owner, TRAIT_PHYSICAL_HEALING_BLOCKED))
+		ADD_TRAIT(owner, TRAIT_PHYSICAL_HEALING_BLOCKED, STATUS_EFFECT_TRAIT)
+	if(ishuman(owner) && !HAS_TRAIT(owner, TRAIT_SANITY_HEALING_BLOCKED))
+		ADD_TRAIT(owner, TRAIT_SANITY_HEALING_BLOCKED, STATUS_EFFECT_TRAIT)
+	return TRUE
+
+/datum/status_effect/healing_block/on_remove()
+	if(locate(/datum/status_effect/healing_block) in owner.status_effects)
+		return
+	REMOVE_TRAIT(owner, TRAIT_PHYSICAL_HEALING_BLOCKED, STATUS_EFFECT_TRAIT)
+	if(ishuman(owner))
+		REMOVE_TRAIT(owner, TRAIT_SANITY_HEALING_BLOCKED, STATUS_EFFECT_TRAIT)

--- a/code/modules/mob/living/carbon/damage_procs.dm
+++ b/code/modules/mob/living/carbon/damage_procs.dm
@@ -78,7 +78,7 @@
 		return FALSE
 	if(amount > 0)
 		take_overall_damage(amount, 0, 0, updating_health, required_status)
-	else
+	else if(forced || !HAS_TRAIT(src, TRAIT_PHYSICAL_HEALING_BLOCKED))
 		heal_overall_damage(abs(amount), 0, 0, required_status ? required_status : BODYPART_ORGANIC, updating_health)
 	return amount
 
@@ -87,7 +87,7 @@
 		return FALSE
 	if(amount > 0)
 		take_overall_damage(0, amount, 0, updating_health, required_status)
-	else
+	else if(forced || !HAS_TRAIT(src, TRAIT_PHYSICAL_HEALING_BLOCKED))
 		heal_overall_damage(0, abs(amount), 0, required_status ? required_status : BODYPART_ORGANIC, updating_health)
 	return amount
 

--- a/code/modules/mob/living/carbon/human/damage_procs.dm
+++ b/code/modules/mob/living/carbon/human/damage_procs.dm
@@ -6,13 +6,15 @@
 	var/damage_amt = amount
 	if(sanity_lost && white_healable) // Heal sanity instead.
 		damage_amt *= -1
-	adjustSanityLoss(damage_amt)
+	adjustSanityLoss(damage_amt, forced)
 	if(updating_health)
 		updatehealth()
 	return damage_amt
 
-/mob/living/carbon/human/proc/adjustSanityLoss(amount)
+/mob/living/carbon/human/proc/adjustSanityLoss(amount, forced = FALSE)
 	if((status_flags & GODMODE) || !attributes || stat == DEAD)
+		return FALSE
+	if(!forced && amount < 0 && HAS_TRAIT(src, TRAIT_SANITY_HEALING_BLOCKED))
 		return FALSE
 	sanityloss = clamp(sanityloss + amount, 0, maxSanity)
 	if(HAS_TRAIT(src, TRAIT_SANITYIMMUNE))

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1064,7 +1064,7 @@
 	remove_all_embedded_objects()
 	set_heartattack(FALSE)
 	drunkenness = 0
-	adjustSanityLoss(-maxSanity)
+	adjustSanityLoss(-maxSanity, TRUE)
 	for(var/datum/mutation/human/HM in dna.mutations)
 		if(HM.quality != POSITIVE)
 			dna.remove_mutation(HM.name)

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/melting_love.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/melting_love.dm
@@ -212,7 +212,7 @@
 	melee_damage_lower = 80
 	melee_damage_upper = 85
 	projectiletype = /obj/projectile/melting_blob/enraged
-	adjustBruteLoss(-maxHealth)
+	adjustBruteLoss(-maxHealth, forced = TRUE)
 	desc += " It looks angry."
 
 /mob/living/simple_animal/hostile/abnormality/melting_love/proc/SpawnBigSlime(mob/living/simple_animal/hostile/slime/big/S)

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/nobody_is.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/nobody_is.dm
@@ -363,7 +363,7 @@
 		ChangeResistances(list(BRUIT = 1, RED_DAMAGE = 0.6, WHITE_DAMAGE = 0.3, BLACK_DAMAGE = 0, PALE_DAMAGE = 0.5))
 		heal_percent_per_second = 0.00425//half of what it was when it had just 5k hp
 		maxHealth = 10000
-		adjustBruteLoss(-maxHealth) // It's not over yet!.
+		adjustBruteLoss(-maxHealth, forced = TRUE) // It's not over yet!.
 		melee_damage_lower = 45
 		melee_damage_upper = 65
 		grab_damage = 140
@@ -669,7 +669,7 @@
 	M.set_lying_angle(0)
 	M.set_body_position(STANDING_UP)
 	M.forceMove(src) // Hide them for examine message to work
-	adjustBruteLoss(-maxHealth)
+	adjustBruteLoss(-maxHealth, forced = TRUE)
 	Transform(M)
 
 /mob/living/simple_animal/hostile/abnormality/nobody_is/proc/Transform(mob/living/carbon/human/M)

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/nothing_there.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/nothing_there.dm
@@ -301,7 +301,7 @@
 			ChangeMoveToDelayBy(1.5)
 			heartbeat.stop()
 			breachloop.start()
-	adjustBruteLoss(-maxHealth)
+	adjustBruteLoss(-maxHealth, forced = TRUE)
 	current_stage = clamp(current_stage + 1, 1, 3)
 
 /mob/living/simple_animal/hostile/abnormality/nothing_there/proc/Hello(target)

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/titania.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/titania.dm
@@ -105,7 +105,7 @@
 		ChangeMoveToDelayBy(-1)
 		melee_damage_lower = 110
 		melee_damage_upper = 140
-		adjustBruteLoss(-maxHealth) // Round 2, baby
+		adjustBruteLoss(-maxHealth, forced = TRUE) // Round 2, baby
 
 		to_chat(src, span_userdanger("[nemesis], my beloved devil, I finally get my revenge."))
 		nemesis = null

--- a/code/modules/mob/living/simple_animal/abnormality/he/basilisoup.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/basilisoup.dm
@@ -159,7 +159,7 @@
 		if(H.nutrition >= NUTRITION_LEVEL_FAT)
 			playsound(get_turf(src), 'sound/abnormalities/bigbird/bite.ogg', 50, 1, 2)
 			H.gib()
-			adjustBruteLoss(-maxHealth) //full heal after a full meal
+			adjustBruteLoss(-maxHealth, forced = TRUE) //full heal after a full meal
 	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/basilisoup/OpenFire(atom/A)

--- a/code/modules/mob/living/simple_animal/abnormality/waw/hatred_queen.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/hatred_queen.dm
@@ -639,7 +639,7 @@
 		return
 	visible_message(span_bolddanger("[src] transforms!")) //Begin Hostile breach
 	REMOVE_TRAIT(src, TRAIT_MOVE_FLYING, ROUNDSTART_TRAIT)
-	adjustBruteLoss(-maxHealth)
+	adjustBruteLoss(-maxHealth, forced = TRUE)
 	friendly = FALSE
 	can_act = TRUE
 	icon = 'ModularTegustation/Teguicons/64x48.dmi'

--- a/code/modules/mob/living/simple_animal/abnormality/waw/wrath_servant.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/wrath_servant.dm
@@ -214,7 +214,7 @@
 	if(!stunned)
 		return
 	status_flags &= ~GODMODE
-	adjustBruteLoss(-maxHealth)
+	adjustBruteLoss(-maxHealth, forced = TRUE)
 	stunned = FALSE
 	icon_state = icon_living
 	desc = "A large red monster with white bandages hanging from it. Its flesh oozes a bubble acid."
@@ -481,7 +481,7 @@
 	can_act = FALSE
 	SLEEP_CHECK_DEATH(1 SECONDS)
 	breach_affected = list()
-	adjustBruteLoss(-maxHealth)
+	adjustBruteLoss(-maxHealth, forced = TRUE)
 	toggle_ai(AI_OFF)
 	status_flags |= GODMODE
 	dir = EAST
@@ -493,7 +493,7 @@
 	ending = TRUE
 	can_act = FALSE
 	target.gib(TRUE)
-	adjustBruteLoss(-maxHealth)
+	adjustBruteLoss(-maxHealth, forced = TRUE)
 	toggle_ai(AI_OFF)
 	status_flags |= GODMODE
 	density = FALSE
@@ -538,7 +538,7 @@
 		Teleport(src.datum_reference.landmark)
 		breach_affected = list()
 		toggle_ai(AI_OFF)
-		adjustBruteLoss(-maxHealth)
+		adjustBruteLoss(-maxHealth, forced = TRUE)
 		can_act = TRUE
 		return FALSE
 	say("GR-RRAHHH!!!")
@@ -547,7 +547,7 @@
 	SLEEP_CHECK_DEATH(15 SECONDS)
 	status_flags &= ~GODMODE
 	icon_state = icon_living
-	adjustBruteLoss(-maxHealth)
+	adjustBruteLoss(-maxHealth, forced = TRUE)
 	visible_message(span_warning("[src] gets back up!"))
 	can_act = TRUE
 
@@ -804,7 +804,7 @@
 	SLEEP_CHECK_DEATH(20 SECONDS)
 	status_flags &= ~GODMODE
 	icon_state = icon_living
-	adjustBruteLoss(-maxHealth)
+	adjustBruteLoss(-maxHealth, forced = TRUE)
 	density = TRUE
 
 /mob/living/simple_animal/hostile/azure_hermit/death()

--- a/code/modules/mob/living/simple_animal/abnormality/waw/yang.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/yang.dm
@@ -154,7 +154,7 @@
 		if(SSlobotomy_events.yin_downed)
 			death()
 			return
-	adjustBruteLoss(-maxHealth)
+	adjustBruteLoss(-maxHealth, forced = TRUE)
 	ChangeResistances(list(RED_DAMAGE = 1, WHITE_DAMAGE = 0.2, BLACK_DAMAGE = 1.7, PALE_DAMAGE = 2))
 	SSlobotomy_events.yang_downed = FALSE
 	icon_state = icon_breach

--- a/code/modules/mob/living/simple_animal/abnormality/waw/yin.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/yin.dm
@@ -150,7 +150,7 @@
 		if(SSlobotomy_events.yang_downed)
 			death()
 			return
-	adjustBruteLoss(-maxHealth)
+	adjustBruteLoss(-maxHealth, forced = TRUE)
 	ChangeResistances(list(RED_DAMAGE = 0.5, WHITE_DAMAGE = 1.5, PALE_DAMAGE = 1))
 	SSlobotomy_events.yin_downed = FALSE
 	icon_state = icon_breach

--- a/code/modules/mob/living/simple_animal/damage_procs.dm
+++ b/code/modules/mob/living/simple_animal/damage_procs.dm
@@ -10,6 +10,8 @@
 /mob/living/simple_animal/proc/adjustHealth(amount, updating_health = TRUE, forced = FALSE)
 	. = FALSE
 	if(forced || !(status_flags & GODMODE))
+		if(!forced && amount < 0 && HAS_TRAIT(src, TRAIT_PHYSICAL_HEALING_BLOCKED))
+			amount = 0
 		bruteloss = round(clamp(bruteloss + amount, 0, maxHealth * 2), DAMAGE_PRECISION)
 		if(updating_health)
 			updatehealth()

--- a/code/modules/suppressions/extraction.dm
+++ b/code/modules/suppressions/extraction.dm
@@ -158,7 +158,7 @@
 	if(life_stage >= 3)
 		return FALSE // Death
 	life_stage += 1
-	adjustHealth(-maxHealth)
+	adjustHealth(-maxHealth, forced = TRUE)
 	ChangeResistances(list(RED_DAMAGE = 0.1, WHITE_DAMAGE = 0.1, BLACK_DAMAGE = 0.1, PALE_DAMAGE = 0.1))
 	fairy_cooldown_time = max(4 SECONDS, fairy_cooldown_time - 2 SECONDS)
 	key_cooldown_time = max(10 SECONDS, fairy_cooldown_time - 4 SECONDS)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds physical and sanity healing block traits for mobs and a base status effect to manage them.
These block most common ways of healing unless its forced.
Made various mob full heal moves be forced.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Is an interesting debuff to play around.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added healing block traits, applied through status effects.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
