### PR TITLE
Fixes incorrect variable override on chairs, chairs now shift your position if they are themselfes pixel shifted

### DIFF
--- a/_maps/map_files/Delta/deltacorp.dmm
+++ b/_maps/map_files/Delta/deltacorp.dmm
@@ -1348,7 +1348,6 @@
 /area/facility_hallway/welfare)
 "dp" = (
 /obj/structure/chair/comfy{
-	can_buckle = 0;
 	dir = 1;
 	pixel_y = 12
 	},
@@ -1849,7 +1848,6 @@
 /area/facility_hallway/command)
 "eu" = (
 /obj/structure/chair/comfy/brown{
-	can_buckle = 0;
 	dir = 8;
 	pixel_x = -5;
 	pixel_y = 4
@@ -2671,7 +2669,6 @@
 	dir = 1
 	},
 /obj/structure/chair/comfy{
-	can_buckle = 0;
 	dir = 8;
 	pixel_x = -6;
 	pixel_y = 4
@@ -3113,7 +3110,6 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/structure/chair/comfy{
-	can_buckle = 0;
 	pixel_y = 3
 	},
 /obj/item/toy/plush/malkuth,
@@ -3325,7 +3321,6 @@
 	color = "#006400"
 	},
 /obj/structure/chair/comfy/lime{
-	can_buckle = 0;
 	dir = 4;
 	pixel_x = 5;
 	pixel_y = 4
@@ -3788,7 +3783,6 @@
 	dir = 8
 	},
 /obj/structure/chair/comfy/lime{
-	can_buckle = 0;
 	dir = 8;
 	pixel_x = -5;
 	pixel_y = 4
@@ -4480,7 +4474,6 @@
 /area/department_main/records)
 "ki" = (
 /obj/structure/chair/comfy/brown{
-	can_buckle = 0;
 	dir = 4;
 	pixel_x = 5;
 	pixel_y = 4
@@ -4566,7 +4559,6 @@
 /area/facility_hallway/information)
 "ky" = (
 /obj/structure/chair/comfy{
-	can_buckle = 0;
 	pixel_y = 3
 	},
 /obj/effect/turf_decal/tile/red{
@@ -5034,7 +5026,6 @@
 	dir = 1
 	},
 /obj/structure/chair/comfy{
-	can_buckle = 0;
 	dir = 1;
 	pixel_y = 12
 	},
@@ -6614,9 +6605,7 @@
 /obj/effect/turf_decal/tile/green{
 	color = "#006400"
 	},
-/obj/structure/chair/comfy/lime{
-	can_buckle = 0
-	},
+/obj/structure/chair/comfy/lime,
 /obj/item/toy/plush/netzach,
 /turf/open/floor/plasteel/sepia,
 /area/department_main/safety)
@@ -7489,7 +7478,6 @@
 /area/department_main/safety)
 "rm" = (
 /obj/structure/chair/comfy/brown{
-	can_buckle = 0;
 	dir = 8;
 	pixel_x = -5;
 	pixel_y = 4
@@ -7709,7 +7697,6 @@
 /area/department_main/control)
 "rJ" = (
 /obj/structure/chair/comfy{
-	can_buckle = 0;
 	dir = 1;
 	pixel_y = 12
 	},
@@ -8657,7 +8644,6 @@
 /area/department_main/training)
 "tF" = (
 /obj/structure/chair/comfy/teal{
-	can_buckle = 0;
 	pixel_y = 1
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -10020,7 +10006,6 @@
 /area/facility_hallway/discipline)
 "xj" = (
 /obj/structure/chair/comfy/teal{
-	can_buckle = 0;
 	dir = 1;
 	pixel_y = 12
 	},
@@ -10610,7 +10595,6 @@
 /area/facility_hallway/command)
 "yF" = (
 /obj/structure/chair/comfy/brown{
-	can_buckle = 0;
 	dir = 1;
 	pixel_y = 9
 	},
@@ -13022,9 +13006,7 @@
 /turf/open/floor/plating,
 /area/department_main/records)
 "DR" = (
-/obj/structure/chair/comfy/black{
-	can_buckle = 0
-	},
+/obj/structure/chair/comfy/black,
 /obj/effect/light_emitter{
 	light_power = 4;
 	light_range = 10;
@@ -13285,7 +13267,6 @@
 "Eu" = (
 /obj/structure/chair/office{
 	anchored = 1;
-	can_buckle = 0;
 	dir = 1;
 	pixel_y = 5
 	},
@@ -13726,9 +13707,7 @@
 	color = "#f8f8f8";
 	dir = 8
 	},
-/obj/structure/chair/comfy/lime{
-	can_buckle = 0
-	},
+/obj/structure/chair/comfy/lime,
 /obj/effect/turf_decal/tile/green{
 	color = "#539b11"
 	},
@@ -15033,7 +15012,6 @@
 /area/department_main/information)
 "IG" = (
 /obj/structure/chair/comfy/teal{
-	can_buckle = 0;
 	pixel_y = 1
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -15743,7 +15721,6 @@
 	dir = 8
 	},
 /obj/structure/chair/comfy{
-	can_buckle = 0;
 	pixel_y = 3
 	},
 /turf/open/floor/plasteel/sepia,
@@ -16564,7 +16541,6 @@
 /area/department_main/safety)
 "Me" = (
 /obj/structure/chair/comfy/brown{
-	can_buckle = 0;
 	dir = 1;
 	pixel_y = 9
 	},
@@ -17271,7 +17247,6 @@
 /area/facility_hallway/safety)
 "NQ" = (
 /obj/structure/chair/comfy/lime{
-	can_buckle = 0;
 	dir = 1;
 	pixel_y = 11
 	},
@@ -17763,9 +17738,7 @@
 	set_cap = 3;
 	set_luminosity = 10
 	},
-/obj/structure/chair/comfy/black{
-	can_buckle = 0
-	},
+/obj/structure/chair/comfy/black,
 /obj/item/toy/plush/binah,
 /turf/open/floor/carpet/royalblack,
 /area/department_main/extraction)
@@ -18157,7 +18130,6 @@
 	dir = 4
 	},
 /obj/structure/chair/comfy{
-	can_buckle = 0;
 	dir = 4;
 	pixel_x = 6;
 	pixel_y = 4
@@ -18570,7 +18542,6 @@
 /area/facility_hallway/information)
 "Ra" = (
 /obj/structure/chair/comfy/brown{
-	can_buckle = 0;
 	dir = 4;
 	pixel_x = 5;
 	pixel_y = 4
@@ -18631,7 +18602,6 @@
 /area/department_main/welfare)
 "Rl" = (
 /obj/structure/chair/comfy/brown{
-	can_buckle = 0;
 	dir = 8;
 	pixel_x = -5;
 	pixel_y = 4
@@ -22217,7 +22187,6 @@
 	dir = 4
 	},
 /obj/structure/chair/comfy/lime{
-	can_buckle = 0;
 	dir = 1;
 	pixel_y = 11
 	},

--- a/_maps/map_files/Epsilon/epsiloncorp.dmm
+++ b/_maps/map_files/Epsilon/epsiloncorp.dmm
@@ -712,7 +712,6 @@
 /obj/effect/turf_decal/tile/red,
 /obj/structure/chair/office/light{
 	anchored = 1;
-	can_buckle = 0;
 	dir = 4;
 	pixel_x = -5;
 	pixel_y = 4
@@ -1094,7 +1093,6 @@
 "du" = (
 /obj/structure/chair/office{
 	anchored = 1;
-	can_buckle = 0;
 	dir = 8;
 	pixel_x = -6;
 	pixel_y = 4
@@ -1533,7 +1531,6 @@
 	dir = 1
 	},
 /obj/structure/chair/sofa/right{
-	can_buckle = 0;
 	dir = 4
 	},
 /turf/open/floor/plasteel/sepia{
@@ -1576,7 +1573,6 @@
 /area/facility_hallway/west)
 "eA" = (
 /obj/structure/chair/comfy/black{
-	can_buckle = 0;
 	dir = 1;
 	pixel_y = 7
 	},
@@ -1673,7 +1669,6 @@
 /area/facility_hallway/human)
 "eW" = (
 /obj/structure/chair/comfy/black{
-	can_buckle = 0;
 	dir = 4;
 	pixel_x = 5;
 	pixel_y = 4
@@ -1703,7 +1698,6 @@
 	dir = 8
 	},
 /obj/structure/chair/plastic{
-	can_buckle = 0;
 	dir = 8;
 	pixel_x = 12
 	},
@@ -2142,7 +2136,6 @@
 /obj/effect/turf_decal/tile/red,
 /obj/structure/chair/office/light{
 	anchored = 1;
-	can_buckle = 0;
 	dir = 4
 	},
 /turf/open/floor/plasteel/sepia,
@@ -2317,7 +2310,6 @@
 	dir = 4
 	},
 /obj/structure/chair/comfy/teal{
-	can_buckle = 0;
 	dir = 1;
 	pixel_y = 12
 	},
@@ -3085,7 +3077,6 @@
 	dir = 1
 	},
 /obj/structure/chair/sofa/left{
-	can_buckle = 0;
 	dir = 4
 	},
 /turf/open/floor/plasteel/sepia{
@@ -3369,9 +3360,7 @@
 	color = "#bf48b1";
 	dir = 8
 	},
-/obj/structure/chair/comfy/black{
-	can_buckle = 0
-	},
+/obj/structure/chair/comfy/black,
 /turf/open/floor/plasteel/sepia,
 /area/department_main/information)
 "jZ" = (
@@ -3572,7 +3561,6 @@
 "kz" = (
 /obj/structure/chair/office/light{
 	anchored = 1;
-	can_buckle = 0;
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
@@ -5297,7 +5285,6 @@
 "qn" = (
 /obj/structure/chair/office{
 	anchored = 1;
-	can_buckle = 0;
 	dir = 8;
 	pixel_x = -6;
 	pixel_y = 4
@@ -5809,7 +5796,6 @@
 /area/facility_hallway/west)
 "rv" = (
 /obj/structure/chair/comfy{
-	can_buckle = 0;
 	dir = 1;
 	pixel_y = 8
 	},
@@ -7341,7 +7327,6 @@
 "wC" = (
 /obj/structure/chair/office{
 	anchored = 1;
-	can_buckle = 0;
 	dir = 4;
 	pixel_x = 6;
 	pixel_y = 4
@@ -7831,9 +7816,7 @@
 	},
 /area/facility_hallway/welfare)
 "yo" = (
-/obj/structure/chair/comfy/black{
-	can_buckle = 0
-	},
+/obj/structure/chair/comfy/black,
 /obj/effect/turf_decal/tile/purple{
 	color = "#bf48b1";
 	dir = 8
@@ -8029,7 +8012,6 @@
 "yO" = (
 /obj/structure/chair/office{
 	anchored = 1;
-	can_buckle = 0;
 	dir = 4;
 	pixel_x = 6;
 	pixel_y = 4
@@ -9363,7 +9345,6 @@
 	icon_state = "LC29"
 	},
 /obj/structure/chair/comfy/black{
-	can_buckle = 0;
 	dir = 8;
 	pixel_x = -6;
 	pixel_y = 4
@@ -9421,7 +9402,6 @@
 "DG" = (
 /obj/structure/chair/office{
 	anchored = 1;
-	can_buckle = 0;
 	dir = 4;
 	pixel_x = 6;
 	pixel_y = 4
@@ -9761,9 +9741,7 @@
 	},
 /area/facility_hallway/central)
 "EA" = (
-/obj/structure/chair/comfy/black{
-	can_buckle = 0
-	},
+/obj/structure/chair/comfy/black,
 /obj/item/toy/plush/binah,
 /obj/effect/light_emitter{
 	light_power = 4;
@@ -10732,7 +10710,6 @@
 "Hk" = (
 /obj/structure/chair/office{
 	anchored = 1;
-	can_buckle = 0;
 	dir = 8;
 	pixel_x = -6;
 	pixel_y = 4
@@ -11444,7 +11421,6 @@
 	dir = 4
 	},
 /obj/structure/chair/plastic{
-	can_buckle = 0;
 	dir = 8;
 	pixel_x = 12
 	},
@@ -11911,7 +11887,6 @@
 	color = "#5269e9"
 	},
 /obj/structure/chair/comfy/teal{
-	can_buckle = 0;
 	pixel_y = 1
 	},
 /turf/open/floor/plasteel/sepia,
@@ -12585,7 +12560,6 @@
 	dir = 1
 	},
 /obj/structure/chair/comfy/brown{
-	can_buckle = 0;
 	dir = 1;
 	pixel_y = 9
 	},
@@ -12827,7 +12801,6 @@
 "Nr" = (
 /obj/structure/chair/office{
 	anchored = 1;
-	can_buckle = 0;
 	dir = 8;
 	pixel_x = -6;
 	pixel_y = 4
@@ -14318,7 +14291,6 @@
 	},
 /obj/structure/chair/office/light{
 	anchored = 1;
-	can_buckle = 0;
 	dir = 8;
 	pixel_x = 5;
 	pixel_y = 4
@@ -14698,7 +14670,6 @@
 	color = "#5269e9"
 	},
 /obj/structure/chair/comfy/teal{
-	can_buckle = 0;
 	pixel_y = 1
 	},
 /obj/item/toy/plush/chesed,
@@ -16723,7 +16694,6 @@
 "ZD" = (
 /obj/structure/chair/office{
 	anchored = 1;
-	can_buckle = 0;
 	dir = 4;
 	pixel_x = 6;
 	pixel_y = 4

--- a/_maps/map_files/Eta/etacorp.dmm
+++ b/_maps/map_files/Eta/etacorp.dmm
@@ -215,7 +215,6 @@
 	dir = 4
 	},
 /obj/structure/chair/comfy/shuttle{
-	can_buckle = 0;
 	desc = "A comfortable, secure seat.";
 	dir = 4;
 	name = "metalic seat"
@@ -1290,7 +1289,6 @@
 "gk" = (
 /obj/structure/chair/office/light{
 	anchored = 1;
-	can_buckle = 0;
 	dir = 4
 	},
 /turf/open/floor/facility/dark{
@@ -1871,7 +1869,6 @@
 /area/facility_hallway/east)
 "iI" = (
 /obj/structure/chair/comfy/shuttle{
-	can_buckle = 0;
 	desc = "A comfortable, secure seat.";
 	dir = 8;
 	name = "metalic seat"
@@ -2038,7 +2035,6 @@
 /area/facility_hallway/safety)
 "jp" = (
 /obj/structure/chair/comfy/shuttle{
-	can_buckle = 0;
 	desc = "A comfortable, secure seat.";
 	name = "metalic seat"
 	},
@@ -2483,7 +2479,6 @@
 /area/department_main/command)
 "lu" = (
 /obj/structure/chair/comfy/shuttle{
-	can_buckle = 0;
 	desc = "A comfortable, secure seat.";
 	dir = 4;
 	name = "metalic seat"
@@ -2714,7 +2709,6 @@
 "mg" = (
 /obj/structure/chair/office/light{
 	anchored = 1;
-	can_buckle = 0;
 	dir = 8
 	},
 /turf/open/floor/facility/dark{
@@ -2988,8 +2982,7 @@
 /area/facility_hallway/information)
 "nj" = (
 /obj/structure/chair/office/light{
-	anchored = 1;
-	can_buckle = 0
+	anchored = 1
 	},
 /turf/open/floor/facility/dark{
 	color = "#ccc8c0"
@@ -3100,7 +3093,6 @@
 /area/department_main/extraction)
 "nJ" = (
 /obj/structure/chair/sofa/left{
-	can_buckle = 0;
 	dir = 4
 	},
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -3521,7 +3513,6 @@
 	dir = 8
 	},
 /obj/structure/chair/comfy/shuttle{
-	can_buckle = 0;
 	desc = "A comfortable, secure seat.";
 	dir = 8;
 	name = "metalic seat"
@@ -3611,7 +3602,6 @@
 	resistance_flags = 115
 	},
 /obj/structure/chair/comfy/shuttle{
-	can_buckle = 0;
 	desc = "A comfortable, secure seat.";
 	dir = 1;
 	name = "metalic seat";
@@ -3914,7 +3904,6 @@
 	dir = 4
 	},
 /obj/structure/chair/sofa/left{
-	can_buckle = 0;
 	dir = 8
 	},
 /turf/open/floor/facility/dark,
@@ -4149,7 +4138,6 @@
 /area/facility_hallway/safety)
 "se" = (
 /obj/structure/chair/comfy/brown{
-	can_buckle = 0;
 	dir = 1;
 	pixel_y = 9
 	},
@@ -4439,7 +4427,6 @@
 	},
 /obj/structure/chair/office{
 	anchored = 1;
-	can_buckle = 0;
 	dir = 8
 	},
 /turf/open/floor/carpet/green,
@@ -5025,7 +5012,6 @@
 	dir = 4
 	},
 /obj/structure/chair/comfy/shuttle{
-	can_buckle = 0;
 	desc = "A comfortable, secure seat.";
 	dir = 4;
 	name = "metalic seat"
@@ -5356,9 +5342,7 @@
 /turf/open/floor/facility/white,
 /area/facility_hallway/safety)
 "xn" = (
-/obj/structure/chair/sofa/right{
-	can_buckle = 0
-	},
+/obj/structure/chair/sofa/right,
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 1
 	},
@@ -6711,9 +6695,7 @@
 /turf/open/floor/plasteel/white,
 /area/facility_hallway/training)
 "CH" = (
-/obj/structure/chair/sofa/left{
-	can_buckle = 0
-	},
+/obj/structure/chair/sofa/left,
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 1
 	},
@@ -7825,7 +7807,6 @@
 /area/facility_hallway/training)
 "Ia" = (
 /obj/structure/chair/comfy/shuttle{
-	can_buckle = 0;
 	desc = "A comfortable, secure seat.";
 	dir = 1;
 	name = "metalic seat";
@@ -8249,7 +8230,6 @@
 "JQ" = (
 /obj/structure/chair/office/light{
 	anchored = 1;
-	can_buckle = 0;
 	dir = 1
 	},
 /obj/item/toy/plush/malkuth,
@@ -8470,7 +8450,6 @@
 /area/facility_hallway/manager)
 "KE" = (
 /obj/structure/chair/comfy/brown{
-	can_buckle = 0;
 	dir = 1;
 	pixel_y = 9
 	},
@@ -8603,7 +8582,6 @@
 	},
 /obj/effect/turf_decal/siding/wideplating/dark,
 /obj/structure/chair/comfy/shuttle{
-	can_buckle = 0;
 	desc = "A comfortable, secure seat.";
 	name = "metalic seat";
 	pixel_x = -4
@@ -8955,7 +8933,6 @@
 	dir = 8
 	},
 /obj/structure/chair/comfy/shuttle{
-	can_buckle = 0;
 	desc = "A comfortable, secure seat.";
 	dir = 8;
 	name = "metalic seat"
@@ -9090,7 +9067,6 @@
 /area/department_main/training)
 "NB" = (
 /obj/structure/chair/sofa/right{
-	can_buckle = 0;
 	dir = 8
 	},
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -9681,7 +9657,6 @@
 "PO" = (
 /obj/structure/chair/office/light{
 	anchored = 1;
-	can_buckle = 0;
 	dir = 8
 	},
 /obj/item/toy/plush/gebura,
@@ -9883,7 +9858,6 @@
 /area/facility_hallway/training)
 "QC" = (
 /obj/structure/chair/sofa/right{
-	can_buckle = 0;
 	dir = 4
 	},
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -10057,7 +10031,6 @@
 "Rt" = (
 /obj/structure/chair/office/light{
 	anchored = 1;
-	can_buckle = 0;
 	dir = 1
 	},
 /turf/open/floor/facility/dark{

--- a/_maps/map_files/Iota/iotacorp.dmm
+++ b/_maps/map_files/Iota/iotacorp.dmm
@@ -471,7 +471,6 @@
 "bN" = (
 /obj/structure/chair/office/light{
 	anchored = 1;
-	can_buckle = 0;
 	pixel_y = 4
 	},
 /turf/open/floor/carpet/purple,
@@ -523,7 +522,6 @@
 /area/department_main/command)
 "ca" = (
 /obj/structure/chair/comfy/shuttle{
-	can_buckle = 0;
 	desc = "A comfortable, secure seat.";
 	dir = 4;
 	name = "metalic seat";
@@ -1406,7 +1404,6 @@
 /area/facility_hallway/training)
 "eG" = (
 /obj/structure/chair/comfy/shuttle{
-	can_buckle = 0;
 	desc = "A comfortable, secure seat.";
 	dir = 1;
 	name = "metalic seat";
@@ -1963,7 +1960,6 @@
 /area/department_main/welfare)
 "gw" = (
 /obj/structure/chair/sofa/left{
-	can_buckle = 0;
 	dir = 8;
 	pixel_x = -5
 	},
@@ -2171,7 +2167,6 @@
 /area/facility_hallway/control)
 "hd" = (
 /obj/structure/chair/sofa/left{
-	can_buckle = 0;
 	dir = 1;
 	pixel_y = 9
 	},
@@ -3445,9 +3440,7 @@
 	},
 /area/department_main/safety)
 "kG" = (
-/obj/structure/chair/sofa/corp/left{
-	can_buckle = 0
-	},
+/obj/structure/chair/sofa/corp/left,
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 1
 	},
@@ -4197,9 +4190,7 @@
 	},
 /area/space)
 "mv" = (
-/obj/structure/chair/sofa/left{
-	can_buckle = 0
-	},
+/obj/structure/chair/sofa/left,
 /obj/effect/turf_decal/siding/brown,
 /turf/open/floor/facility/dark,
 /area/department_main/training)
@@ -5013,9 +5004,7 @@
 	},
 /area/facility_hallway/welfare)
 "pm" = (
-/obj/structure/chair/sofa/right{
-	can_buckle = 0
-	},
+/obj/structure/chair/sofa/right,
 /obj/effect/turf_decal/siding/brown,
 /obj/item/toy/plush/pierre,
 /turf/open/floor/facility/dark,
@@ -5213,7 +5202,6 @@
 "pR" = (
 /obj/structure/chair/office/light{
 	anchored = 1;
-	can_buckle = 0;
 	dir = 1;
 	pixel_y = 4
 	},
@@ -5258,7 +5246,6 @@
 /area/department_main/command)
 "qk" = (
 /obj/structure/chair/comfy/shuttle{
-	can_buckle = 0;
 	desc = "A comfortable, secure seat.";
 	dir = 4;
 	name = "metalic seat";
@@ -5746,7 +5733,6 @@
 /area/facility_hallway/command)
 "rL" = (
 /obj/structure/chair/comfy/shuttle{
-	can_buckle = 0;
 	desc = "A comfortable, secure seat.";
 	dir = 1;
 	name = "metalic seat";
@@ -6429,7 +6415,6 @@
 /area/department_main/command)
 "tR" = (
 /obj/structure/chair/comfy/shuttle{
-	can_buckle = 0;
 	desc = "A comfortable, secure seat.";
 	dir = 1;
 	name = "metalic seat";
@@ -6690,7 +6675,6 @@
 /area/facility_hallway/training)
 "ux" = (
 /obj/structure/chair/sofa/right{
-	can_buckle = 0;
 	dir = 8;
 	pixel_x = -5
 	},
@@ -7461,9 +7445,7 @@
 	},
 /area/facility_hallway/training)
 "wy" = (
-/obj/structure/chair/sofa/right{
-	can_buckle = 0
-	},
+/obj/structure/chair/sofa/right,
 /obj/effect/turf_decal/siding/brown,
 /turf/open/floor/facility/dark,
 /area/department_main/training)
@@ -8137,7 +8119,6 @@
 /area/facility_hallway/training)
 "yC" = (
 /obj/structure/chair/sofa/corp/right{
-	can_buckle = 0;
 	dir = 4
 	},
 /turf/open/floor/carpet/royalblue,
@@ -8916,7 +8897,6 @@
 /area/facility_hallway/training)
 "By" = (
 /obj/structure/chair/comfy/shuttle{
-	can_buckle = 0;
 	desc = "A comfortable, secure seat.";
 	name = "metalic seat"
 	},
@@ -9791,7 +9771,6 @@
 /area/facility_hallway/safety)
 "Ek" = (
 /obj/structure/chair/sofa/right{
-	can_buckle = 0;
 	dir = 4;
 	pixel_x = 5
 	},
@@ -10416,9 +10395,7 @@
 	},
 /area/department_main/control)
 "Gz" = (
-/obj/structure/chair/sofa/corp/right{
-	can_buckle = 0
-	},
+/obj/structure/chair/sofa/corp/right,
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 1
 	},
@@ -10606,7 +10583,6 @@
 /area/department_main/information)
 "GY" = (
 /obj/structure/chair/comfy/brown{
-	can_buckle = 0;
 	dir = 1;
 	pixel_y = 12
 	},
@@ -10655,7 +10631,6 @@
 	dir = 8
 	},
 /obj/structure/chair/sofa/left{
-	can_buckle = 0;
 	dir = 8;
 	pixel_x = -5
 	},
@@ -11206,7 +11181,6 @@
 /area/department_main/command)
 "Jv" = (
 /obj/structure/chair/sofa/left{
-	can_buckle = 0;
 	dir = 4;
 	pixel_x = 5
 	},
@@ -11243,7 +11217,6 @@
 "JA" = (
 /obj/structure/chair/office/light{
 	anchored = 1;
-	can_buckle = 0;
 	dir = 8;
 	pixel_x = -7;
 	pixel_y = 4
@@ -11341,9 +11314,7 @@
 	},
 /area/facility_hallway/welfare)
 "JS" = (
-/obj/structure/chair/sofa/corp/corner{
-	can_buckle = 0
-	},
+/obj/structure/chair/sofa/corp/corner,
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 1
 	},
@@ -12413,7 +12384,6 @@
 /area/facility_hallway/safety)
 "NI" = (
 /obj/structure/chair/sofa/corp/corner{
-	can_buckle = 0;
 	dir = 4
 	},
 /obj/effect/turf_decal/siding/wideplating/dark{
@@ -13089,9 +13059,7 @@
 /turf/open/floor/facility/dark,
 /area/department_main/control)
 "PM" = (
-/obj/structure/chair/sofa/corp/left{
-	can_buckle = 0
-	},
+/obj/structure/chair/sofa/corp/left,
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 1
 	},
@@ -13312,9 +13280,7 @@
 /turf/open/floor/plasteel/elevatorshaft,
 /area/facility_hallway/east)
 "Qy" = (
-/obj/structure/chair/comfy/brown{
-	can_buckle = 0
-	},
+/obj/structure/chair/comfy/brown,
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 1
 	},
@@ -14191,7 +14157,6 @@
 /area/facility_hallway/welfare)
 "TI" = (
 /obj/structure/chair/sofa/corp/left{
-	can_buckle = 0;
 	dir = 8
 	},
 /turf/open/floor/carpet/royalblue,
@@ -14251,9 +14216,7 @@
 	},
 /area/facility_hallway/east)
 "TS" = (
-/obj/structure/chair/comfy/brown{
-	can_buckle = 0
-	},
+/obj/structure/chair/comfy/brown,
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 1
 	},
@@ -14936,7 +14899,6 @@
 /area/facility_hallway/command)
 "VL" = (
 /obj/structure/chair/sofa/right{
-	can_buckle = 0;
 	dir = 1;
 	pixel_y = 9
 	},
@@ -14962,7 +14924,6 @@
 /area/department_main/control)
 "VO" = (
 /obj/structure/chair/comfy/shuttle{
-	can_buckle = 0;
 	desc = "A comfortable, secure seat.";
 	name = "metalic seat"
 	},

--- a/_maps/map_files/Kappa/kappacorp.dmm
+++ b/_maps/map_files/Kappa/kappacorp.dmm
@@ -258,7 +258,6 @@
 	dir = 1
 	},
 /obj/structure/chair/comfy/shuttle{
-	can_buckle = 0;
 	desc = "A comfortable, secure seat.";
 	name = "metalic seat"
 	},
@@ -375,7 +374,6 @@
 /area/facility_hallway/control)
 "bY" = (
 /obj/structure/chair/sofa/corp/left{
-	can_buckle = 0;
 	dir = 8
 	},
 /turf/open/floor/facility/dark{
@@ -1900,7 +1898,6 @@
 "kD" = (
 /obj/structure/chair/office{
 	anchored = 1;
-	can_buckle = 0;
 	dir = 1;
 	pixel_y = 10
 	},
@@ -2875,7 +2872,6 @@
 /area/facility_hallway/information)
 "nQ" = (
 /obj/structure/chair/comfy/shuttle{
-	can_buckle = 0;
 	desc = "A comfortable, secure seat.";
 	dir = 8;
 	name = "metalic seat";
@@ -2979,7 +2975,6 @@
 /area/facility_hallway/safety)
 "oo" = (
 /obj/structure/chair/comfy/shuttle{
-	can_buckle = 0;
 	desc = "A comfortable, secure seat.";
 	dir = 8;
 	name = "metalic seat";
@@ -3332,8 +3327,7 @@
 /area/department_main/safety)
 "pJ" = (
 /obj/structure/chair/office{
-	anchored = 1;
-	can_buckle = 0
+	anchored = 1
 	},
 /obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/pod/dark,
@@ -3599,7 +3593,6 @@
 "rk" = (
 /obj/structure/chair/office{
 	anchored = 1;
-	can_buckle = 0;
 	dir = 1;
 	pixel_y = 10
 	},
@@ -4081,8 +4074,7 @@
 /area/facility_hallway/information)
 "tq" = (
 /obj/structure/chair/office{
-	anchored = 1;
-	can_buckle = 0
+	anchored = 1
 	},
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/item/toy/plush/malkuth,
@@ -4861,7 +4853,6 @@
 "wY" = (
 /obj/structure/chair/office{
 	anchored = 1;
-	can_buckle = 0;
 	dir = 8;
 	pixel_x = -6;
 	pixel_y = 4
@@ -5413,7 +5404,6 @@
 "zj" = (
 /obj/structure/chair/office{
 	anchored = 1;
-	can_buckle = 0;
 	dir = 4;
 	pixel_x = 6;
 	pixel_y = 4
@@ -6159,7 +6149,6 @@
 	dir = 1
 	},
 /obj/structure/chair/comfy/shuttle{
-	can_buckle = 0;
 	desc = "A comfortable, secure seat.";
 	name = "metalic seat"
 	},
@@ -7434,7 +7423,6 @@
 	dir = 1
 	},
 /obj/structure/chair/comfy/shuttle{
-	can_buckle = 0;
 	desc = "A comfortable, secure seat.";
 	dir = 1;
 	name = "metalic seat";
@@ -8070,7 +8058,6 @@
 /area/department_main/safety)
 "MI" = (
 /obj/structure/chair/sofa/corp/right{
-	can_buckle = 0;
 	dir = 4
 	},
 /turf/open/floor/facility/dark{
@@ -8636,8 +8623,7 @@
 /area/facility_hallway/control)
 "Pp" = (
 /obj/structure/chair/office{
-	anchored = 1;
-	can_buckle = 0
+	anchored = 1
 	},
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/effect/turf_decal/siding/red{
@@ -8816,7 +8802,6 @@
 /area/department_main/training)
 "Qi" = (
 /obj/structure/chair/comfy/brown{
-	can_buckle = 0;
 	dir = 1;
 	pixel_y = 12
 	},
@@ -8883,7 +8868,6 @@
 "Qv" = (
 /obj/structure/chair/office{
 	anchored = 1;
-	can_buckle = 0;
 	dir = 1;
 	pixel_y = 10
 	},
@@ -9677,7 +9661,6 @@
 /area/department_main/control)
 "Uw" = (
 /obj/structure/chair/comfy/shuttle{
-	can_buckle = 0;
 	desc = "A comfortable, secure seat.";
 	dir = 4;
 	name = "metalic seat";
@@ -10359,7 +10342,6 @@
 /area/facility_hallway/training)
 "XM" = (
 /obj/structure/chair/sofa/corp/right{
-	can_buckle = 0;
 	dir = 8
 	},
 /obj/item/toy/plush/yuri,

--- a/_maps/map_files/Lambda/lambdacorp.dmm
+++ b/_maps/map_files/Lambda/lambdacorp.dmm
@@ -80,9 +80,7 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
 	},
-/obj/structure/chair/comfy/brown{
-	can_buckle = 0
-	},
+/obj/structure/chair/comfy/brown,
 /turf/open/floor/pod,
 /area/department_main/training)
 "ax" = (
@@ -597,7 +595,6 @@
 	dir = 1
 	},
 /obj/structure/chair/comfy/brown{
-	can_buckle = 0;
 	dir = 4;
 	pixel_x = 10;
 	pixel_y = 4
@@ -845,7 +842,6 @@
 	},
 /obj/structure/chair/office{
 	anchored = 1;
-	can_buckle = 0;
 	dir = 8;
 	pixel_x = -6;
 	pixel_y = 4
@@ -1356,7 +1352,6 @@
 	},
 /obj/structure/chair/office{
 	anchored = 1;
-	can_buckle = 0;
 	dir = 8;
 	pixel_x = -6;
 	pixel_y = 4
@@ -1388,7 +1383,6 @@
 	},
 /obj/structure/chair/office/light{
 	anchored = 1;
-	can_buckle = 0;
 	dir = 4;
 	pixel_x = 5;
 	pixel_y = 4
@@ -1448,7 +1442,6 @@
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/structure/chair/office{
 	anchored = 1;
-	can_buckle = 0;
 	dir = 1;
 	pixel_y = 10
 	},
@@ -1942,7 +1935,6 @@
 	},
 /obj/structure/chair/office/light{
 	anchored = 1;
-	can_buckle = 0;
 	dir = 8;
 	pixel_x = -5;
 	pixel_y = 4
@@ -3094,7 +3086,6 @@
 	},
 /obj/structure/chair/office/light{
 	anchored = 1;
-	can_buckle = 0;
 	dir = 8;
 	pixel_x = -5;
 	pixel_y = 4
@@ -3730,7 +3721,6 @@
 	dir = 4
 	},
 /obj/structure/chair/comfy/brown{
-	can_buckle = 0;
 	dir = 8;
 	pixel_x = -10;
 	pixel_y = 4
@@ -3866,7 +3856,6 @@
 	},
 /obj/structure/chair/office/light{
 	anchored = 1;
-	can_buckle = 0;
 	dir = 4;
 	pixel_x = 5;
 	pixel_y = 4
@@ -5550,7 +5539,6 @@
 	},
 /obj/structure/chair/office{
 	anchored = 1;
-	can_buckle = 0;
 	dir = 8;
 	pixel_x = -6;
 	pixel_y = 4
@@ -6654,9 +6642,7 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
 	},
-/obj/structure/chair/comfy/brown{
-	can_buckle = 0
-	},
+/obj/structure/chair/comfy/brown,
 /obj/item/toy/plush/hod,
 /turf/open/floor/pod,
 /area/department_main/training)
@@ -7411,7 +7397,6 @@
 	},
 /obj/structure/chair/office/light{
 	anchored = 1;
-	can_buckle = 0;
 	dir = 4;
 	pixel_x = 5;
 	pixel_y = 4
@@ -7838,7 +7823,6 @@
 	},
 /obj/structure/chair/office/light{
 	anchored = 1;
-	can_buckle = 0;
 	dir = 8;
 	pixel_x = -7;
 	pixel_y = 4
@@ -8018,7 +8002,6 @@
 "MJ" = (
 /obj/structure/chair/office{
 	anchored = 1;
-	can_buckle = 0;
 	dir = 1;
 	pixel_y = 10
 	},
@@ -8058,7 +8041,6 @@
 	},
 /obj/structure/chair/office/light{
 	anchored = 1;
-	can_buckle = 0;
 	dir = 4;
 	pixel_x = 5;
 	pixel_y = 4
@@ -8424,7 +8406,6 @@
 /obj/effect/turf_decal/trimline/green/filled/line,
 /obj/structure/chair/office/light{
 	anchored = 1;
-	can_buckle = 0;
 	dir = 1;
 	pixel_y = 6
 	},
@@ -8937,9 +8918,7 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
 	},
-/obj/structure/chair/comfy/brown{
-	can_buckle = 0
-	},
+/obj/structure/chair/comfy/brown,
 /obj/item/toy/plush/chesed,
 /turf/open/floor/pod,
 /area/department_main/training)
@@ -9025,7 +9004,6 @@
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/structure/chair/office/light{
 	anchored = 1;
-	can_buckle = 0;
 	dir = 1;
 	pixel_y = 10
 	},
@@ -9092,8 +9070,7 @@
 	dir = 1
 	},
 /obj/structure/chair/office/light{
-	anchored = 1;
-	can_buckle = 0
+	anchored = 1
 	},
 /obj/item/toy/plush/yesod,
 /turf/open/floor/pod/dark,
@@ -10581,8 +10558,7 @@
 	dir = 1
 	},
 /obj/structure/chair/office/light{
-	anchored = 1;
-	can_buckle = 0
+	anchored = 1
 	},
 /turf/open/floor/pod/dark,
 /area/department_main/information)

--- a/_maps/map_files/Theta/thetacorp.dmm
+++ b/_maps/map_files/Theta/thetacorp.dmm
@@ -2300,7 +2300,6 @@
 /area/facility_hallway/training)
 "ho" = (
 /obj/structure/chair/comfy{
-	can_buckle = 0;
 	dir = 4;
 	pixel_x = 6;
 	pixel_y = 4
@@ -2329,7 +2328,6 @@
 /area/department_main/information)
 "hu" = (
 /obj/structure/chair/comfy/shuttle{
-	can_buckle = 0;
 	desc = "A comfortable, secure seat.";
 	name = "metalic seat"
 	},
@@ -3394,7 +3392,6 @@
 /area/department_main/information)
 "kS" = (
 /obj/structure/chair/comfy/lime{
-	can_buckle = 0;
 	dir = 1;
 	pixel_y = 11
 	},
@@ -4016,9 +4013,7 @@
 	},
 /area/facility_hallway/safety)
 "nn" = (
-/obj/structure/chair/wood/wings{
-	can_buckle = 0
-	},
+/obj/structure/chair/wood/wings,
 /obj/item/toy/plush/chesed,
 /turf/open/floor/plasteel/sepia,
 /area/department_main/training)
@@ -4672,9 +4667,7 @@
 /turf/open/floor/plasteel/sepia,
 /area/facility_hallway/training)
 "pT" = (
-/obj/structure/chair/comfy{
-	can_buckle = 0
-	},
+/obj/structure/chair/comfy,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -5812,7 +5805,6 @@
 /area/department_main/command)
 "tP" = (
 /obj/structure/chair/comfy/shuttle{
-	can_buckle = 0;
 	desc = "A comfortable, secure seat.";
 	name = "metalic seat"
 	},
@@ -6150,7 +6142,6 @@
 /area/department_main/information)
 "vc" = (
 /obj/structure/chair/comfy/lime{
-	can_buckle = 0;
 	dir = 8;
 	pixel_x = -5;
 	pixel_y = 4
@@ -6311,9 +6302,7 @@
 /turf/open/floor/plasteel/sepia,
 /area/department_main/command)
 "vH" = (
-/obj/structure/chair/wood/wings{
-	can_buckle = 0
-	},
+/obj/structure/chair/wood/wings,
 /turf/open/floor/plasteel/sepia,
 /area/department_main/training)
 "vJ" = (
@@ -6518,7 +6507,6 @@
 	dir = 1
 	},
 /obj/structure/chair/comfy/shuttle{
-	can_buckle = 0;
 	desc = "A comfortable, secure seat.";
 	dir = 1;
 	name = "metalic seat";
@@ -7279,7 +7267,6 @@
 	dir = 8
 	},
 /obj/structure/chair/comfy{
-	can_buckle = 0;
 	dir = 8;
 	pixel_x = -6;
 	pixel_y = 4
@@ -7536,7 +7523,6 @@
 	},
 /obj/effect/turf_decal/tile/brown,
 /obj/structure/chair/comfy/brown{
-	can_buckle = 0;
 	dir = 8;
 	pixel_x = 5;
 	pixel_y = 4
@@ -7703,7 +7689,6 @@
 /area/facility_hallway/training)
 "At" = (
 /obj/structure/chair/wood/wings{
-	can_buckle = 0;
 	dir = 1;
 	pixel_y = 4
 	},
@@ -8016,7 +8001,6 @@
 	},
 /obj/structure/chair/office{
 	anchored = 1;
-	can_buckle = 0;
 	dir = 8;
 	pixel_y = 4
 	},
@@ -8887,7 +8871,6 @@
 /area/department_main/extraction)
 "EO" = (
 /obj/structure/chair/wood/wings{
-	can_buckle = 0;
 	dir = 8;
 	pixel_x = -5;
 	pixel_y = 4
@@ -9206,7 +9189,6 @@
 /area/department_main/control)
 "FQ" = (
 /obj/structure/chair/wood/wings{
-	can_buckle = 0;
 	dir = 4;
 	pixel_x = 5;
 	pixel_y = 4
@@ -9284,9 +9266,7 @@
 	},
 /area/department_main/extraction)
 "Gh" = (
-/obj/structure/chair/comfy/lime{
-	can_buckle = 0
-	},
+/obj/structure/chair/comfy/lime,
 /obj/item/toy/plush/netzach,
 /turf/open/floor/carpet/green,
 /area/department_main/safety)
@@ -9631,9 +9611,7 @@
 /turf/open/floor/carpet/green,
 /area/department_main/safety)
 "Hf" = (
-/obj/structure/chair/comfy/brown{
-	can_buckle = 0
-	},
+/obj/structure/chair/comfy/brown,
 /obj/item/toy/plush/hod,
 /turf/open/floor/carpet/orange,
 /area/department_main/training)
@@ -11243,7 +11221,6 @@
 	dir = 1
 	},
 /obj/structure/chair/comfy/shuttle{
-	can_buckle = 0;
 	desc = "A comfortable, secure seat.";
 	dir = 1;
 	name = "metalic seat";
@@ -12169,7 +12146,6 @@
 /area/department_main/training)
 "Pv" = (
 /obj/structure/chair/comfy/brown{
-	can_buckle = 0;
 	dir = 1;
 	pixel_y = 9
 	},
@@ -12285,7 +12261,6 @@
 	dir = 8
 	},
 /obj/structure/chair/comfy/shuttle{
-	can_buckle = 0;
 	desc = "A comfortable, secure seat.";
 	dir = 8;
 	name = "metalic seat";
@@ -12519,7 +12494,6 @@
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/structure/chair/comfy/shuttle{
-	can_buckle = 0;
 	desc = "A comfortable, secure seat.";
 	dir = 4;
 	name = "metalic seat";
@@ -12627,7 +12601,6 @@
 	dir = 1
 	},
 /obj/structure/chair/comfy{
-	can_buckle = 0;
 	dir = 8;
 	pixel_x = -6;
 	pixel_y = 4
@@ -13359,7 +13332,6 @@
 /area/facility_hallway/command)
 "TJ" = (
 /obj/structure/chair/comfy{
-	can_buckle = 0;
 	dir = 1;
 	pixel_y = 16
 	},
@@ -14195,7 +14167,6 @@
 /area/department_main/command)
 "WI" = (
 /obj/structure/chair/comfy/lime{
-	can_buckle = 0;
 	dir = 4;
 	pixel_x = 5;
 	pixel_y = 4
@@ -14793,7 +14764,6 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/structure/chair/comfy{
-	can_buckle = 0;
 	dir = 4;
 	pixel_x = 6;
 	pixel_y = 4

--- a/_maps/map_files/Zeta/zetacorp.dmm
+++ b/_maps/map_files/Zeta/zetacorp.dmm
@@ -233,9 +233,7 @@
 	color = "#006400";
 	dir = 8
 	},
-/obj/structure/chair/comfy/lime{
-	can_buckle = 0
-	},
+/obj/structure/chair/comfy/lime,
 /turf/open/floor/plasteel/dark,
 /area/department_main/safety)
 "aT" = (
@@ -1873,7 +1871,6 @@
 	},
 /obj/structure/chair/office/light{
 	anchored = 1;
-	can_buckle = 0;
 	dir = 4;
 	pixel_x = 7;
 	pixel_y = 4
@@ -2428,7 +2425,6 @@
 	dir = 4
 	},
 /obj/structure/chair/comfy/lime{
-	can_buckle = 0;
 	dir = 1;
 	pixel_y = 11
 	},
@@ -3327,9 +3323,7 @@
 /turf/open/floor/facility/dark,
 /area/department_main/information)
 "jr" = (
-/obj/structure/chair/comfy/lime{
-	can_buckle = 0
-	},
+/obj/structure/chair/comfy/lime,
 /obj/effect/turf_decal/siding/thinplating/dark,
 /obj/item/toy/plush/netzach,
 /turf/open/floor/plasteel/dark,
@@ -3939,7 +3933,6 @@
 	dir = 8
 	},
 /obj/structure/chair/sofa/left{
-	can_buckle = 0;
 	dir = 8;
 	pixel_x = -5
 	},
@@ -3959,7 +3952,6 @@
 	},
 /obj/structure/chair/office/light{
 	anchored = 1;
-	can_buckle = 0;
 	dir = 1;
 	pixel_y = 4
 	},
@@ -4420,7 +4412,6 @@
 	},
 /obj/structure/chair/office{
 	anchored = 1;
-	can_buckle = 0;
 	dir = 4;
 	pixel_x = 6;
 	pixel_y = 6
@@ -5412,7 +5403,6 @@
 	dir = 8
 	},
 /obj/structure/chair/sofa/left{
-	can_buckle = 0;
 	dir = 8;
 	pixel_x = -5
 	},
@@ -5659,9 +5649,7 @@
 /turf/open/floor/plasteel/freezer,
 /area/facility_hallway/north)
 "qh" = (
-/obj/structure/chair/comfy/lime{
-	can_buckle = 0
-	},
+/obj/structure/chair/comfy/lime,
 /obj/effect/turf_decal/siding/thinplating/dark,
 /obj/effect/turf_decal/siding/green/corner{
 	color = "#006400";
@@ -6179,7 +6167,6 @@
 /area/facility_hallway/information)
 "ru" = (
 /obj/structure/chair/comfy/lime{
-	can_buckle = 0;
 	dir = 1;
 	pixel_y = 11
 	},
@@ -6727,9 +6714,7 @@
 /obj/effect/turf_decal/siding/thinplating/corner{
 	dir = 1
 	},
-/obj/structure/chair/comfy/lime{
-	can_buckle = 0
-	},
+/obj/structure/chair/comfy/lime,
 /turf/open/floor/plasteel/dark,
 /area/department_main/safety)
 "tb" = (
@@ -7818,7 +7803,6 @@
 	},
 /obj/structure/chair/office{
 	anchored = 1;
-	can_buckle = 0;
 	dir = 1;
 	pixel_x = -13;
 	pixel_y = 10
@@ -7835,7 +7819,6 @@
 	},
 /obj/structure/chair/office{
 	anchored = 1;
-	can_buckle = 0;
 	pixel_x = -2
 	},
 /obj/item/toy/plush/malkuth,
@@ -8471,7 +8454,6 @@
 	},
 /obj/structure/chair/office{
 	anchored = 1;
-	can_buckle = 0;
 	dir = 8;
 	pixel_x = -5;
 	pixel_y = 22
@@ -8573,7 +8555,6 @@
 	},
 /obj/structure/chair/office{
 	anchored = 1;
-	can_buckle = 0;
 	dir = 4;
 	pixel_x = 6;
 	pixel_y = 6
@@ -8757,7 +8738,6 @@
 /area/facility_hallway/south)
 "zc" = (
 /obj/structure/chair/comfy/lime{
-	can_buckle = 0;
 	dir = 1;
 	pixel_y = 11
 	},
@@ -9217,7 +9197,6 @@
 /area/department_main/training)
 "Ak" = (
 /obj/structure/chair/comfy/brown{
-	can_buckle = 0;
 	dir = 1;
 	pixel_y = 9
 	},
@@ -9978,7 +9957,6 @@
 	},
 /obj/structure/chair/office/light{
 	anchored = 1;
-	can_buckle = 0;
 	dir = 8;
 	pixel_x = -7;
 	pixel_y = 4
@@ -13460,7 +13438,6 @@
 	dir = 8
 	},
 /obj/structure/chair/sofa/right{
-	can_buckle = 0;
 	dir = 8;
 	pixel_x = -5
 	},
@@ -14579,7 +14556,6 @@
 "PO" = (
 /obj/effect/turf_decal/siding/thinplating/corner,
 /obj/structure/chair/comfy/lime{
-	can_buckle = 0;
 	dir = 1;
 	pixel_y = 11
 	},
@@ -14897,7 +14873,6 @@
 	dir = 1
 	},
 /obj/structure/chair/comfy/brown{
-	can_buckle = 0;
 	dir = 1;
 	pixel_y = 12
 	},
@@ -15525,7 +15500,6 @@
 "SM" = (
 /obj/structure/chair/office/light{
 	anchored = 1;
-	can_buckle = 0;
 	dir = 1;
 	pixel_y = 4
 	},
@@ -16130,7 +16104,6 @@
 	dir = 1
 	},
 /obj/structure/chair/sofa/right{
-	can_buckle = 0;
 	dir = 8;
 	pixel_x = -5
 	},
@@ -17123,7 +17096,6 @@
 	},
 /obj/structure/chair/office{
 	anchored = 1;
-	can_buckle = 0;
 	dir = 8;
 	pixel_x = -6;
 	pixel_y = 6
@@ -17198,7 +17170,6 @@
 	},
 /obj/structure/chair/office{
 	anchored = 1;
-	can_buckle = 0;
 	dir = 8;
 	pixel_x = -6;
 	pixel_y = 6

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -116,10 +116,14 @@
 /obj/structure/chair/post_buckle_mob(mob/living/M)
 	. = ..()
 	handle_layer()
+	M.pixel_x += pixel_x // LOBOTOMYCORPORATION ADDITION -- BETTER CHAIRS FOR MAPPERS
+	M.pixel_y += pixel_y
 
-/obj/structure/chair/post_unbuckle_mob()
+/obj/structure/chair/post_unbuckle_mob(mob/living/M)
 	. = ..()
 	handle_layer()
+	M.pixel_x -= pixel_x // LOBOTOMYCORPORATION ADDITION -- BETTER CHAIRS FOR MAPPERS
+	M.pixel_y -= pixel_y
 
 /obj/structure/chair/setDir(newdir)
 	..()


### PR DESCRIPTION

## About The Pull Request

- Makes chairs add their pixel_x and pixel_y values to you when buckling, and removes them when unbuckling. Makes them correctly show your sprite even when mappers shift them
- Fixes a var being overriden on post_unbuckle() on chairs
- Removes randomly unbuckleable chairs from all maps
- Removes purposefully unbuckleable chairs from all maps

## Why It's Good For The Game

- Makes chairs add their pixel_x and pixel_y values to you when buckling, and removes them when unbuckling. Makes them correctly show your sprite even when mappers shift them
> Moar flavor is always good, this encurages it.

- Fixes a var being overriden on post_unbuckle() on chairs
> I dunno, TG moment or something. Noticed it as i needed it

- Removes randomly unbuckleable chairs from all maps
> I have no idea why some random chairs were just unbuckleable, regex fixes all

- Removes purposefully unbuckleable chairs from all maps
> Now that characters sprites shift with the chairs, there's no reason to have them be blocking buckling anymore

## Changelog
:cl:
fix: fixes mappers making chairs unbuckleable (a well known bug)
/:cl:
