### PR TITLE
Airlock De Densification[WIP]

### DIFF
--- a/code/game/machinery/doors/airlock_types.dm
+++ b/code/game/machinery/doors/airlock_types.dm
@@ -479,7 +479,7 @@
 	return TRUE
 
 /obj/machinery/door/airlock/cult/allowed(mob/living/L)
-	if(!density)
+	if(!closed_door)
 		return TRUE
 	if(friendly || iscultist(L) || istype(L, /mob/living/simple_animal/shade) || isconstruct(L))
 		if(!stealthy)

--- a/code/game/machinery/doors/brigdoors.dm
+++ b/code/game/machinery/doors/brigdoors.dm
@@ -77,7 +77,7 @@
 		update_icon()
 
 // open/closedoor checks if door_timer has power, if so it checks if the
-// linked door is open/closed (by density) then opens it/closes it.
+// linked door is open/closed (by closed_door) then opens it/closes it.
 /obj/machinery/door_timer/proc/timer_start()
 	if(machine_stat & (NOPOWER|BROKEN))
 		return 0
@@ -86,7 +86,7 @@
 	timing = TRUE
 
 	for(var/obj/machinery/door/window/brigdoor/door in targets)
-		if(door.density)
+		if(door.closed_door)
 			continue
 		INVOKE_ASYNC(door, TYPE_PROC_REF(/obj/machinery/door/window/brigdoor, close))
 
@@ -115,7 +115,7 @@
 	update_icon()
 
 	for(var/obj/machinery/door/window/brigdoor/door in targets)
-		if(!door.density)
+		if(!door.closed_door)
 			continue
 		INVOKE_ASYNC(door, TYPE_PROC_REF(/obj/machinery/door/window/brigdoor, open))
 

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -8,7 +8,7 @@
 	icon = 'icons/obj/doors/Doorfireglass.dmi'
 	icon_state = "door_open"
 	opacity = FALSE
-	density = FALSE
+	closed_door = FALSE
 	max_integrity = 300
 	resistance_flags = FIRE_PROOF
 	heat_proof = TRUE
@@ -31,7 +31,7 @@
 
 /obj/machinery/door/firedoor/examine(mob/user)
 	. = ..()
-	if(!density)
+	if(!closed_door)
 		. += "<span class='notice'>It is open, but could be <b>pried</b> closed.</span>"
 	else if(!welded)
 		. += "<span class='notice'>It is closed, but could be <i>pried</i> open. Deconstruction would require it to be <b>welded</b> shut.</span>"
@@ -49,7 +49,7 @@
 
 /obj/machinery/door/firedoor/closed
 	icon_state = "door_closed"
-	density = TRUE
+	closed_door = TRUE
 
 //see also turf/AfterChange for adjacency shennanigans
 
@@ -67,7 +67,7 @@
 /obj/machinery/door/firedoor/Bumped(atom/movable/AM)
 	if(panel_open || operating)
 		return
-	if(!density)
+	if(!closed_door)
 		return ..()
 	return FALSE
 
@@ -82,7 +82,7 @@
 	. = ..()
 	if(.)
 		return
-	if(operating || !density)
+	if(operating || !closed_door)
 		return
 	user.changeNext_move(CLICK_CD_MELEE)
 
@@ -134,7 +134,7 @@
 	if(welded || operating)
 		return
 
-	if(density)
+	if(closed_door)
 		open()
 	else
 		close()
@@ -143,7 +143,7 @@
 	add_fingerprint(user)
 	if(welded || operating || machine_stat & NOPOWER)
 		return TRUE
-	if(density)
+	if(closed_door)
 		open()
 	else
 		close()
@@ -167,7 +167,7 @@
 			flick("door_closing", src)
 
 /obj/machinery/door/firedoor/update_icon_state()
-	if(density)
+	if(closed_door)
 		icon_state = "door_closed"
 	else
 		icon_state = "door_open"
@@ -176,7 +176,7 @@
 	. = ..()
 	if(!welded)
 		return
-	if(density)
+	if(closed_door)
 		. += "welded"
 	else
 		. += "welded_open"
@@ -226,7 +226,7 @@
 /obj/machinery/door/firedoor/border_only/closed
 	icon_state = "door_closed"
 	opacity = TRUE
-	density = TRUE
+	closed_door = TRUE
 
 /obj/machinery/door/firedoor/border_only/CanAllowThrough(atom/movable/mover, turf/target)
 	. = ..()
@@ -235,12 +235,12 @@
 
 /obj/machinery/door/firedoor/border_only/CheckExit(atom/movable/mover as mob|obj, turf/target)
 	if(get_dir(loc, target) == dir)
-		return !density
+		return !closed_door
 	return TRUE
 
 /obj/machinery/door/firedoor/border_only/CanAtmosPass(turf/T)
 	if(get_dir(loc, T) == dir)
-		return !density
+		return !closed_door
 	else
 		return TRUE
 

--- a/code/game/machinery/doors/passworddoor.dm
+++ b/code/game/machinery/doors/passworddoor.dm
@@ -24,26 +24,26 @@
 
 /obj/machinery/door/password/Hear(message, atom/movable/speaker, message_language, raw_message, radio_freq, list/spans, list/message_mods = list())
 	. = ..()
-	if(!density || !voice_activated || radio_freq)
+	if(!closed_door || !voice_activated || radio_freq)
 		return
 	if(findtext(raw_message,password))
 		open()
 
 /obj/machinery/door/password/Bumped(atom/movable/AM)
-	return !density && ..()
+	return !closed_door && ..()
 
 /obj/machinery/door/password/try_to_activate_door(mob/user)
 	add_fingerprint(user)
 	if(operating)
 		return
-	if(density)
+	if(closed_door)
 		if(ask_for_pass(user))
 			open()
 		else
 			do_animate("deny")
 
 /obj/machinery/door/password/update_icon_state()
-	if(density)
+	if(closed_door)
 		icon_state = "closed"
 	else
 		icon_state = "open"

--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -25,7 +25,7 @@
 		return
 
 	if(W.tool_behaviour == TOOL_SCREWDRIVER)
-		if(density)
+		if(closed_door)
 			to_chat(user, "<span class='warning'>You need to open [src] before opening its maintenance panel.</span>")
 			return
 		else if(default_deconstruction_screwdriver(user, icon_state, icon_state, W))
@@ -37,7 +37,7 @@
 			var/change_id = input("Set the shutters/blast door/blast door controllers ID. It must be a number between 1 and 100.", "ID", id) as num|null
 			if(change_id)
 				id = clamp(round(change_id, 1), 1, 100)
-				to_chat(user, "<span class='notice'>You change the ID to [id].</span>")	
+				to_chat(user, "<span class='notice'>You change the ID to [id].</span>")
 
 		if(W.tool_behaviour == TOOL_CROWBAR && deconstruction == INTACT)
 			to_chat(user, "<span class='notice'>You start to remove the airlock electronics.</span>")
@@ -68,7 +68,7 @@
 
 /obj/machinery/door/poddoor/preopen
 	icon_state = "open"
-	density = FALSE
+	closed_door = FALSE
 	opacity = FALSE
 
 /obj/machinery/door/poddoor/ert
@@ -131,7 +131,7 @@
 	id = MASSDRIVER_DISPOSALS
 
 /obj/machinery/door/poddoor/Bumped(atom/movable/AM)
-	if(density)
+	if(closed_door)
 		return 0
 	else
 		return ..()
@@ -155,7 +155,7 @@
 			playsound(src, 'sound/machines/blastdoor.ogg', 30, TRUE)
 
 /obj/machinery/door/poddoor/update_icon_state()
-	if(density)
+	if(closed_door)
 		icon_state = "closed"
 	else
 		icon_state = "open"
@@ -168,7 +168,7 @@
 		open(TRUE)
 
 /obj/machinery/door/poddoor/attack_alien(mob/living/carbon/alien/humanoid/user)
-	if(density & !(resistance_flags & INDESTRUCTIBLE))
+	if(closed_door & !(resistance_flags & INDESTRUCTIBLE))
 		add_fingerprint(user)
 		user.visible_message("<span class='warning'>[user] begins prying open [src].</span>",\
 					"<span class='noticealien'>You begin digging your claws into [src] with all your might!</span>",\
@@ -180,7 +180,7 @@
 			time_to_open = 15 SECONDS
 
 		if(do_after(user, time_to_open, src))
-			if(density && !open(TRUE)) //The airlock is still closed, but something prevented it opening. (Another player noticed and bolted/welded the airlock in time!)
+			if(closed_door && !open(TRUE)) //The airlock is still closed, but something prevented it opening. (Another player noticed and bolted/welded the airlock in time!)
 				to_chat(user, "<span class='warning'>Despite your efforts, [src] managed to resist your attempts to open it!</span>")
 
 	else

--- a/code/game/machinery/doors/shutters.dm
+++ b/code/game/machinery/doors/shutters.dm
@@ -11,7 +11,7 @@
 
 /obj/machinery/door/poddoor/shutters/preopen
 	icon_state = "open"
-	density = FALSE
+	closed_door = FALSE
 	opacity = FALSE
 
 /obj/machinery/door/poddoor/shutters/indestructible
@@ -28,7 +28,7 @@
 
 /obj/machinery/door/poddoor/shutters/radiation/preopen
 	icon_state = "open"
-	density = FALSE
+	closed_door = FALSE
 	opacity = FALSE
 	rad_insulation = RAD_NO_INSULATION
 
@@ -50,4 +50,4 @@
 
 /obj/machinery/door/poddoor/shutters/window/preopen
 	icon_state = "open"
-	density = FALSE
+	closed_door = FALSE

--- a/code/game/machinery/doors/unpowered.dm
+++ b/code/game/machinery/doors/unpowered.dm
@@ -21,5 +21,5 @@
 	name = "door"
 	icon_state = "door1"
 	opacity = TRUE
-	density = TRUE
+	closed_door = TRUE
 	explosion_block = 1

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -48,7 +48,7 @@
 	AddComponent(/datum/component/ntnet_interface)
 
 /obj/machinery/door/window/Destroy()
-	density = FALSE
+	closed_door = FALSE
 	QDEL_LIST(debris)
 	if(obj_integrity == 0)
 		playsound(src, "shatter", 70, TRUE)
@@ -58,7 +58,7 @@
 	return ..()
 
 /obj/machinery/door/window/update_icon_state()
-	if(density)
+	if(closed_door)
 		icon_state = base_state
 	else
 		icon_state = "[base_state]open"
@@ -71,11 +71,11 @@
 		sleep(50)
 	else //secure doors close faster
 		sleep(20)
-	if(!density && autoclose) //did someone change state while we slept?
+	if(!closed_door && autoclose) //did someone change state while we slept?
 		close()
 
 /obj/machinery/door/window/Bumped(atom/movable/AM)
-	if(operating || !density)
+	if(operating || !closed_door)
 		return
 	if(!ismob(AM))
 		if(ismecha(AM))
@@ -95,7 +95,7 @@
 	bumpopen(M)
 
 /obj/machinery/door/window/bumpopen(mob/user)
-	if(operating || !density)
+	if(operating || !closed_door)
 		return
 	add_fingerprint(user)
 	if(!requiresID())
@@ -126,19 +126,19 @@
 
 /obj/machinery/door/window/CanAtmosPass(turf/T)
 	if(get_dir(loc, T) == dir)
-		return !density
+		return !closed_door
 	else
 		return TRUE
 
 //used in the AStar algorithm to determinate if the turf the door is on is passable
 /obj/machinery/door/window/CanAStarPass(obj/item/card/id/ID, to_dir)
-	return !density || (dir != to_dir) || (check_access(ID) && hasPower())
+	return !closed_door || (dir != to_dir) || (check_access(ID) && hasPower())
 
 /obj/machinery/door/window/CheckExit(atom/movable/mover, turf/target)
 	if((pass_flags_self & mover.pass_flags) || ((pass_flags_self & LETPASSTHROW) && mover.throwing))
 		return TRUE
 	if(get_dir(loc, target) == dir)
-		return !density
+		return !closed_door
 	return TRUE
 
 /obj/machinery/door/window/open(forced=FALSE)
@@ -156,7 +156,7 @@
 	playsound(src, 'sound/machines/windowdoor.ogg', 100, TRUE)
 	icon_state ="[base_state]open"
 	sleep(10)
-	density = FALSE
+	closed_door = FALSE
 	air_update_turf(TRUE, FALSE)
 	update_freelook_sight()
 
@@ -178,7 +178,7 @@
 	playsound(src, 'sound/machines/windowdoor.ogg', 100, TRUE)
 	icon_state = base_state
 
-	density = TRUE
+	closed_door = TRUE
 	air_update_turf(TRUE, TRUE)
 	update_freelook_sight()
 	sleep(10)
@@ -213,7 +213,7 @@
 
 
 /obj/machinery/door/window/emag_act(mob/user)
-	if(!operating && density && !(obj_flags & EMAGGED))
+	if(!operating && closed_door && !(obj_flags & EMAGGED))
 		obj_flags |= EMAGGED
 		operating = TRUE
 		flick("[base_state]spark", src)
@@ -231,7 +231,7 @@
 	add_fingerprint(user)
 	if(!(flags_1&NODECONSTRUCT_1))
 		if(I.tool_behaviour == TOOL_SCREWDRIVER)
-			if(density || operating)
+			if(closed_door || operating)
 				to_chat(user, span_warning("You need to open the door to access the maintenance panel!"))
 				return
 			I.play_tool_sound(src)
@@ -240,11 +240,11 @@
 			return
 
 		if(I.tool_behaviour == TOOL_CROWBAR)
-			if(panel_open && !density && !operating)
+			if(panel_open && !closed_door && !operating)
 				user.visible_message(span_notice("[user] removes the electronics from the [name]."), \
 					span_notice("You start to remove electronics from the [name]..."))
 				if(I.use_tool(src, user, 40, volume=50))
-					if(panel_open && !density && !operating && loc)
+					if(panel_open && !closed_door && !operating && loc)
 						var/obj/structure/windoor_assembly/WA = new /obj/structure/windoor_assembly(loc)
 						switch(base_state)
 							if("left")
@@ -296,7 +296,7 @@
 
 /obj/machinery/door/window/try_to_crowbar(obj/item/I, mob/user)
 	if(!hasPower())
-		if(density)
+		if(closed_door)
 			open(2)
 		else
 			close(2)
@@ -325,13 +325,13 @@
 	var/command_value = data.data["data_secondary"]
 	switch(command)
 		if("open")
-			if(command_value == "on" && !density)
+			if(command_value == "on" && !closed_door)
 				return
 
-			if(command_value == "off" && density)
+			if(command_value == "off" && closed_door)
 				return
 
-			if(density)
+			if(closed_door)
 				INVOKE_ASYNC(src, PROC_REF(open))
 			else
 				INVOKE_ASYNC(src, PROC_REF(close))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Replaces the density variable in doors into closed_door variable. This seems to block all things including projectiles.
Go_to proc paths around structures that are dense. If a door is defined as not dense then AI will attempt to enter through the door rather than bang on the window.

TESTING CHECKLIST

- [x] Projectiles are blocked by closed doors and pass through open doors.
- [x] Monsters actually path around obstacles through doors.
- [ ] Bolted Doors cannot be opened.
- [ ] Welded doors cant be opened
- [ ] People standing on doors are not immune to effects.

## Why It's Good For The Game
AI can path through doors if the doors are not defined as dense.

## Changelog
:cl:
tweak: Door density is replaced with closed_door variable
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
