### PR TITLE
Swaps the snow queens and morii's armor and weapon locations around

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/he/better_memories.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/better_memories.dm
@@ -29,8 +29,8 @@
 	work_damage_type = WHITE_DAMAGE
 
 	ego_list = list(
+		/datum/ego_datum/weapon/morii,
 		/datum/ego_datum/armor/morii,
-		/datum/ego_datum/weapon/morii
 	)
 	gift_type = /datum/ego_gifts/morii
 	//Abnormality Jam Submission

--- a/code/modules/mob/living/simple_animal/abnormality/he/snow_queen.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/snow_queen.dm
@@ -56,8 +56,8 @@
 	observation_fail_message = "Gerda saved Kai and returned home. <br>They lived happily ever after."
 
 	ego_list = list(
+		/datum/ego_datum/weapon/frostsplinter,
 		/datum/ego_datum/armor/frostsplinter,
-		/datum/ego_datum/weapon/frostsplinter
 	)
 	gift_type = null
 	//Gift is rewarded at the end of a duel with Snow Queen.


### PR DESCRIPTION
## About The Pull Request

Title

## Why It's Good For The Game

Because every other abno has it like that, lets stop people from buying the wrong things

## Changelog
:cl:
fix: snow queens and morii's ego armor is now at the bottom of the buying page, and weapon at the top
/:cl:
