### PR TITLE
Weapon rebalance 07 24

### DIFF
--- a/code/game/objects/items/ego_weapons/aleph.dm
+++ b/code/game/objects/items/ego_weapons/aleph.dm
@@ -178,7 +178,7 @@
 							JUSTICE_ATTRIBUTE = 80
 							)
 
-	wielded_force = 70
+	wielded_force = 80
 	should_slow = TRUE
 	wielded_slow_down = 1.5
 

--- a/code/game/objects/items/ego_weapons/aleph.dm
+++ b/code/game/objects/items/ego_weapons/aleph.dm
@@ -155,7 +155,7 @@
 /obj/item/ego_weapon/da_capo/get_clamped_volume()
 	return 40
 
-/obj/item/ego_weapon/wield/mimicry
+/obj/item/ego_weapon/mimicry
 	name = "mimicry"
 	desc = "The yearning to imitate the human form is sloppily reflected on the E.G.O, \
 	as if it were a reminder that it should remain a mere desire."
@@ -165,7 +165,7 @@
 	righthand_file = 'icons/mob/inhands/64x64_righthand.dmi'
 	inhand_x_dimension = 64
 	inhand_y_dimension = 64
-	force = 55
+	force = 65
 	damtype = RED_DAMAGE
 	swingstyle = WEAPONSWING_LARGESWEEP
 	attack_verb_continuous = list("slashes", "slices", "rips", "cuts")
@@ -178,9 +178,6 @@
 							JUSTICE_ATTRIBUTE = 80
 							)
 
-	wielded_force = 80
-	should_slow = TRUE
-	wielded_slow_down = 1.5
 
 /obj/item/ego_weapon/mimicry/attack(mob/living/target, mob/living/carbon/human/user)
 	if(!CanUseEgo(user))

--- a/code/game/objects/items/ego_weapons/aleph.dm
+++ b/code/game/objects/items/ego_weapons/aleph.dm
@@ -112,6 +112,7 @@
 	icon_state = "da_capo"
 	force = 40 // It attacks very fast
 	attack_speed = 0.5
+	swingstyle = WEAPONSWING_LARGESWEEP
 	damtype = WHITE_DAMAGE
 	attack_verb_continuous = list("slashes", "slices", "rips", "cuts")
 	attack_verb_simple = list("slash", "slice", "rip", "cut")
@@ -154,7 +155,7 @@
 /obj/item/ego_weapon/da_capo/get_clamped_volume()
 	return 40
 
-/obj/item/ego_weapon/mimicry
+/obj/item/ego_weapon/wield/mimicry
 	name = "mimicry"
 	desc = "The yearning to imitate the human form is sloppily reflected on the E.G.O, \
 	as if it were a reminder that it should remain a mere desire."
@@ -164,8 +165,9 @@
 	righthand_file = 'icons/mob/inhands/64x64_righthand.dmi'
 	inhand_x_dimension = 64
 	inhand_y_dimension = 64
-	force = 70
+	force = 55
 	damtype = RED_DAMAGE
+	swingstyle = WEAPONSWING_LARGESWEEP
 	attack_verb_continuous = list("slashes", "slices", "rips", "cuts")
 	attack_verb_simple = list("slash", "slice", "rip", "cut")
 	hitsound = 'sound/abnormalities/nothingthere/attack.ogg'
@@ -175,6 +177,10 @@
 							TEMPERANCE_ATTRIBUTE = 80,
 							JUSTICE_ATTRIBUTE = 80
 							)
+
+	wielded_force = 70
+	should_slow = TRUE
+	wielded_slow_down = 1.5
 
 /obj/item/ego_weapon/mimicry/attack(mob/living/target, mob/living/carbon/human/user)
 	if(!CanUseEgo(user))
@@ -201,6 +207,7 @@
 	icon_state = "twilight"
 	worn_icon_state = "twilight"
 	force = 35
+	swingstyle = WEAPONSWING_LARGESWEEP
 	damtype = RED_DAMAGE // It's all damage types, actually
 	attack_verb_continuous = list("slashes", "slices", "rips", "cuts")
 	attack_verb_simple = list("slash", "slice", "rip", "cut")
@@ -328,6 +335,7 @@
 	icon_state = "rosered"
 	force = 80 //Less damage, can swap damage type
 	damtype = RED_DAMAGE
+	swingstyle = WEAPONSWING_LARGESWEEP
 	attack_verb_continuous = list("cuts", "slices")
 	attack_verb_simple = list("cuts", "slices")
 	hitsound = 'sound/weapons/ego/rapier2.ogg'
@@ -364,6 +372,7 @@
 	worn_icon_state = "censored"
 	force = 70	//there's a focus on the ranged attack here.
 	damtype = BLACK_DAMAGE
+	swingstyle = WEAPONSWING_THRUST
 	attack_verb_continuous = list("attacks")
 	attack_verb_simple = list("attack")
 	hitsound = 'sound/weapons/ego/censored1.ogg'
@@ -436,6 +445,7 @@
 	special = "Hitting enemies will mark them. Hitting marked enemies will give different buffs depending on attack type."
 	icon_state = "soulmate"
 	force = 40
+	swingstyle = WEAPONSWING_LARGESWEEP
 	damtype = RED_DAMAGE
 	attack_speed = 0.8
 	attack_verb_continuous = list("cuts", "slices")
@@ -545,6 +555,7 @@
 	icon_state = "space"
 	force = 50	//Half white, half black.
 	damtype = WHITE_DAMAGE
+	swingstyle = WEAPONSWING_LARGESWEEP
 	attack_verb_continuous = list("cuts", "attacks", "slashes")
 	attack_verb_simple = list("cut", "attack", "slash")
 	hitsound = 'sound/weapons/rapierhit.ogg'

--- a/code/game/objects/items/ego_weapons/he.dm
+++ b/code/game/objects/items/ego_weapons/he.dm
@@ -33,8 +33,9 @@
 	desc = "The last legacy of the man who sought wisdom. The rake tilled the human brain instead of farmland."
 	special = "Use this weapon in your hand to damage every non-human within reach."
 	icon_state = "harvest"
-	force = 30
+	force = 25
 	damtype = BLACK_DAMAGE
+	swingstyle = WEAPONSWING_LARGESWEEP
 	attack_verb_continuous = list("attacks", "bashes", "tills")
 	attack_verb_simple = list("attack", "bash", "till")
 	hitsound = 'sound/weapons/ego/harvest.ogg'
@@ -135,8 +136,9 @@
 	name = "life for a daredevil"
 	desc = "An ancient sword surrounded in death, yet it's having it in your grasp that makes you feel the most alive."
 	icon_state = "daredevil"
-	force = 12
+	force = 11
 	attack_speed = 0.5
+	swingstyle = WEAPONSWING_LARGESWEEP
 	damtype = PALE_DAMAGE
 	attack_verb_continuous = list("decimates", "bisects")
 	attack_verb_simple = list("decimate", "bisect")
@@ -365,6 +367,7 @@
 	special = "This weapon deals more damage the more allies you can see."
 	icon_state = "courage"
 	force = 10 //if 4 people are around, the weapon can deal up to 70 damage per strike, but alone it's a glorified baton.
+	swingstyle = WEAPONSWING_LARGESWEEP
 	damtype = RED_DAMAGE
 	attack_verb_continuous = list("slashes")
 	attack_verb_simple = list("slash")
@@ -484,6 +487,7 @@
 	desc = "Looks to be a fan blade with a handle welded to it."
 	icon_state = "metal"
 	force = 40
+	swingstyle = WEAPONSWING_LARGESWEEP
 	attack_speed = 1.5
 	damtype = RED_DAMAGE
 	attack_verb_continuous = list("slices", "cleaves", "chops")
@@ -599,8 +603,9 @@
 	desc = "Death, where is thy sting?"
 	special = "This weapon attacks faster when hitting targets below 50% health"
 	icon_state = "revelation"
-	force = 25
+	force = 22
 	attack_speed = 1.5
+	swingstyle = WEAPONSWING_LARGESWEEP
 	damtype = PALE_DAMAGE
 	attack_verb_continuous = list("slashes", "slices", "rips", "cuts")
 	attack_verb_simple = list("slash", "slice", "rip", "cut")
@@ -734,7 +739,7 @@
 	var/mode = "Spear"
 	var/list/mode_stats = list(
 		"Spear" = list("_sp", 42, 1, 2, list("pokes", "jabs"), list("poke", "jab"), 'sound/weapons/ego/spear1.ogg'),	//Now immobilizes you.
-		"Sword" = list("_sw", 25, 1, 1, list("slashes", "slices"), list("slash", "slice"), 'sound/weapons/bladeslice.ogg'),
+		"Sword" = list("_sw", 22, 1, 1, list("slashes", "slices"), list("slash", "slice"), 'sound/weapons/bladeslice.ogg'),
 		"Gauntlet" = list("_f", 50, 3, 1, list("crushes", "smashes"), list("crush", "smash"), 'sound/weapons/ego/strong_gauntlet.ogg')
 		)
 	var/windup = 0
@@ -751,10 +756,13 @@
 	switch(mode)
 		if("Spear")
 			mode = "Sword"
+			swingstyle = WEAPONSWING_LARGESWEEP
 		if("Sword")
 			mode = "Gauntlet"
+			swingstyle = WEAPONSWING_SMALLSWEEP
 		if("Gauntlet")
 			mode = "Spear"
