### PR TITLE
Turns Off Atmos Subsystem[DONE?]

### DIFF
--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -2,8 +2,8 @@ SUBSYSTEM_DEF(air)
 	name = "Atmospherics"
 	init_order = INIT_ORDER_AIR
 	priority = FIRE_PRIORITY_AIR
-	wait = 0.5 SECONDS
-	flags = SS_BACKGROUND
+	wait = 2.5 SECONDS
+	flags = SS_NO_FIRE
 	runlevels = RUNLEVEL_GAME | RUNLEVEL_POSTGAME
 
 	var/cached_cost = 0

--- a/code/game/turfs/open/lobotomy.dm
+++ b/code/game/turfs/open/lobotomy.dm
@@ -2,6 +2,7 @@
 	icon = 'icons/turf/floors/facility.dmi'
 	icon_state = "fulltile"
 	floor_tile = /obj/item/stack/tile/plasteel
+	tiled_dirt = FALSE
 
 /turf/open/floor/facility/dark
 	icon_state = "darktile"

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -408,6 +408,8 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 	///Compares sample to self to see if within acceptable ranges that group processing may be enabled
 	///Returns: a string indicating what check failed, or "" if check passes
 /datum/gas_mixture/proc/compare(datum/gas_mixture/sample)
+	if(!sample)
+		return ""
 	var/list/sample_gases = sample.gases //accessing datum vars is slower than proc vars
 	var/list/cached_gases = gases
 

--- a/code/modules/atmospherics/gasmixtures/immutable_mixtures.dm
+++ b/code/modules/atmospherics/gasmixtures/immutable_mixtures.dm
@@ -92,5 +92,3 @@
 		ADD_GAS(id, gases)
 		gases[id][MOLES] = mix[id][MOLES]
 		gases[id][ARCHIVE] = mix[id][MOLES]
-
-

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -160,7 +160,7 @@
 	var/safe_tox_max = 0.05
 	var/SA_para_min = 1
 	var/SA_sleep_min = 5
-	var/oxygen_used = 0
+	//var/oxygen_used = 0
 	var/breath_pressure = (breath.total_moles()*R_IDEAL_GAS_EQUATION*breath.temperature)/BREATH_VOLUME
 
 	var/list/breath_gases = breath.gases
@@ -178,7 +178,7 @@
 			var/ratio = 1 - O2_partialpressure/safe_oxy_min
 			adjustOxyLoss(min(5*ratio, 3))
 			failed_last_breath = TRUE
-			oxygen_used = breath_gases[/datum/gas/oxygen][MOLES]*ratio
+			//oxygen_used = breath_gases[/datum/gas/oxygen][MOLES]*ratio
 		else
 			adjustOxyLoss(3)
 			failed_last_breath = TRUE
@@ -188,12 +188,13 @@
 		failed_last_breath = FALSE
 		if(health >= crit_threshold)
 			adjustOxyLoss(-5)
-		oxygen_used = breath_gases[/datum/gas/oxygen][MOLES]
+		//oxygen_used = breath_gases[/datum/gas/oxygen][MOLES]
 		clear_alert("not_enough_oxy")
-
+/*
+		This is the function that converts O2 into CO2.
 	breath_gases[/datum/gas/oxygen][MOLES] -= oxygen_used
 	breath_gases[/datum/gas/carbon_dioxide][MOLES] += oxygen_used
-
+*/
 	//CARBON DIOXIDE
 	if(CO2_partialpressure > safe_co2_max)
 		if(!co2overloadtime)


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Looked at TGCM to see what they did to disable their atmosphere and i did this. Prevents Carbons from actively converting O2 to CO2 Turns off Air subsystem.
In a local test i seemed to suffocate and get effected by gas normally.
![Screenshot 2024-06-30 004649](https://github.com/vlggms/lobotomy-corp13/assets/109536843/4cee04e5-f391-4c72-93cb-ce2aff5df457)
![Screenshot 2024-06-29 194628](https://github.com/vlggms/lobotomy-corp13/assets/109536843/7a7a31d5-9f6c-469a-8e2c-c6c6abbc3667)


## Why It's Good For The Game
Reduces our tick_usage by 600.

Having low tick usage is apparently good since it prevents lag according to this https://www.byond.com/docs/ref/#/world/var/tick_usage

Though to be safe we should test merge it sometime... hopefully it doesnt do anything really weird.

## Changelog
:cl:
tweak: set Atmos subsystem from SS_BACKGROUND to SS_NO_FIRE
tweak: gas_mixtures will no longer runtime in space
tweak: life
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
