### PR TITLE
Fixes runtime when someone finishes off a mob that qdeletes on death with a knockback weapon

### DIFF
--- a/code/game/objects/items/ego_weapons/_ego_weapon.dm
+++ b/code/game/objects/items/ego_weapons/_ego_weapon.dm
@@ -42,7 +42,7 @@
 	if(charge && attack_charge_gain)
 		HandleCharge(1, target)
 
-	if(target.anchored || !knockback) // lets not throw machines around
+	if(target.anchored || !knockback || QDELETED(target)) // lets not throw machines around
 		return TRUE
 
 	var/atom/throw_target = get_edge_target_turf(target, user.dir)


### PR DESCRIPTION

## About The Pull Request

Game dosen't like when you tell it to throw an object if its being qdeleted
So just added another check

## Why It's Good For The Game

moar squashed bugs

## Changelog
:cl:
code: Runtimes are no longer created when enemies that qdel on death are killed by a knockback weapon
/:cl:
