### PR TITLE
Makes Some Abnormalities Not Bleed[DONE]

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/_abnormality.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_abnormality.dm
@@ -594,6 +594,11 @@
 		if(5)
 			C.icon = 'ModularTegustation/Teguicons/abno_cores/aleph.dmi'
 
+/mob/living/simple_animal/hostile/abnormality/spawn_gibs()
+	if(blood_volume <= 0)
+		return
+	return new /obj/effect/gibspawner/generic(drop_location(), src, get_static_viruses())
+
 // Actions
 /datum/action/innate/abnormality_attack
 	name = "Abnormality Attack"

--- a/code/modules/mob/living/simple_animal/abnormality/he/ardor_blossom_moth.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/ardor_blossom_moth.dm
@@ -9,6 +9,7 @@
 	portrait = "blossom_moth"
 	maxHealth = 1200
 	health = 1200
+	blood_volume = 0
 	ranged = TRUE
 	attack_verb_continuous = "sears"
 	attack_verb_simple = "sear"
@@ -87,6 +88,8 @@
 				qdel(floor_fire)
 		new /obj/structure/turf_fire(T)
 
+/mob/living/simple_animal/hostile/abnormality/ardor_moth/spawn_gibs()
+	return new /obj/effect/decal/cleanable/ash(drop_location(), src)
 
 // Turf Fire
 /obj/structure/turf_fire

--- a/code/modules/mob/living/simple_animal/abnormality/he/funeral.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/funeral.dm
@@ -9,6 +9,7 @@
 	del_on_death = FALSE
 	maxHealth = 1350 //I am a menace to society.
 	health = 1350
+	blood_volume = 0
 
 	ranged = TRUE
 	minimum_distance = 2

--- a/code/modules/mob/living/simple_animal/abnormality/he/helper.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/helper.dm
@@ -14,6 +14,7 @@
 	death_message = "falls to the ground, deactivating."
 	maxHealth = 1000
 	health = 1000
+	blood_volume = 0
 	rapid_melee = 4
 	ranged = TRUE
 	attack_verb_continuous = "slashes"

--- a/code/modules/mob/living/simple_animal/abnormality/he/snow_queen.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/snow_queen.dm
@@ -20,6 +20,7 @@
 	mob_biotypes = MOB_MINERAL
 	maxHealth = 1500
 	health = 1500
+	blood_volume = 0
 	move_to_delay = 5
 	damage_coeff = list(BRUTE = 1, RED_DAMAGE = 1.1, WHITE_DAMAGE = 0.8, BLACK_DAMAGE = 0.8, PALE_DAMAGE = 0.8) //ASK SOMEONE GOOD AT BALANCING ABOUT THIS -IP
 	base_pixel_x = -16
@@ -238,6 +239,12 @@
 	density = FALSE
 	animate(src, alpha = 0, time = 10 SECONDS)
 	QDEL_IN(src, 10 SECONDS)
+	return ..()
+
+//Prevents gibbing during the duel.
+/mob/living/simple_animal/hostile/abnormality/snow_queen/gib()
+	if(arena_attacks)
+		return FALSE
 	return ..()
 
 //This is here so that people can see the death animation before snow queen is defeated.

--- a/code/modules/mob/living/simple_animal/abnormality/he/steam_transport_machine.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/steam_transport_machine.dm
@@ -10,6 +10,7 @@
 	del_on_death = FALSE
 	maxHealth = 1600
 	health = 1600
+	blood_volume = 0
 	ranged = TRUE
 	attack_sound = 'sound/abnormalities/steam/attack.ogg'
 	friendly_verb_continuous = "bonks"

--- a/code/modules/mob/living/simple_animal/abnormality/teth/MHz.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/MHz.dm
@@ -11,6 +11,7 @@
 	base_pixel_y = -32
 	maxHealth = 400
 	health = 400
