### PR TITLE
Fixes constant runtimes when sweeper equipment is used

### DIFF
--- a/code/game/objects/items/ego_weapons/non_abnormality/sweeper.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/sweeper.dm
@@ -7,8 +7,8 @@
 	force = 27
 	damtype = BLACK_DAMAGE
 
-	attack_verb_continuous = "stabs"
-	attack_verb_simple = "stab"
+	attack_verb_continuous = list("stabs")
+	attack_verb_simple = list("stab")
 	hitsound = 'sound/effects/ordeals/indigo/stab_1.ogg'
 	attribute_requirements = list(
 		FORTITUDE_ATTRIBUTE = 40,


### PR DESCRIPTION

## About The Pull Request

The attack verbs have to be a list, else it runtimes

## Why It's Good For The Game

less bugs :3

## Changelog
:cl:
code: sweeper weaponry no longer runtimes when used
/:cl:
