### PR TITLE
Turns eta-corp wastefull var-edited turfs into actual coded ones

### DIFF
--- a/ModularTegustation/turfs.dm
+++ b/ModularTegustation/turfs.dm
@@ -1,0 +1,11 @@
+/turf/open/lava/enkephalin
+	name = "Unrefined Enkephalin"
+	desc = "A fortune's worth of L Corporation's known product. Do Not Drink"
+	color = "#006700"
+	light_range = 0
+	slowdown = 0
+
+/obj/structure/lattice/lava/enkephalin
+	name = "heatproof reinforced glass floor"
+	desc = "Made from specialized glass and metals, allowing for easy traversal above and transparency below. Watch your step."
+	resistance_flags = 115

--- a/_maps/map_files/Eta/etacorp.dmm
+++ b/_maps/map_files/Eta/etacorp.dmm
@@ -378,24 +378,13 @@
 	},
 /area/department_main/extraction)
 "bB" = (
-/obj/structure/lattice/lava{
-	desc = "Made from specialized glass and metals, allowing for easy traversal above and transparency below. Watch your step.";
-	name = "heatproof reinforced glass floor";
-	resistance_flags = 115
-	},
 /obj/machinery/light{
 	dir = 4;
 	pixel_x = 9;
 	pixel_y = 4
 	},
-/turf/open/lava{
-	color = "#006700";
-	desc = "A fortune's worth of L Corporation's known product. Do Not Drink";
-	light_power = 0;
-	light_range = 0;
-	name = "Unrefined Enkephalin";
-	slowdown = 0
-	},
+/obj/structure/lattice/lava/enkephalin,
+/turf/open/lava/enkephalin,
 /area/facility_hallway/west)
 "bE" = (
 /obj/machinery/recharger{
@@ -427,22 +416,11 @@
 /turf/open/floor/pod/dark,
 /area/facility_hallway/human)
 "bH" = (
-/obj/structure/lattice/lava{
-	desc = "Made from specialized glass and metals, allowing for easy traversal above and transparency below. Watch your step.";
-	name = "heatproof reinforced glass floor";
-	resistance_flags = 115
-	},
 /obj/structure/window/reinforced/spawner{
 	resistance_flags = 115
 	},
-/turf/open/lava{
-	color = "#006700";
-	desc = "A fortune's worth of L Corporation's known product. Do Not Drink";
-	light_power = 0;
-	light_range = 0;
-	name = "Unrefined Enkephalin";
-	slowdown = 0
-	},
+/obj/structure/lattice/lava/enkephalin,
+/turf/open/lava/enkephalin,
 /area/facility_hallway/west)
 "bN" = (
 /obj/effect/turf_decal/bot/right,
@@ -578,25 +556,13 @@
 /turf/open/floor/carpet/red,
 /area/department_main/control)
 "cH" = (
-/obj/structure/lattice/lava{
-	resistance_flags = 115
-	},
-/obj/structure/lattice/lava{
-	resistance_flags = 115
-	},
 /obj/machinery/light{
 	dir = 8;
 	pixel_x = -9;
 	pixel_y = 4
 	},
-/turf/open/lava{
-	color = "#006700";
-	desc = "A fortune's worth of L Corporation's known product. Do Not Drink";
-	light_power = 0;
-	light_range = 0;
-	name = "Unrefined Enkephalin";
-	slowdown = 0
-	},
+/obj/structure/lattice/lava/enkephalin,
+/turf/open/lava/enkephalin,
 /area/facility_hallway/east)
 "cK" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -657,12 +623,7 @@
 	pixel_y = 128;
 	resistance_flags = 115
 	},
-/turf/open/lava{
-	color = "#006700";
-	density = 1;
-	desc = "A fortune's worth of L Corporation's known product. Do Not Drink";
-	name = "Unrefined Enkephalin"
-	},
+/turf/open/lava/enkephalin,
 /area/facility_hallway/east)
 "dj" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -792,14 +753,6 @@
 	color = "#ccc8c0"
 	},
 /area/department_main/command)
-"dE" = (
-/turf/open/lava{
-	color = "#006700";
-	density = 1;
-	desc = "A fortune's worth of L Corporation's known product. Do Not Drink";
-	name = "Unrefined Enkephalin"
-	},
-/area/facility_hallway/west)
 "dF" = (
 /obj/effect/light_emitter{
 	light_power = 4;
@@ -830,19 +783,8 @@
 	network = list("ss13");
 	pixel_x = -16
 	},
-/obj/structure/lattice/lava{
-	desc = "Made from specialized glass and metals, allowing for easy traversal above and transparency below. Watch your step.";
-	name = "heatproof reinforced glass floor";
-	resistance_flags = 115
-	},
-/turf/open/lava{
-	color = "#006700";
-	desc = "A fortune's worth of L Corporation's known product. Do Not Drink";
-	light_power = 0;
-	light_range = 0;
-	name = "Unrefined Enkephalin";
-	slowdown = 0
-	},
+/obj/structure/lattice/lava/enkephalin,
+/turf/open/lava/enkephalin,
 /area/department_main/control)
 "dO" = (
 /obj/machinery/door/airlock{
@@ -915,26 +857,6 @@
 	},
 /turf/open/floor/carpet/red,
 /area/department_main/control)
-"eg" = (
-/obj/structure/lattice/lava{
-	desc = "Made from specialized glass and metals, allowing for easy traversal above and transparency below. Watch your step.";
-	name = "heatproof reinforced glass floor";
-	resistance_flags = 115
-	},
-/obj/structure/lattice/lava{
-	desc = "Made from specialized glass and metals, allowing for easy traversal above and transparency below. Watch your step.";
-	name = "heatproof reinforced glass floor";
-	resistance_flags = 115
-	},
-/turf/open/lava{
-	color = "#006700";
-	desc = "A fortune's worth of L Corporation's known product. Do Not Drink";
-	light_power = 0;
-	light_range = 0;
-	name = "Unrefined Enkephalin";
-	slowdown = 0
-	},
-/area/department_main/command)
 "eh" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 8
@@ -966,11 +888,6 @@
 /turf/open/floor/plasteel/white,
 /area/facility_hallway/training)
 "eo" = (
-/obj/structure/lattice/lava{
-	desc = "Made from specialized glass and metals, allowing for easy traversal above and transparency below. Watch your step.";
-	name = "heatproof reinforced glass floor";
-	resistance_flags = 115
-	},
 /obj/structure/window/reinforced/spawner{
 	resistance_flags = 115
 	},
@@ -978,14 +895,8 @@
 	pixel_x = 32;
 	resistance_flags = 115
 	},
-/turf/open/lava{
-	color = "#006700";
-	desc = "A fortune's worth of L Corporation's known product. Do Not Drink";
-	light_power = 0;
-	light_range = 0;
-	name = "Unrefined Enkephalin";
-	slowdown = 0
-	},
+/obj/structure/lattice/lava/enkephalin,
+/turf/open/lava/enkephalin,
 /area/facility_hallway/west)
 "ep" = (
 /obj/machinery/light{
@@ -1528,19 +1439,8 @@
 	},
 /area/space)
 "hg" = (
-/obj/structure/lattice/lava{
-	desc = "Made from specialized glass and metals, allowing for easy traversal above and transparency below. Watch your step.";
-	name = "heatproof reinforced glass floor";
-	resistance_flags = 115
-	},
-/turf/open/lava{
-	color = "#006700";
-	desc = "A fortune's worth of L Corporation's known product. Do Not Drink";
-	light_power = 0;
-	light_range = 0;
-	name = "Unrefined Enkephalin";
-	slowdown = 0
-	},
+/obj/structure/lattice/lava/enkephalin,
+/turf/open/lava/enkephalin,
 /area/department_main/safety)
 "hh" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -1644,19 +1544,8 @@
 	dir = 8;
 	resistance_flags = 115
 	},
-/obj/structure/lattice/lava{
-	desc = "Made from specialized glass and metals, allowing for easy traversal above and transparency below. Watch your step.";
-	name = "heatproof reinforced glass floor";
-	resistance_flags = 115
-	},
-/turf/open/lava{
-	color = "#006700";
-	desc = "A fortune's worth of L Corporation's known product. Do Not Drink";
-	light_power = 0;
-	light_range = 0;
-	name = "Unrefined Enkephalin";
-	slowdown = 0
-	},
+/obj/structure/lattice/lava/enkephalin,
+/turf/open/lava/enkephalin,
 /area/department_main/command)
 "hB" = (
 /obj/effect/turf_decal/siding/green{
@@ -1950,19 +1839,8 @@
 /turf/open/floor/plasteel/white,
 /area/facility_hallway/training)
 "iP" = (
-/obj/structure/lattice/lava{
-	desc = "Made from specialized glass and metals, allowing for easy traversal above and transparency below. Watch your step.";
-	name = "heatproof reinforced glass floor";
-	resistance_flags = 115
-	},
-/turf/open/lava{
-	color = "#006700";
-	desc = "A fortune's worth of L Corporation's known product. Do Not Drink";
-	light_power = 0;
-	light_range = 0;
-	name = "Unrefined Enkephalin";
-	slowdown = 0
-	},
+/obj/structure/lattice/lava/enkephalin,
+/turf/open/lava/enkephalin,
 /area/facility_hallway/west)
 "iR" = (
 /obj/effect/landmark/xeno_spawn,
@@ -2041,17 +1919,8 @@
 /turf/open/floor/plasteel/dark,
 /area/department_main/information)
 "ju" = (
-/obj/structure/lattice/lava{
-	resistance_flags = 115
-	},
-/turf/open/lava{
-	color = "#006700";
-	desc = "A fortune's worth of L Corporation's known product. Do Not Drink";
-	light_power = 0;
-	light_range = 0;
-	name = "Unrefined Enkephalin";
-	slowdown = 0
-	},
+/obj/structure/lattice/lava/enkephalin,
+/turf/open/lava/enkephalin,
 /area/facility_hallway/east)
 "jw" = (
 /obj/effect/landmark/latejoin,
@@ -2092,19 +1961,8 @@
 /obj/structure/window/reinforced/spawner{
 	resistance_flags = 115
 	},
-/obj/structure/lattice/lava{
-	desc = "Made from specialized glass and metals, allowing for easy traversal above and transparency below. Watch your step.";
-	name = "heatproof reinforced glass floor";
-	resistance_flags = 115
-	},
-/turf/open/lava{
-	color = "#006700";
-	desc = "A fortune's worth of L Corporation's known product. Do Not Drink";
-	light_power = 0;
-	light_range = 0;
-	name = "Unrefined Enkephalin";
-	slowdown = 0
-	},
+/obj/structure/lattice/lava/enkephalin,
+/turf/open/lava/enkephalin,
 /area/department_main/command)
 "jG" = (
 /obj/structure/window/reinforced/fulltile{
@@ -2309,19 +2167,8 @@
 	max_integrity = 25;
 	resistance_flags = 115
 	},
-/obj/structure/lattice/lava{
-	desc = "Made from specialized glass and metals, allowing for easy traversal above and transparency below. Watch your step.";
-	name = "heatproof reinforced glass floor";
-	resistance_flags = 115
-	},
-/turf/open/lava{
-	color = "#006700";
-	desc = "A fortune's worth of L Corporation's known product. Do Not Drink";
-	light_power = 0;
-	light_range = 0;
-	name = "Unrefined Enkephalin";
-	slowdown = 0
-	},
+/obj/structure/lattice/lava/enkephalin,
+/turf/open/lava/enkephalin,
 /area/department_main/command)
 "kC" = (
 /obj/effect/turf_decal/siding/yellow/end,
@@ -2569,12 +2416,7 @@
 	set_cap = 3;
 	set_luminosity = 24
 	},
-/turf/open/lava{
-	color = "#006700";
-	density = 1;
-	desc = "A fortune's worth of L Corporation's known product. Do Not Drink";
-	name = "Unrefined Enkephalin"
-	},
+/turf/open/lava/enkephalin,
 /area/space)
 "lK" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -3199,19 +3041,8 @@
 	pixel_x = -16;
 	pixel_y = 13
 	},
-/obj/structure/lattice/lava{
-	desc = "Made from specialized glass and metals, allowing for easy traversal above and transparency below. Watch your step.";
-	name = "heatproof reinforced glass floor";
-	resistance_flags = 115
-	},
-/turf/open/lava{
-	color = "#006700";
-	desc = "A fortune's worth of L Corporation's known product. Do Not Drink";
-	light_power = 0;
-	light_range = 0;
-	name = "Unrefined Enkephalin";
-	slowdown = 0
-	},
+/obj/structure/lattice/lava/enkephalin,
+/turf/open/lava/enkephalin,
 /area/department_main/control)
 "oc" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -3245,19 +3076,8 @@
 	},
 /area/department_main/extraction)
 "of" = (
-/obj/structure/lattice/lava{
-	desc = "Made from specialized glass and metals, allowing for easy traversal above and transparency below. Watch your step.";
-	name = "heatproof reinforced glass floor";
-	resistance_flags = 115
-	},
-/turf/open/lava{
-	color = "#006700";
-	desc = "A fortune's worth of L Corporation's known product. Do Not Drink";
-	light_power = 0;
-	light_range = 0;
-	name = "Unrefined Enkephalin";
-	slowdown = 0
-	},
+/obj/structure/lattice/lava/enkephalin,
+/turf/open/lava/enkephalin,
 /area/facility_hallway/south)
 "oi" = (
 /obj/effect/turf_decal/tile/green,
@@ -3313,24 +3133,6 @@
 	color = "#ccc8c0"
 	},
 /area/facility_hallway/safety)
-"or" = (
-/obj/structure/lattice/lava{
-	resistance_flags = 115
-	},
-/obj/structure/lattice/lava{
-	desc = "Made from specialized glass and metals, allowing for easy traversal above and transparency below. Watch your step.";
-	name = "heatproof reinforced glass floor";
-	resistance_flags = 115
-	},
-/turf/open/lava{
-	color = "#006700";
-	desc = "A fortune's worth of L Corporation's known product. Do Not Drink";
-	light_power = 0;
-	light_range = 0;
-	name = "Unrefined Enkephalin";
-	slowdown = 0
-	},
-/area/facility_hallway/east)
 "os" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 4
@@ -3366,12 +3168,7 @@
 /turf/open/floor/carpet/red,
 /area/department_main/control)
 "oF" = (
-/turf/open/lava{
-	color = "#006700";
-	density = 1;
-	desc = "A fortune's worth of L Corporation's known product. Do Not Drink";
-	name = "Unrefined Enkephalin"
-	},
+/turf/open/lava/enkephalin,
 /area/facility_hallway/north)
 "oN" = (
 /obj/effect/turf_decal/stripes/white/corner{
@@ -3379,22 +3176,6 @@
 	},
 /turf/open/floor/facility/dark,
 /area/department_main/extraction)
-"oQ" = (
-/obj/structure/lattice/lava{
-	resistance_flags = 115
-	},
-/obj/structure/lattice/lava{
-	resistance_flags = 115
-	},
-/turf/open/lava{
-	color = "#006700";
-	desc = "A fortune's worth of L Corporation's known product. Do Not Drink";
-	light_power = 0;
-	light_range = 0;
-	name = "Unrefined Enkephalin";
-	slowdown = 0
-	},
-/area/facility_hallway/east)
 "oT" = (
 /obj/effect/spawner/abnormality_room,
 /obj/structure/sign/directions/evac,
@@ -3588,22 +3369,11 @@
 	},
 /area/department_main/extraction)
 "pE" = (
-/obj/structure/lattice/lava{
-	desc = "Made from specialized glass and metals, allowing for easy traversal above and transparency below. Watch your step.";
-	name = "heatproof reinforced glass floor";
-	resistance_flags = 115
-	},
 /obj/machinery/facility_holomap{
 	dir = 4
 	},
-/turf/open/lava{
-	color = "#006700";
-	desc = "A fortune's worth of L Corporation's known product. Do Not Drink";
-	light_power = 0;
-	light_range = 0;
-	name = "Unrefined Enkephalin";
-	slowdown = 0
-	},
+/obj/structure/lattice/lava/enkephalin,
+/turf/open/lava/enkephalin,
 /area/department_main/safety)
 "pG" = (
 /obj/effect/turf_decal/siding/wideplating/dark{
@@ -3765,12 +3535,7 @@
 	pixel_y = 128;
 	resistance_flags = 115
 	},
-/turf/open/lava{
-	color = "#006700";
-	density = 1;
-	desc = "A fortune's worth of L Corporation's known product. Do Not Drink";
-	name = "Unrefined Enkephalin"
-	},
+/turf/open/lava/enkephalin,
 /area/facility_hallway/west)
 "qx" = (
 /obj/effect/turf_decal/siding/green{
@@ -3782,19 +3547,8 @@
 /turf/open/floor/carpet/green,
 /area/department_main/safety)
 "qz" = (
-/obj/structure/lattice/lava{
-	desc = "Made from specialized glass and metals, allowing for easy traversal above and transparency below. Watch your step.";
-	name = "heatproof reinforced glass floor";
-	resistance_flags = 115
-	},
-/turf/open/lava{
-	color = "#006700";
-	desc = "A fortune's worth of L Corporation's known product. Do Not Drink";
-	light_power = 0;
-	light_range = 0;
-	name = "Unrefined Enkephalin";
-	slowdown = 0
-	},
+/obj/structure/lattice/lava/enkephalin,
+/turf/open/lava/enkephalin,
 /area/department_main/control)
 "qA" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -4004,12 +3758,7 @@
 /turf/open/floor/plasteel/dark,
 /area/facility_hallway/control)
 "rv" = (
-/turf/open/lava{
-	color = "#006700";
-	density = 1;
-	desc = "A fortune's worth of L Corporation's known product. Do Not Drink";
-	name = "Unrefined Enkephalin"
-	},
+/turf/open/lava/enkephalin,
 /area/facility_hallway/south)
 "rz" = (
 /obj/effect/turf_decal/siding/wideplating/dark{
@@ -4027,19 +3776,8 @@
 	pixel_x = -16;
 	pixel_y = 16
 	},
-/obj/structure/lattice/lava{
-	desc = "Made from specialized glass and metals, allowing for easy traversal above and transparency below. Watch your step.";
-	name = "heatproof reinforced glass floor";
-	resistance_flags = 115
-	},
-/turf/open/lava{
-	color = "#006700";
-	desc = "A fortune's worth of L Corporation's known product. Do Not Drink";
-	light_power = 0;
-	light_range = 0;
-	name = "Unrefined Enkephalin";
-	slowdown = 0
-	},
+/obj/structure/lattice/lava/enkephalin,
+/turf/open/lava/enkephalin,
 /area/department_main/control)
 "rG" = (
 /obj/effect/landmark/latejoin,
@@ -4468,17 +4206,8 @@
 	},
 /area/facility_hallway/safety)
 "tA" = (
-/obj/structure/lattice/lava{
-	resistance_flags = 115
-	},
-/turf/open/lava{
-	color = "#006700";
-	desc = "A fortune's worth of L Corporation's known product. Do Not Drink";
-	light_power = 0;
-	light_range = 0;
-	name = "Unrefined Enkephalin";
-	slowdown = 0
-	},
+/obj/structure/lattice/lava/enkephalin,
+/turf/open/lava/enkephalin,
 /area/facility_hallway/north)
 "tB" = (
 /obj/effect/turf_decal/stripes/red/line{
@@ -4749,24 +4478,6 @@
 	color = "#ccc8c0"
 	},
 /area/facility_hallway/west)
-"uL" = (
-/obj/structure/window/reinforced/spawner/west{
-	resistance_flags = 115
-	},
-/obj/structure/lattice/lava{
-	desc = "Made from specialized glass and metals, allowing for easy traversal above and transparency below. Watch your step.";
-	name = "heatproof reinforced glass floor";
-	resistance_flags = 115
-	},
-/turf/open/lava{
-	color = "#006700";
-	desc = "A fortune's worth of L Corporation's known product. Do Not Drink";
-	light_power = 0;
-	light_range = 0;
-	name = "Unrefined Enkephalin";
-	slowdown = 0
-	},
-/area/department_main/command)
 "uQ" = (
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 8
@@ -4899,12 +4610,7 @@
 /turf/open/floor/facility/halls,
 /area/facility_hallway/east)
 "vu" = (
-/turf/open/lava{
-	color = "#006700";
-	density = 1;
-	desc = "A fortune's worth of L Corporation's known product. Do Not Drink";
-	name = "Unrefined Enkephalin"
-	},
+/turf/open/lava/enkephalin,
 /area/department_main/safety)
 "vw" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -5422,20 +5128,11 @@
 /turf/open/floor/plasteel/sepia,
 /area/facility_hallway/training)
 "xI" = (
-/obj/structure/lattice/lava{
-	resistance_flags = 115
-	},
 /obj/structure/window/reinforced/spawner{
 	resistance_flags = 115
 	},
-/turf/open/lava{
-	color = "#006700";
-	desc = "A fortune's worth of L Corporation's known product. Do Not Drink";
-	light_power = 0;
-	light_range = 0;
-	name = "Unrefined Enkephalin";
-	slowdown = 0
-	},
+/obj/structure/lattice/lava/enkephalin,
+/turf/open/lava/enkephalin,
 /area/facility_hallway/east)
 "xL" = (
 /obj/structure/bodycontainer/crematorium{
@@ -5739,19 +5436,8 @@
 	pixel_x = -16;
 	pixel_y = 8
 	},
-/obj/structure/lattice/lava{
-	desc = "Made from specialized glass and metals, allowing for easy traversal above and transparency below. Watch your step.";
-	name = "heatproof reinforced glass floor";
-	resistance_flags = 115
-	},
-/turf/open/lava{
-	color = "#006700";
-	desc = "A fortune's worth of L Corporation's known product. Do Not Drink";
-	light_power = 0;
-	light_range = 0;
-	name = "Unrefined Enkephalin";
-	slowdown = 0
-	},
+/obj/structure/lattice/lava/enkephalin,
+/turf/open/lava/enkephalin,
 /area/department_main/control)
 "yS" = (
 /obj/effect/turf_decal/siding/red{
@@ -5773,9 +5459,6 @@
 /turf/open/floor/plating,
 /area/facility_hallway/west)
 "za" = (
-/obj/structure/lattice/lava{
-	resistance_flags = 115
-	},
 /obj/structure/window/reinforced/spawner/east{
 	density = 0;
 	resistance_flags = 115
@@ -5785,14 +5468,8 @@
 	pixel_y = -32;
 	resistance_flags = 115
 	},
-/turf/open/lava{
-	color = "#006700";
-	desc = "A fortune's worth of L Corporation's known product. Do Not Drink";
-	light_power = 0;
-	light_range = 0;
-	name = "Unrefined Enkephalin";
-	slowdown = 0
-	},
+/obj/structure/lattice/lava/enkephalin,
+/turf/open/lava/enkephalin,
 /area/facility_hallway/north)
 "zc" = (
 /obj/machinery/computer/security/telescreen{
@@ -6093,21 +5770,12 @@
 	},
 /area/department_main/training)
 "Az" = (
-/obj/structure/lattice/lava{
-	resistance_flags = 115
-	},
 /obj/structure/window/reinforced/spawner/east{
 	density = 0;
 	resistance_flags = 115
 	},
-/turf/open/lava{
-	color = "#006700";
-	desc = "A fortune's worth of L Corporation's known product. Do Not Drink";
-	light_power = 0;
-	light_range = 0;
-	name = "Unrefined Enkephalin";
-	slowdown = 0
-	},
+/obj/structure/lattice/lava/enkephalin,
+/turf/open/lava/enkephalin,
 /area/facility_hallway/north)
 "AA" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -6117,32 +5785,6 @@
 	color = "#ccc8c0"
 	},
 /area/facility_hallway/south)
-"AC" = (
-/obj/structure/lattice/lava{
-	resistance_flags = 115
-	},
-/obj/structure/lattice/lava{
-	resistance_flags = 115
-	},
-/obj/machinery/light{
-	dir = 8;
-	pixel_x = -9;
-	pixel_y = 4
-	},
-/obj/structure/lattice/lava{
-	desc = "Made from specialized glass and metals, allowing for easy traversal above and transparency below. Watch your step.";
-	name = "heatproof reinforced glass floor";
-	resistance_flags = 115
-	},
-/turf/open/lava{
-	color = "#006700";
-	desc = "A fortune's worth of L Corporation's known product. Do Not Drink";
-	light_power = 0;
-	light_range = 0;
-	name = "Unrefined Enkephalin";
-	slowdown = 0
-	},
-/area/facility_hallway/east)
 "AF" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/disposalpipe/junction{
@@ -6254,9 +5896,6 @@
 /turf/open/floor/carpet/green,
 /area/department_main/safety)
 "AX" = (
-/obj/structure/lattice/lava{
-	resistance_flags = 115
-	},
 /obj/structure/window/reinforced/spawner/west{
 	max_integrity = 25;
 	resistance_flags = 115
@@ -6266,14 +5905,8 @@
 	pixel_y = -32;
 	resistance_flags = 115
 	},
-/turf/open/lava{
-	color = "#006700";
-	desc = "A fortune's worth of L Corporation's known product. Do Not Drink";
-	light_power = 0;
-	light_range = 0;
-	name = "Unrefined Enkephalin";
-	slowdown = 0
-	},
+/obj/structure/lattice/lava/enkephalin,
+/turf/open/lava/enkephalin,
 /area/facility_hallway/north)
 "AY" = (
 /obj/effect/turf_decal/bot/left,
@@ -6716,22 +6349,8 @@
 /obj/structure/window/reinforced/spawner/west{
 	resistance_flags = 115
 	},
-/obj/structure/lattice/lava{
-	resistance_flags = 115
-	},
-/obj/structure/lattice/lava{
-	desc = "Made from specialized glass and metals, allowing for easy traversal above and transparency below. Watch your step.";
-	name = "heatproof reinforced glass floor";
-	resistance_flags = 115
-	},
-/turf/open/lava{
-	color = "#006700";
-	desc = "A fortune's worth of L Corporation's known product. Do Not Drink";
-	light_power = 0;
-	light_range = 0;
-	name = "Unrefined Enkephalin";
-	slowdown = 0
-	},
+/obj/structure/lattice/lava/enkephalin,
+/turf/open/lava/enkephalin,
 /area/department_main/command)
 "CM" = (
 /obj/effect/turf_decal/bot/left,
@@ -6808,21 +6427,12 @@
 /turf/open/floor/facility/dark,
 /area/department_main/command)
 "Dc" = (
-/obj/structure/lattice/lava{
-	resistance_flags = 115
-	},
 /obj/structure/window/reinforced/spawner{
 	density = 0;
 	resistance_flags = 115
 	},
-/turf/open/lava{
-	color = "#006700";
-	desc = "A fortune's worth of L Corporation's known product. Do Not Drink";
-	light_power = 0;
-	light_range = 0;
-	name = "Unrefined Enkephalin";
-	slowdown = 0
-	},
+/obj/structure/lattice/lava/enkephalin,
+/turf/open/lava/enkephalin,
 /area/facility_hallway/north)
 "Dg" = (
 /obj/machinery/light{
@@ -6917,21 +6527,12 @@
 	},
 /area/department_main/safety)
 "Dx" = (
-/obj/structure/lattice/lava{
-	resistance_flags = 115
-	},
 /obj/structure/window/reinforced/spawner/west{
 	max_integrity = 25;
 	resistance_flags = 115
 	},
-/turf/open/lava{
-	color = "#006700";
-	desc = "A fortune's worth of L Corporation's known product. Do Not Drink";
-	light_power = 0;
-	light_range = 0;
-	name = "Unrefined Enkephalin";
-	slowdown = 0
-	},
+/obj/structure/lattice/lava/enkephalin,
+/turf/open/lava/enkephalin,
 /area/facility_hallway/north)
 "DA" = (
 /obj/structure/disposalpipe/junction{
@@ -6994,9 +6595,6 @@
 /turf/open/floor/facility/dark,
 /area/department_main/command)
 "DJ" = (
-/obj/structure/lattice/lava{
-	resistance_flags = 115
-	},
 /obj/structure/window/reinforced/spawner{
 	density = 0;
 	resistance_flags = 115
@@ -7006,14 +6604,8 @@
 	pixel_x = -32;
 	resistance_flags = 115
 	},
-/turf/open/lava{
-	color = "#006700";
-	desc = "A fortune's worth of L Corporation's known product. Do Not Drink";
-	light_power = 0;
-	light_range = 0;
-	name = "Unrefined Enkephalin";
-	slowdown = 0
-	},
+/obj/structure/lattice/lava/enkephalin,
+/turf/open/lava/enkephalin,
 /area/facility_hallway/north)
 "DK" = (
 /obj/structure/disposalpipe/junction/yjunction{
@@ -7259,12 +6851,7 @@
 	},
 /area/facility_hallway/training)
 "Fb" = (
-/turf/open/lava{
-	color = "#006700";
-	density = 1;
-	desc = "A fortune's worth of L Corporation's known product. Do Not Drink";
-	name = "Unrefined Enkephalin"
-	},
+/turf/open/lava/enkephalin,
 /area/space)
 "Fe" = (
 /obj/machinery/light{
@@ -7317,19 +6904,8 @@
 /obj/structure/window/reinforced/spawner/east{
 	resistance_flags = 115
 	},
-/obj/structure/lattice/lava{
-	desc = "Made from specialized glass and metals, allowing for easy traversal above and transparency below. Watch your step.";
-	name = "heatproof reinforced glass floor";
-	resistance_flags = 115
-	},
-/turf/open/lava{
-	color = "#006700";
-	desc = "A fortune's worth of L Corporation's known product. Do Not Drink";
-	light_power = 0;
-	light_range = 0;
-	name = "Unrefined Enkephalin";
-	slowdown = 0
-	},
+/obj/structure/lattice/lava/enkephalin,
+/turf/open/lava/enkephalin,
 /area/department_main/command)
 "FA" = (
 /obj/structure/rack{
@@ -7390,22 +6966,11 @@
 	},
 /area/department_main/extraction)
 "FD" = (
-/obj/structure/lattice/lava{
-	desc = "Made from specialized glass and metals, allowing for easy traversal above and transparency below. Watch your step.";
-	name = "heatproof reinforced glass floor";
-	resistance_flags = 115
-	},
 /obj/structure/window/reinforced/spawner/east{
 	resistance_flags = 115
 	},
-/turf/open/lava{
-	color = "#006700";
-	desc = "A fortune's worth of L Corporation's known product. Do Not Drink";
-	light_power = 0;
-	light_range = 0;
-	name = "Unrefined Enkephalin";
-	slowdown = 0
-	},
+/obj/structure/lattice/lava/enkephalin,
+/turf/open/lava/enkephalin,
 /area/facility_hallway/west)
 "FE" = (
 /obj/structure/sign/ordealmonitor,
@@ -7415,19 +6980,8 @@
 	},
 /area/facility_hallway/safety)
 "FK" = (
-/obj/structure/lattice/lava{
-	desc = "Made from specialized glass and metals, allowing for easy traversal above and transparency below. Watch your step.";
-	name = "heatproof reinforced glass floor";
-	resistance_flags = 115
-	},
-/turf/open/lava{
-	color = "#006700";
-	desc = "A fortune's worth of L Corporation's known product. Do Not Drink";
-	light_power = 0;
-	light_range = 0;
-	name = "Unrefined Enkephalin";
-	slowdown = 0
-	},
+/obj/structure/lattice/lava/enkephalin,
+/turf/open/lava/enkephalin,
 /area/department_main/command)
 "FO" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -7578,28 +7132,6 @@
 	color = "#ccc8c0"
 	},
 /area/department_main/control)
-"GP" = (
-/obj/structure/lattice/lava{
-	resistance_flags = 115
-	},
-/obj/structure/window/reinforced/spawner/north{
-	max_integrity = 25;
-	resistance_flags = 115
-	},
-/obj/structure/lattice/lava{
-	desc = "Made from specialized glass and metals, allowing for easy traversal above and transparency below. Watch your step.";
-	name = "heatproof reinforced glass floor";
-	resistance_flags = 115
-	},
-/turf/open/lava{
-	color = "#006700";
-	desc = "A fortune's worth of L Corporation's known product. Do Not Drink";
-	light_power = 0;
-	light_range = 0;
-	name = "Unrefined Enkephalin";
-	slowdown = 0
-	},
-/area/department_main/command)
 "GQ" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 8
@@ -8048,17 +7580,7 @@
 /turf/open/floor/plasteel/dark,
 /area/department_main/command)
 "IY" = (
-/obj/structure/lattice/lava{
-	resistance_flags = 115
-	},
-/turf/open/lava{
-	color = "#006700";
-	desc = "A fortune's worth of L Corporation's known product. Do Not Drink";
-	light_power = 0;
-	light_range = 0;
-	name = "Unrefined Enkephalin";
-	slowdown = 0
-	},
+/turf/open/lava/enkephalin,
 /area/facility_hallway/west)
 "IZ" = (
 /obj/effect/turf_decal/tile/bar,
@@ -8269,19 +7791,8 @@
 	pixel_x = -9;
 	pixel_y = 4
 	},
-/obj/structure/lattice/lava{
-	desc = "Made from specialized glass and metals, allowing for easy traversal above and transparency below. Watch your step.";
-	name = "heatproof reinforced glass floor";
-	resistance_flags = 115
-	},
-/turf/open/lava{
-	color = "#006700";
-	desc = "A fortune's worth of L Corporation's known product. Do Not Drink";
-	light_power = 0;
-	light_range = 0;
-	name = "Unrefined Enkephalin";
-	slowdown = 0
-	},
+/obj/structure/lattice/lava/enkephalin,
+/turf/open/lava/enkephalin,
 /area/department_main/control)
 "JW" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -8561,12 +8072,7 @@
 	pixel_y = 32;
 	resistance_flags = 115
 	},
-/turf/open/lava{
-	color = "#006700";
-	density = 1;
-	desc = "A fortune's worth of L Corporation's known product. Do Not Drink";
-	name = "Unrefined Enkephalin"
-	},
+/turf/open/lava/enkephalin,
 /area/facility_hallway/west)
 "Lh" = (
 /obj/effect/turf_decal/stripes/line{
@@ -8638,20 +8144,12 @@
 	},
 /area/department_main/training)
 "Lw" = (
-/obj/structure/lattice/lava{
-	resistance_flags = 115
-	},
 /obj/machinery/camera{
 	alpha = 0;
 	mouse_opacity = 0;
 	name = "hidden security camera";
 	short_range = 5;
 	view_range = 5
-	},
-/obj/structure/lattice/lava{
-	desc = "Made from specialized glass and metals, allowing for easy traversal above and transparency below. Watch your step.";
-	name = "heatproof reinforced glass floor";
-	resistance_flags = 115
 	},
 /obj/structure/window/reinforced/spawner{
 	resistance_flags = 115
@@ -8660,14 +8158,8 @@
 	pixel_x = -32;
 	resistance_flags = 115
 	},
-/turf/open/lava{
-	color = "#006700";
-	desc = "A fortune's worth of L Corporation's known product. Do Not Drink";
-	light_power = 0;
-	light_range = 0;
-	name = "Unrefined Enkephalin";
-	slowdown = 0
-	},
+/obj/structure/lattice/lava/enkephalin,
+/turf/open/lava/enkephalin,
 /area/facility_hallway/east)
 "Lz" = (
 /obj/machinery/light{
@@ -9196,26 +8688,12 @@
 /turf/open/floor/carpet/orange,
 /area/department_main/training)
 "NU" = (
-/obj/structure/lattice/lava{
-	resistance_flags = 115
-	},
-/obj/structure/lattice/lava{
-	desc = "Made from specialized glass and metals, allowing for easy traversal above and transparency below. Watch your step.";
-	name = "heatproof reinforced glass floor";
-	resistance_flags = 115
-	},
 /obj/structure/window/reinforced/spawner/north{
 	max_integrity = 25;
 	resistance_flags = 115
 	},
-/turf/open/lava{
-	color = "#006700";
-	desc = "A fortune's worth of L Corporation's known product. Do Not Drink";
-	light_power = 0;
-	light_range = 0;
-	name = "Unrefined Enkephalin";
-	slowdown = 0
-	},
+/obj/structure/lattice/lava/enkephalin,
+/turf/open/lava/enkephalin,
 /area/facility_hallway/east)
 "NV" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -9277,12 +8755,7 @@
 	set_cap = 3;
 	set_luminosity = 24
 	},
-/turf/open/lava{
-	color = "#006700";
-	density = 1;
-	desc = "A fortune's worth of L Corporation's known product. Do Not Drink";
-	name = "Unrefined Enkephalin"
-	},
+/turf/open/lava/enkephalin,
 /area/facility_hallway/north)
 "On" = (
 /obj/effect/turf_decal/bot,
@@ -9793,11 +9266,6 @@
 	},
 /area/facility_hallway/control)
 "Qo" = (
-/obj/structure/lattice/lava{
-	desc = "Made from specialized glass and metals, allowing for easy traversal above and transparency below. Watch your step.";
-	name = "heatproof reinforced glass floor";
-	resistance_flags = 115
-	},
 /obj/structure/window/reinforced/spawner/west{
 	max_integrity = 25;
 	resistance_flags = 115
@@ -9807,14 +9275,8 @@
 	pixel_y = 32;
 	resistance_flags = 115
 	},
-/turf/open/lava{
-	color = "#006700";
-	desc = "A fortune's worth of L Corporation's known product. Do Not Drink";
-	light_power = 0;
-	light_range = 0;
-	name = "Unrefined Enkephalin";
-	slowdown = 0
-	},
+/obj/structure/lattice/lava/enkephalin,
+/turf/open/lava/enkephalin,
 /area/facility_hallway/south)
 "Qp" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -9938,12 +9400,7 @@
 /turf/open/floor/facility/halls,
 /area/facility_hallway/training)
 "QY" = (
-/turf/open/lava{
-	color = "#006700";
-	density = 1;
-	desc = "A fortune's worth of L Corporation's known product. Do Not Drink";
-	name = "Unrefined Enkephalin"
-	},
+/turf/open/lava/enkephalin,
 /area/facility_hallway/east)
 "QZ" = (
 /obj/effect/turf_decal/stripes/red/line{
@@ -10290,34 +9747,14 @@
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 8
 	},
-/obj/structure/lattice/lava{
-	resistance_flags = 115
-	},
-/obj/structure/lattice/lava{
-	desc = "Made from specialized glass and metals, allowing for easy traversal above and transparency below. Watch your step.";
-	name = "heatproof reinforced glass floor";
-	resistance_flags = 115
-	},
 /obj/structure/window/reinforced/spawner{
 	dir = 8;
 	resistance_flags = 115
 	},
-/turf/open/lava{
-	color = "#006700";
-	desc = "A fortune's worth of L Corporation's known product. Do Not Drink";
-	light_power = 0;
-	light_range = 0;
-	name = "Unrefined Enkephalin";
-	slowdown = 0
-	},
+/obj/structure/lattice/lava/enkephalin,
+/turf/open/lava/enkephalin,
 /area/facility_hallway/east)
 "SI" = (
-/obj/structure/lattice/lava{
-	resistance_flags = 115
-	},
-/obj/structure/lattice/lava{
-	resistance_flags = 115
-	},
 /obj/structure/window/reinforced/spawner{
 	density = 0;
 	resistance_flags = 115
@@ -10332,14 +9769,8 @@
 	pixel_x = 32;
 	resistance_flags = 115
 	},
-/turf/open/lava{
-	color = "#006700";
-	desc = "A fortune's worth of L Corporation's known product. Do Not Drink";
-	light_power = 0;
-	light_range = 0;
-	name = "Unrefined Enkephalin";
-	slowdown = 0
-	},
+/obj/structure/lattice/lava/enkephalin,
+/turf/open/lava/enkephalin,
 /area/facility_hallway/east)
 "SK" = (
 /obj/machinery/telecomms/broadcaster/preset_left,
@@ -10679,12 +10110,7 @@
 /turf/open/floor/facility/dark,
 /area/department_main/safety)
 "UB" = (
-/turf/open/lava{
-	color = "#006700";
-	density = 1;
-	desc = "A fortune's worth of L Corporation's known product. Do Not Drink";
-	name = "Unrefined Enkephalin"
-	},
+/turf/open/lava/enkephalin,
 /area/department_main/command)
 "UE" = (
 /obj/structure/table/wood,
@@ -10721,19 +10147,8 @@
 	pixel_x = -16;
 	pixel_y = 8
 	},
-/obj/structure/lattice/lava{
-	desc = "Made from specialized glass and metals, allowing for easy traversal above and transparency below. Watch your step.";
-	name = "heatproof reinforced glass floor";
-	resistance_flags = 115
-	},
-/turf/open/lava{
-	color = "#006700";
-	desc = "A fortune's worth of L Corporation's known product. Do Not Drink";
-	light_power = 0;
-	light_range = 0;
-	name = "Unrefined Enkephalin";
-	slowdown = 0
-	},
+/obj/structure/lattice/lava/enkephalin,
+/turf/open/lava/enkephalin,
 /area/department_main/control)
 "UR" = (
 /obj/structure/rack,
@@ -11194,11 +10609,6 @@
 /turf/open/floor/plasteel/dark,
 /area/department_main/information)
 "Xr" = (
-/obj/structure/lattice/lava{
-	desc = "Made from specialized glass and metals, allowing for easy traversal above and transparency below. Watch your step.";
-	name = "heatproof reinforced glass floor";
-	resistance_flags = 115
-	},
 /obj/structure/window/reinforced/spawner/east{
 	pixel_y = 32;
 	resistance_flags = 115
@@ -11206,14 +10616,8 @@
 /obj/structure/window/reinforced/spawner/east{
 	resistance_flags = 115
 	},
-/turf/open/lava{
-	color = "#006700";
-	desc = "A fortune's worth of L Corporation's known product. Do Not Drink";
-	light_power = 0;
-	light_range = 0;
-	name = "Unrefined Enkephalin";
-	slowdown = 0
-	},
+/obj/structure/lattice/lava/enkephalin,
+/turf/open/lava/enkephalin,
 /area/facility_hallway/south)
 "Xt" = (
 /obj/structure/toolabnormality/touch,
@@ -11404,19 +10808,8 @@
 	pixel_x = -16;
 	pixel_y = 20
 	},
-/obj/structure/lattice/lava{
-	desc = "Made from specialized glass and metals, allowing for easy traversal above and transparency below. Watch your step.";
-	name = "heatproof reinforced glass floor";
-	resistance_flags = 115
-	},
-/turf/open/lava{
-	color = "#006700";
-	desc = "A fortune's worth of L Corporation's known product. Do Not Drink";
-	light_power = 0;
-	light_range = 0;
-	name = "Unrefined Enkephalin";
-	slowdown = 0
-	},
+/obj/structure/lattice/lava/enkephalin,
+/turf/open/lava/enkephalin,
 /area/department_main/control)
 "Yy" = (
 /turf/closed/indestructible/reinforced{
@@ -11475,19 +10868,8 @@
 	pixel_x = -16;
 	pixel_y = 3
 	},
-/obj/structure/lattice/lava{
-	desc = "Made from specialized glass and metals, allowing for easy traversal above and transparency below. Watch your step.";
-	name = "heatproof reinforced glass floor";
-	resistance_flags = 115
-	},
-/turf/open/lava{
-	color = "#006700";
-	desc = "A fortune's worth of L Corporation's known product. Do Not Drink";
-	light_power = 0;
-	light_range = 0;
-	name = "Unrefined Enkephalin";
-	slowdown = 0
-	},
+/obj/structure/lattice/lava/enkephalin,
+/turf/open/lava/enkephalin,
 /area/department_main/control)
 "YJ" = (
 /obj/effect/turf_decal/siding/red{
@@ -40690,9 +40072,9 @@ lX
 Jp
 bN
 bH
-dE
-dE
-dE
+IY
+IY
+IY
 Yg
 Mh
 Mh
@@ -40947,9 +40329,9 @@ wP
 wP
 lT
 eo
-dE
-dE
-dE
+IY
+IY
+IY
 Yg
 Mh
 Mh
@@ -41204,9 +40586,9 @@ iP
 iP
 iP
 bB
-dE
-dE
-dE
+IY
+IY
+IY
 Yg
 Mh
 Mh
@@ -41453,9 +40835,9 @@ Yg
 nR
 Pn
 bH
-dE
-dE
-dE
+IY
+IY
+IY
 Yg
 Yg
 Yg
@@ -41705,14 +41087,14 @@ Mh
 Mh
 Mh
 Yg
-dE
-dE
+IY
+IY
 IY
 hG
 bH
 Lg
 qt
-dE
+IY
 Yg
 Mh
 Mh
@@ -41962,14 +41344,14 @@ Mh
 Mh
 Mh
 Yg
-dE
-dE
+IY
+IY
 IY
 Jr
 iP
-dE
-dE
-dE
+IY
+IY
+IY
 Yg
 Mh
 Mh
@@ -42730,7 +42112,7 @@ KF
 uf
 UB
 UB
-GP
+kz
 FK
 FK
 FK
@@ -43245,7 +42627,7 @@ uf
 zr
 FK
 FK
-eg
+FK
 Fv
 Fv
 kp
@@ -45816,15 +45198,15 @@ Wh
 FK
 FK
 FK
-uL
-uL
+CK
+CK
 kp
 gN
 YT
 Ix
 Iv
-uL
-uL
+CK
+CK
 FK
 FK
 FK
@@ -46330,8 +45712,8 @@ UB
 UB
 kz
 FK
-eg
-eg
+FK
+FK
 kp
 gN
 YT
@@ -47104,9 +46486,9 @@ zA
 kL
 QY
 QY
-or
+ju
 dy
-or
+ju
 QY
 de
 QY
@@ -47877,14 +47259,14 @@ ME
 kL
 pw
 OF
-or
+ju
 SH
 SH
 SH
-AC
-oQ
-oQ
-oQ
+cH
+ju
+ju
+ju
 cH
 QY
 QY

--- a/_maps/map_files/Eta/etacorp.dmm
+++ b/_maps/map_files/Eta/etacorp.dmm
@@ -266,7 +266,6 @@
 	},
 /obj/structure/window/reinforced/spawner/north{
 	max_integrity = 25;
-	pixel_x = 32;
 	resistance_flags = 115
 	},
 /obj/effect/light_emitter{
@@ -618,13 +617,13 @@
 /turf/open/floor/facility/dark,
 /area/department_main/information)
 "de" = (
+/obj/structure/lattice/lava/enkephalin,
 /obj/structure/window/reinforced/spawner/north{
 	max_integrity = 25;
-	pixel_y = 128;
 	resistance_flags = 115
 	},
 /turf/open/lava/enkephalin,
-/area/facility_hallway/east)
+/area/facility_hallway/west)
 "dj" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 1
@@ -888,16 +887,17 @@
 /turf/open/floor/plasteel/white,
 /area/facility_hallway/training)
 "eo" = (
-/obj/structure/window/reinforced/spawner{
-	resistance_flags = 115
-	},
-/obj/structure/window/reinforced/spawner{
-	pixel_x = 32;
-	resistance_flags = 115
+/obj/machinery/light{
+	dir = 8;
+	pixel_x = -9;
+	pixel_y = 4
 	},
 /obj/structure/lattice/lava/enkephalin,
+/obj/structure/window/reinforced/spawner{
+	resistance_flags = 115
+	},
 /turf/open/lava/enkephalin,
-/area/facility_hallway/west)
+/area/facility_hallway/east)
 "ep" = (
 /obj/machinery/light{
 	dir = 4;
@@ -1979,9 +1979,7 @@
 	name = "wing-grade railing";
 	resistance_flags = 115
 	},
-/obj/structure/window/reinforced/spawner{
-	pixel_y = 2
-	},
+/obj/structure/window/reinforced/spawner,
 /obj/machinery/computer/abnormality_logs{
 	dir = 8
 	},
@@ -2186,13 +2184,9 @@
 /area/department_main/safety)
 "kG" = (
 /obj/structure/window/reinforced/spawner/east{
-	pixel_x = -224;
 	resistance_flags = 115
 	},
-/obj/structure/window/reinforced/spawner{
-	pixel_x = -224;
-	pixel_y = 25
-	},
+/obj/structure/window/reinforced/spawner,
 /turf/closed/indestructible/rock,
 /area/space)
 "kI" = (
@@ -3077,6 +3071,10 @@
 /area/department_main/extraction)
 "of" = (
 /obj/structure/lattice/lava/enkephalin,
+/obj/structure/window/reinforced/spawner/west{
+	max_integrity = 25;
+	resistance_flags = 115
+	},
 /turf/open/lava/enkephalin,
 /area/facility_hallway/south)
 "oi" = (
@@ -3444,8 +3442,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced/spawner/west{
-	max_integrity = 25;
-	pixel_x = -6
+	max_integrity = 25
 	},
 /turf/open/floor/plasteel/dark{
 	color = "#ccc8c0"
@@ -3524,19 +3521,12 @@
 	},
 /area/facility_hallway/east)
 "qt" = (
-/obj/structure/window/reinforced/spawner/north{
-	max_integrity = 25;
-	pixel_y = 128;
-	resistance_flags = 115
-	},
-/obj/structure/window/reinforced/spawner/north{
-	max_integrity = 25;
-	pixel_x = 32;
-	pixel_y = 128;
+/obj/structure/lattice/lava/enkephalin,
+/obj/structure/window/reinforced/spawner/east{
 	resistance_flags = 115
 	},
 /turf/open/lava/enkephalin,
-/area/facility_hallway/west)
+/area/facility_hallway/north)
 "qx" = (
 /obj/effect/turf_decal/siding/green{
 	color = "#006400";
@@ -5459,18 +5449,12 @@
 /turf/open/floor/plating,
 /area/facility_hallway/west)
 "za" = (
-/obj/structure/window/reinforced/spawner/east{
-	density = 0;
-	resistance_flags = 115
-	},
-/obj/structure/window/reinforced/spawner/east{
-	density = 0;
-	pixel_y = -32;
-	resistance_flags = 115
-	},
 /obj/structure/lattice/lava/enkephalin,
+/obj/structure/window/reinforced/spawner{
+	resistance_flags = 115
+	},
 /turf/open/lava/enkephalin,
-/area/facility_hallway/north)
+/area/facility_hallway/west)
 "zc" = (
 /obj/machinery/computer/security/telescreen{
 	dir = 4;
@@ -5515,14 +5499,17 @@
 	},
 /area/facility_hallway/east)
 "zl" = (
-/obj/structure/window/reinforced/spawner/north{
-	density = 0;
-	max_integrity = 25;
-	pixel_x = -128;
+/obj/machinery/light{
+	dir = 4;
+	pixel_x = 9;
+	pixel_y = 4
+	},
+/obj/structure/lattice/lava/enkephalin,
+/obj/structure/window/reinforced/spawner{
 	resistance_flags = 115
 	},
-/turf/closed/indestructible/rock,
-/area/space)
+/turf/open/lava/enkephalin,
+/area/facility_hallway/west)
 "zn" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 1
@@ -5771,7 +5758,6 @@
 /area/department_main/training)
 "Az" = (
 /obj/structure/window/reinforced/spawner/east{
-	density = 0;
 	resistance_flags = 115
 	},
 /obj/structure/lattice/lava/enkephalin,
@@ -5896,16 +5882,11 @@
 /turf/open/floor/carpet/green,
 /area/department_main/safety)
 "AX" = (
-/obj/structure/window/reinforced/spawner/west{
-	max_integrity = 25;
-	resistance_flags = 115
-	},
-/obj/structure/window/reinforced/spawner/west{
-	max_integrity = 25;
-	pixel_y = -32;
-	resistance_flags = 115
-	},
 /obj/structure/lattice/lava/enkephalin,
+/obj/structure/window/reinforced/spawner/west{
+	max_integrity = 25;
+	resistance_flags = 115
+	},
 /turf/open/lava/enkephalin,
 /area/facility_hallway/north)
 "AY" = (
@@ -6428,7 +6409,6 @@
 /area/department_main/command)
 "Dc" = (
 /obj/structure/window/reinforced/spawner{
-	density = 0;
 	resistance_flags = 115
 	},
 /obj/structure/lattice/lava/enkephalin,
@@ -6464,9 +6444,7 @@
 	name = "wing-grade railing";
 	resistance_flags = 115
 	},
-/obj/structure/window/reinforced/spawner{
-	pixel_y = 2
-	},
+/obj/structure/window/reinforced/spawner,
 /obj/machinery/computer/message_monitor{
 	dir = 1
 	},
@@ -6595,18 +6573,12 @@
 /turf/open/floor/facility/dark,
 /area/department_main/command)
 "DJ" = (
-/obj/structure/window/reinforced/spawner{
-	density = 0;
-	resistance_flags = 115
-	},
-/obj/structure/window/reinforced/spawner{
-	density = 0;
-	pixel_x = -32;
-	resistance_flags = 115
-	},
 /obj/structure/lattice/lava/enkephalin,
+/obj/structure/window/reinforced/spawner{
+	resistance_flags = 115
+	},
 /turf/open/lava/enkephalin,
-/area/facility_hallway/north)
+/area/facility_hallway/east)
 "DK" = (
 /obj/structure/disposalpipe/junction/yjunction{
 	dir = 4
@@ -7951,6 +7923,9 @@
 /obj/item/reagent_containers/hypospray/emais{
 	pixel_y = 9
 	},
+/obj/structure/window/reinforced/spawner/east{
+	resistance_flags = 115
+	},
 /turf/open/floor/facility/white,
 /area/department_main/safety)
 "KC" = (
@@ -8067,13 +8042,12 @@
 	},
 /area/facility_hallway/human)
 "Lg" = (
-/obj/structure/window/reinforced/spawner{
-	pixel_x = 32;
-	pixel_y = 32;
+/obj/structure/lattice/lava/enkephalin,
+/obj/structure/window/reinforced/spawner/east{
 	resistance_flags = 115
 	},
 /turf/open/lava/enkephalin,
-/area/facility_hallway/west)
+/area/facility_hallway/south)
 "Lh" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -8152,10 +8126,6 @@
 	view_range = 5
 	},
 /obj/structure/window/reinforced/spawner{
-	resistance_flags = 115
-	},
-/obj/structure/window/reinforced/spawner{
-	pixel_x = -32;
 	resistance_flags = 115
 	},
 /obj/structure/lattice/lava/enkephalin,
@@ -8483,6 +8453,10 @@
 /obj/item/reagent_containers/hypospray/medipen/mental,
 /obj/item/reagent_containers/hypospray/medipen/mental,
 /obj/item/reagent_containers/hypospray/medipen/mental,
+/obj/structure/window/reinforced/spawner/north{
+	max_integrity = 25;
+	resistance_flags = 115
+	},
 /turf/open/floor/facility/white,
 /area/department_main/safety)
 "Ne" = (
@@ -9270,11 +9244,6 @@
 	max_integrity = 25;
 	resistance_flags = 115
 	},
-/obj/structure/window/reinforced/spawner/west{
-	max_integrity = 25;
-	pixel_y = 32;
-	resistance_flags = 115
-	},
 /obj/structure/lattice/lava/enkephalin,
 /turf/open/lava/enkephalin,
 /area/facility_hallway/south)
@@ -9307,12 +9276,9 @@
 /area/facility_hallway/control)
 "Qx" = (
 /obj/structure/window/reinforced/spawner/east{
-	pixel_x = 6;
 	resistance_flags = 115
 	},
 /obj/structure/window/reinforced/spawner/east{
-	pixel_x = 6;
-	pixel_y = 32;
 	resistance_flags = 115
 	},
 /obj/item/toy/plush/mosb,
@@ -9703,7 +9669,6 @@
 	color = "#7D6521"
 	},
 /obj/structure/window/reinforced/spawner/east{
-	pixel_x = 6;
 	resistance_flags = 115
 	},
 /turf/open/floor/plasteel/dark{
@@ -9755,21 +9720,11 @@
 /turf/open/lava/enkephalin,
 /area/facility_hallway/east)
 "SI" = (
-/obj/structure/window/reinforced/spawner{
-	density = 0;
-	resistance_flags = 115
-	},
-/obj/structure/window/reinforced/spawner{
-	density = 0;
-	pixel_x = -32;
-	resistance_flags = 115
-	},
-/obj/structure/window/reinforced/spawner{
-	density = 0;
-	pixel_x = 32;
-	resistance_flags = 115
-	},
 /obj/structure/lattice/lava/enkephalin,
+/obj/structure/window/reinforced/spawner/north{
+	max_integrity = 25;
+	resistance_flags = 115
+	},
 /turf/open/lava/enkephalin,
 /area/facility_hallway/east)
 "SK" = (
@@ -10254,12 +10209,12 @@
 /turf/open/floor/plasteel/dark,
 /area/department_main/safety)
 "Vq" = (
-/obj/structure/window/reinforced/spawner/east{
-	pixel_x = -160;
+/obj/structure/lattice/lava/enkephalin,
+/obj/structure/window/reinforced/spawner{
 	resistance_flags = 115
 	},
-/turf/closed/indestructible/rock,
-/area/space)
+/turf/open/lava/enkephalin,
+/area/facility_hallway/north)
 "Vs" = (
 /obj/effect/turf_decal/siding/red{
 	color = "#440000";
@@ -10609,10 +10564,6 @@
 /turf/open/floor/plasteel/dark,
 /area/department_main/information)
 "Xr" = (
-/obj/structure/window/reinforced/spawner/east{
-	pixel_y = 32;
-	resistance_flags = 115
-	},
 /obj/structure/window/reinforced/spawner/east{
 	resistance_flags = 115
 	},
@@ -40328,7 +40279,7 @@ wP
 wP
 wP
 lT
-eo
+bH
 IY
 IY
 IY
@@ -40585,7 +40536,7 @@ bB
 iP
 iP
 iP
-bB
+zl
 IY
 IY
 IY
@@ -41089,11 +41040,11 @@ Mh
 Yg
 IY
 IY
-IY
+de
 hG
 bH
-Lg
-qt
+IY
+IY
 IY
 Yg
 Mh
@@ -41346,9 +41297,9 @@ Mh
 Yg
 IY
 IY
-IY
+de
 Jr
-iP
+za
 IY
 IY
 IY
@@ -42619,7 +42570,7 @@ Bi
 wM
 Ic
 ys
-tA
+Vq
 oF
 oF
 oF
@@ -42876,7 +42827,7 @@ Bi
 wM
 oo
 ys
-DJ
+Dc
 oF
 oF
 Ok
@@ -43649,8 +43600,8 @@ HD
 Et
 tA
 Dx
+Dx
 AX
-tA
 sB
 Xn
 Xn
@@ -44163,8 +44114,8 @@ qk
 Qc
 tA
 Az
-za
-tA
+Az
+qt
 sB
 CA
 CA
@@ -44184,7 +44135,7 @@ CA
 CA
 CA
 sB
-of
+Lg
 Xr
 AA
 Qp
@@ -46486,11 +46437,11 @@ zA
 kL
 QY
 QY
-ju
+SI
 dy
-ju
+DJ
 QY
-de
+QY
 QY
 kL
 Mh
@@ -47267,7 +47218,7 @@ cH
 ju
 ju
 ju
-cH
+eo
 QY
 QY
 QY
@@ -47524,7 +47475,7 @@ rj
 rj
 rj
 iG
-SI
+xI
 QY
 QY
 QY
@@ -47781,7 +47732,7 @@ ZO
 ZO
 ct
 ed
-ju
+DJ
 QY
 QY
 QY
@@ -55732,8 +55683,8 @@ Mh
 Mh
 Mh
 Mh
-Vq
-zl
+Mh
+Mh
 Mh
 Mh
 Mh

--- a/lobotomy-corp13.dme
+++ b/lobotomy-corp13.dme
@@ -3976,6 +3976,7 @@
 #include "ModularTegustation\tegufood.dm"
 #include "ModularTegustation\tegushuttles.dm"
 #include "ModularTegustation\trusted.dm"
+#include "ModularTegustation\turfs.dm"
 #include "ModularTegustation\_adventure_console\adventure_layout.dm"
 #include "ModularTegustation\_adventure_console\console.dm"
 #include "ModularTegustation\_adventure_console\adventure_events\_event.dm"


### PR DESCRIPTION
## About The Pull Request

It was wastefull to have so many turfs on the map be var-edited, not to mention some having the wrong description/not certain variables on them whilst others did

This PR cleans up duplicate lattices, wrong vars, and makes them into actual code

Also it adds windows where there previously were pixel shifted windows that you can walk though, because mappers

## Why It's Good For The Game

Its probably better for game performance, also storage, a lot
