### PR TITLE
change steam machine and puss in boots scaling

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/he/puss_in_boots.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/puss_in_boots.dm
@@ -373,19 +373,29 @@
 	return ..()
 
 /datum/status_effect/chosen/proc/StatUpdate(mob/living/carbon/human/user)
-	var/new_bonus = 0
-	if(world.time >= 75 MINUTES) // Full facility expected
-		new_bonus = 80
-	else if(world.time >= 60 MINUTES) // More than one ALEPH
-		new_bonus = 60
-	else if(world.time >= 45 MINUTES) // Wowzer, an ALEPH?
-		new_bonus = 50
-	else if(world.time >= 30 MINUTES) // Expecting WAW
-		new_bonus = 40
-	else if(world.time >= 15 MINUTES) // Usual time for HEs
-		new_bonus = 30
-	else
-		new_bonus = 20
+	var/new_bonus = 20
+	var/facility_full_percentage = 0
+	if(SSabnormality_queue.spawned_abnos) // dont divide by 0
+		facility_full_percentage = 100 * (SSabnormality_queue.spawned_abnos / SSabnormality_queue.rooms_start)
+	// how full the facility is, from 0 abnormalities out of 24 cells being 0% and 24/24 cells being 100%
+	switch(facility_full_percentage)
+		if(15 to 29) // Shouldn't be anything more than TETHs (4 Abnormalities)
+			new_bonus *= 1.5
+
+		if(29 to 44) // HEs (8 Abnormalities)
+			new_bonus *= 2
+
+		if(44 to 59) // A bit before WAWs (11 Abnormalities)
+			new_bonus *= 2.5
+
+		if(59 to 69) // WAWs around here (15 Abnormalities)
+			new_bonus *= 3
+
+		if(69 to 79) // ALEPHs starting to spawn (17 Abnormalities)
+			new_bonus *= 3.5
+
+		if(79 to 100) // ALEPHs around here (20 Abnormalities)
+			new_bonus *= 4
 	if(new_bonus <= attribute_bonus)
 		return
 	for(var/attribute in user.attributes)

--- a/code/modules/mob/living/simple_animal/abnormality/he/steam_transport_machine.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/steam_transport_machine.dm
@@ -76,16 +76,21 @@
 //Gear Shift - Most mechanics are determined by round time
 /mob/living/simple_animal/hostile/abnormality/steam/proc/GearUpdate()
 	var/new_gear = gear
-	if(world.time >= 105 MINUTES) // Full facility expected
-		new_gear = 4
-	else if(world.time >= 90 MINUTES) // More than one ALEPH
-		new_gear = 3
-	else if(world.time >= 75 MINUTES) // Wowzer, an ALEPH?
-		new_gear = 2
-	else if(world.time >= 45 MINUTES) // Expecting WAW
-		new_gear = 1
-	else
-		new_gear = 0
+	var/facility_full_percentage = 0
+	if(SSabnormality_queue.spawned_abnos) // dont divide by 0
+		facility_full_percentage = 100 * (SSabnormality_queue.spawned_abnos / SSabnormality_queue.rooms_start)
+	// how full the facility is, from 0 abnormalities out of 24 cells being 0% and 24/24 cells being 100%
+	switch(facility_full_percentage)
+		if(0 to 49) // Expecting Hes and Teths still
+			new_gear = 1
+		if(50 to 69)  // Expecting WAW
+			new_gear = 1
+		if(70 to 79) // Wowzer, an ALEPH?
+			new_gear = 2
+		if(80 to 99) // More than one ALEPH
+			new_gear = 3
+		if(100) // Full facility expected
+			new_gear = 4
 	if(gear != new_gear)
 		gear = new_gear
 		ClankSound()

--- a/code/modules/mob/living/simple_animal/abnormality/he/steam_transport_machine.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/steam_transport_machine.dm
@@ -76,13 +76,13 @@
 //Gear Shift - Most mechanics are determined by round time
 /mob/living/simple_animal/hostile/abnormality/steam/proc/GearUpdate()
 	var/new_gear = gear
-	if(world.time >= 75 MINUTES) // Full facility expected
+	if(world.time >= 105 MINUTES) // Full facility expected
 		new_gear = 4
-	else if(world.time >= 60 MINUTES) // More than one ALEPH
+	else if(world.time >= 90 MINUTES) // More than one ALEPH
 		new_gear = 3
-	else if(world.time >= 45 MINUTES) // Wowzer, an ALEPH?
+	else if(world.time >= 75 MINUTES) // Wowzer, an ALEPH?
 		new_gear = 2
-	else if(world.time >= 30 MINUTES) // Expecting WAW
+	else if(world.time >= 45 MINUTES) // Expecting WAW
 		new_gear = 1
 	else
 		new_gear = 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

puss in boots and steam machine now scale off of how many abnos there are
## Why It's Good For The Game

they were using out of date time rather then % like how agents scale

## Changelog
:cl:
tweak: tweaked stm's and pib scaling
balance: rebalanced stm's and pib scaling
fix: fixed stm's and pib scaling
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