+			swingstyle = WEAPONSWING_THRUST
 	to_chat(user, span_notice("[src] makes a whirling sound as it changes shape!"))
 	if(prob(5))
 		to_chat(user, span_notice("Do you love your city?"))
@@ -1200,7 +1208,8 @@
 	desc = "The elderly man showed a red thread connecting the young boy with his future lover. Disgusted at the sight, he ordered her to be executed."
 	special = "This weapon deals significantly more damage when attacking the same target repeatedly."
 	icon_state = "destiny"
-	force = 12
+	force = 11
+	swingstyle = WEAPONSWING_LARGESWEEP
 	attack_speed = 0.5
 	damtype = RED_DAMAGE
 	attack_verb_continuous = list("stabs", "slashes", "attacks")
@@ -1719,7 +1728,8 @@
 	desc = "What seems to be a giant half of a scissors pair."
 	icon_state = "voodoo"
 	special = "This weapon can be paired with a second copy to use both at the same time."
-	force = 20
+	force = 18
+	swingstyle = WEAPONSWING_LARGESWEEP
 	attack_speed = 0.7
 	damtype = WHITE_DAMAGE
 	attack_verb_continuous = list("stabs", "slashes", "attacks")
@@ -1756,6 +1766,7 @@
 	inhand_x_dimension = 64
 	inhand_y_dimension = 64
 	force = 60
+	swingstyle = WEAPONSWING_LARGESWEEP
 	attack_speed = 3
 	damtype = RED_DAMAGE
 	attack_verb_continuous = list("bashes", "clubs")

--- a/code/game/objects/items/ego_weapons/he.dm
+++ b/code/game/objects/items/ego_weapons/he.dm
@@ -117,8 +117,9 @@
 	name = "bear paw"
 	desc = "The paws made form, and given life."
 	icon_state = "bear_paw"
-	force = 12
-	attack_speed = 0.3
+	force = 17
+	attack_speed = 0.5
+	swingstyle = WEAPONSWING_LARGESWEEP
 	damtype = RED_DAMAGE
 	attack_verb_continuous = list("punches", "jabs", "slaps")
 	attack_verb_simple = list("punches", "jabs", "slaps")
@@ -501,8 +502,9 @@
 	name = "alleyway"
 	desc = "It's a small knife forged of black metal."
 	icon_state = "alleyway"
-	force = 9
-	attack_speed = 0.3
+	force = 17
+	attack_speed = 0.5
+	swingstyle = WEAPONSWING_LARGESWEEP
 	damtype = BLACK_DAMAGE
 	attack_verb_continuous = list("slices", "cleaves", "chops")
 	attack_verb_simple = list("slice", "cleave", "chop")
@@ -945,6 +947,7 @@
 	icon_state = "sanguine"
 	force = 40//about 1.3x the average dps
 	attack_speed = 1
+	swingstyle = WEAPONSWING_LARGESWEEP
 	damtype = RED_DAMAGE
 	attack_verb_continuous = list("hacks", "slashes", "attacks")
 	attack_verb_simple = list("hack", "slash", "attack")
@@ -1122,7 +1125,8 @@
 	righthand_file = 'icons/mob/inhands/64x64_righthand.dmi'
 	inhand_x_dimension = 64
 	inhand_y_dimension = 64
-	force = 24
+	force = 23
+	swingstyle = WEAPONSWING_LARGESWEEP
 	attack_speed = 0.8
 	reach = 1
 	stuntime = 0

--- a/code/game/objects/items/ego_weapons/non_abnormality/dawn.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/dawn.dm
@@ -6,6 +6,7 @@
 	icon_state = "philip"
 	inhand_icon_state = "philip"
 	damtype = RED_DAMAGE
+	swingstyle = WEAPONSWING_LARGESWEEP
 
 	attack_verb_continuous = list("bashes", "crushes")
 	attack_verb_simple = list("bash", "crush")
@@ -52,6 +53,7 @@
 	force = 40		//Bigger range, less force
 	attack_speed = 1.5
 	aoe_range = 5
+	swingstyle = WEAPONSWING_SMALLSWEEP
 
 //Salvador's Zweihander
 /obj/item/ego_weapon/city/dawn/zwei

--- a/code/game/objects/items/ego_weapons/non_abnormality/gradeone.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/gradeone.dm
@@ -8,6 +8,7 @@
 	force = 60
 	attack_speed = 0.8
 	damtype = RED_DAMAGE
+	swingstyle = WEAPONSWING_LARGESWEEP
 
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb_continuous = list("attacks", "slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "cuts")

--- a/code/game/objects/items/ego_weapons/non_abnormality/index.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/index.dm
@@ -8,6 +8,7 @@
 	inhand_icon_state = "index"
 	force = 37
 	damtype = PALE_DAMAGE
+	swingstyle = WEAPONSWING_LARGESWEEP
 
 	attack_verb_continuous = list("smacks", "hammers", "beats")
 	attack_verb_simple = list("smack", "hammer", "beat")
@@ -108,6 +109,7 @@
 	hitsound = 'sound/weapons/fixer/generic/nail1.ogg'
 	attack_speed = 1.2
 	reach = 2
+	swingstyle = WEAPONSWING_THRUST
 
 //Fockin massive sword
 /obj/item/ego_weapon/city/index/yan

--- a/code/game/objects/items/ego_weapons/non_abnormality/jcorp.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/jcorp.dm
@@ -48,6 +48,7 @@
 	icon_state = "tingtang_knife"
 	inhand_icon_state = "tingtang_knife"
 	force = 37
+	swingstyle = WEAPONSWING_LARGESWEEP
 	attack_speed = 1
 	hitsound = 'sound/weapons/fixer/generic/knife1.ogg'
 	attribute_requirements = list(

--- a/code/game/objects/items/ego_weapons/non_abnormality/jeong.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/jeong.dm
@@ -8,6 +8,7 @@
 	force = 30
 	attack_speed = 0.7
 	damtype = BLACK_DAMAGE
+	swingstyle = WEAPONSWING_LARGESWEEP
 
 	attack_verb_continuous = list("slices", "stabs")
 	attack_verb_simple = list("slice", "stab")

--- a/code/game/objects/items/ego_weapons/non_abnormality/limbus_ego.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/limbus_ego.dm
@@ -53,8 +53,9 @@
 	inhand_icon_state = "shiv"
 	lefthand_file = 'icons/mob/inhands/weapons/swords_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
-	force = 25
+	force = 24
 	attack_speed = 0.5 //this shit goes FAST
+	swingstyle = WEAPONSWING_LARGESWEEP
 	damtype = WHITE_DAMAGE
 	attack_verb_continuous = list("stabs", "slices", "rips", "shanks")
 	attack_verb_simple = list("stab", "slice", "rip", "shank")

--- a/code/game/objects/items/ego_weapons/non_abnormality/limbus_sinner.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/limbus_sinner.dm
@@ -32,9 +32,10 @@
 	icon = 'icons/obj/limbus_weapons.dmi'
 	lefthand_file = 'icons/mob/inhands/weapons/limbus_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/limbus_righthand.dmi'
-	force = 35
+	force = 33
 	attack_speed = 1.6
 	damtype = WHITE_DAMAGE
+	swingstyle = WEAPONSWING_LARGESWEEP
 
 	attack_verb_continuous = list("cuts", "smacks", "bashes")
 	attack_verb_simple = list("cuts", "smacks", "bashes")
@@ -75,9 +76,10 @@
 	lefthand_file = 'icons/mob/inhands/weapons/limbus_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/limbus_righthand.dmi'
 	hitsound = 'sound/weapons/bladeslice.ogg'
-	force = 13
+	force = 12
 	attack_speed = 0.5
 	damtype = BLACK_DAMAGE
+	swingstyle = WEAPONSWING_LARGESWEEP
 
 	attack_verb_continuous = list("pokes", "jabs", "tears", "lacerates", "gores")
 	attack_verb_simple = list("poke", "jab", "tear", "lacerate", "gore")
@@ -226,8 +228,9 @@
 	icon = 'icons/obj/limbus_weapons.dmi'
 	lefthand_file = 'icons/mob/inhands/weapons/limbus_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/limbus_righthand.dmi'
-	force = 20
+	force = 19
 	damtype = RED_DAMAGE
+	swingstyle = WEAPONSWING_LARGESWEEP
 
 	attack_speed = 0.8
 	attack_verb_continuous = list("cuts", "slices")

--- a/code/game/objects/items/ego_weapons/non_abnormality/liu.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/liu.dm
@@ -28,6 +28,7 @@
 							TEMPERANCE_ATTRIBUTE = 40,
 							JUSTICE_ATTRIBUTE = 40
 							)
+	swingstyle = WEAPONSWING_LARGESWEEP
 
 /obj/item/ego_weapon/city/liu/fire/examine(mob/user)
 	. = ..()
@@ -55,6 +56,7 @@
 							TEMPERANCE_ATTRIBUTE = 60,
 							JUSTICE_ATTRIBUTE = 60
 							)
+	swingstyle = WEAPONSWING_SMALLSWEEP
 
 /obj/item/ego_weapon/city/liu/fire/spear
 	name = "liu spear"
@@ -69,6 +71,7 @@
 							TEMPERANCE_ATTRIBUTE = 60,
 							JUSTICE_ATTRIBUTE = 80
 							)
+	swingstyle = WEAPONSWING_THRUST
 
 
 /obj/item/ego_weapon/city/liu/fire/sword
@@ -82,6 +85,7 @@
 							TEMPERANCE_ATTRIBUTE = 100,
 							JUSTICE_ATTRIBUTE = 100
 							)
+	swingstyle = WEAPONSWING_LARGESWEEP
 
 
 

--- a/code/game/objects/items/ego_weapons/non_abnormality/miscfixer.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/miscfixer.dm
@@ -22,24 +22,26 @@
 	name = "fixer blade"
 	desc = "A common fixer blade, mass-produced and easy to use."
 	icon_state = "fixer_blade"
-	force = 22
+	force = 20
 	damtype = RED_DAMAGE
 
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb_continuous = list("attacks", "slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "cuts")
 	attack_verb_simple = list("attack", "slash", "stab", "slice", "tear", "lacerate", "rip", "dice", "cut")
+	swingstyle = WEAPONSWING_LARGESWEEP
 
 /obj/item/ego_weapon/city/fixergreatsword
 	name = "fixer greatsword"
 	desc = "A heftier variant of the more common fixer blade."
 	icon_state = "fixer_greatsword"
-	force = 38
+	force = 36
 	attack_speed = 2
 	damtype = RED_DAMAGE
 
 	hitsound = 'sound/weapons/genhit3.ogg'
 	attack_verb_continuous = list("attacks", "slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "cuts")
 	attack_verb_simple = list("attack", "slash", "stab", "slice", "tear", "lacerate", "rip", "dice", "cut")
+	swingstyle = WEAPONSWING_LARGESWEEP
 
 /obj/item/ego_weapon/city/fixerhammer
 	name = "fixer hammer"

--- a/code/game/objects/items/ego_weapons/non_abnormality/molar.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/molar.dm
@@ -32,7 +32,7 @@
 	name = "molar chainknife"
 	desc = "A short chainsword used by the Molar Office's leader. Its chain sings with the speed it moves at."
 	icon_state = "olga"
-	force = 38
+	force = 37
 	attack_speed = 0.7
 	attribute_requirements = list(
 							FORTITUDE_ATTRIBUTE = 100,
@@ -40,3 +40,4 @@
 							TEMPERANCE_ATTRIBUTE = 60,	//She's got bad temperance, get it? Because temperance is another word for not drinking alcohol?
 							JUSTICE_ATTRIBUTE = 80
 							)
+	swingstyle = WEAPONSWING_LARGESWEEP

--- a/code/game/objects/items/ego_weapons/non_abnormality/pierre.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/pierre.dm
@@ -5,8 +5,9 @@
 	desc = "A cleaver found in the backstreets of district 23. This one is rusted, but still performs it's functions."
 	special = "This weapon heals you on hit."
 	icon_state = "jack"
-	force = 30
+	force = 28
 	attack_speed = 2
+	swingstyle = WEAPONSWING_LARGESWEEP
 	damtype = RED_DAMAGE
 
 	attack_verb_continuous = list("cleavess", "cuts")
@@ -31,7 +32,7 @@
 	name = "district 23 carving knife"
 	desc = "A carving knife found in the backstreets of district 23. This one is rusted, and seems to require a bit of skill to wield.."
 	icon_state = "pierre"
-	force = 26
+	force = 24
 	attack_speed = 1
 	attack_verb_continuous = list("slashes", "slices", "rips", "cuts")
 	attack_verb_simple = list("slash", "slice", "rip", "cut")

--- a/code/game/objects/items/ego_weapons/non_abnormality/rats.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/rats.dm
@@ -13,8 +13,9 @@
 	name = "rat combat knife"
 	desc = "A combat knife sometimes found in the hands of rats. This one belonged to a rat who once had a dream of something bigger."
 	icon_state = "ratknife"
-	force = 10
+	force = 9
 	attack_speed = 0.5
+	swingstyle = WEAPONSWING_LARGESWEEP
 	attack_verb_continuous = list("slices", "slashes", "stabs")
 	attack_verb_simple = list("slice", "slash", "stab")
 	hitsound = 'sound/weapons/bladeslice.ogg'

--- a/code/game/objects/items/ego_weapons/non_abnormality/seven.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/seven.dm
@@ -13,8 +13,9 @@
 				Use weapon in hand to see stored target, and its current health."
 	icon_state = "sevenassociation"
 	inhand_icon_state = "sevenassociation"
-	force = 38
+	force = 36
 	damtype = BLACK_DAMAGE
+	swingstyle = WEAPONSWING_LARGESWEEP
 
 	var/stored_target
 	var/stored_target_hp

--- a/code/game/objects/items/ego_weapons/non_abnormality/shi.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/shi.dm
@@ -6,8 +6,9 @@
 	desc = "A blade that is used by Shi Section 2 assassins to go out with honour."
 	special = "Attack yourself with this weapon to instantly kill yourself."
 	icon_state = "shi_dagger"
-	force = 44
+	force = 40
 	damtype = RED_DAMAGE
+	swingstyle = WEAPONSWING_LARGESWEEP
 
 	attack_verb_continuous = list("pokes", "jabs", "tears", "lacerates", "gores")
 	attack_verb_simple = list("poke", "jab", "tear", "lacerate", "gore")
@@ -43,9 +44,10 @@
 	desc = "A blade that is used by Shi Section 2."
 	special = "Use this weapon in hand to immobilize yourself for 1 second, cut your HP by 25%, and deal 2x damage in pale."
 	icon_state = "shiassassin"
-	force = 44
+	force = 42
 	attack_speed = 1.2
 	damtype = RED_DAMAGE
+	swingstyle = WEAPONSWING_LARGESWEEP
 
 	attack_verb_continuous = list("pokes", "jabs", "tears", "lacerates", "gores")
 	attack_verb_simple = list("poke", "jab", "tear", "lacerate", "gore")
@@ -100,7 +102,7 @@
 	name = "shi association veteran sheathed blade"
 	desc = "A blade that is used by Shi Section 2 veterans. It's extremely sharp."
 	icon_state = "shiassassin_vet"
-	force = 52
+	force = 50
 	attribute_requirements = list(
 							FORTITUDE_ATTRIBUTE = 80,
 							PRUDENCE_ATTRIBUTE = 80,
@@ -113,7 +115,7 @@
 	name = "shi association director sheathed blade"
 	desc = "A blade that is used by Shi Section 2 directors. It's extremely sharp."
 	icon_state = "shiassassin_director"
-	force = 65
+	force = 63
 	attribute_requirements = list(
 							FORTITUDE_ATTRIBUTE = 80,
 							PRUDENCE_ATTRIBUTE = 100,
@@ -139,7 +141,7 @@
 /obj/item/ego_weapon/city/shi_assassin/yokai
 	name = "shi association yokai blade"
 	desc = "A unique specialized assassin blade that is used by Shi Section 2. Created for highly armored targets, this one deals pale damage"
-	force = 20
+	force = 18
 	icon_state = "shi_yokai"
 	damtype = PALE_DAMAGE
 

--- a/code/game/objects/items/ego_weapons/non_abnormality/streetlight.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/streetlight.dm
@@ -4,8 +4,9 @@
 	name = "streetlight greatsword"
 	desc = "A greatsword used by a fixer with big shoes to fill.'Maybe... I should have told her how I felt.'"
 	icon_state = "streetlight_greatsword"
-	force = 38
+	force = 36
 	attack_speed = 2
+	swingstyle = WEAPONSWING_LARGESWEEP
 	damtype = RED_DAMAGE
 
 	inhand_icon_state = "claymore"
@@ -42,6 +43,7 @@
 	inhand_icon_state = "streetlight_founder"
 	force = 32
 	damtype = BLACK_DAMAGE
+	swingstyle = WEAPONSWING_SMALLSWEEP
 
 	attack_verb_continuous = list("bashes", "crushes")
 	attack_verb_simple = list("bash", "crush")

--- a/code/game/objects/items/ego_weapons/non_abnormality/syndicate.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/syndicate.dm
@@ -38,6 +38,7 @@
 	force = 52
 	attack_speed = 1.2
 	damtype = RED_DAMAGE
+	swingstyle = WEAPONSWING_LARGESWEEP
 
 	attack_verb_continuous = list("pokes", "jabs", "tears", "lacerates", "gores")
 	attack_verb_simple = list("poke", "jab", "tear", "lacerate", "gore")
@@ -84,6 +85,7 @@
 	force = 46
 	attack_speed = 1.2
 	damtype = RED_DAMAGE
+	swingstyle = WEAPONSWING_LARGESWEEP
 
 	attack_verb_continuous = list("pokes", "jabs", "tears", "lacerates", "gores")
 	attack_verb_simple = list("poke", "jab", "tear", "lacerate", "gore")

--- a/code/game/objects/items/ego_weapons/non_abnormality/wcorp.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/wcorp.dm
@@ -50,7 +50,7 @@
 	desc = "A glowing blue axe used by senior W corp staff."
 	icon_state = "wcorp_axe"
 	inhand_icon_state = "wcorp_axe"
-	force = 70
+	force = 67
 	attack_speed = 2
 	attack_verb_continuous = list("cleaves", "cuts")
 	attack_verb_simple = list("cleave", "cut")
@@ -64,6 +64,7 @@
 	charge_cost = 4
 	charge_effect = "deal 3x damage and slow your next attack down."
 	successfull_activation = "You release your charge, attempting to execute your opponent!"
+	swingstyle = WEAPONSWING_LARGESWEEP
 
 /obj/item/ego_weapon/city/wcorp/axe/ChargeAttack(mob/living/target, mob/living/user)
 	. = ..()
@@ -112,7 +113,7 @@
 	desc = "A glowing blue dagger used by senior W corp staff."
 	icon_state = "wcorp_dagger"
 	inhand_icon_state = "wcorp_dagger"
-	force = 24
+	force = 22
 	attack_speed = 0.5
 
 	attack_verb_continuous = list("slices", "stabs")
@@ -123,6 +124,7 @@
 							TEMPERANCE_ATTRIBUTE = 80,
 							JUSTICE_ATTRIBUTE = 60
 							)
+	swingstyle = WEAPONSWING_LARGESWEEP
 
 	charge_cost = 8
 	charge_effect = "rip the space itself!"
@@ -154,6 +156,7 @@
 	inhand_y_dimension = 64
 	force = 34	//Slowing is massive.
 	attack_speed = 1
+	swingstyle = WEAPONSWING_LARGESWEEP
 	attack_verb_continuous = list("cleaves", "slashes", "carves")
 	attack_verb_simple = list("cleave", "slash", "carve")
 	attribute_requirements = list(

--- a/code/game/objects/items/ego_weapons/non_abnormality/yun.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/yun.dm
@@ -18,6 +18,7 @@
 	attack_verb_continuous = list("slices", "slashes", "stabs")
 	attack_verb_simple = list("slice", "slash", "stab")
 	hitsound = 'sound/weapons/bladeslice.ogg'
+	swingstyle = WEAPONSWING_LARGESWEEP
 
 /obj/item/ego_weapon/city/yun/chainsaw
 	name = "yun office chainsword"

--- a/code/game/objects/items/ego_weapons/non_abnormality/zwei.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/zwei.dm
@@ -10,6 +10,7 @@
 	force = 55
 	attack_speed = 2
 	damtype = RED_DAMAGE
+	swingstyle = WEAPONSWING_LARGESWEEP
 
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb_continuous = list("attacks", "slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "cuts")

--- a/code/game/objects/items/ego_weapons/teth.dm
+++ b/code/game/objects/items/ego_weapons/teth.dm
@@ -109,7 +109,7 @@
 	desc = "The flesh cleanly cut by a sharp tool creates a grotesque pattern with the bloodstains on the suit."
 	special = "Upon throwing, this weapon returns to the user."
 	icon_state = "blossoms"
-	force = 15
+	force = 17
 	swingstyle = WEAPONSWING_LARGESWEEP
 	throwforce = 30
 	throw_speed = 1

--- a/code/game/objects/items/ego_weapons/teth.dm
+++ b/code/game/objects/items/ego_weapons/teth.dm
@@ -197,8 +197,9 @@
 	name = "magic bean"
 	desc = "We may never find out what lies at the top, but perhaps those who made it are doing well up there."
 	icon_state = "bean"
-	force = 20
+	force = 18
 	damtype = BLACK_DAMAGE
+	swingstyle = WEAPONSWING_LARGESWEEP
 	attack_verb_continuous = list("slices", "slashes", "stabs")
 	attack_verb_simple = list("slice", "slash", "stab")
 	hitsound = 'sound/weapons/fixer/generic/knife3.ogg'

--- a/code/game/objects/items/ego_weapons/teth.dm
+++ b/code/game/objects/items/ego_weapons/teth.dm
@@ -74,8 +74,9 @@
 	desc = "The flesh cleanly cut by a sharp tool creates a grotesque pattern with the bloodstains on the suit."
 	special = "Use this weapon in hand to dodgeroll."
 	icon_state = "wrist"
-	force = 7
-	attack_speed = 0.3
+	force = 12
+	attack_speed = 0.5
+	swingstyle = WEAPONSWING_LARGESWEEP
 	damtype = WHITE_DAMAGE
 	hitsound = 'sound/weapons/fixer/generic/knife2.ogg'
 	var/dodgelanding
@@ -108,7 +109,8 @@
 	desc = "The flesh cleanly cut by a sharp tool creates a grotesque pattern with the bloodstains on the suit."
 	special = "Upon throwing, this weapon returns to the user."
 	icon_state = "blossoms"
-	force = 17
+	force = 15
+	swingstyle = WEAPONSWING_LARGESWEEP
 	throwforce = 30
 	throw_speed = 1
 	throw_range = 7
@@ -132,13 +134,15 @@
 	force = 13
 	attack_speed = 0.5
 	damtype = RED_DAMAGE
+	swingstyle = WEAPONSWING_LARGESWEEP
 	hitsound = 'sound/weapons/slashmiss.ogg'
 
 /obj/item/ego_weapon/mini/trick
 	name = "hat trick"
 	desc = "Imagination is the only weapon in the war with reality."
 	icon_state = "trick"
-	force = 16
+	force = 15
+	swingstyle = WEAPONSWING_LARGESWEEP
 	throwforce = 35		//You can only hold 4 so go nuts.
 	throw_speed = 5
 	throw_range = 7
@@ -450,6 +454,7 @@
 	icon_state = "fourleaf_clover"
 	force = 12
 	attack_speed = 0.5
+	swingstyle = WEAPONSWING_LARGESWEEP
 	damtype = RED_DAMAGE
 	attack_verb_continuous = list("slices", "slashes", "stabs")
 	attack_verb_simple = list("slice", "slash", "stab")

--- a/code/game/objects/items/ego_weapons/waw.dm
+++ b/code/game/objects/items/ego_weapons/waw.dm
@@ -100,6 +100,7 @@
 	special = "Use in hand to unlock its full power."
 	icon_state = "totalitarianism"
 	force = 80
+	swingstyle = WEAPONSWING_LARGESWEEP
 	attack_speed = 3
 	damtype = RED_DAMAGE
 	attack_verb_continuous = list("cleaves", "cuts")
@@ -130,6 +131,7 @@
 	special = "This weapon builds up charge on every hit. Use the weapon in hand to charge the blade."
 	icon_state = "oppression"
 	force = 13
+	swingstyle = WEAPONSWING_LARGESWEEP
 	attack_speed = 0.3
 	damtype = BLACK_DAMAGE
 	attack_verb_continuous = list("cleaves", "cuts")
@@ -220,7 +222,8 @@
 	special = "Use it in hand to activate ranged attack."
 	icon_state = "crimsonclaw"
 	special = "This weapon hits faster than usual."
-	force = 18
+	force = 17
+	swingstyle = WEAPONSWING_LARGESWEEP
 	attack_speed = 0.5
 	damtype = RED_DAMAGE
 	hitsound = 'sound/abnormalities/redhood/attack_1.ogg'
@@ -325,7 +328,8 @@
 	desc = "Time flows as life does, and life goes as time does."
 	special = "This weapon deals an absurd amount of damage on the 13th hit."
 	icon_state = "thirteen"
-	force = 30
+	force = 28
+	swingstyle = WEAPONSWING_LARGESWEEP
 	damtype = PALE_DAMAGE
 	attack_verb_continuous = list("cuts", "attacks", "slashes")
 	attack_verb_simple = list("cut", "attack", "slash")
@@ -1006,8 +1010,9 @@
 	desc = "Look on my Works, ye Mighty, and despair!"
 	special = "This weapon can remove petrification."
 	icon_state = "pharaoh"
-	force = 20
+	force = 19
 	attack_speed = 0.5
+	swingstyle = WEAPONSWING_LARGESWEEP
 	damtype = WHITE_DAMAGE
 	attack_verb_continuous = list("decimates", "bisects")
 	attack_verb_simple = list("decimate", "bisect")
@@ -1128,7 +1133,8 @@
 	desc = "Many employees have sustained injuries from erroneous calculation."
 	special = "This weapon deals double damage to targets under 20% HP."
 	icon_state = "diffraction"
-	force = 40
+	force = 35
+	swingstyle = WEAPONSWING_LARGESWEEP
 	damtype = WHITE_DAMAGE
 	attack_verb_continuous = list("slices", "cuts")
 	attack_verb_simple = list("slice", "cut")
@@ -1561,6 +1567,7 @@
 	icon_state = "cobalt"
 	force = 24
 	attack_speed = 0.5
+	swingstyle = WEAPONSWING_LARGESWEEP
 	damtype = RED_DAMAGE
 	attack_verb_continuous = list("claws")
 	attack_verb_simple = list("claw")
@@ -1687,8 +1694,9 @@
 	desc = "It was a good day to die, but everybody did."
 	special = "Upon throwing, this weapon returns to the user. Throwing will activate the charge effect."
 	icon_state = "warring2"
-	force = 30
+	force = 28
 	attack_speed = 0.8
+	swingstyle = WEAPONSWING_LARGESWEEP
 	throwforce = 55
 	throw_speed = 1
 	throw_range = 7
@@ -2003,8 +2011,9 @@
 	special = "This weapon has a combo system ending with a dive attack. To turn off this combo system, use in hand. \
 			This weapon has a fast attack speed"
 	icon_state = "abyssal_route"
-	force = 20
+	force = 18
 	damtype = BLACK_DAMAGE
+	swingstyle = WEAPONSWING_LARGESWEEP
 	attack_verb_continuous = list("stabs", "attacks", "slashes")
 	attack_verb_simple = list("stab", "attack", "slash")
 	hitsound = 'sound/weapons/ego/rapier1.ogg'


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
All slashing swords (Not Rapiers), scythes, daggers, Claws and some axes now do a 3 tile swing instead of a 1 tile swing. Their damage has been decreased slightly in exchange

This affects around 30 weapons.

## Why It's Good For The Game
Weapons that should slash, now slash
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: weapons that should slash, now do slash
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
