### PR TITLE
Evangelion Elevator Scene (manager elevator now takes 53 seconds)

### DIFF
--- a/_maps/shuttles/manager_elevator.dmm
+++ b/_maps/shuttles/manager_elevator.dmm
@@ -16,10 +16,10 @@
 /area/shuttle/mining)
 "m" = (
 /obj/machinery/computer/shuttle/mining{
+	dir = 4;
 	name = "elevator console";
-	shuttleId = "manager";
 	possible_destinations = "elevator_home;elevator_away";
-	dir = 4
+	shuttleId = "manager"
 	},
 /obj/machinery/light{
 	dir = 8
@@ -31,11 +31,12 @@
 /area/shuttle/mining)
 "I" = (
 /obj/docking_port/mobile{
-	name = "manager elevator";
-	id = "manager";
-	port_direction = 2;
+	callTime = 530;
 	dwidth = 2;
 	height = 4;
+	id = "manager";
+	name = "manager elevator";
+	port_direction = 2;
 	width = 4
 	},
 /obj/machinery/door/airlock/public/glass{


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The Manager Elevator now takes 53 seconds instead of 1.
This is the exact amount of time as the Neon Genesis Evangelion elevator scene.

Optional To-Do
- [ ] Make Elevator music from scratch

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
People have been using the manager floor for immunity since time immemorial.
While it does not bother me, I am the only person that has the ability to do this without taking like a whole day (It only took me 3 hrs)

This serves a few things:
1) Less clerks want to go to the manager's floor, hopefully pushing them to instead use shelter
2) When people still want to go to the manager's floor, they still can it will just take fuckign forever.

Hopefully, players won't be running up and down like fools becuase they odn't want to take the elevator except when necessary.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: The Elevator now takes 53 seconds.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
