### PR TITLE
Changes meat lantern to a temp 3 check

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/teth/meat_lantern.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/meat_lantern.dm
@@ -135,10 +135,9 @@
 		return
 	..()
 
-/mob/living/simple_animal/hostile/abnormality/meat_lantern/PostWorkEffect(mob/living/carbon/human/user, work_type, pe, work_time, canceled)
-	if(work_time < 18 SECONDS)
-		if(prob(80))
-			datum_reference.qliphoth_change(-1)
+/mob/living/simple_animal/hostile/abnormality/meat_lantern/PostWorkEffect(mob/living/carbon/human/user, work_type, pe, work_time)
+	if (get_attribute_level(user, TEMPERANCE_ATTRIBUTE) >= 60)
+		datum_reference.qliphoth_change(-1)
 	return
 
 /mob/living/simple_animal/hostile/abnormality/meat_lantern/FailureEffect(mob/living/carbon/human/user, work_type, pe)

--- a/code/modules/mob/living/simple_animal/abnormality/teth/meat_lantern.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/meat_lantern.dm
@@ -135,7 +135,7 @@
 		return
 	..()
 
-/mob/living/simple_animal/hostile/abnormality/meat_lantern/PostWorkEffect(mob/living/carbon/human/user, work_type, pe, work_time)
+/mob/living/simple_animal/hostile/abnormality/meat_lantern/PostWorkEffect(mob/living/carbon/human/user, work_type, pe, work_time, canceled)
 	if (get_attribute_level(user, TEMPERANCE_ATTRIBUTE) >= 60)
 		datum_reference.qliphoth_change(-1)
 	return

--- a/code/modules/paperwork/records/info/teth.dm
+++ b/code/modules/paperwork/records/info/teth.dm
@@ -219,7 +219,7 @@
 	abno_code = "O-04-84"
 	abno_info = list(
 		"When the work result was Bad, the Qliphoth Counter lowered.",
-		"When the work took less than 18 seconds to complete, the Qliphoth Counter lowered with a high probability.",
+		"When an Agent with Level 3 Temperance or above completed the work the Qliphoth Counter lowered.",
 		"The facility’s systems and the employees will be unable to detect the Abnormality when it escapes. Thus the manager will need to manually pinpoint it and order suppression directly.")
 
 //Lady facing the Wall


### PR DESCRIPTION

## About The Pull Request

Changes meat lantern to a temp3 check instead of a work time check

## Why It's Good For The Game

meat lantern's current timer req isnt easy to know if you meet it or not and changing it to a flat stat check makes it slightly better whilst also making it much more obvious if you can work it without breaching

## Changelog
:cl:
balance: changes meatlantern to a stat check



