### PR TITLE
makes the minigun good

### DIFF
--- a/code/game/objects/items/ego_weapons/non_abnormality/shrimp.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/shrimp.dm
@@ -11,7 +11,6 @@
 	drag_slowdown = 3
 	slowdown = 2
 	spread = 40
-	projectile_damage_multiplier = 0.25
 	item_flags = SLOWS_WHILE_IN_HAND
 	fire_sound = 'sound/weapons/gun/smg/shot.ogg'
 	autofire = 0.04 SECONDS

--- a/code/game/objects/items/ego_weapons/non_abnormality/shrimp.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/shrimp.dm
@@ -10,6 +10,12 @@
 	weapon_weight = WEAPON_HEAVY
 	drag_slowdown = 3
 	slowdown = 2
+	attribute_requirements = list(
+							FORTITUDE_ATTRIBUTE = 40,
+							PRUDENCE_ATTRIBUTE = 40,
+							TEMPERANCE_ATTRIBUTE = 40,
+							JUSTICE_ATTRIBUTE = 40
+							)
 	spread = 40
 	item_flags = SLOWS_WHILE_IN_HAND
 	fire_sound = 'sound/weapons/gun/smg/shot.ogg'
@@ -26,3 +32,24 @@
 	burst_size = 3
 	fire_delay = 5
 	fire_sound = 'sound/weapons/gun/rifle/shot.ogg'
+
+/obj/item/gun/ego_gun/shrimp/rambominigun
+	name = "Shrimp Rambo's Minigun"
+	desc = "A gun used by THE shrimp rambo."
+	icon = 'ModularTegustation/Teguicons/lc13_weapons.dmi'
+	icon_state = "sodaminigun"
+	inhand_icon_state = "sodaminigun"
+	ammo_type = /obj/item/ammo_casing/caseless/ego_soda
+	weapon_weight = WEAPON_HEAVY
+	drag_slowdown = 2
+	slowdown = 1.5
+	item_flags = SLOWS_WHILE_IN_HAND
+	fire_sound = 'sound/weapons/gun/smg/shot.ogg'
+	autofire = 0.01 SECONDS
+	projectile_damage_multiplier = 1.25
+	attribute_requirements = list(
+							FORTITUDE_ATTRIBUTE = 120,
+							PRUDENCE_ATTRIBUTE = 120,
+							TEMPERANCE_ATTRIBUTE = 120,
+							JUSTICE_ATTRIBUTE = 120
+							)

--- a/code/game/objects/items/ego_weapons/non_abnormality/shrimp.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/shrimp.dm
@@ -16,12 +16,6 @@
 							JUSTICE_ATTRIBUTE = 40
 							)
 	slowdown = 2
-	attribute_requirements = list(
-							FORTITUDE_ATTRIBUTE = 40,
-							PRUDENCE_ATTRIBUTE = 40,
-							TEMPERANCE_ATTRIBUTE = 40,
-							JUSTICE_ATTRIBUTE = 40
-							)
 	spread = 40
 	item_flags = SLOWS_WHILE_IN_HAND
 	fire_sound = 'sound/weapons/gun/smg/shot.ogg'

--- a/code/modules/mob/living/simple_animal/distortion/star/shrimp.dm
+++ b/code/modules/mob/living/simple_animal/distortion/star/shrimp.dm
@@ -29,15 +29,15 @@
 	attack_sound = 'sound/abnormalities/distortedform/slam.ogg'
 
 	ego_list = list(
-		/obj/item/gun/ego_gun/shrimp/minigun,
+		/obj/item/gun/ego_gun/shrimp/rambominigun,
 		/obj/item/clothing/suit/armor/ego_gear/realization/wellcheers
 		)
 
 	egoist_names = list("Prawnold Schwarzenegger", "Swim Shady", "Shrimpy Smalls", "Shaqkrill O'Neill")
 	gender = MALE
 	egoist_outfit = /datum/outfit/job/fishing
-	egoist_attributes = 100
-	loot = list(/obj/item/gun/ego_gun/shrimp/minigun)
+	egoist_attributes = 120
+	loot = list(/obj/item/gun/ego_gun/shrimp/rambominigun)
 	unmanifest_effect = /obj/effect/temp_visual/water_waves
 	can_spawn = 0
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes the shrimp corp minigun actually good

## Why It's Good For The Game

The minigun is genuinely terrible currently and there is absolutely NO reason to use it, this just unnerfs the damage

## Changelog
:cl:

balance: rebalanced shrimpigun to remove it's damage nerfd

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
