### PR TITLE
Adds abnormalities in a seperate tab on the orbit menu

### DIFF
--- a/code/modules/mob/dead/observer/orbit.dm
+++ b/code/modules/mob/dead/observer/orbit.dm
@@ -56,7 +56,7 @@
 	var/list/ghosts = list()
 	var/list/misc = list()
 	var/list/npcs = list()
-	var/list/abnormalities = list()
+	var/list/abnormalities = list() // LOBOTOMYCORPORATION ADDITION -- Abnormalities
 
 	var/list/pois = getpois(skip_mindless = TRUE, specify_dead_role = FALSE)
 	for (var/name in pois)
@@ -75,7 +75,7 @@
 					serialized["orbiters"] = number_of_orbiters
 				ghosts += list(serialized)
 
-			else if (isabnormalitymob(M))
+			else if (isabnormalitymob(M)) // LOBOTOMYCORPORATION ADDITION -- Abnormalities
 				abnormalities += list(serialized)
 
 			else if (M.stat == DEAD)
@@ -103,7 +103,7 @@
 		else
 			misc += list(serialized)
 
-	data["abnormalities"] = abnormalities
+	data["abnormalities"] = abnormalities // LOBOTOMYCORPORATION ADDITION -- Abnormalities
 	data["alive"] = alive
 	data["antagonists"] = antagonists
 	data["dead"] = dead

--- a/code/modules/mob/dead/observer/orbit.dm
+++ b/code/modules/mob/dead/observer/orbit.dm
@@ -56,6 +56,7 @@
 	var/list/ghosts = list()
 	var/list/misc = list()
 	var/list/npcs = list()
+	var/list/abnormalities = list()
 
 	var/list/pois = getpois(skip_mindless = TRUE, specify_dead_role = FALSE)
 	for (var/name in pois)
@@ -73,6 +74,10 @@
 				if (number_of_orbiters)
 					serialized["orbiters"] = number_of_orbiters
 				ghosts += list(serialized)
+
+			else if (isabnormalitymob(M))
+				abnormalities += list(serialized)
+
 			else if (M.stat == DEAD)
 				dead += list(serialized)
 			else if (M.mind == null)
@@ -98,6 +103,7 @@
 		else
 			misc += list(serialized)
 
+	data["abnormalities"] = abnormalities
 	data["alive"] = alive
 	data["antagonists"] = antagonists
 	data["dead"] = dead

--- a/code/modules/mob/dead/observer/orbit.dm
+++ b/code/modules/mob/dead/observer/orbit.dm
@@ -76,6 +76,12 @@
 				ghosts += list(serialized)
 
 			else if (isabnormalitymob(M)) // LOBOTOMYCORPORATION ADDITION -- Abnormalities
+				var/mob/living/simple_animal/hostile/abnormality/abno = M
+				if(!abno.can_spawn)
+					npcs += list(serialized)
+					continue
+
+				serialized["is_contained"] = abno.IsContained()
 				abnormalities += list(serialized)
 
 			else if (M.stat == DEAD)

--- a/tgui/packages/tgui/interfaces/Orbit.js
+++ b/tgui/packages/tgui/interfaces/Orbit.js
@@ -80,6 +80,7 @@ const OrbitedButton = (props, context) => {
 export const Orbit = (props, context) => {
   const { act, data } = useBackend(context);
   const {
+    abnormalities,
     alive,
     antagonists,
     auto_observe,
@@ -194,6 +195,12 @@ export const Orbit = (props, context) => {
                 thing={thing} />
             ))}
         </Section>
+
+        <BasicSection
+          title="Abnormalities"
+          source={abnormalities}
+          searchText={searchText}
+        />
 
         <Section title={`Ghosts - (${ghosts.length})`}>
           {ghosts

--- a/tgui/packages/tgui/interfaces/Orbit.js
+++ b/tgui/packages/tgui/interfaces/Orbit.js
@@ -80,7 +80,7 @@ const OrbitedButton = (props, context) => {
 export const Orbit = (props, context) => {
   const { act, data } = useBackend(context);
   const {
-    abnormalities,
+    abnormalities, // LOBOTOMYCORPORATION ADDITION -- Abnormalities
     alive,
     antagonists,
     auto_observe,
@@ -196,7 +196,7 @@ export const Orbit = (props, context) => {
             ))}
         </Section>
 
-        <BasicSection
+        <BasicSection // LOBOTOMYCORPORATION ADDITION -- Abnormalities
           title="Abnormalities"
           source={abnormalities}
           searchText={searchText}

--- a/tgui/packages/tgui/interfaces/Orbit.js
+++ b/tgui/packages/tgui/interfaces/Orbit.js
@@ -196,11 +196,17 @@ export const Orbit = (props, context) => {
             ))}
         </Section>
 
-        <BasicSection // LOBOTOMYCORPORATION ADDITION -- Abnormalities
-          title="Abnormalities"
-          source={abnormalities}
-          searchText={searchText}
-        />
+        <Section title={`Abnormalities - (${abnormalities.length})`}>
+          {abnormalities // LOBOTOMYCORPORATION ADDITION -- Abnormalities
+            .filter(searchFor(searchText))
+            .sort(compareNumberedText)
+            .map(thing => (
+              <OrbitedButton
+                key={thing.name}
+                color={thing.is_contained ? "green" : "red"}
+                thing={thing} />
+            ))}
+        </Section>
 
         <Section title={`Ghosts - (${ghosts.length})`}>
           {ghosts


### PR DESCRIPTION
## About The Pull Request

Makes abnos show up below the living section of the orbit menu in their own little corner
If the abnormality is contained, it will have a green color
if its not, then it will be red
if its a tutorial abno, it will just show up in NPC's because who gives a shit
![image](https://github.com/user-attachments/assets/6808762a-bee9-478c-beb9-12a7ecc7b61d)

## Why It's Good For The Game

Bit weird to have them be in the same sections as all the other cleanbots and such, this is much clearer

## Changelog
:cl:
add: Abnormality orbit menu
/:cl:
