### PR TITLE
Shrimply a miracle -- Shrimp changes (buffs?) and injector cleanup

### DIFF
--- a/ModularTegustation/tegu_items/injectors.dm
+++ b/ModularTegustation/tegu_items/injectors.dm
@@ -80,7 +80,7 @@
 		return ..()
 	to_chat(user, span_userdanger("The injector burns red before switching to green and dissapearing. You feel uneasy."))
 	qdel(src)
-	sleep(rand(2 SECONDS, 5 SECONDS)) // 2 to 5 seconds
+	sleep(rand(2 SECONDS, 5 SECONDS))
 	if(prob(30) || is_species(user, /datum/species/shrimp))
 		new /mob/living/simple_animal/hostile/shrimp_soldier(get_turf(user))
 	else

--- a/ModularTegustation/tegu_items/injectors.dm
+++ b/ModularTegustation/tegu_items/injectors.dm
@@ -16,9 +16,10 @@
 	InjectTrait(user)
 
 /obj/item/trait_injector/proc/InjectTrait(mob/living/carbon/human/user)
-	if(HAS_TRAIT(user, trait))
-		to_chat(user, span_notice("You wouldn't double-dip, would you?"))
-		return
+	if(trait)
+		if(HAS_TRAIT(user, trait)) // we need to check for if there is a trait in the first place
+			to_chat(user, span_notice("You wouldn't double-dip, would you?"))
+			return
 	to_chat(user, span_nicegreen("The injector blinks green before it disintegrates. [success_message]"))
 	if(trait)
 		ADD_TRAIT(user, trait, JOB_TRAIT)

--- a/ModularTegustation/tegu_items/injectors.dm
+++ b/ModularTegustation/tegu_items/injectors.dm
@@ -16,6 +16,9 @@
 	InjectTrait(user)
 
 /obj/item/trait_injector/proc/InjectTrait(mob/living/carbon/human/user)
+	if(HAS_TRAIT(user, trait))
+		to_chat(user, span_notice("You wouldn't double-dip, would you?"))
+		return
 	to_chat(user, span_nicegreen("The injector blinks green before it disintegrates. [success_message]"))
 	if(trait)
 		ADD_TRAIT(user, trait, JOB_TRAIT)
@@ -32,8 +35,7 @@
 
 /obj/item/trait_injector/officer_upgrade_injector/InjectTrait(mob/living/carbon/human/user)
 	user.adjust_all_attribute_levels(20)
-	..()
-	return
+	return ..()
 
 /obj/item/trait_injector/agent_workchance_trait_injector
 	name = "Agent Work Chance Injector"
@@ -43,9 +45,11 @@
 	error_message = "You aren't an agent."
 	success_message = "You feel enlightened and wiser."
 
-/obj/item/trait_injector/agent_workchance_trait_injector/Initialize()
-	. = ..()
-	roles = GLOB.security_positions
+/obj/item/trait_injector/attack_self(mob/living/carbon/human/user)
+	if(!istype(user) || HAS_TRAIT(user, TRAIT_WORK_FORBIDDEN))
+		to_chat(user, span_notice("The injector light flashes red. [error_message] Check the label before use."))
+		return
+	InjectTrait(user)
 
 /obj/item/trait_injector/clerk_fear_immunity_injector
 	name = "C-Fear Protection Injector"
@@ -73,13 +77,12 @@
 /obj/item/trait_injector/shrimp_injector/InjectTrait(mob/living/carbon/human/user)
 	if(!faction_check(user.faction, list("shrimp")))
 		user.faction |= "shrimp"
-		..()
-		return
+		return ..()
 	to_chat(user, span_userdanger("The injector burns red before switching to green and dissapearing. You feel uneasy."))
 	qdel(src)
-	sleep(rand(20, 50)) // 2 to 5 seconds
-	if(prob(70))
-		new /mob/living/simple_animal/hostile/shrimp(get_turf(user))
-	else
+	sleep(rand(2 SECONDS, 5 SECONDS)) // 2 to 5 seconds
+	if(prob(30) || is_species(user, /datum/species/shrimp))
 		new /mob/living/simple_animal/hostile/shrimp_soldier(get_turf(user))
+	else
+		new /mob/living/simple_animal/hostile/shrimp(get_turf(user))
 	user.gib()

--- a/ModularTegustation/tegu_items/injectors.dm
+++ b/ModularTegustation/tegu_items/injectors.dm
@@ -20,9 +20,8 @@
 		if(HAS_TRAIT(user, trait)) // we need to check for if there is a trait in the first place
 			to_chat(user, span_notice("You wouldn't double-dip, would you?"))
 			return
-	to_chat(user, span_nicegreen("The injector blinks green before it disintegrates. [success_message]"))
-	if(trait)
 		ADD_TRAIT(user, trait, JOB_TRAIT)
+	to_chat(user, span_nicegreen("The injector blinks green before it disintegrates. [success_message]"))
 	qdel(src)
 	return
 

--- a/code/modules/mob/living/carbon/human/species_types/shrimp.dm
+++ b/code/modules/mob/living/carbon/human/species_types/shrimp.dm
@@ -3,11 +3,12 @@
 	id = "shrimp"
 	mutant_bodyparts = list()
 	say_mod = "burbles"
-	sexes = 0
+	sexes = 0 // shrimp are shrimp, nothing more nothing less
 
+	mutanttongue = /obj/item/organ/tongue/shrimp
 	nojumpsuit = TRUE
-	species_traits = list(NO_UNDERWEAR,NOEYESPRITES)
-	inherent_traits = list(TRAIT_ADVANCEDTOOLUSER,TRAIT_GENELESS)
+	species_traits = list(NO_UNDERWEAR, NOEYESPRITES)
+	inherent_traits = list(TRAIT_ADVANCEDTOOLUSER, TRAIT_GENELESS)
 	use_skintones = FALSE
 	limbs_id = "shrimp"
 	no_equip = list(ITEM_SLOT_EYES, ITEM_SLOT_MASK)
@@ -20,24 +21,40 @@
 	var/shrimp_name = pick(special_names)
 	if(prob(human_name_chance))
 		shrimp_name = pick(GLOB.last_names)
-	return shrimp_name//95% chance to pick a shrimp name, 5% to pick a human lastname. These guys only use one name
+	return shrimp_name // 95% chance to pick a shrimp name, 5% to pick a human lastname. These guys only use one name
 
-/mob/living/carbon/human/species/shrimp/attack_ghost(mob/dead/observer/O)
-	if(!(src.key))
-		if(O.can_reenter_corpse)
-			var/response = alert(O,"Do you want to take it over?","This creature has no soul","Yes","No")
-			if(response == "Yes")
-				if(!(src.key))
-					src.transfer_personality(O.client)
-				else if(src.key)
-					to_chat(src, span_notice("Somebody is already controlling this creature."))
-		else if(!(O.can_reenter_corpse))
-			to_chat(O,span_notice("You cannot control this creature."))
-
-/mob/living/carbon/human/species/shrimp/proc/transfer_personality(client/candidate)
-	if(!candidate)
+/mob/living/carbon/human/species/shrimp/attack_ghost(mob/dead/observer/ghost)
+	if(key)
+		to_chat(src, span_notice("Somebody is already controlling this crustacean."))
 		return
-	src.ckey = candidate.ckey
-	if(src.mind)
-		src.mind.assigned_role = "Clerk"
-		to_chat(src, span_info("You are a Clerk. You're the jack of all trades in LCorp. You are to assist with cleanup, cooking, medical and other miscellaneous tasks. You are fragile, but important."))
+
+	var/response = alert(ghost, "Do you want to take it over?", "Soul transfer", "Yes", "No")
+	if(response == "No")
+		return
+
+	if(key)
+		to_chat(src, span_notice("Somebody has taken this crustacean whilst you were busy selecting!"))
+		return
+
+	ckey = ghost.client.ckey
+	mind?.assigned_role = "Clerk"
+	to_chat(src, span_info("You are a shrimp, your possibilities are endless. You can both choose a path of an agent or a path of a clerk. All gates are open to you."))
+
+/obj/item/organ/tongue/shrimp
+	name = "shrimp tongue"
+	desc = "A fleshy muscle mostly used for making shrimp puns."
+	say_mod = "hisses"
+	taste_sensitivity = 5 // The most sensitive tongue that exists, the shrimp has fried rice so many times it can tell anything apart
+	modifies_speech = TRUE
+
+/obj/item/organ/tongue/shrimp/handle_speech(datum/source, list/speech_args)
+	var/message = speech_args[SPEECH_MESSAGE]
+	if(message[1] == "*") // They are emoting, no point in looking
+		return
+
+	message = replacetext(message, "simp", "shrimp") // We are not simps
+	message = replacetext(message, "confusing", "conchfusing")
+	message = replacetext(message, "complicated", "clampified")
+	message = replacetext(message, "self", "shellf")
+	message = replacetext(message, "kill", "krill") // Krill yourshellf... or skrill issue
+	speech_args[SPEECH_MESSAGE] = message


### PR DESCRIPTION
## About The Pull Request

- Shrimp people are now forced to speak in shrimp puns for as long as they have their tongue
- Shrimps no longer require you to have a non-DNR body to possess them

- The work chance injector now can be injected to anyone without the work forbidden trait, covering edge-cases
- The shrimp faction injector will now always turn a shrimp(the species) into a shrimp soldier
- Trait injectors now cannot be double-dipped for double the trait

## Why It's Good For The Game

- Shrimp people are now forced to speak in shrimp puns for as long as they have their tongue
>They were unbalanced without this, they might still need a nerf for working in the future but for now this should do :)

- Shrimps no longer require you to have a non-DNR body to possess them
>Ah yes, lets force the ghosts to respawn, become a clerk and shoot themselfes in the face then possess the shrimp.
>Just let ghosts possess them... man

- The work chance injector now can be injected to anyone without the work forbidden trait, covering edge-cases
>Shrimps couldn't inject it despite being able to work, so i looked in the code and imo, its better to cover such edge-cases as the injectors are still usefull for them. Most likelly wont ever exist but we don't know

- The shrimp faction injector will now always turn a shrimp(the species) into a shrimp soldier
>I was so tempted to make it spawn a rambo, but no.
>I just found it weird that the shrimps dont have a unique interaction for using the injector, so have a guaranteed warrior

- Trait injectors now cannot be double-dipped for double the trait
>Yeaaaa kinda found this whilst testing, weird that it was never fixed and remained un-noticed/fixed for so long

## Changelog
:cl:
balance: shrimps are now forced to speak with shrimpler language (yes, this is balance)
fix: injector (except shrimp) now cannot be double-injected into the same person
/:cl:
