### PR TITLE
Tweaks Green Stem Ego and New Move_Resist Proc[DONE]

### DIFF
--- a/code/game/objects/items/ego_weapons/_ego_weapon.dm
+++ b/code/game/objects/items/ego_weapons/_ego_weapon.dm
@@ -42,17 +42,17 @@
 	switch(knockback)
 		if(KNOCKBACK_LIGHT)
 			var/whack_speed = (prob(60) ? 1 : 4)
-			target.throw_at(throw_target, rand(1, 2), whack_speed, user)
+			target.safe_throw_at(throw_target, rand(1, 2), whack_speed, user)
 
 		if(KNOCKBACK_MEDIUM)
 			var/whack_speed = (prob(60) ? 3 : 6)
-			target.throw_at(throw_target, rand(2, 3), whack_speed, user)
+			target.safe_throw_at(throw_target, rand(2, 3), whack_speed, user)
 
 		if(KNOCKBACK_HEAVY) // neck status: snapped
-			target.throw_at(throw_target, 7, 7, user)
+			target.safe_throw_at(throw_target, 7, 7, user)
 
 		else // should only be used by admins messing around in-game, please consider using above variables as a coder
-			target.throw_at(throw_target, (knockback * 0.5) , knockback, user)
+			target.safe_throw_at(throw_target, (knockback * 0.5) , knockback, user)
 
 	return TRUE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Tweaks and reworks some of the green stem ego code so that it works better as a weapon.
increased vine damage to 40
increased vineburst range from 3 to 5
changed vine cooldown from 3 seconds to 1 second.
removed sanity consumption
added a move_resist alteration to prevent knockback.
This change would make the attack deal 
40*6 = 240 damage or 360 damage if below 30% sanity
1+0.5+0.333+0.25+0.2+0.1667 = 2.45 SECONDS

- 1sec = 40 damage
- 1.5sec = 80 damage
- 1.8sec = 120 damage
- 2.1sec = 160 damage
- 2.3sec = 200 damage
- **2.4sec = 240 damage**

For perspective Amber Dawn has 80 health so a swarm would be annihilated in 1.5 seconds
Steel Dawns have 220 health and would be annihilated in a full burst.
Though since this is a waw weapon it might be acceptable. Cooldown is now based on 
`vine_cooldown = world.time + (channeling_duration_start * channeling_cycle_max)`

THIS REQUIRES A MASSIVE BALANCE CHECK SINCE THE AOE ATTACK HAS NO LIMIT ON THE AMOUNT OF ENEMIES IT CAN HIT.

Replaced the throw_at() in /obj/item/ego_weapon/attack() with safe_throw_at() so that move_resist can be used to prevent knockback.

What i did was make a proc that alters the move_resist of the user. move_resist if greater than the force applied by safe_throw_at(force) will cancel the knockback throw but not the damage applied beforehand.

Instead of making it a proc unique to green stem i may move it back to ego_weapons or put the move_resist change proc in mobs. My other choice was to use anchored but it was a bit wonky since client mobs can still move while anchored and altering a TRUE/FALSE var felt like it'd cause more confusion than nessesary.

## Why It's Good For The Game
I can atomize the move_resist to a separate PR since its a edit that could be used on shields to prevent knockback from destroying tanky agents that are holding the line.

## Changelog
:cl:
tweak: ego_weapon/stem
tweak: ego_weapon.dm
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
