### PR TITLE
Minor change to ERA buff description

### DIFF
--- a/code/game/objects/items/ego_weapons/non_abnormality/_cityweapons.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/_cityweapons.dm
@@ -14,7 +14,7 @@ Kirie*/
 	. = ..()
 	if(user.mind)
 		if(user.mind.assigned_role in list("Disciplinary Officer", "Emergency Response Agent")) //These guys get a bonus to equipping gacha.
-			. += span_notice("Due to your abilities, you get a +20 to your stats when equipping this weapon.")
+			. += span_notice("Due to your abilities, you get a -20 reduction to stat requirements when equipping this weapon.")
 
 /obj/item/ego_weapon/city/CanUseEgo(mob/living/user)
 	if(user.mind)
@@ -35,7 +35,7 @@ Kirie*/
 	. = ..()
 	if(user.mind)
 		if(user.mind.assigned_role in list("Disciplinary Officer", "Emergency Response Agent")) //These guys get a bonus to equipping gacha.
-			. += span_notice("Due to your abilities, you get a +20 to your stats when equipping this weapon.")
+			. += span_notice("Due to your abilities, you get a -20 reduction to stat requirements when equipping this weapon.")
 
 /obj/item/gun/ego_gun/city/CanUseEgo(mob/living/user)
 	if(user.mind)

--- a/code/modules/clothing/suits/ego_gear/non_abnormality/_cityarmor.dm
+++ b/code/modules/clothing/suits/ego_gear/non_abnormality/_cityarmor.dm
@@ -8,7 +8,7 @@
 	. = ..()
 	if(user.mind)
 		if(user.mind.assigned_role in list("Disciplinary Officer", "Emergency Response Agent")) //These guys get a bonus to equipping gacha.
-			. += span_notice("Due to your abilities, you get a +20 to your stats when equipping this armor.")
+			. += span_notice("Due to your abilities, you get a -20 reduction to stat requirements when equipping this armor.")
 
 /obj/item/clothing/suit/armor/ego_gear/city/CanUseEgo(mob/living/user)
 	if(user.mind)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes it from saying +20 stat buff to -20 stat requirement

## Why It's Good For The Game

Because for **_some_** reason, most ERAs think that they're STRONGER when wearing gacha gear, when they're really just wearing it with lower stats

## Changelog
:cl:

tweak: tweaked ERA buff thingamababa
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