+	blood_volume = 0
 	start_qliphoth = 4
 	threat_level = TETH_LEVEL
 	work_chances = list(

--- a/code/modules/mob/living/simple_animal/abnormality/teth/book.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/book.dm
@@ -6,6 +6,7 @@
 	portrait = "book"
 	maxHealth = 600
 	health = 600
+	blood_volume = 0
 	start_qliphoth = 2
 	threat_level = TETH_LEVEL
 	work_chances = list(
@@ -133,6 +134,7 @@
 	spawnedmob.health = spawnedmob.maxHealth
 	spawnedmob.death_message = "collapses into a bunch of writing material."
 	spawnedmob.filters += filter(type="drop_shadow", x=0, y=0, size=1, offset=0, color=rgb(0, 0, 0))
+	spawnedmob.blood_volume = 0
 	src.visible_message(span_warning("Pages of [src] fold into [spawnedmob]!"))
 	playsound(get_turf(src), 'sound/items/handling/paper_pickup.ogg', 90, 1, FALSE)
 

--- a/code/modules/mob/living/simple_animal/abnormality/teth/faelantern.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/faelantern.dm
@@ -10,6 +10,7 @@
 	portrait = "faelantern"
 	maxHealth = 1200
 	health = 1200
+	blood_volume = 0
 	base_pixel_x = -16
 	pixel_x = -16
 	threat_level = TETH_LEVEL

--- a/code/modules/mob/living/simple_animal/abnormality/waw/dimension_refraction.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/dimension_refraction.dm
@@ -13,6 +13,7 @@
 
 	maxHealth = 1200
 	health = 1200
+	blood_volume = 0
 	density = FALSE
 	damage_coeff = list(RED_DAMAGE = 0, WHITE_DAMAGE = 1.5, BLACK_DAMAGE = 0.8, PALE_DAMAGE = 1)
 	stat_attack = HARD_CRIT

--- a/code/modules/mob/living/simple_animal/abnormality/waw/ebony_queen.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/ebony_queen.dm
@@ -12,6 +12,7 @@
 	health = 2000
 	pixel_x = -16
 	base_pixel_x = -16
+	blood_volume = 0
 	melee_damage_type = BLACK_DAMAGE
 	melee_damage_lower = 35
 	melee_damage_upper = 45

--- a/code/modules/mob/living/simple_animal/abnormality/waw/screenwriter.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/screenwriter.dm
@@ -14,6 +14,7 @@ Defeating the murderer also surpresses the abnormality.
 	faction = list("hostile")
 	threat_level = WAW_LEVEL
 	start_qliphoth = 2
+	blood_volume = 0
 	work_chances = list(
 		"Nutrition" = 35,
 		"Cleanliness" = 35,

--- a/code/modules/mob/living/simple_animal/abnormality/waw/snow_whites_apple.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/snow_whites_apple.dm
@@ -10,6 +10,7 @@
 	portrait = "snow_whites_apple"
 	maxHealth = 1600
 	health = 1600
+	blood_volume = 0
 	obj_damage = 0
 	damage_coeff = list(RED_DAMAGE = 0.5, WHITE_DAMAGE = 1.0, BLACK_DAMAGE = 0, PALE_DAMAGE = 1.5)
 	ranged = TRUE

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/quiet_day.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/quiet_day.dm
@@ -11,6 +11,7 @@
 	core_icon = "quiet_day"
 	maxHealth = 451
 	health = 451
+	blood_volume = 0
 	threat_level = ZAYIN_LEVEL
 	faction = list("hostile", "neutral")
 	//Bad for stat gain, but the damage is negligable and there's a nice bonus at the end


### PR DESCRIPTION
## About The Pull Request
Makes some abnormalities not bleed or produce meaty gibs when they are not meat based organisms.

> /mob/living/simple_animal/hostile/abnormality/proc/spawn_gibs()
> 	if(blood_volume <= 0)
> 		return
> 	return new /obj/effect/gibspawner/generic(drop_location(), src, get_static_viruses())

- Ardor Blossom Moth
- Funderal
- Helper
- Snow Queen
- Steam Transport Machine
- MHz
- Book Without Pictures or Dialogue
- Faelantern
- Dimensional Refraction Varient
- Ebony Queen
- Snow Whites Apple
- Quiet Day

## Why It's Good For The Game
Just a personal immersion thing since a ice monster exploding into blood and gibs is a bit strange.

## Changelog
:cl:
tweak: Removes bleeding and organic gibs from inorganic abnormalities.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
