### PR TITLE
Weapon Maintenance PR

### DIFF
--- a/code/game/objects/items/ego_weapons/_lists.dm
+++ b/code/game/objects/items/ego_weapons/_lists.dm
@@ -7,6 +7,9 @@ GLOBAL_LIST_INIT(small_ego, list (
 	/obj/item/ego_weapon/support/letter_opener,
 	/obj/item/ego_weapon/warring,
 	/obj/item/gun/ego_gun/feather,
+	/obj/item/gun/ego_gun/intentions,
+	/obj/item/gun/ego_gun/beak,
+	/obj/item/ego_weapon/lance/visions,
 
 	//Non-EGO weapons
 	/obj/item/ego_weapon/city/ncorp_mark,

--- a/code/modules/projectiles/guns/ego_gun.dm
+++ b/code/modules/projectiles/guns/ego_gun.dm
@@ -31,9 +31,6 @@
 	. += EgoAttackInfo(user)
 	if(special)
 		. += "<span class='notice'>[special]</span>"
-	if(weapon_weight != WEAPON_HEAVY)
-		. += "<span class='notice'>This weapon can be fired with one hand.</span>"
-
 	if(reloadtime)
 		. += "Ammo Counter: [shotsleft]/[initial(shotsleft)]."
 	else
@@ -51,6 +48,14 @@
 				. += "<span class='notice'>This weapon has a slow reload.</span>"
 			if(2.51 to INFINITY)
 				. += "<span class='notice'>This weapon has an extremely slow reload.</span>"
+
+	switch(weapon_weight)
+		if(WEAPON_HEAVY)
+			. += "<span class='notice'>This weapon requires both hands to fire.</span>"
+		if(WEAPON_MEDIUM)
+			. += "<span class='notice'>This weapon can be fired with one hand.</span>"
+		if(WEAPON_LIGHT)
+			. += "<span class='notice'>This weapon can be dual wielded.</span>"
 
 	if(!autofire)
 		switch(fire_delay)

--- a/code/modules/projectiles/guns/ego_gun/he.dm
+++ b/code/modules/projectiles/guns/ego_gun/he.dm
@@ -42,7 +42,7 @@
 	ammo_type =	/obj/item/ammo_casing/caseless/ego_galaxy
 	fire_delay = 15
 	fire_sound = 'sound/magic/wand_teleport.ogg'
-	weapon_weight = WEAPON_HEAVY
+	weapon_weight = WEAPON_MEDIUM
 	fire_sound_volume = 70
 	attribute_requirements = list(
 							TEMPERANCE_ATTRIBUTE = 40
@@ -178,7 +178,7 @@
 	inhand_icon_state = "song"
 	ammo_type = /obj/item/ammo_casing/caseless/ego_song
 	fire_sound = 'sound/weapons/gun/pistol/shot_alt.ogg'
-	weapon_weight = WEAPON_HEAVY
+	weapon_weight = WEAPON_MEDIUM
 	shotsleft = 32
 	reloadtime = 1.6 SECONDS
 	spread = 8
@@ -280,7 +280,7 @@
 	inhand_icon_state = "syrinx"
 	special = "This weapon fires slow bullets with limited range."
 	ammo_type = /obj/item/ammo_casing/caseless/ego_syrinx
-	weapon_weight = WEAPON_HEAVY
+	weapon_weight = WEAPON_MEDIUM
 	spread = 40
 	shotsleft = 40
 	reloadtime = 2 SECONDS

--- a/code/modules/projectiles/guns/ego_gun/teth.dm
+++ b/code/modules/projectiles/guns/ego_gun/teth.dm
@@ -23,7 +23,7 @@
 	icon_state = "beak"
 	inhand_icon_state = "beak"
 	ammo_type = /obj/item/ammo_casing/caseless/ego_beak
-	weapon_weight = WEAPON_HEAVY
+	weapon_weight = WEAPON_MEDIUM
 	spread = 10
 	shotsleft = 30
 	reloadtime = 1.3 SECONDS

--- a/code/modules/projectiles/guns/ego_gun/waw.dm
+++ b/code/modules/projectiles/guns/ego_gun/waw.dm
@@ -221,6 +221,7 @@
 	icon_state = "crimsonscar"
 	inhand_icon_state = "crimsonscar"
 	ammo_type = /obj/item/ammo_casing/caseless/ego_crimson
+	weapon_weight = WEAPON_MEDIUM
 	special = "This weapon fires 3 pellets."
 	fire_delay = 7
 	shotsleft = 9
@@ -238,7 +239,7 @@
 	inhand_icon_state = "ecstasy"
 	special = "This weapon fires slow bullets with limited range."
 	ammo_type = /obj/item/ammo_casing/caseless/ego_ecstasy
-	weapon_weight = WEAPON_HEAVY
+	weapon_weight = WEAPON_MEDIUM
 	spread = 40
 	fire_sound = 'sound/weapons/ego/ecstasy.ogg'
 	autofire = 0.08 SECONDS
@@ -318,7 +319,7 @@
 	icon_state = "intentions"
 	inhand_icon_state = "intentions"
 	ammo_type = /obj/item/ammo_casing/caseless/ego_intentions
-	weapon_weight = WEAPON_HEAVY
+	weapon_weight = WEAPON_MEDIUM
 	spread = 40
 	fire_sound = 'sound/weapons/gun/smg/mp7.ogg'
 	autofire = 0.07 SECONDS

--- a/code/modules/projectiles/projectile/ego_bullets/waw.dm
+++ b/code/modules/projectiles/projectile/ego_bullets/waw.dm
@@ -99,7 +99,7 @@
 
 /obj/projectile/ego_bullet/ego_crimson
 	name = "crimson"
-	damage = 18
+	damage = 14
 	damage_type = RED_DAMAGE
 
 /obj/projectile/ego_bullet/ego_ecstasy


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
- Updates Weapon weight system to make more use of Medium guns
- The following weapons are now medium guns: Beak, Crimson Scar, Ecstasy, Good Intention, Syrinx, Songs of the past, Galaxy
- Crimson Scar's damage has been reduced from an absurd 54 (108 Dual Wielded) to a more reasonable 42 and can no longer be dual wielded.
- The following weapons can now be put into a belt: Good Intentions, Beak, Visions of Future Past.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Making use of Medium weapons would be very nice.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: More weapons can now fit into a belt.
balance: SMG is now a more distinct gun class, that can be fired wtih one hand and fit into a belt.
balance: Crimson Scar damage has been reduced.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
