### PR TITLE
Fixes the training officer having a "Newbie Agent" alt-title

### DIFF
--- a/code/modules/jobs/job_types/mentor/trainingofficer.dm
+++ b/code/modules/jobs/job_types/mentor/trainingofficer.dm
@@ -16,6 +16,7 @@
 
 	job_abbreviation = "TO"
 	mentor_only = TRUE
+	alt_titles = list()
 
 /datum/job/agent/training_officer/announce(mob/living/carbon/human/outfit_owner)
 	..()


### PR DESCRIPTION

## About The Pull Request

Fixes the training officer having a "Newbie Agent" alt-title, shrimple as that
tis because on agent it has the alt title defined, and we didnt previous override it in the Training Officer role, whilst it is a subtype of agent

## Why It's Good For The Game

its weird that it can have that

## Changelog
:cl:
fix: Training officer no longer has the "Newbie Agent" alt-title
/:cl:
