### PR TITLE
Records Officer Information Update[DONE AND FIXED]

### DIFF
--- a/ModularTegustation/tegu_items/abnoconsole_upgrades.dm
+++ b/ModularTegustation/tegu_items/abnoconsole_upgrades.dm
@@ -1,0 +1,51 @@
+/*
+* Work console upgrades.
+*/
+/obj/item/work_console_upgrade
+	name = "chemical extraction cell upgrade"
+	desc = "Attaches to the abnormality cell console of completely understood abnormalities and allows for the extraction of enkephalin-derived substances."
+	icon = 'ModularTegustation/Teguicons/teguitems.dmi'
+	icon_state = "abnochem_attachment"
+	var/upgrade_slot = ""
+
+/obj/item/work_console_upgrade/attack_obj(obj/O, mob/living/user)
+	if(istype(O, /obj/machinery/computer/abnormality))
+		var/obj/machinery/computer/abnormality/work_machine = O
+		to_chat(user, span_notice("You start attaching \the [O] to \the [src]..."))
+		if(!UpgradeReq(O, user))
+			return
+		work_machine.InstallUpgrade(src,upgrade_slot)
+		src.desc += "\n[src] installation successful."
+		playsound(get_turf(O), 'sound/effects/servostep.ogg', 50, TRUE)
+		return
+	return ..()
+
+/obj/item/work_console_upgrade/proc/UpgradeReq(obj/machinery/computer/abnormality/A, mob/living/installer)
+	if(!A)
+		return FALSE
+	if(A.mechanical_upgrades[upgrade_slot])
+		to_chat(installer, span_notice("Theres already a upgrade of this type installed."))
+		return FALSE
+	return TRUE
+
+//Upgrade Subtypes
+
+/obj/item/work_console_upgrade/chemical_extraction_attachment
+	name = "chemical extraction cell upgrade"
+	desc = "Attaches to the abnormality cell console of completely understood abnormalities and allows for the extraction of enkephalin-derived substances."
+	upgrade_slot = "abnochem"
+
+/obj/item/work_console_upgrade/chemical_extraction_attachment/UpgradeReq(obj/machinery/computer/abnormality/A, mob/living/installer)
+	. = ..()
+	//If the root code returns FALSE just return that.
+	if(!.)
+		return
+	if(A.datum_reference.understanding < A.datum_reference.max_understanding)
+		to_chat(installer, span_notice("Abnormality is not yet fully understood."))
+		return FALSE
+
+/obj/item/work_console_upgrade/work_prediction_attachment
+	name = "predictive workrate formula upgrade"
+	desc = "Using information collected from employee files and security footage this upgrade allows the user to see their success rate."
+	upgrade_slot = "workrate"
+	color = COLOR_SOFT_RED

--- a/ModularTegustation/tegu_items/gadgets/unpowered.dm
+++ b/ModularTegustation/tegu_items/gadgets/unpowered.dm
@@ -36,6 +36,132 @@
 			else
 				walk_to(SA, 0)
 
+	//Portable Photocopier
+/obj/item/portacopier
+	name = "porta copier"
+	desc = "A compact photocopier that will print any paper it is used on. \
+	Must be fed replacement paper once in a while."
+	icon = 'ModularTegustation/Teguicons/teguitems.dmi'
+	icon_state = "gadget3"
+	var/paperstock = 1
+
+/obj/item/portacopier/attackby(obj/item/W, mob/user)
+	if(istype(W, /obj/item/paper))
+		if(paperstock <= 6)
+			to_chat(user, span_notice("[src] whirrs and buzzes."))
+			playsound(get_turf(src), 'sound/effects/refill.ogg', 50, TRUE)
+			qdel(W)
+			paperstock++
+			return
+	return ..()
+
+/obj/item/portacopier/afterattack(atom/target, mob/user, proximity_flag)
+	. = ..()
+	// Adjacent thing.
+	if(proximity_flag == 1)
+		if(istype(target, /obj/item/paper))
+			if(paperstock > 0)
+				PrintPaperCopy(target)
+				paperstock--
+				to_chat(user, span_notice("[src] whirrs and taps quietly like a typewriter."))
+				playsound(get_turf(src), 'sound/effects/servostep.ogg', 50, TRUE)
+				return
+			else
+				to_chat(user, span_notice("[src] makes a mechanical chunk, sound like its run out of something."))
+				return
+
+/obj/item/portacopier/proc/PrintPaperCopy(obj/item/paper/paper_copy)
+	. = TRUE
+	if(!paper_copy)
+		return FALSE
+	var/obj/item/paper/copied_paper = new(get_turf(src))
+	copied_paper.info = "<font color = #000000>"
+
+	var/copied_info = paper_copy.info
+	copied_info = replacetext(copied_info, "<font face=\"[PEN_FONT]\" color=", "<font face=\"[PEN_FONT]\" nocolor=")	//state of the art techniques in action
+	copied_info = replacetext(copied_info, "<font face=\"[CRAYON_FONT]\" color=", "<font face=\"[CRAYON_FONT]\" nocolor=")	//This basically just breaks the existing color tag, which we need to do because the innermost tag takes priority.
+	copied_paper.info += copied_info
+	copied_paper.info += "</font>"
+	copied_paper.name = paper_copy.name
+	copied_paper.update_icon()
+	copied_paper.stamps = paper_copy.stamps
+	if(paper_copy.stamped)
+		copied_paper.stamped = paper_copy.stamped.Copy()
+	copied_paper.copy_overlays(paper_copy, TRUE)
+
+	/*
+	* Portable Prediction Device
+	* I feel strange about this device since its
+	* function is redundant. But that might
+	* be intentional if this is a level 1
+	* thing.
+	*/
+/obj/item/portablepredict
+	name = "portable prediction device"
+	desc = "A portable mini computer that can be used on \
+		a abnormality and a agent to see workrate chances.\
+		Needs to be recharged at a printer."
+	icon = 'ModularTegustation/Teguicons/teguitems.dmi'
+	icon_state = "gadget3"
+	var/mob/living/simple_animal/hostile/abnormality/target_abno
+	var/mob/living/carbon/human/target_agent
+	var/print_charges = 1
+
+/obj/item/portablepredict/afterattack(atom/target, mob/user, proximity_flag)
+	. = ..()
+	// Adjacent thing.
+	if(proximity_flag == 1)
+		var/mob/living/carbon/human/H = user
+		if(ishuman(H))
+			if(H?.mind?.assigned_role == "Records Officer")
+				if(isliving(target))
+					RegisterTarget(target, user)
+			else
+				to_chat(user, span_notice("[src] requires a Records Officer to activate."))
+
+/obj/item/portablepredict/attack_obj(obj/O, mob/living/user)
+	if(istype(O, /obj/machinery/photocopier))
+		if(print_charges < 3)
+			print_charges = 3
+			to_chat(user, span_notice("[src] whirrs and taps quietly like a typewriter."))
+			playsound(get_turf(src), 'sound/effects/servostep.ogg', 50, TRUE)
+			return
+	return ..()
+
+/obj/item/portablepredict/proc/RegisterTarget(mob/living/L, mob/living/carbon/human/user)
+	if(L.stat == DEAD)
+		return
+	if(print_charges <= 0)
+		to_chat(user, span_notice("[src] has run out of charges."))
+		return
+	if(ishuman(L))
+		target_agent = L
+	if(isabnormalitymob(L))
+		target_abno = L
+	if(target_agent && target_abno)
+		CalculateChance(target_abno.datum_reference, target_agent, user)
+		target_agent = null
+		target_abno = null
+	playsound(get_turf(src), 'sound/items/syringeproj.ogg', 50, TRUE)
+
+/obj/item/portablepredict/proc/CalculateChance(datum/abnormality/A, mob/living/carbon/human/target, mob/living/carbon/human/user)
+	if(QDELETED(A) || QDELETED(target))
+		return
+	to_chat(user, span_notice("[src] prints out a slip of paper."))
+	print_charges--
+
+	var/obj/item/paper/printed_paper = new(get_turf(src))
+	printed_paper.name = "Employee Workchance Calculations [A.name]+[target]"
+	printed_paper.info = "<tt><font color = #000000>\
+	[A.name]+[target]<br>\
+	Run_Employee_[pick("Previous_Reports","Work_Footage","Medical_History")]<br>\
+	Instinct:---[A.get_work_chance(ABNORMALITY_WORK_INSTINCT, target)]<br> \
+	Insight:----[A.get_work_chance(ABNORMALITY_WORK_INSIGHT, target)]<br> \
+	Attachment:-[A.get_work_chance(ABNORMALITY_WORK_ATTACHMENT, target)]<br> \
+	Repression:-[A.get_work_chance(ABNORMALITY_WORK_REPRESSION, target)]</font></tt>"
+	printed_paper.update_icon()
+	user.put_in_inactive_hand(printed_paper)
+
 	//Dosage Estimator
 /obj/item/dosage_est
 	name = "Dosage Estimator"

--- a/code/game/machinery/computer/abnormality_work.dm
+++ b/code/game/machinery/computer/abnormality_work.dm
@@ -27,6 +27,11 @@
 	var/work_bonus = 0
 	/// Stored reference to Extraction Officer Tool
 	var/obj/item/extraction/key/EOTool = null
+	/// Console Upgrades
+	var/list/mechanical_upgrades = list(
+		"abnochem" = 0,
+		"workrate" = 0,
+		)
 
 /obj/machinery/computer/abnormality/Initialize()
 	. = ..()
@@ -67,6 +72,14 @@
 			if(MELTDOWN_BLACK)
 				melt_text = " of Lunacy. Failure to clear the meltdown will cause another abnormality to breach"
 		. += span_warning("The containment unit is currently affected by a Qliphoth Meltdown[melt_text]. Time left: [meltdown_time].")
+	//Show what upgrades you have. I dont have visuals for the upgrades yet so for now just exsamine tell them.
+	. += span_info("This console is augmented with the following upgrades:")
+	var/upgrade_list = ""
+	for(var/i in mechanical_upgrades)
+		if(mechanical_upgrades[i] == 0)
+			continue
+		upgrade_list += "[i]|"
+	. += upgrade_list
 
 /obj/machinery/computer/abnormality/ui_interact(mob/user)
 	. = ..()
@@ -110,7 +123,7 @@
 		var/datum/suppression/information/I = GetCoreSuppression(/datum/suppression/information)
 		if(!tutorial && istype(I))
 			work_display = Gibberish(work_display, TRUE, I.gibberish_value)
-		if(HAS_TRAIT(user, TRAIT_WORK_KNOWLEDGE))
+		if(HAS_TRAIT(user, TRAIT_WORK_KNOWLEDGE) || mechanical_upgrades["workrate"])
 			dat += "<A href='byond://?src=[REF(src)];do_work=[wt]'>[work_display] \[[datum_reference.get_work_chance(wt, user)]%\]</A> <br>"
 		else
 			dat += "<A href='byond://?src=[REF(src)];do_work=[wt]'>[work_display]</A> <br>"
@@ -303,8 +316,7 @@
 		datum_reference.work_complete(user, work_type, pe, work_speed*datum_reference.max_boxes, was_melting, canceled)
 		if(recorded) //neither rabbit nor tutorial calls this
 			SSlobotomy_corp.WorkComplete(pe, (meltdown_time <= 0))
-	var/obj/item/chemical_extraction_attachment/attachment = locate() in src.contents
-	if(attachment)
+	if(mechanical_upgrades["abnochem"])
 		chem_charges += 1
 	else
 		chem_charges = min(chem_charges + 0.2, 10)
@@ -390,6 +402,14 @@
 		return TRUE
 	return FALSE
 
+//Install a work console upgrade
+/obj/machinery/computer/abnormality/proc/InstallUpgrade(obj/upgrade_tech, upgrade_slot = "")
+	if(!upgrade_tech)
+		return
+	if(!upgrade_slot)
+		return
+	upgrade_tech.forceMove(src)
+	mechanical_upgrades[upgrade_slot] = upgrade_tech
 
 //special console just for training rabbit
 /obj/machinery/computer/abnormality/training_rabbit

--- a/code/game/machinery/computer/extraction_cargo.dm
+++ b/code/game/machinery/computer/extraction_cargo.dm
@@ -25,7 +25,7 @@
 		new /datum/data/extraction_cargo("Keen-Sense Rangefinder ",		/obj/item/powered_gadget/detector_gadget/ordeal,					200, CAT_GADGET) = 1,
 		new /datum/data/extraction_cargo("EMAIS	Capacity Upgrade ",		/obj/item/hypo_upgrade/cap_increase,								200, CAT_GADGET) = 1,
 		new /datum/data/extraction_cargo("Prototype Enkephalin Injector ",/obj/item/powered_gadget/enkephalin_injector,						200, CAT_GADGET) = 1,
-		new /datum/data/extraction_cargo("Instant Clerkbot Constructor ",/obj/item/clerkbot_gadget,							250, CAT_GADGET) = 1,
+		new /datum/data/extraction_cargo("Instant Clerkbot Constructor ",/obj/item/clerkbot_gadget,											250, CAT_GADGET) = 1,
 		//new /datum/data/extraction_cargo("C-Fear Protection Injector ",	/obj/item/trait_injector/clerk_fear_immunity_injector,			300, CAT_GADGET) = 1,
 		new /datum/data/extraction_cargo("Handheld Taser",				/obj/item/powered_gadget/handheld_taser,							300, CAT_GADGET) = 1,
 		new /datum/data/extraction_cargo("Vitals Projector ",			/obj/item/powered_gadget/vitals_projector,							300, CAT_GADGET) = 1,
@@ -67,8 +67,9 @@
 		new /datum/data/extraction_cargo("Red Filter ",					/obj/item/refiner_filter/red,										10, CAT_RESOURCE) = 1,
 		new /datum/data/extraction_cargo("Yellow Filter ",				/obj/item/refiner_filter/yellow,									10, CAT_RESOURCE) = 1,
 		new /datum/data/extraction_cargo("Raw PE Box ",					/obj/item/rawpe,													50, CAT_RESOURCE) = 1,
-		new /datum/data/extraction_cargo("Abnormality Chemistry Pack ",	/obj/structure/closet/crate/science/abnochem_startercrate,			100, CAT_RESOURCE) = 1,
-		new /datum/data/extraction_cargo("Chemical Extraction Upgrade ",/obj/item/chemical_extraction_attachment,							150, CAT_RESOURCE) = 1,
+		new /datum/data/extraction_cargo("Chemical Extraction Upgrade ",/obj/item/work_console_upgrade/chemical_extraction_attachment,		150, CAT_RESOURCE) = 1,
+		new /datum/data/extraction_cargo("Workchance Calculator Upgrade ",/obj/item/work_console_upgrade/work_prediction_attachment,		200, CAT_RESOURCE) = 1,
+		new /datum/data/extraction_cargo("AbnoChem Starter Pack ",		/obj/structure/closet/crate/science/abnochem_startercrate,			250, CAT_RESOURCE) = 1,
 		new /datum/data/extraction_cargo("Mysterious Invitation ",		/obj/item/invitation,												1500, CAT_RESOURCE) = 1,
 
 		//Random stuff

--- a/code/modules/jobs/job_types/command.dm
+++ b/code/modules/jobs/job_types/command.dm
@@ -90,3 +90,8 @@
 	name = "Records Officer"
 	jobtype = /datum/job/command/records
 	suit =  /obj/item/clothing/suit/armor/records
+
+	backpack_contents = list(
+		/obj/item/portacopier,
+		/obj/item/portablepredict,
+	)

--- a/code/modules/mob/living/simple_animal/abnormality/_abnormality.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_abnormality.dm
@@ -236,8 +236,7 @@
 	if(!(status_flags & GODMODE))
 		to_chat(user, span_notice("Now isn't the time!"))
 		return
-	var/obj/item/chemical_extraction_attachment/attachment = locate() in datum_reference.console.contents
-	if(!attachment)
+	if(datum_reference.console.mechanical_upgrades["abnochem"] == 0)
 		to_chat(user, span_notice("This abnormality's cell is not properly equipped for substance extraction."))
 		return
 	if(world.time < chem_cooldown_timer)

--- a/code/modules/reagents/chemistry/reagents/abnormality_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/abnormality_reagents.dm
@@ -323,27 +323,6 @@
 		for(var/reportLine in readout2)
 			to_chat(usr, reportLine)
 
-/obj/item/chemical_extraction_attachment
-	name = "chemical extraction cell upgrade"
-	desc = "Attaches to the abnormality cell console of completely understood abnormalities and allows for the extraction of enkephalin-derived substances."
-	icon = 'ModularTegustation/Teguicons/teguitems.dmi'
-	icon_state = "abnochem_attachment"
-
-/obj/machinery/computer/abnormality/attackby(obj/O, mob/user, params)
-	if(istype(O, /obj/item/chemical_extraction_attachment))
-		if(datum_reference.understanding < datum_reference.max_understanding)
-			to_chat(user, span_notice("Abnormality [datum_reference.current] is not yet fully understood."))
-			return ..()
-		var/obj/item/chemical_extraction_attachment/attachment = locate() in contents
-		if(attachment)
-			to_chat(user, span_notice("This cell already has a chemical extraction upgrade installed."))
-			return ..()
-		to_chat(user, span_notice("You start attaching \the [O] to \the [src]..."))
-		if(do_after(user, 5 SECONDS, src))
-			user.transferItemToLoc(O, src)
-			src.desc += "\nIt seems to be equipped with a chemical extraction upgrade."
-	return ..()
-
 /obj/structure/closet/crate/science/abnochem_startercrate
 	name = "Abnormality chemistry crate"
 	desc = "A crate containing abnormality chemistry materials."
@@ -357,3 +336,4 @@
 	new /obj/item/paper/guides/jobs/abnochem_effects_he(src)
 	new /obj/item/storage/box/beakers(src)
 	new /obj/item/storage/box/beakers(src)
+	new /obj/item/work_console_upgrade/chemical_extraction_attachment(src)

--- a/lobotomy-corp13.dme
+++ b/lobotomy-corp13.dme
@@ -4088,6 +4088,7 @@
 #include "ModularTegustation\tegu_drinks\drinks.dm"
 #include "ModularTegustation\tegu_drinks\twistedtea.dm"
 #include "ModularTegustation\tegu_items\_belt.dm"
+#include "ModularTegustation\tegu_items\abnoconsole_upgrades.dm"
 #include "ModularTegustation\tegu_items\debug_items.dm"
 #include "ModularTegustation\tegu_items\injectors.dm"
 #include "ModularTegustation\tegu_items\lc13boss_summon.dm"


### PR DESCRIPTION
## About The Pull Request
Adds a portable photocopier gadget that can convert paper into copies of any paper it is used on.
Reworks how abnormality work console upgrades work and adds a new work console upgrade for seeing workrates.

RO Update Checklist
- [X] Handheld Photocopier
- [x] Gadget to recharge at a photocopier that gives you 3 uses. One to print exact work rates, one to print records.
- [x] Scanner to point at an abno and then a player to print exact work rates
- [X] Machine to upgrade one console at a time to show exact percentages

additionally i changed the name of the abnormality chemistry pack and added a free extractor into it.

## Why It's Good For The Game
Gadgets were requested by kirie in order to improve the flow of information around the facility and improve RO gameplay.

## Changelog
:cl:
add: Portable Photocopier Gadget
add: Abnormality Work Console Upgrade root
add: Predictive workrate work console upgrade
tweak: abnormality work console upgrade mechanics
tweak: abno chem extraction attachment
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
