### PR TITLE
Removes stat equalizers from ERA's/DO's, stats automatically get assigned when available instead

### DIFF
--- a/code/controllers/subsystem/abnormality_queue.dm
+++ b/code/controllers/subsystem/abnormality_queue.dm
@@ -126,7 +126,7 @@ SUBSYSTEM_DEF(abnormality_queue)
 
 	current_milestone += 1
 	for(var/mob/living/carbon/human/person as anything in active_suppression_agents)
-		if(!istype(person)) // gibbed or cryo'd, we no longer care about them
+		if(!istype(person) || QDELETED(person)) // gibbed or cryo'd, we no longer care about them
 			active_suppression_agents -= person
 			continue
 

--- a/code/controllers/subsystem/abnormality_queue.dm
+++ b/code/controllers/subsystem/abnormality_queue.dm
@@ -131,7 +131,6 @@ SUBSYSTEM_DEF(abnormality_queue)
 			continue
 
 		person.adjust_all_attribute_levels(10)
-
 		to_chat(person, span_notice("You feel stronger than before."))
 
 /datum/controller/subsystem/abnormality_queue/proc/PickAbno()

--- a/code/controllers/subsystem/abnormality_queue.dm
+++ b/code/controllers/subsystem/abnormality_queue.dm
@@ -39,6 +39,13 @@ SUBSYSTEM_DEF(abnormality_queue)
 	/// Due to Managers not passing the Litmus Test, divine approval is now necessary for red roll
 	var/hardcore_roll_enabled = FALSE
 
+	/// Contains all suppression agents, clears itself of agents that are without a body.
+	var/list/active_suppression_agents = list()
+	/// the % values of when we give the agents in active_suppression_agents +10 attributes
+	var/list/abnormality_milestones = list(0.15, 0.29, 0.44, 0.59, 0.69, 0.79, 100)
+	/// How far we currently are along the chain of milestones
+	var/current_milestone = 1
+
 /datum/controller/subsystem/abnormality_queue/Initialize(timeofday)
 	RegisterSignal(SSdcs, COMSIG_GLOB_ORDEAL_END, PROC_REF(OnOrdealEnd))
 	rooms_start = GLOB.abnormality_room_spawners.len
@@ -101,16 +108,31 @@ SUBSYSTEM_DEF(abnormality_queue)
 		PickAbno()
 
 /datum/controller/subsystem/abnormality_queue/proc/PostSpawn()
-	if(queued_abnormality)
-		if(possible_abnormalities[initial(queued_abnormality.threat_level)][queued_abnormality] <= 0)
-			stack_trace("Queued abnormality had no weight!?")
-		possible_abnormalities[initial(queued_abnormality.threat_level)] -= queued_abnormality
-		for(var/obj/machinery/computer/abnormality_queue/Q in GLOB.lobotomy_devices)
-			Q.audible_message("<span class='announce'>[initial(queued_abnormality.name)] has arrived at the facility!</span>")
-			playsound(get_turf(Q), 'sound/machines/dun_don_alert.ogg', 50, TRUE)
-			Q.updateUsrDialog()
-		queued_abnormality = null
-		spawned_abnos++
+	if(!queued_abnormality)
+		return
+
+	if(possible_abnormalities[initial(queued_abnormality.threat_level)][queued_abnormality] <= 0)
+		stack_trace("Queued abnormality had no weight!?")
+	possible_abnormalities[initial(queued_abnormality.threat_level)] -= queued_abnormality
+	for(var/obj/machinery/computer/abnormality_queue/Q in GLOB.lobotomy_devices)
+		Q.audible_message("<span class='announce'>[initial(queued_abnormality.name)] has arrived at the facility!</span>")
+		playsound(get_turf(Q), 'sound/machines/dun_don_alert.ogg', 50, TRUE)
+		Q.updateUsrDialog()
+	queued_abnormality = null
+	spawned_abnos++
+
+	if((SSabnormality_queue.spawned_abnos / SSabnormality_queue.rooms_start) < abnormality_milestones[current_milestone])
+		return
+
+	current_milestone += 1
+	for(var/mob/living/carbon/human/person as anything in active_suppression_agents)
+		if(!istype(person)) // gibbed or cryo'd, we no longer care about them
+			active_suppression_agents -= person
+			continue
+
+		person.adjust_all_attribute_levels(10)
+
+		to_chat(person, span_notice("You feel stronger than before."))
 
 /datum/controller/subsystem/abnormality_queue/proc/PickAbno()
 	if(!LAZYLEN(available_levels))

--- a/code/controllers/subsystem/abnormality_queue.dm
+++ b/code/controllers/subsystem/abnormality_queue.dm
@@ -121,7 +121,7 @@ SUBSYSTEM_DEF(abnormality_queue)
 	queued_abnormality = null
 	spawned_abnos++
 
-	if((SSabnormality_queue.spawned_abnos / SSabnormality_queue.rooms_start) < abnormality_milestones[current_milestone])
+	if((spawned_abnos / rooms_start) < abnormality_milestones[current_milestone])
 		return
 
 	current_milestone += 1

--- a/code/controllers/subsystem/abnormality_queue.dm
+++ b/code/controllers/subsystem/abnormality_queue.dm
@@ -42,7 +42,7 @@ SUBSYSTEM_DEF(abnormality_queue)
 	/// Contains all suppression agents, clears itself of agents that are without a body.
 	var/list/active_suppression_agents = list()
 	/// the % values of when we give the agents in active_suppression_agents +10 attributes
-	var/list/abnormality_milestones = list(0.15, 0.29, 0.44, 0.59, 0.69, 0.79, 100)
+	var/list/abnormality_milestones = list(0.15, 0.29, 0.44, 0.59, 0.69, 0.79, 1000000)
 	/// How far we currently are along the chain of milestones
 	var/current_milestone = 1
 

--- a/code/datums/facility_upgrade.dm
+++ b/code/datums/facility_upgrade.dm
@@ -172,7 +172,7 @@
 /datum/facility_upgrade/agent_spawn_stats_bonus/Upgrade()
 	value = min(max_value, value + value_increase)
 	// Applies newly purchased bonus to all living agents
-	for(var/mob/living/carbon/human/H in AllLivingAgents())
+	for(var/mob/living/carbon/human/H in AllLivingAgents(TRUE))
 		H.adjust_all_attribute_levels(value_increase)
 		to_chat(H, span_notice("Facility upgrade increased your attributes by [value_increase] points!"))
 	. = ..()

--- a/code/modules/jobs/job_types/mentor/trainingofficer.dm
+++ b/code/modules/jobs/job_types/mentor/trainingofficer.dm
@@ -89,11 +89,7 @@
 		if(79 to 100) // ALEPHs around here (20 Abnormalities)
 			set_attribute *= 4
 
-	if(user?.mind?.assigned_role == "Records Agent") //only give these if you're the guy that's allowed to have this, it's here so the Rec Agent can use it on interns
-		set_attribute += GetFacilityUpgradeValue(UPGRADE_AGENT_STATS) + SSlobotomy_corp.ordeal_stats
-
-	else
-		return
+	set_attribute += GetFacilityUpgradeValue(UPGRADE_AGENT_STATS)
 
 	//Set all stats to 0
 	for(var/A in attribute_list)

--- a/code/modules/jobs/job_types/mentor/trainingofficer.dm
+++ b/code/modules/jobs/job_types/mentor/trainingofficer.dm
@@ -39,26 +39,67 @@
 		/obj/item/melee/classic_baton,
 		/obj/item/info_printer,
 		/obj/item/announcementmaker/lcorp,
-		/obj/item/suppressionupdate/training_officer,
+		/obj/item/stat_equalizer,
 		/obj/item/sensor_device,
 	)
 
 	//Training Stat update
-/obj/item/suppressionupdate/training_officer
+/obj/item/stat_equalizer
 	name = "training stat equalizer"
 	desc = "A localized source of stats, only usable by the Training Officers to equalize the stats of them and any interns."
 	icon_state = "records_stats"
-	allowedroles = list("Records Agent")
 
-/obj/item/suppressionupdate/training_officer/attack_self(mob/living/carbon/human/user)
-	if(!LAZYLEN(allowedroles))
-		if(!istype(user) || !(user?.mind?.assigned_role in allowedroles))
-			to_chat(user, span_notice("The Gadget's light flashes red. You aren't a Training Officer. Check the label before use."))
-			return
+/obj/item/stat_equalizer/attack_self(mob/living/carbon/human/user)
+	if(!istype(user) || user?.mind?.assigned_role != "Records Agent")
+		to_chat(user, span_notice("The Gadget's light flashes red. You aren't a Training Officer. Check the label before use."))
+		return
 	update_stats(user)
 
-/obj/item/suppressionupdate/training_officer/attack(mob/living/M, mob/user)
-	if(!istype(user) || !(user?.mind?.assigned_role in allowedroles))
+/obj/item/stat_equalizer/attack(mob/living/M, mob/user)
+	if(!istype(user) || user?.mind?.assigned_role != "Records Agent")
 		to_chat(user, span_notice("The Gadget's light flashes red. You aren't a Training Officer. Check the label before use."))
 		return
 	update_stats(M)
+
+/obj/item/stat_equalizer/proc/update_stats(mob/living/carbon/human/user)
+	var/list/attribute_list = list(FORTITUDE_ATTRIBUTE, PRUDENCE_ATTRIBUTE, TEMPERANCE_ATTRIBUTE, JUSTICE_ATTRIBUTE)
+
+	//I got lazy and this needs to be shipped out today
+	var/set_attribute = 20
+	var/facility_full_percentage = 0
+	if(SSabnormality_queue.spawned_abnos) // dont divide by 0
+		facility_full_percentage = 100 * (SSabnormality_queue.spawned_abnos / SSabnormality_queue.rooms_start)
+	// how full the facility is, from 0 abnormalities out of 24 cells being 0% and 24/24 cells being 100%
+	switch(facility_full_percentage)
+		if(15 to 29) // Shouldn't be anything more than TETHs (4 Abnormalities)
+			set_attribute *= 1.5
+
+		if(29 to 44) // HEs (8 Abnormalities)
+			set_attribute *= 2
+
+		if(44 to 59) // A bit before WAWs (11 Abnormalities)
+			set_attribute *= 2.5
+
+		if(59 to 69) // WAWs around here (15 Abnormalities)
+			set_attribute *= 3
+
+		if(69 to 79) // ALEPHs starting to spawn (17 Abnormalities)
+			set_attribute *= 3.5
+
+		if(79 to 100) // ALEPHs around here (20 Abnormalities)
+			set_attribute *= 4
+
+	if(user?.mind?.assigned_role == "Records Agent") //only give these if you're the guy that's allowed to have this, it's here so the Rec Agent can use it on interns
+		set_attribute += GetFacilityUpgradeValue(UPGRADE_AGENT_STATS) + SSlobotomy_corp.ordeal_stats
+
+	else
+		return
+
+	//Set all stats to 0
+	for(var/A in attribute_list)
+		var/processing = get_attribute_level(user, A)
+		user.adjust_attribute_level(A, -1*processing)
+
+	//Now we have to bring it back up
+	user.adjust_all_attribute_levels(set_attribute)
+	to_chat(user, span_notice("You feel reset, and more ready for combat."))

--- a/code/modules/jobs/job_types/suppression.dm
+++ b/code/modules/jobs/job_types/suppression.dm
@@ -51,7 +51,6 @@
 		if(79 to 100) // ALEPHs around here (20 Abnormalities)
 			set_attribute *= 4
 
-
 	set_attribute += GetFacilityUpgradeValue(UPGRADE_AGENT_STATS) + SSlobotomy_corp.ordeal_stats //Used to have doubled respawn stats, but that might be a bit too broken with stats from ordeals.
 
 	for(var/A in roundstart_attributes)
@@ -76,7 +75,6 @@
 
 	backpack_contents = list(
 		/obj/item/melee/classic_baton,
-		/obj/item/suppressionupdate,
 		/obj/item/powered_gadget/enkephalin_injector,
 	)
 
@@ -108,6 +106,8 @@
 		if(istype(processing, /datum/job/suppression/captain))
 			processing.total_positions = 1
 
+	SSabnormality_queue.active_suppression_agents += M
+
 /datum/outfit/job/suppression/captain
 	name = "Disciplinary Officer"
 	jobtype = /datum/job/suppression/captain
@@ -118,68 +118,5 @@
 	backpack_contents = list(
 		/obj/item/melee/classic_baton,
 		/obj/item/announcementmaker/lcorp,
-		/obj/item/suppressionupdate,
 		/obj/item/powered_gadget/enkephalin_injector,
 	)
-
-	//Stat update
-/obj/item/suppressionupdate
-	name = "stat equalizer"
-	desc = "A localized source of stats, only usable by Emergency Response Agents and the Disciplinary Officer"
-	icon = 'ModularTegustation/Teguicons/teguitems.dmi'
-	icon_state = "disc_stats"
-	w_class = WEIGHT_CLASS_SMALL
-	slot_flags = ITEM_SLOT_BELT | ITEM_SLOT_POCKETS
-	var/list/allowedroles = list("Emergency Response Agent", "Disciplinary Officer")
-
-/obj/item/suppressionupdate/attack_self(mob/living/carbon/human/user)
-	if(!LAZYLEN(allowedroles))
-		if(!istype(user) || !(user?.mind?.assigned_role in allowedroles))
-			to_chat(user, span_notice("The Gadget's light flashes red. You aren't an ERA or Disciplinary Officer. Check the label before use."))
-			return
-	update_stats(user)
-
-
-/obj/item/suppressionupdate/proc/update_stats(mob/living/carbon/human/user)
-	var/list/attribute_list = list(FORTITUDE_ATTRIBUTE, PRUDENCE_ATTRIBUTE, TEMPERANCE_ATTRIBUTE, JUSTICE_ATTRIBUTE)
-
-	//I got lazy and this needs to be shipped out today
-	var/set_attribute = 20
-	var/facility_full_percentage = 0
-	if(SSabnormality_queue.spawned_abnos) // dont divide by 0
-		facility_full_percentage = 100 * (SSabnormality_queue.spawned_abnos / SSabnormality_queue.rooms_start)
-	// how full the facility is, from 0 abnormalities out of 24 cells being 0% and 24/24 cells being 100%
-	switch(facility_full_percentage)
-		if(15 to 29) // Shouldn't be anything more than TETHs (4 Abnormalities)
-			set_attribute *= 1.5
-
-		if(29 to 44) // HEs (8 Abnormalities)
-			set_attribute *= 2
-
-		if(44 to 59) // A bit before WAWs (11 Abnormalities)
-			set_attribute *= 2.5
-
-		if(59 to 69) // WAWs around here (15 Abnormalities)
-			set_attribute *= 3
-
-		if(69 to 79) // ALEPHs starting to spawn (17 Abnormalities)
-			set_attribute *= 3.5
-
-		if(79 to 100) // ALEPHs around here (20 Abnormalities)
-			set_attribute *= 4
-
-	if(user?.mind?.assigned_role in allowedroles)		//only give these if you're the guy that's allowed to have this, it's here so the Rec Agent can use it on interns
-		set_attribute += GetFacilityUpgradeValue(UPGRADE_AGENT_STATS) + SSlobotomy_corp.ordeal_stats
-
-	else
-		return
-
-	//Set all stats to 0
-	for(var/A in attribute_list)
-		var/processing = get_attribute_level(user, A)
-		user.adjust_attribute_level(A, -1*processing)
-
-	//Now we have to bring it back up
-	user.adjust_all_attribute_levels(set_attribute)
-	to_chat(user, span_notice("You feel reset, and more ready for combat."))
-

--- a/code/modules/jobs/job_types/suppression.dm
+++ b/code/modules/jobs/job_types/suppression.dm
@@ -25,6 +25,7 @@
 
 /datum/job/suppression/after_spawn(mob/living/carbon/human/outfit_owner, mob/M, latejoin = FALSE)
 	ADD_TRAIT(outfit_owner, TRAIT_WORK_FORBIDDEN, JOB_TRAIT)
+	SSabnormality_queue.active_suppression_agents += M
 
 	//Blatant Copypasta. pls fix
 	var/set_attribute = normal_attribute_level
@@ -105,8 +106,6 @@
 
 		if(istype(processing, /datum/job/suppression/captain))
 			processing.total_positions = 1
-
-	SSabnormality_queue.active_suppression_agents += M
 
 /datum/outfit/job/suppression/captain
 	name = "Disciplinary Officer"

--- a/code/modules/ordeals/_ordeal.dm
+++ b/code/modules/ordeals/_ordeal.dm
@@ -59,7 +59,7 @@
 	SSlobotomy_corp.current_ordeals -= src
 	SSlobotomy_corp.ordeal_stats += 5
 	for(var/mob/living/carbon/human/person as anything in SSabnormality_queue.active_suppression_agents)
-		if(!istype(person)) // gibbed or cryo'd, we no longer care about them
+		if(!istype(person) || QDELETED(person)) // gibbed or cryo'd, we no longer care about them
 			SSabnormality_queue.active_suppression_agents -= person
 			continue
 

--- a/code/modules/ordeals/_ordeal.dm
+++ b/code/modules/ordeals/_ordeal.dm
@@ -58,6 +58,13 @@
 	SSlobotomy_corp.AdjustAvailableBoxes(total_reward)
 	SSlobotomy_corp.current_ordeals -= src
 	SSlobotomy_corp.ordeal_stats += 5
+	for(var/mob/living/carbon/human/person as anything in SSabnormality_queue.active_suppression_agents)
+		if(!istype(person)) // gibbed or cryo'd, we no longer care about them
+			SSabnormality_queue.active_suppression_agents -= person
+			continue
+
+		person.adjust_all_attribute_levels(5)
+		to_chat(person, span_notice("You feel stronger than before."))
 	//Gives a medal to survivors.
 	RewardSurvivors()
 	SSlobotomy_corp.AddLobPoints(level * 0.5, "Ordeal Reward")


### PR DESCRIPTION

## About The Pull Request

ERA's / DO's now have their stats automatically adjusted to what they should be whenever enough abnos exist

## Why It's Good For The Game

I hate using the device in my hand every 30 seconds to see if i can have higher stats or not

## Changelog
:cl:
tweak: ERA's / DO's now automatically have their stats adjusted according to what they should be, the stat equalizer is now a training officer only tool
/:cl:
