### PR TITLE
Makes the cherry tree no longer stop you from working or hold your gained attributes hostage for 10 seconds upon breaching

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/teth/cherry_blossoms.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/cherry_blossoms.dm
@@ -39,13 +39,12 @@
 		There is beauty even in great and terrible things. <br>\
 		Even the bodies underneath this tree would agree with you."
 
-	var/numbermarked = 5
+	var/number_of_marks = 5
 
 
 /mob/living/simple_animal/hostile/abnormality/cherry_blossoms/PostWorkEffect(mob/living/carbon/human/user, work_type, pe, work_time)
 	if(user.sanity_lost)
 		datum_reference.qliphoth_change(-1)
-	return
 
 /mob/living/simple_animal/hostile/abnormality/cherry_blossoms/SuccessEffect(mob/living/carbon/human/user, work_type, pe)
 	. = ..()
@@ -54,10 +53,9 @@
 		icon_state = "graveofcherryblossoms_[datum_reference.qliphoth_meter]"
 
 /mob/living/simple_animal/hostile/abnormality/cherry_blossoms/ZeroQliphoth(mob/living/carbon/human/user)
-	mark_for_death()
+	INVOKE_ASYNC(src, PROC_REF(mark_for_death))
 	icon_state = "graveofcherryblossoms_0"
 	datum_reference.qliphoth_change(3)
-	return
 
 /mob/living/simple_animal/hostile/abnormality/cherry_blossoms/proc/mark_for_death()
 	var/list/potentialmarked = list()
@@ -70,18 +68,16 @@
 		to_chat(L, span_danger("It's cherry blossom season."))
 
 	SLEEP_CHECK_DEATH(10 SECONDS)
-	for(var/i=numbermarked, i>=1, i--)
+	for(var/blossoming in 1 to number_of_marks)
 		var/mob/living/Y = pick(potentialmarked)
 		if(faction_check_mob(Y, FALSE) || Y.z != z || Y.stat == DEAD)
 			continue
 		if(Y in marked)
 			continue
-		marked+=Y
+		marked += Y
 		new /obj/effect/temp_visual/markedfordeath(get_turf(Y))
 		to_chat(Y, span_userdanger("You feel like you're going to die!"))
 		Y.apply_status_effect(STATUS_EFFECT_MARKEDFORDEATH)
-
-
 
 //Mark for Death
 //A very quick, frantic 10 seconds of instadeath.


### PR DESCRIPTION

## About The Pull Request

Gives the cherry blossom an async calling the proc instead of directly calling it
Cleans up some code to use `for(var/i in 1 to number of executions)` instead of `for(var/i=5,  i>=1, i--)`

## Why It's Good For The Game

Gives the cherry blossom an async calling the proc instead of directly calling it
> It just feels jank that you don't immediatelly get your stats upon completing its work, and have to wait for it to start cherrying
> This does mean you can immediatelly start working it again instead of waiting those dreadfull 10 seconds, so kinda a buff in that regard

Cleans up some code to use `for(var/i in 1 to number of executions)` instead of `for(var/i=5,  i>=1, i--)`
> Its a lot more clear to see what its doing, imo the format of the method thats being used rn is just... bad

## Changelog
:cl:
tweak: The Grave of Cherry Blossoms no longer makes you wait 10 seconds to give its attributes from work if it starts the blossom season
/:cl:
