### PR TITLE
Makes a parent for Snake oil/Skin prophecy/Viva la voce/Theonite slab. They can always and only be used 10 times now

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/_tools/basic_attribute_giver.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_tools/basic_attribute_giver.dm
@@ -1,0 +1,36 @@
+/obj/structure/toolabnormality/attribute_giver
+	name = "all-natural snake oil"
+	desc = "A purported panacea that will supposedly treat anything from minor scratches to Alzheimer's."
+	icon_state = "snake_oil"
+	/// Users that used this tool
+	var/list/mob/captured_users = list()
+	/// The maximum boost that users can get from using this tool
+	var/max_boost = 100
+	/// The attribute thats given to the user
+	var/given_attribute = FORTITUDE_ATTRIBUTE
+	/// The status effect given to the user upon first consumption
+	var/given_status_effect = null
+	/// The feedback message you get from using the tool
+	var/feedback_message = "You take a sip, ugh, it tastes nasty!"
+	/// The message the user gets if they try to get more then possible
+	var/full_boost_message = "You've had enough."
+
+/obj/structure/toolabnormality/attribute_giver/attack_hand(mob/living/carbon/human/user)
+	. = ..()
+	if(user in captured_users)
+		if(captured_users[user] == max_boost) // You don't need any more.
+			to_chat(user, span_notice(full_boost_message))
+			return FALSE
+
+	if(!do_after(user, 0.5 SECONDS, user))
+		return FALSE
+
+	. = TRUE
+	if(!(user in captured_users))
+		user.apply_status_effect(given_status_effect)
+		captured_users += user
+
+	user.adjust_attribute_buff(given_attribute, max_boost / 10) // always 10 uses
+	captured_users[user] += max_boost / 10
+
+	to_chat(user, span_userdanger(feedback_message))

--- a/code/modules/mob/living/simple_animal/abnormality/_tools/basic_attribute_giver.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_tools/basic_attribute_giver.dm
@@ -3,7 +3,7 @@
 	desc = "A purported panacea that will supposedly treat anything from minor scratches to Alzheimer's."
 	icon_state = "snake_oil"
 	/// Users that used this tool
-	var/list/mob/captured_users = list()
+	var/list/mob/used_by = list()
 	/// The maximum boost that users can get from using this tool
 	var/max_boost = 100
 	/// The attribute thats given to the user
@@ -17,8 +17,8 @@
 
 /obj/structure/toolabnormality/attribute_giver/attack_hand(mob/living/carbon/human/user)
 	. = ..()
-	if(user in captured_users)
-		if(captured_users[user] == max_boost) // You don't need any more.
+	if(user in used_by)
+		if(used_by[user] == 10) // You don't need any more.
 			to_chat(user, span_notice(full_boost_message))
 			return FALSE
 
@@ -26,11 +26,11 @@
 		return FALSE
 
 	. = TRUE
-	if(!(user in captured_users))
+	if(!(user in used_by))
 		user.apply_status_effect(given_status_effect)
-		captured_users += user
+		used_by += user
 
 	user.adjust_attribute_buff(given_attribute, max_boost / 10) // always 10 uses
-	captured_users[user] += max_boost / 10
+	used_by[user] += 1
 
 	to_chat(user, span_userdanger(feedback_message))

--- a/code/modules/mob/living/simple_animal/abnormality/_tools/he/theonite_slab.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_tools/he/theonite_slab.dm
@@ -23,7 +23,7 @@
 
 	flick(icon_state, src)
 
-	if(captured_users[user] == 5) // Lets start effects AFTER their first use
+	if(used_by[user] == 1) // Lets start effects AFTER their first use
 		return
 
 	user.physiology.pale_mod *= 1.06

--- a/code/modules/mob/living/simple_animal/abnormality/_tools/he/theonite_slab.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_tools/he/theonite_slab.dm
@@ -1,35 +1,34 @@
 #define STATUS_EFFECT_SLAB /datum/status_effect/stacking/slab
-/obj/structure/toolabnormality/theonite_slab
+/obj/structure/toolabnormality/attribute_giver/theonite_slab
 	name = "theonite slab"
 	desc = "A slab, made out of a seamless mixture of stone and metal. It's covered in runes, and bloody spikes erupt from the centerpiece."
 	icon_state = "slab"
 	var/list/users = list()
+
+	max_boost = 50
+	given_attribute = JUSTICE_ATTRIBUTE
+	given_status_effect = STATUS_EFFECT_SLAB
+	feedback_message = "You caress the slab, and blood painlessly flows from your fingers. The runes begin to glow."
+	full_boost_message = "That's enough."
 
 	ego_list = list(
 		/datum/ego_datum/weapon/divinity,
 		/datum/ego_datum/armor/divinity,
 	)
 
-/obj/structure/toolabnormality/theonite_slab/attack_hand(mob/living/carbon/human/user)
-	..()
-	if(!do_after(user, 6, user))
+/obj/structure/toolabnormality/attribute_giver/theonite_slab/attack_hand(mob/living/carbon/human/user)
+	. = ..()
+	if(!.)
 		return
-	if(get_level_buff(user, JUSTICE_ATTRIBUTE) >= 50)
-		to_chat(user, span_notice("That's enough."))
-		return //You don't need any more.
 
 	flick(icon_state, src)
-	user.adjust_attribute_buff(JUSTICE_ATTRIBUTE, 5)
-	var/datum/status_effect/stacking/slab/S = user.has_status_effect(/datum/status_effect/stacking/slab)
-	if(!(user in users))
-		users += user
-	else
-		user.physiology.pale_mod *= 1.06
-		if(S)
-			S.add_stacks(1)
 
-	user.apply_status_effect(STATUS_EFFECT_SLAB)
-	to_chat(user, span_userdanger("You caress the slab, and blood painlessly flows from your fingers. The runes begin to glow."))
+	if(captured_users[user] == 5) // Lets start effects AFTER their first use
+		return
+
+	user.physiology.pale_mod *= 1.06
+	var/datum/status_effect/stacking/rolecall/R = user.has_status_effect(/datum/status_effect/stacking/rolecall)
+	R.add_stacks(1)
 
 // Status Effect
 /datum/status_effect/stacking/slab

--- a/code/modules/mob/living/simple_animal/abnormality/_tools/he/theonite_slab.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_tools/he/theonite_slab.dm
@@ -27,8 +27,8 @@
 		return
 
 	user.physiology.pale_mod *= 1.06
-	var/datum/status_effect/stacking/rolecall/R = user.has_status_effect(/datum/status_effect/stacking/rolecall)
-	R.add_stacks(1)
+	var/datum/status_effect/stacking/slab/status_effect = user.has_status_effect(/datum/status_effect/stacking/slab)
+	status_effect.add_stacks(1)
 
 // Status Effect
 /datum/status_effect/stacking/slab

--- a/code/modules/mob/living/simple_animal/abnormality/_tools/he/vivavoce.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_tools/he/vivavoce.dm
@@ -20,7 +20,7 @@
 	if(!.)
 		return
 
-	if(captured_users[user] == 5) // First use
+	if(used_by[user] == 1) // First use
 		if(prob(50))
 			playsound(user, 'sound/abnormalities/vivavoce/doorknock.ogg', 100, FALSE, -5)
 		return

--- a/code/modules/mob/living/simple_animal/abnormality/_tools/he/vivavoce.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_tools/he/vivavoce.dm
@@ -1,36 +1,33 @@
 #define STATUS_EFFECT_ROLECALL /datum/status_effect/stacking/rolecall
-/obj/structure/toolabnormality/vivavoce
+/obj/structure/toolabnormality/attribute_giver/vivavoce
 	name = "viva voce"
 	desc = "A very old-fashioned communication device."
 	icon_state = "vivavoce"
-	var/list/users = list()
+
+	max_boost = 50
+	given_attribute = TEMPERANCE_ATTRIBUTE
+	given_status_effect = STATUS_EFFECT_ROLECALL
+	feedback_message = "You pick up the phone and hear nothing, but you feel as if someone is behind you."
+	full_boost_message = "It's silent."
 
 	ego_list = list(
 		/datum/ego_datum/weapon/ringing,
 		/datum/ego_datum/armor/ringing,
 	)
 
-/obj/structure/toolabnormality/vivavoce/attack_hand(mob/living/carbon/human/user)
-	..()
-	if(!do_after(user, 6, user))
+/obj/structure/toolabnormality/attribute_giver/vivavoce/attack_hand(mob/living/carbon/human/user)
+	. = ..()
+	if(!.)
 		return
-	if(get_level_buff(user, TEMPERANCE_ATTRIBUTE) >= 50)
-		to_chat(user, span_notice("It's silent."))
-		return //You don't need any more.
 
-	user.adjust_attribute_buff(TEMPERANCE_ATTRIBUTE, 5)
-	var/datum/status_effect/stacking/rolecall/R = user.has_status_effect(/datum/status_effect/stacking/rolecall)
-	if(!(user in users))
-		users += user
+	if(captured_users[user] == 5) // First use
 		if(prob(50))
 			playsound(user, 'sound/abnormalities/vivavoce/doorknock.ogg', 100, FALSE, -5)
-	else
-		user.physiology.black_mod *= 1.10
-		if(R)
-			R.add_stacks(1)
+		return
 
-	user.apply_status_effect(STATUS_EFFECT_ROLECALL)
-	to_chat(user, span_userdanger("You pick up the phone and hear nothing, but you feel as if someone is behind you."))
+	user.physiology.black_mod *= 1.10
+	var/datum/status_effect/stacking/rolecall/R = user.has_status_effect(/datum/status_effect/stacking/rolecall)
+	R.add_stacks(1)
 
 // Status Effect
 /datum/status_effect/stacking/rolecall

--- a/code/modules/mob/living/simple_animal/abnormality/_tools/teth/bracelet.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_tools/teth/bracelet.dm
@@ -12,9 +12,13 @@
 	if(user in active_users)
 		active_users -= user
 		user.remove_status_effect(STATUS_EFFECT_BRACELET)
-		if((user.health != user.maxHealth) && !user.oxyloss) // check for oxyloss, because of anemics
-			to_chat(user, span_userdanger("You put the bracelet back, and feel your heart explode!"))
-			user.gib()
+		if(user.health != user.maxHealth) // check for oxyloss, because of anemics
+			if(user.oxyloss > 0)
+				to_chat(user, span_userdanger("You put the bracelet back, feeling as if you body wanted to tear itself apart!"))
+				user.deal_damage(user.health * 0.75, BRUTE)
+			else
+				to_chat(user, span_userdanger("You put the bracelet back, and feel your heart explode!"))
+				user.gib()
 		else
 			to_chat(user, span_userdanger("You put the bracelet back, and take a sigh of relief."))
 	else

--- a/code/modules/mob/living/simple_animal/abnormality/_tools/teth/bracelet.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_tools/teth/bracelet.dm
@@ -12,7 +12,7 @@
 	if(user in active_users)
 		active_users -= user
 		user.remove_status_effect(STATUS_EFFECT_BRACELET)
-		if(user.health != user.maxHealth)
+		if((user.health != user.maxHealth) && !user.oxyloss) // check for oxyloss, because of anemics
 			to_chat(user, span_userdanger("You put the bracelet back, and feel your heart explode!"))
 			user.gib()
 		else
@@ -49,8 +49,7 @@
 	//Count down to 5 minutes of wearing
 	if(healthtracker>=300)
 		if(warningtracker == 0)
-			to_chat(H, span_hypnophrase("You have been wearing the luminous bracelet for a long time. Any longer could be dangerous!"))
-			H.playsound_local(get_turf(H), 'sound/abnormalities/nothingthere/heartbeat.ogg', 50, 0, 3)
+			to_chat(H, span_danger("You have been wearing the luminous bracelet for a long time. Any longer could be dangerous!"))
 		warningtracker+=1
 	if(warningtracker >= 150)
 		H.gib()

--- a/code/modules/mob/living/simple_animal/abnormality/_tools/teth/bracelet.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_tools/teth/bracelet.dm
@@ -49,7 +49,8 @@
 	//Count down to 5 minutes of wearing
 	if(healthtracker>=300)
 		if(warningtracker == 0)
-			to_chat(H, span_danger("You have been wearing the luminous bracelet for a long time. Any longer could be dangerous!"))
+			to_chat(H, span_hypnophrase("You have been wearing the luminous bracelet for a long time. Any longer could be dangerous!"))
+			H.playsound_local(get_turf(H), 'sound/abnormalities/nothingthere/heartbeat.ogg', 50, 0, 3)
 		warningtracker+=1
 	if(warningtracker >= 150)
 		H.gib()

--- a/code/modules/mob/living/simple_animal/abnormality/_tools/teth/bracelet.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_tools/teth/bracelet.dm
@@ -40,7 +40,7 @@
 	. = ..()
 	if(ishuman(owner))
 		var/mob/living/carbon/human/H = owner
-		H.adjust_attribute_bonus(FORTITUDE_ATTRIBUTE, 40)
+		H.adjust_attribute_bonus(FORTITUDE_ATTRIBUTE, -40)
 
 /datum/status_effect/display/bracelet/tick()
 	. = ..()
@@ -63,6 +63,6 @@
 	. = ..()
 	if(ishuman(owner))
 		var/mob/living/carbon/human/H = owner
-		H.adjust_attribute_bonus(FORTITUDE_ATTRIBUTE, -40)
+		H.adjust_attribute_bonus(FORTITUDE_ATTRIBUTE, 40)
 
 #undef STATUS_EFFECT_BRACELET

--- a/code/modules/mob/living/simple_animal/abnormality/_tools/teth/skin.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_tools/teth/skin.dm
@@ -1,26 +1,21 @@
 #define STATUS_EFFECT_SKIN /datum/status_effect/skin
-/obj/structure/toolabnormality/skin
+/obj/structure/toolabnormality/attribute_giver/skin
 	name = "skin prophecy"
 	desc = "A book that seems to be made out of skin. Something is written on it."
 	icon_state = "skin_prophecy"
-	var/list/readers = list()
 
-/obj/structure/toolabnormality/skin/attack_hand(mob/living/carbon/human/user)
-	..()
-	if(!do_after(user, 6, user))
+	given_attribute = PRUDENCE_ATTRIBUTE
+	given_status_effect = STATUS_EFFECT_SKIN
+	feedback_message = "You read the book, and take the time to burn these passages into your brain."
+	full_boost_message = "You've learned all that you could."
+
+/obj/structure/toolabnormality/attribute_giver/skin/attack_hand(mob/living/carbon/human/user)
+	. = ..()
+	if(!.)
 		return
-	if(get_level_buff(user, PRUDENCE_ATTRIBUTE) >= 100)
-		to_chat(user, span_notice("You've learned all that you could."))
-		return //You don't need any more.
 
-	user.adjust_attribute_buff(PRUDENCE_ATTRIBUTE, 10)
-	if(!(user in readers))
-		readers += user
-	else
+	if(captured_users[user] != 10) // Not their first use
 		user.physiology.white_mod *= 1.10
-
-	user.apply_status_effect(STATUS_EFFECT_SKIN)
-	to_chat(user, span_userdanger("You read the book, and take the time to burn these passages into your brain."))
 
 // Status Effect
 /datum/status_effect/skin

--- a/code/modules/mob/living/simple_animal/abnormality/_tools/teth/skin.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_tools/teth/skin.dm
@@ -14,7 +14,7 @@
 	if(!.)
 		return
 
-	if(captured_users[user] != 10) // Not their first use
+	if(used_by[user] != 1) // Not their first use
 		user.physiology.white_mod *= 1.10
 
 // Status Effect

--- a/code/modules/mob/living/simple_animal/abnormality/_tools/teth/snake_oil.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_tools/teth/snake_oil.dm
@@ -15,7 +15,7 @@
 
 	playsound(user.loc, 'sound/items/drink.ogg', rand(10,50), TRUE)
 
-	if(captured_users[user] != 10) // Not their first use
+	if(used_by[user] != 1) // Not their first use
 		user.physiology.red_mod *= 1.10
 
 // Status Effect

--- a/code/modules/mob/living/simple_animal/abnormality/_tools/teth/snake_oil.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_tools/teth/snake_oil.dm
@@ -1,32 +1,22 @@
 #define STATUS_EFFECT_SNAKE_OIL /datum/status_effect/snake_oil
-/obj/structure/toolabnormality/snake_oil
-	name = "all-natural snake oil"
-	desc = "A purported panacea that will supposedly treat anything from minor scratches to Alzheimer's."
-	icon_state = "snake_oil"
-	var/list/users = list()
+
+/obj/structure/toolabnormality/attribute_giver/snake_oil
+	given_status_effect = STATUS_EFFECT_SNAKE_OIL
 
 	ego_list = list(
 		/datum/ego_datum/weapon/swindle,
 		/datum/ego_datum/armor/swindle,
 	)
 
-/obj/structure/toolabnormality/snake_oil/attack_hand(mob/living/carbon/human/user)
-	..()
-	if(!do_after(user, 6, user))
+/obj/structure/toolabnormality/attribute_giver/snake_oil/attack_hand(mob/living/carbon/human/user)
+	. = ..()
+	if(!.)
 		return
-	if(get_level_buff(user, FORTITUDE_ATTRIBUTE) >= 100)
-		to_chat(user, span_notice("You've had enough."))
-		return //You don't need any more.
 
-	user.adjust_attribute_buff(FORTITUDE_ATTRIBUTE, 10)
-	if(!(user in users))
-		users += user
-	else
-		user.physiology.red_mod *= 1.10
-
-	user.apply_status_effect(STATUS_EFFECT_SNAKE_OIL)
-	to_chat(user, span_userdanger("You take a sip, ugh, it tastes nasty!"))
 	playsound(user.loc, 'sound/items/drink.ogg', rand(10,50), TRUE)
+
+	if(captured_users[user] != 10) // Not their first use
+		user.physiology.red_mod *= 1.10
 
 // Status Effect
 /datum/status_effect/snake_oil

--- a/code/modules/mob/living/simple_animal/abnormality/_tools/tool_abnormality.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_tools/tool_abnormality.dm
@@ -11,21 +11,24 @@
 	var/list/ego_list = list()
 
 GLOBAL_LIST_INIT(unspawned_tools, list(
+	/obj/structure/toolabnormality/attribute_giver/snake_oil,
+	/obj/structure/toolabnormality/attribute_giver/skin,
+	/obj/structure/toolabnormality/attribute_giver/vivavoce,
+	/obj/structure/toolabnormality/attribute_giver/theonite_slab,
 	/obj/structure/toolabnormality/dr_jekyll,
 	/obj/structure/toolabnormality/fateloom,
-	/obj/structure/toolabnormality/theonite_slab,
 	/obj/structure/toolabnormality/treesap,
-	/obj/structure/toolabnormality/vivavoce,
 	/obj/structure/toolabnormality/behavior,
 	/obj/structure/toolabnormality/bracelet,
 	/obj/structure/toolabnormality/aspiration,
-	/obj/structure/toolabnormality/skin,
-	/obj/structure/toolabnormality/snake_oil,
 	/obj/structure/toolabnormality/theresia,
 	/obj/structure/toolabnormality/mirror,
 	/obj/structure/toolabnormality/researcher,
 	/obj/structure/toolabnormality/promise,
 	/obj/structure/toolabnormality/you_happy,
+//	/obj/structure/toolabnormality/touch,
+//	/obj/structure/toolabnormality/wishwell,
+//	/obj/structure/toolabnormality/realization,
 ))
 
 /obj/effect/landmark/toolspawn

--- a/code/modules/paperwork/records/info/tools.dm
+++ b/code/modules/paperwork/records/info/tools.dm
@@ -63,7 +63,7 @@
 	Name : Behavior Adjustment <br>
 	Risk Class: TETH <br>
 	- Stats regarding Justice will increase greatly when Behavior Adjustment is used. However, all stats regarding Prudence will drop at the same time. <br>
-	- If the employee’s SP hits 0 while Behavior Adjustment is used, they will instantly die."}
+	- If the employee’s SP hits 0 while Behavior Adjustment is active, they will tear their eyes out, whilst this is extremelly disturbing it is often not deadly."}
 
 //Tree Sap
 /obj/item/paper/fluff/info/tool/treesap

--- a/code/modules/paperwork/records/info/tools.dm
+++ b/code/modules/paperwork/records/info/tools.dm
@@ -63,7 +63,7 @@
 	Name : Behavior Adjustment <br>
 	Risk Class: TETH <br>
 	- Stats regarding Justice will increase greatly when Behavior Adjustment is used. However, all stats regarding Prudence will drop at the same time. <br>
-	- If the employee’s SP hits 0 while Behavior Adjustment is active, they will tear their eyes out, whilst this is extremelly disturbing it is often not deadly."}
+	- If the employee’s SP hits 0 while Behavior Adjustment is active, they will tear their eyes out."}
 
 //Tree Sap
 /obj/item/paper/fluff/info/tool/treesap

--- a/lobotomy-corp13.dme
+++ b/lobotomy-corp13.dme
@@ -2792,6 +2792,7 @@
 #include "code\modules\mob\living\simple_animal\abnormality\_auxiliary_modes\joke\aleph\sukuna.dm"
 #include "code\modules\mob\living\simple_animal\abnormality\_auxiliary_modes\joke\aleph\wild_ride.dm"
 #include "code\modules\mob\living\simple_animal\abnormality\_auxiliary_modes\joke\zayin\riblin.dm"
+#include "code\modules\mob\living\simple_animal\abnormality\_tools\basic_attribute_giver.dm"
 #include "code\modules\mob\living\simple_animal\abnormality\_tools\tool_abnormality.dm"
 #include "code\modules\mob\living\simple_animal\abnormality\_tools\he\fateloom.dm"
 #include "code\modules\mob\living\simple_animal\abnormality\_tools\he\researcher.dm"


### PR DESCRIPTION
## About The Pull Request

- They are really similar in how they function, so made a parent for them. Now you can legally say "Viva la voce's daddy"
- The tool abnos can only now be used 10 times, regardless of the bonus attributes
- Bracelet no longer gibs people if they have oxygen damage, instead it deals 75% of their current health
- Tools will no longer allow you to do a do_after bar to tell you "thou cannot use this tool". They do it before instead

## Why It's Good For The Game

>They are really similar in how they function, so made a parent for them.
- Less copy-paste is gud

>The tool abnos can only now be used 10 times, regardless of the bonus attributes
- Training suppression or skin prophet, need i say more?
- Actually, yeah i do. You could have even gotten a minus in one of your attributes via a gift and used them again...

>Bracelet no longer gibs people if they have oxygen damage, instead it deals 75% of their current health
- Anemiacs will have oxygen damage 95% of the round, and lets be honest no one will use blood bags to fix it. So lets deal damage to them instead, a lot of it

> Tools will no longer allow you to do a do_after bar to tell you "thou cannot use this tool". They do it before instead
- Feels a bit weird to make a player do an interaction just to refuse working

## Changelog
:cl:
balance: Tool abnormalities can now only be used 10 times, no more. Regardless of your bonus
balance: bracelet no longer kills anemiacs
balance: bracelet now properly takes 40 max health, instead of giving it
/:cl:
