### PR TITLE
Quiet day fixes and improvements

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/zayin/quiet_day.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/quiet_day.dm
@@ -161,7 +161,7 @@
 		if(ABNORMALITY_WORK_INSTINCT)
 			for(var/line in war_story)
 				say(line)
-				SLEEP_CHECK_DEATH(50)
+				SLEEP_CHECK_DEATH(5 SECONDS)
 				if(!PlayerInView(user))
 					ResetIcon()
 					return
@@ -169,7 +169,7 @@
 		if(ABNORMALITY_WORK_INSIGHT)
 			for(var/line in parable)
 				say(line)
-				SLEEP_CHECK_DEATH(50)
+				SLEEP_CHECK_DEATH(5 SECONDS)
 				if(!PlayerInView(user))
 					ResetIcon()
 					return
@@ -177,22 +177,19 @@
 		if(ABNORMALITY_WORK_ATTACHMENT)
 			for(var/line in wife)
 				say(line)
-				SLEEP_CHECK_DEATH(50)
+				SLEEP_CHECK_DEATH(5 SECONDS)
 				if(!PlayerInView(user))
 					ResetIcon()
 					return
 
 		if(ABNORMALITY_WORK_REPRESSION)
-			for(var/i=7, i>=1, i--)
-				var/current = pick(dementia)
-				dementia -= current
-				say(current)
-				SLEEP_CHECK_DEATH(50)
+			var/list/dementia_clone = dementia.Copy()
+			for(var/left_lines = 7, left_lines >= 1, left_lines--)
+				say(length(dementia_clone) > 1 ? pick_n_take(dementia_clone) : pick(dementia_clone)) // if the list has 1 object, dont remove it
+				SLEEP_CHECK_DEATH(5 SECONDS)
 				if(!PlayerInView(user))
-					dementia = initial(dementia)
 					ResetIcon()
 					return
-			dementia = initial(dementia)
 
 	TalkEnd(user)
 

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/quiet_day.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/quiet_day.dm
@@ -184,7 +184,7 @@
 
 		if(ABNORMALITY_WORK_REPRESSION)
 			var/list/dementia_clone = dementia.Copy()
-			for(var/left_lines = 7, left_lines >= 1, left_lines--)
+			for(var/i in 1 to 7)
 				say(length(dementia_clone) > 1 ? pick_n_take(dementia_clone) : pick(dementia_clone)) // if the list has 1 object, dont remove it
 				SLEEP_CHECK_DEATH(5 SECONDS)
 				if(!PlayerInView(user))


### PR DESCRIPTION

## About The Pull Request

- Makes Quiet day copy the dementia list instead of removing stuff from it and then doing `list = initial(list)` (this makes it have fewer lines and allows admins to change the list to their liking
- Changes accurances where time is mentioned to use the `SECONDS` define, for clearer code
- Adds safeties to make it so if for some reason quiet day's dementia list is below the wanted lines, it wont runtime

## Why It's Good For The Game

- Makes Quiet day copy the dementia list instead of removing stuff from it and then doing `list = initial(list)` (this makes it have fewer lines and allows admins to change the list to their liking
> Less code for more value is always good, the admin thing was a funny little benefit i didn't even think about when coding it

- Changes accurances where time is mentioned to use the `SECONDS` define, for clearer code
> Buh, muh code quality

- Adds safeties to make it so if for some reason quiet day's dementia list is below the wanted lines, it wont runtime
> Needed to add it because admins

## Changelog
:cl:
fix: Quiet day can now properly tell his repression story
admin: Admins can now make Quiet day say custom lines on his repression story by editing the list (im sorry)
/:cl:
