### PR TITLE
Removes Attack Speed Variable = 1 Runtime[DONE]

### DIFF
--- a/code/game/objects/items/ego_weapons/_ego_weapon.dm
+++ b/code/game/objects/items/ego_weapons/_ego_weapon.dm
@@ -9,7 +9,7 @@
 	slot_flags = ITEM_SLOT_BELT
 	drag_slowdown = 1
 	var/list/attribute_requirements = list()
-	var/attack_speed
+	var/attack_speed = 1
 	var/special
 	var/force_multiplier = 1
 
@@ -29,7 +29,7 @@
 	if(!CanUseEgo(user))
 		return FALSE
 	. = ..()
-	if(attack_speed)
+	if(attack_speed && attack_speed != 1)
 		user.changeNext_move(CLICK_CD_MELEE * attack_speed)
 
 	if(charge && attack_charge_gain)
@@ -104,10 +104,6 @@
 
 		if(0.7 to 0.99)
 			. += span_notice("This weapon attacks slightly faster than normal.")
-
-		if(1) // why
-			attack_speed = FALSE
-			CRASH("[src] has a unique attack speed variable that does nothing, please inform coders to delete the variable")
 
 		if(1.01 to 1.49)
 			. += span_notice("This weapon attacks slightly slower than normal.")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
A runtime is occuring in line 110 of _ego_weapon.dm due to the inclusion of a unused attack_speed var.

Also changes default attack_speed from null to 1

The purpose of this crash message was because attack speed = 1 was redundant and attack speed = 0 defaulted to 1 anyways. However making this crash message or altering the resto f the code to remove 1 would be difficult since alot of attack_speed buffs and alterations are made on the assumption that the weapon has attack_speed = 1. Maybe in the future ill replace the attack speed alterations with a proc that defaults 0 to 1 but that would be alot.

The reason that so many shields have their attack_speed overrided is because the default attack speed of the shield subtype is 3.

## Changelog
:cl:

tweak: _ego_weapon.dm
fix: _ego_weapon.dm

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
