### PR TITLE
Reusable visual optimisation

### DIFF
--- a/code/game/objects/effects/reusable_visual.dm
+++ b/code/game/objects/effects/reusable_visual.dm
@@ -11,21 +11,18 @@
 	invisibility = 101
 	///Reference to the pool that created this object. Do not edit this.
 	var/datum/reusable_visual_pool/pool
-	///How long the effect will be in use. 0 means until manually returned to pool. Only the pool datum should edit this.
+	///How long the effect will be in use. Only the pool datum should edit this.
 	var/duration = 0
 	///Only the pool datum should edit this.
-	var/timer_id = null
-	///Only the pool datum should edit this.
 	var/is_being_used = FALSE
+	///How many DelayedReturn procs are currently existing for this object, it will only be returned by the last remaining DelayedReturn proc.
+	var/delayed_return_count = 0
 
 /obj/effect/reusable_visual/New(datum/reusable_visual_pool/creator_pool)
 	pool = creator_pool
 	return ..()
 
 /obj/effect/reusable_visual/Destroy()
-	if(timer_id)
-		deltimer(timer_id)
-		timer_id = null
 	pool = null
 	return ..()
 

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/white_night.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/white_night.dm
@@ -137,14 +137,14 @@ Thou who carries burden, came to seek the answer."
 					(target_c.y + i <= world.maxy ? getline(locate(min(target_c.x + i, world.maxx), target_c.y + i, target_c.z), locate(max(target_c.x - i + 1, 1), target_c.y + i, target_c.z)) : list()) +\
 					(target_c.x - i > 0 			? getline(locate(target_c.x - i, min(target_c.y + i, world.maxy), target_c.z), locate(target_c.x - i, max(target_c.y - i + 1, 1), target_c.z)) : list())
 		for(var/turf/open/T in turf_list)
+			CHECK_TICK
 			if(faction_check != "apostle")
 				RVP.NewSparkles(T, 10, "#AAFFAA") // Indicating that it's a good thing
 			else
 				RVP.NewCultSparks(T, 10)
 			for(var/mob/living/L in T)
 				RVP.NewCultIn(T, L.dir)
-				addtimer(CALLBACK(src, PROC_REF(revive_target), L, i, faction_check))
-			CHECK_TICK
+				INVOKE_ASYNC(src, PROC_REF(revive_target), L, i, faction_check)
 		SLEEP_CHECK_DEATH(1.5)
 
 /mob/living/simple_animal/hostile/abnormality/white_night/proc/revive_target(mob/living/L, attack_range = 1, faction_check = "apostle")

--- a/code/modules/mob/living/simple_animal/hostile/ordeal/violet.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/violet.dm
@@ -631,13 +631,13 @@
 
 /datum/reusable_visual_pool/proc/NewPaleEyeAttack(turf/location, duration = 5)
 	var/obj/effect/reusable_visual/RV = TakePoolElement()
-	SET_RV_RETURN_TIMER(RV, duration)
 	RV.name = "pale particles"
 	RV.icon = 'icons/effects/effects.dmi'
 	RV.icon_state = "ion_fade_flight"
 	RV.dir = pick(GLOB.cardinals)
 	RV.loc = location
 	animate(RV, alpha = 0, time = duration)
+	DelayedReturn(RV, duration)
 	return RV
 
 /obj/effect/pale_eye


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Replaces timers with just sleeping for reusable visual effects which improves performance by quite a bit.
White night pulse should not lag this time surely.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Less lag for certain effects.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
code: Reusable visuals dont use timers anymore.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
