### PR TITLE
Pushes back the closet hiding variables to just open turfs

### DIFF
--- a/ModularTegustation/hiding/abnormality.dm
+++ b/ModularTegustation/hiding/abnormality.dm
@@ -3,14 +3,14 @@
 	if(!isopenturf(newloc) || target)
 		return
 
-	var/turf/open/floor/our_floor = newloc
+	var/turf/open/our_floor = newloc
 	if(our_floor.possible_hiding_players.len < 1)
 		return
 
 	if(prob(our_floor.noise))
 		var/possible_target = pick(our_floor.possible_hiding_players)
 		if(get_dist(src, possible_target) > 10)
-			for(var/turf/open/floor/turf in range(10, src))
+			for(var/turf/open/turf in range(10, src))
 				turf.possible_hiding_players -= possible_target
 
 			CRASH("[possible_target] was in a floor's \"possible_hiding_players\" list whilst being out of range!")

--- a/ModularTegustation/hiding/closet.dm
+++ b/ModularTegustation/hiding/closet.dm
@@ -16,7 +16,7 @@
 		return ..()
 
 	for(var/mob/living/person in src)
-		for(var/turf/open/floor/funky_turf in range(2, drop_location()))
+		for(var/turf/open/funky_turf in range(2, drop_location()))
 			funky_turf.noise = initial(funky_turf.noise)
 			funky_turf.possible_hiding_players -= person
 
@@ -40,7 +40,7 @@
 		if(!istype(object, /mob/living))
 			continue
 		var/mob/living/beast = object
-		var/turf/open/floor/corpse_dirt = get_turf(src)
+		var/turf/open/corpse_dirt = get_turf(src)
 		for(var/person as anything in corpse_dirt.possible_hiding_players)
 			if(beast != person)
 				continue
@@ -77,7 +77,7 @@
  */
 /obj/structure/closet/proc/toggle_breathing(opened = TRUE)
 	if(!opened)
-		for(var/turf/open/floor/funky_turf in range(2, drop_location()))
+		for(var/turf/open/funky_turf in range(2, drop_location()))
 			if(show_breathing)
 				funky_turf.color = rgb(255, 255, 0)
 
@@ -91,7 +91,7 @@
 		return
 
 	// the closet is being opened, we need to remove the mobs and noise values from the lists
-	for(var/turf/open/floor/funky_turf in range(2, drop_location()))
+	for(var/turf/open/funky_turf in range(2, drop_location()))
 		if(show_breathing)
 			funky_turf.color = initial(funky_turf.color)
 

--- a/ModularTegustation/hiding/turf.dm
+++ b/ModularTegustation/hiding/turf.dm
@@ -1,9 +1,9 @@
-/turf/open/floor
+/turf/open
 	/// What players are currently hiding near us
 	var/list/possible_hiding_players = list()
 	/// How likelly they are to be detected per tile moved (in %)
 	var/noise = 10
 
-/turf/open/floor/Destroy()
+/turf/open/Destroy()
 	possible_hiding_players = null
 	return ..()


### PR DESCRIPTION

## About The Pull Request

Pushes back hiding variables into open turfs, rather than just floors

## Why It's Good For The Game

One less runtime to think about

## Changelog
:cl:
fix: Trash carts can no longer eat items
/:cl:
