### PR TITLE
Makes more abnormalities ignore other Z levels for checks

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/_auxiliary_modes/community/aleph/crying_children.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_auxiliary_modes/community/aleph/crying_children.dm
@@ -149,8 +149,6 @@
 		return FALSE
 	if(!died.ckey)
 		return FALSE
-	if(died.z != z)
-		return FALSE
 	death_counter += 1
 	if(death_counter >= 2)
 		death_counter = 0
@@ -192,7 +190,7 @@
 		new /obj/effect/temp_visual/fire/fast(get_turf(L))
 
 /mob/living/simple_animal/hostile/abnormality/crying_children/BreachEffect(mob/living/carbon/human/user, breach_type)
-	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(show_global_blurb), 20, "No oneï¿½s going to cry on my behalf even if Iï¿½m sad.", 25))
+	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(show_global_blurb), 20, "No one’s going to cry on my behalf even if I’m sad.", 25))
 	..()
 	desc = "A towering angel statue, setting everything on it's path ablaze"
 	icon = 'ModularTegustation/Teguicons/96x96.dmi'
@@ -458,7 +456,7 @@
 		forceMove(T)
 
 /mob/living/simple_animal/hostile/abnormality/crying_children/proc/FinalPhase()
-	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(show_global_blurb), 20, "I donï¿½t want to hear anything. I donï¿½t want to see anything, or speak anythingï¿½", 25))
+	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(show_global_blurb), 20, "I don’t want to hear anything. I don’t want to see anything, or speak anything…", 25))
 	icon_phase = "desperation"
 	icon_living = "[icon_phase]_idle"
 	icon_state = "[icon_phase]_idle"

--- a/code/modules/mob/living/simple_animal/abnormality/_auxiliary_modes/community/aleph/crying_children.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_auxiliary_modes/community/aleph/crying_children.dm
@@ -149,6 +149,8 @@
 		return FALSE
 	if(!died.ckey)
 		return FALSE
+	if(died.z != z)
+		return FALSE
 	death_counter += 1
 	if(death_counter >= 2)
 		death_counter = 0
@@ -190,7 +192,7 @@
 		new /obj/effect/temp_visual/fire/fast(get_turf(L))
 
 /mob/living/simple_animal/hostile/abnormality/crying_children/BreachEffect(mob/living/carbon/human/user, breach_type)
-	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(show_global_blurb), 20, "No one’s going to cry on my behalf even if I’m sad.", 25))
+	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(show_global_blurb), 20, "No oneï¿½s going to cry on my behalf even if Iï¿½m sad.", 25))
 	..()
 	desc = "A towering angel statue, setting everything on it's path ablaze"
 	icon = 'ModularTegustation/Teguicons/96x96.dmi'
@@ -456,7 +458,7 @@
 		forceMove(T)
 
 /mob/living/simple_animal/hostile/abnormality/crying_children/proc/FinalPhase()
-	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(show_global_blurb), 20, "I don’t want to hear anything. I don’t want to see anything, or speak anything…", 25))
+	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(show_global_blurb), 20, "I donï¿½t want to hear anything. I donï¿½t want to see anything, or speak anythingï¿½", 25))
 	icon_phase = "desperation"
 	icon_living = "[icon_phase]_idle"
 	icon_state = "[icon_phase]_idle"

--- a/code/modules/mob/living/simple_animal/abnormality/_auxiliary_modes/community/aleph/crying_children.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_auxiliary_modes/community/aleph/crying_children.dm
@@ -192,7 +192,7 @@
 		new /obj/effect/temp_visual/fire/fast(get_turf(L))
 
 /mob/living/simple_animal/hostile/abnormality/crying_children/BreachEffect(mob/living/carbon/human/user, breach_type)
-	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(show_global_blurb), 20, "No one's going to cry on my behalf even if I'm sad.", 25))
+	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(show_global_blurb), 20, "No one�s going to cry on my behalf even if I�m sad.", 25))
 	..()
 	desc = "A towering angel statue, setting everything on it's path ablaze"
 	icon = 'ModularTegustation/Teguicons/96x96.dmi'
@@ -458,7 +458,8 @@
 		forceMove(T)
 
 /mob/living/simple_animal/hostile/abnormality/crying_children/proc/FinalPhase()
-	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(show_global_blurb), 20, "I don't want to hear anything. I don't want to see anything, or speak anything..", 25))
+
+	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(show_global_blurb), 20, "I don�t want to hear anything. I don�t want to see anything, or speak anything�", 25))
 	icon_phase = "desperation"
 	icon_living = "[icon_phase]_idle"
 	icon_state = "[icon_phase]_idle"

--- a/code/modules/mob/living/simple_animal/abnormality/_auxiliary_modes/community/aleph/crying_children.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_auxiliary_modes/community/aleph/crying_children.dm
@@ -192,7 +192,7 @@
 		new /obj/effect/temp_visual/fire/fast(get_turf(L))
 
 /mob/living/simple_animal/hostile/abnormality/crying_children/BreachEffect(mob/living/carbon/human/user, breach_type)
-	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(show_global_blurb), 20, "No one�s going to cry on my behalf even if I�m sad.", 25))
+	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(show_global_blurb), 20, "No one's going to cry on my behalf even if I'm sad.", 25))
 	..()
 	desc = "A towering angel statue, setting everything on it's path ablaze"
 	icon = 'ModularTegustation/Teguicons/96x96.dmi'
@@ -458,8 +458,7 @@
 		forceMove(T)
 
 /mob/living/simple_animal/hostile/abnormality/crying_children/proc/FinalPhase()
-
-	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(show_global_blurb), 20, "I don�t want to hear anything. I don�t want to see anything, or speak anything�", 25))
+	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(show_global_blurb), 20, "I don't want to hear anything. I don't want to see anything, or speak anything..", 25))
 	icon_phase = "desperation"
 	icon_living = "[icon_phase]_idle"
 	icon_state = "[icon_phase]_idle"

--- a/code/modules/mob/living/simple_animal/abnormality/_auxiliary_modes/community/aleph/crying_children.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_auxiliary_modes/community/aleph/crying_children.dm
@@ -192,7 +192,7 @@
 		new /obj/effect/temp_visual/fire/fast(get_turf(L))
 
 /mob/living/simple_animal/hostile/abnormality/crying_children/BreachEffect(mob/living/carbon/human/user, breach_type)
-	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(show_global_blurb), 20, "No one's going to cry on my behalf even if I'm sad.", 25))
+	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(show_global_blurb), 20, "No one�s going to cry on my behalf even if I�m sad.", 25))
 	..()
 	desc = "A towering angel statue, setting everything on it's path ablaze"
 	icon = 'ModularTegustation/Teguicons/96x96.dmi'
@@ -458,7 +458,7 @@
 		forceMove(T)
 
 /mob/living/simple_animal/hostile/abnormality/crying_children/proc/FinalPhase()
-	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(show_global_blurb), 20, "I don't want to hear anything. I don't want to see anything, or speak anything..", 25))
+	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(show_global_blurb), 20, "I don�t want to hear anything. I don�t want to see anything, or speak anything�", 25))
 	icon_phase = "desperation"
 	icon_living = "[icon_phase]_idle"
 	icon_state = "[icon_phase]_idle"

--- a/code/modules/mob/living/simple_animal/abnormality/_auxiliary_modes/community/aleph/crying_children.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_auxiliary_modes/community/aleph/crying_children.dm
@@ -192,7 +192,7 @@
 		new /obj/effect/temp_visual/fire/fast(get_turf(L))
 
 /mob/living/simple_animal/hostile/abnormality/crying_children/BreachEffect(mob/living/carbon/human/user, breach_type)
-	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(show_global_blurb), 20, "No one�s going to cry on my behalf even if I�m sad.", 25))
+	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(show_global_blurb), 20, "No one's going to cry on my behalf even if I'm sad.", 25))
 	..()
 	desc = "A towering angel statue, setting everything on it's path ablaze"
 	icon = 'ModularTegustation/Teguicons/96x96.dmi'
@@ -458,7 +458,7 @@
 		forceMove(T)
 
 /mob/living/simple_animal/hostile/abnormality/crying_children/proc/FinalPhase()
-	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(show_global_blurb), 20, "I don�t want to hear anything. I don�t want to see anything, or speak anything�", 25))
+	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(show_global_blurb), 20, "I don't want to hear anything. I don't want to see anything, or speak anything..", 25))
 	icon_phase = "desperation"
 	icon_living = "[icon_phase]_idle"
 	icon_state = "[icon_phase]_idle"

--- a/code/modules/mob/living/simple_animal/abnormality/_auxiliary_modes/community/aleph/crying_children.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_auxiliary_modes/community/aleph/crying_children.dm
@@ -149,6 +149,8 @@
 		return FALSE
 	if(!died.ckey)
 		return FALSE
+	if(died.z != z)
+		return FALSE
 	death_counter += 1
 	if(death_counter >= 2)
 		death_counter = 0

--- a/code/modules/mob/living/simple_animal/abnormality/he/blue_shepherd.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/blue_shepherd.dm
@@ -320,8 +320,6 @@
 		return FALSE
 	if(!died.ckey)
 		return FALSE
-	if(died.z != z)
-		return FALSE
 	death_counter += 1
 	if(death_counter >= 2)
 		death_counter = 0

--- a/code/modules/mob/living/simple_animal/abnormality/he/blue_shepherd.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/blue_shepherd.dm
@@ -320,6 +320,8 @@
 		return FALSE
 	if(!died.ckey)
 		return FALSE
+	if(died.z != z)
+		return FALSE
 	death_counter += 1
 	if(death_counter >= 2)
 		death_counter = 0

--- a/code/modules/mob/living/simple_animal/abnormality/he/norinori.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/norinori.dm
@@ -94,8 +94,6 @@
 		return FALSE
 	if(!died.ckey)
 		return FALSE
-	if(died.z != z)
-		return FALSE
 	datum_reference.qliphoth_change(-1) // One death reduces it
 	return TRUE
 

--- a/code/modules/mob/living/simple_animal/abnormality/he/norinori.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/norinori.dm
@@ -94,6 +94,8 @@
 		return FALSE
 	if(!died.ckey)
 		return FALSE
+	if(died.z != z)
+		return FALSE
 	datum_reference.qliphoth_change(-1) // One death reduces it
 	return TRUE
 

--- a/code/modules/mob/living/simple_animal/abnormality/teth/pale_horse.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/pale_horse.dm
@@ -76,6 +76,8 @@
 		return FALSE
 	if(!died.ckey)
 		return FALSE
+	if(died.z != z)
+		return FALSE
 	datum_reference.qliphoth_change(-1)
 	return TRUE
 

--- a/code/modules/mob/living/simple_animal/abnormality/teth/pale_horse.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/pale_horse.dm
@@ -76,8 +76,6 @@
 		return FALSE
 	if(!died.ckey)
 		return FALSE
-	if(died.z != z)
-		return FALSE
 	datum_reference.qliphoth_change(-1)
 	return TRUE
 

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/hammer_light.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/hammer_light.dm
@@ -74,6 +74,8 @@ The $0 Hammer of Light shined."
 	for(var/mob/living/simple_animal/hostile/abnormality/A in GLOB.abnormality_mob_list) //How many breaching abnormalities? How dangerous are they?
 		if(A.IsContained())
 			continue
+		if(died.z != z)
+			return FALSE
 		switch(A.threat_level)
 			if(ZAYIN_LEVEL)
 				points += 5 //practically nothing

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/hammer_light.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/hammer_light.dm
@@ -74,8 +74,8 @@ The $0 Hammer of Light shined."
 	for(var/mob/living/simple_animal/hostile/abnormality/A in GLOB.abnormality_mob_list) //How many breaching abnormalities? How dangerous are they?
 		if(A.IsContained())
 			continue
-		if(died.z != z)
-			return FALSE
+		if(A.z != z)
+			continue
 		switch(A.threat_level)
 			if(ZAYIN_LEVEL)
 				points += 5 //practically nothing

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/hammer_light.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/hammer_light.dm
@@ -74,6 +74,8 @@ The $0 Hammer of Light shined."
 	for(var/mob/living/simple_animal/hostile/abnormality/A in GLOB.abnormality_mob_list) //How many breaching abnormalities? How dangerous are they?
 		if(A.IsContained())
 			continue
+		if(A.z != z)
+			continue
 		switch(A.threat_level)
 			if(ZAYIN_LEVEL)
 				points += 5 //practically nothing

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/hammer_light.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/hammer_light.dm
@@ -74,8 +74,6 @@ The $0 Hammer of Light shined."
 	for(var/mob/living/simple_animal/hostile/abnormality/A in GLOB.abnormality_mob_list) //How many breaching abnormalities? How dangerous are they?
 		if(A.IsContained())
 			continue
-		if(A.z != z)
-			continue
 		switch(A.threat_level)
 			if(ZAYIN_LEVEL)
 				points += 5 //practically nothing


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes the rest of the death counter abnormalities that count deaths from other z levels, don't count those deaths. Also makes Hammer require the breached abnos to be on the same z level.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bugfixes are good for the game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Z Level Checks
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
