### PR TITLE
Adds some custom suicides to some LC13 items.

### DIFF
--- a/ModularTegustation/tegu_items/gadgets/manager_bullets.dm
+++ b/ModularTegustation/tegu_items/gadgets/manager_bullets.dm
@@ -30,6 +30,11 @@
 /obj/item/managerbullet/proc/bulletshatter(mob/living/L) //apply effect slot
 	return
 
+/obj/item/managerbullet/suicide_act(mob/living/carbon/user)
+	. = ..()
+	user.visible_message(span_suicide("[user] holds the bullet in front of them, with the desire to shield themselves from oxygen! It looks like [user.p_theyre()] trying to commit suicide!"))
+	return OXYLOSS
+
 
 /datum/status_effect/interventionshield
 	id = "physical intervention shield"

--- a/ModularTegustation/tegu_items/gadgets/powered.dm
+++ b/ModularTegustation/tegu_items/gadgets/powered.dm
@@ -219,6 +219,24 @@
 	inuse = FALSE
 	update_icon()
 
+/obj/item/powered_gadget/teleporter/suicide_act(mob/living/carbon/user)
+	. = ..()
+	user.visible_message(span_suicide("[user] tries to pull the switch of \the [src] off to break it! It looks like [user.p_theyre()] trying to commit suicide!"))
+	new /obj/effect/temp_visual/dir_setting/ninja/phase/out (get_turf(user))
+	var/obj/item/bodypart/head/head = user.get_bodypart(BODY_ZONE_HEAD)
+	var/obj/item/bodypart/l_arm/l_arm = user.get_bodypart(BODY_ZONE_L_ARM)
+	var/obj/item/bodypart/r_arm/r_arm = user.get_bodypart(BODY_ZONE_R_ARM)
+	var/obj/item/bodypart/l_leg/l_leg = user.get_bodypart(BODY_ZONE_L_LEG)
+	var/obj/item/bodypart/r_leg/r_leg = user.get_bodypart(BODY_ZONE_R_LEG)
+	var/list/limbs = list(head, l_arm, r_arm, l_leg, r_leg)
+	for(var/obj/item/bodypart/limb in limbs)
+		limb.dismember()
+		var/turf/T = pick(GLOB.department_centers)
+		limb.forceMove(T)
+		new /obj/effect/temp_visual/dir_setting/ninja/phase (get_turf(limb))
+		playsound(limb, 'sound/effects/contractorbatonhit.ogg', 100, FALSE, 9)
+	return MANUAL_SUICIDE
+
 //The taser
 /obj/item/powered_gadget/handheld_taser
 	name = "Handheld Taser"

--- a/ModularTegustation/tegu_items/gadgets/unpowered.dm
+++ b/ModularTegustation/tegu_items/gadgets/unpowered.dm
@@ -456,7 +456,7 @@
 	var/obj/item/organ/brain/brain = user.getorganslot(ORGAN_SLOT_BRAIN)
 	qdel(brain)
 	playsound(user, 'sound/weapons/circsawhit.ogg', 20, TRUE, -1)
-	return MANUAL_SUICIDE
+	return BRUTELOSS
 
 //Clerkbot Spawner
 /obj/item/clerkbot_gadget

--- a/ModularTegustation/tegu_items/gadgets/unpowered.dm
+++ b/ModularTegustation/tegu_items/gadgets/unpowered.dm
@@ -450,6 +450,14 @@
 	mid_length = 2 SECONDS
 	volume = 20
 
+/obj/item/lobotomizer/suicide_act(mob/living/carbon/user)
+	. = ..()
+	user.visible_message(span_suicide("[user] changes \the [src]'s setting from 'Lobotomize' to 'Decimate'! It looks like [user.p_theyre()] trying to commit suicide!"))
+	var/obj/item/organ/brain/brain = user.getorganslot(ORGAN_SLOT_BRAIN)
+	qdel(brain)
+	playsound(user, 'sound/weapons/circsawhit.ogg', 20, TRUE, -1)
+	return MANUAL_SUICIDE
+
 //Clerkbot Spawner
 /obj/item/clerkbot_gadget
 	name = "Instant Clerkbot Constructor"

--- a/code/game/objects/items/ego_weapons/aleph.dm
+++ b/code/game/objects/items/ego_weapons/aleph.dm
@@ -314,6 +314,13 @@
 /obj/item/ego_weapon/smile/get_clamped_volume()
 	return 50
 
+/obj/item/ego_weapon/smile/suicide_act(mob/living/carbon/user)
+	. = ..()
+	user.visible_message(span_suicide("[user] holds \the [src] in front of [user.p_them()], and begins to swing [user.p_them()]self with it! It looks like [user.p_theyre()] trying to commit suicide!"))
+	playsound(user, 'sound/weapons/ego/hammer.ogg', 50, TRUE, -1)
+	user.gib()
+	return MANUAL_SUICIDE
+
 /obj/item/ego_weapon/blooming
 	name = "blooming"
 	desc = "A rose is a rose, by any other name."

--- a/code/game/objects/items/ego_weapons/zayin.dm
+++ b/code/game/objects/items/ego_weapons/zayin.dm
@@ -120,6 +120,14 @@
 		L.adjustBruteLoss(pulse_healing)
 		to_chat(L, span_nicegreen("Fairies come from [user] to heal your wounds."))
 
+/obj/item/ego_weapon/support/wingbeat/suicide_act(mob/living/carbon/user)
+	. = ..()
+	user.visible_message(span_suicide("[user] yells to the fairies around [user.p_them()] that [user.p_they()] won't spend time with the fairies anymore! It looks like [user.p_theyre()] trying to commit suicide!"))
+	playsound(user, 'sound/abnormalities/fairyfestival/fairy_festival_bite.ogg', 50, TRUE, -1)
+	user.unequip_everything()
+	user.dust()
+	return MANUAL_SUICIDE
+
 /obj/item/ego_weapon/change
 	name = "change"
 	desc = "A hammer made with the desire to change anything"

--- a/code/modules/projectiles/guns/ego_gun/aleph.dm
+++ b/code/modules/projectiles/guns/ego_gun/aleph.dm
@@ -25,6 +25,14 @@
 							JUSTICE_ATTRIBUTE = 80
 							)
 
+/obj/item/gun/ego_gun/star/suicide_act(mob/living/carbon/user)
+	. = ..()
+	user.visible_message(span_suicide("[user]'s legs distort and face opposite directions, as [user.p_their()] torso seems to pulsate! It looks like [user.p_theyre()] trying to commit suicide!"))
+	playsound(src, 'sound/abnormalities/bluestar/pulse.ogg', 50, FALSE, 40, falloff_distance = 10)
+	user.unequip_everything()
+	QDEL_IN(user, 1)
+	return MANUAL_SUICIDE
+
 /obj/item/gun/ego_gun/adoration
 	name = "adoration"
 	desc = "A big mug filled with mysterious slime that never runs out. \


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds custom suicides to manager bullets, W corp Teleporter, lobotomizer, Smile, Wingbeat and Sound of a Star.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
They can be funny.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Adds custom suicides.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
