### PR TITLE
Snow Queen Lag Reduction[DONE]

### DIFF
--- a/code/game/objects/effects/abnormality.dm
+++ b/code/game/objects/effects/abnormality.dm
@@ -271,22 +271,6 @@
 	alpha = 255
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 
-/obj/effect/temp_visual/floor_cracks
-	icon = 'ModularTegustation/Teguicons/tegu_effects.dmi'
-	icon_state = "cracks_dark"
-	duration = 30
-	layer = ABOVE_MOB_LAYER
-
-/obj/effect/temp_visual/ice_spike
-	icon = 'ModularTegustation/Teguicons/32x48.dmi'
-	icon_state = "ice_spike1"
-	duration = 5
-	layer = ABOVE_MOB_LAYER
-
-/obj/effect/temp_visual/ice_spike/Initialize()
-	. = ..()
-	icon_state = pick("ice_spike1", "ice_spike2", "ice_spike3")
-
 /obj/effect/areaflavor_snow
 	icon = 'icons/effects/weather_effects.dmi'
 	icon_state = "snowfall_calm"


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Replaces temporary effects with reusable visual effects. Removes telegraph cracks and ice spike from temporary effects.


## Changelog
:cl:
tweak: Changes Snow Queens telegraph effects from temporary effects to reusable visual effects.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
