### PR TITLE
Reduces Blood Refinery PE Cost

### DIFF
--- a/ModularTegustation/tegu_items/refinery/alt_refinery/blood.dm
+++ b/ModularTegustation/tegu_items/refinery/alt_refinery/blood.dm
@@ -2,7 +2,7 @@
 	name = "Blood Refinery"
 	desc = "A machine used by the Extraction Officer to give all but 1 of their HP for a chance at a PE box."
 	icon_state = "dominator-red"
-	extraction_cost = 100
+	extraction_cost = 75
 
 /obj/structure/altrefiner/blood/attack_hand(mob/living/carbon/M)
 	if(M.health <= 20)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes the Blood Refinery cost 75 PE to use instead of 100 PE.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
As is it is worse than the regular refinery in all possible ways, as it takes a good amount of time to heal and is more expensive than using the refinery with filters. With this change, it might make the blood refinery more worth it. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: rebalanced blood refinery
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
