### PR TITLE
Disabling Atmospherics Subsystem Hotfix

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -65,11 +65,11 @@
 
 /mob/living/carbon/human/handle_mutations_and_radiation()
 	if(!dna || !dna.species.handle_mutations_and_radiation(src))
-		..()
+		return ..()
 
 /mob/living/carbon/human/breathe()
 	if(!dna.species.breathe(src))
-		..()
+		return ..()
 
 /mob/living/carbon/human/check_breath(datum/gas_mixture/breath)
 

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -178,7 +178,6 @@
 			var/ratio = 1 - O2_partialpressure/safe_oxy_min
 			adjustOxyLoss(min(5*ratio, 3))
 			failed_last_breath = TRUE
-			//oxygen_used = breath_gases[/datum/gas/oxygen][MOLES]*ratio
 		else
 			adjustOxyLoss(3)
 			failed_last_breath = TRUE
@@ -188,13 +187,8 @@
 		failed_last_breath = FALSE
 		if(health >= crit_threshold)
 			adjustOxyLoss(-5)
-		//oxygen_used = breath_gases[/datum/gas/oxygen][MOLES]
 		clear_alert("not_enough_oxy")
-/*
-		This is the function that converts O2 into CO2.
-	breath_gases[/datum/gas/oxygen][MOLES] -= oxygen_used
-	breath_gases[/datum/gas/carbon_dioxide][MOLES] += oxygen_used
-*/
+
 	//CARBON DIOXIDE
 	if(CO2_partialpressure > safe_co2_max)
 		if(!co2overloadtime)
@@ -297,8 +291,7 @@
 
 //Fourth and final link in a breath chain
 /mob/living/carbon/proc/handle_breath_temperature(datum/gas_mixture/breath)
-	// The air you breathe out should match your body temperature
-	breath.temperature = bodytemperature
+	return
 
 /mob/living/carbon/proc/get_breath_from_internal(volume_needed)
 	if(internal)

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -157,8 +157,6 @@
 			H.clear_alert("not_enough_oxy")
 
 	//Exhale
-	breath_gases[/datum/gas/oxygen][MOLES] -= gas_breathed
-	breath_gases[/datum/gas/carbon_dioxide][MOLES] += gas_breathed
 	gas_breathed = 0
 
 	//-- Nitrogen --//
@@ -222,8 +220,6 @@
 			H.clear_alert("not_enough_co2")
 
 	//Exhale
-	breath_gases[/datum/gas/carbon_dioxide][MOLES] -= gas_breathed
-	breath_gases[/datum/gas/oxygen][MOLES] += gas_breathed
 	gas_breathed = 0
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Air was still being removed from turf due to assume_air. Bit embaressing that i didnt notice this during testing.
Im not sure what i removed initially but my goal right now is to prevent air being removed from turfs while allowing it to be taken from internal tanks.

Testing went smoothly air is no longer removed from the enviorment from mob/life() or lungs. Internal tanks still function if we ever want to utilize those. If this wasnt a hotfix id refactor simple animal air breathing since simple mobs dont take oxygen but register how much is in the turf.

Since crit damage is connected to breathing i had to check that too and noticed it took a very long time to expire from crit damage.
After returning to a code before my PR i found that crit is just very slow.

## Changelog
:cl:
fix: carbon/life
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
