### PR TITLE
Fix Naked Nest 0 Breach[DONE]

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/waw/naked_nest.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/naked_nest.dm
@@ -79,7 +79,7 @@
 		return
 	if(serpentsnested <= 2)
 		serpentsnested = serpentsnested + 1
-	return
+	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/naked_nest/death(gibbed)
 	for(var/atom/movable/AM in src)
@@ -87,7 +87,7 @@
 	if(serpentsnested > 0)
 		var/mob/living/simple_animal/hostile/naked_nest_serpent/S = new(get_turf(src))
 		S.Hide()
-	..()
+	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/naked_nest/Move()
 	return FALSE
@@ -298,7 +298,7 @@
 /mob/living/simple_animal/hostile/naked_nested/gib()
 	for(var/atom/movable/AM in src) //morph code
 		AM.forceMove(loc)
-	..()
+	return ..()
 
 /mob/living/simple_animal/hostile/naked_nested/proc/Nest()
 	var/mob/living/simple_animal/hostile/abnormality/naked_nest/N = new(get_turf(src))


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Naked Nest was missing some code that would allow their Qliphoth to be restored.

## Changelog
:cl:
fix: naked nest Qliphoth remaining 0 after breach..
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
