### PR TITLE
Makes abnormalities where you avoid goods give more understanding on Neutrals

### DIFF
--- a/code/datums/abnormality/datum/abnormality.dm
+++ b/code/datums/abnormality/datum/abnormality.dm
@@ -69,6 +69,9 @@
 	// final obervation details
 	var/observation_ready = FALSE
 
+	//Check for Neutral abnormalities
+	var/good_hater = FALSE
+
 /datum/abnormality/New(obj/effect/landmark/abnormality_spawn/new_landmark, mob/living/simple_animal/hostile/abnormality/new_type = null)
 	if(!istype(new_landmark))
 		CRASH("Abnormality datum was created without reference to landmark.")
@@ -125,6 +128,7 @@
 		neutral_boxes = round(max_boxes * 0.4)
 	else
 		neutral_boxes = current.neutral_boxes
+	good_hater = current.good_hater
 	available_work = current.work_chances
 	switch(threat_level)
 		if(ZAYIN_LEVEL)
@@ -197,7 +201,10 @@
 	if (pe >= success_boxes) // If they got a good result, adds 10% understanding, up to 100%
 		UpdateUnderstanding(10, pe)
 	else if (pe >= neutral_boxes) // Otherwise if they got a Neutral result, adds 5% understanding up to 100%
-		UpdateUnderstanding(5, pe)
+		if(good_hater == TRUE) //Exception for abnormalities that hate goods or are even impossible.
+			UpdateUnderstanding(10, pe)
+		else
+			UpdateUnderstanding(5, pe)
 	stored_boxes += round(pe * SSlobotomy_corp.box_work_multiplier)
 	overload_chance[user.ckey] = max(overload_chance[user.ckey] + overload_chance_amount, overload_chance_limit)
 

--- a/code/modules/mob/living/simple_animal/abnormality/_abnormality.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_abnormality.dm
@@ -60,6 +60,8 @@
 	var/success_boxes = null
 	/// How much PE you have to produce for neutral result, if not null or 0.
 	var/neutral_boxes = null
+	/// Check to see if the abnormality hates goods or can't get them.
+	var/good_hater = FALSE
 	/// List of ego equipment datums
 	var/list/ego_list = list()
 	/// EGO Gifts

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/silent_orchestra.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/silent_orchestra.dm
@@ -19,6 +19,7 @@
 	)
 	work_damage_amount = 16
 	work_damage_type = WHITE_DAMAGE
+	good_hater = TRUE
 	can_patrol = FALSE
 
 	wander = FALSE

--- a/code/modules/mob/living/simple_animal/abnormality/teth/cherry_blossoms.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/cherry_blossoms.dm
@@ -21,6 +21,7 @@
 	start_qliphoth = 3
 	work_damage_amount = 5
 	work_damage_type = WHITE_DAMAGE
+	good_hater = TRUE
 
 	ego_list = list(
 		/datum/ego_datum/weapon/blossom,

--- a/code/modules/mob/living/simple_animal/abnormality/teth/spider_bud.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/spider_bud.dm
@@ -19,6 +19,7 @@
 
 	work_damage_amount = 7
 	work_damage_type = RED_DAMAGE
+	good_hater = TRUE
 	ego_list = list(
 		/datum/ego_datum/weapon/eyes,
 		/datum/ego_datum/armor/eyes,

--- a/code/modules/mob/living/simple_animal/abnormality/waw/alriune.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/alriune.dm
@@ -26,6 +26,7 @@
 	)
 	work_damage_amount = 10
 	work_damage_type = WHITE_DAMAGE
+	good_hater = TRUE
 
 	light_color = COLOR_PINK
 	light_range = 9

--- a/code/modules/mob/living/simple_animal/abnormality/waw/clown_smiling.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/clown_smiling.dm
@@ -39,6 +39,7 @@
 	)
 	work_damage_amount = 12
 	work_damage_type = WHITE_DAMAGE
+	good_hater = TRUE
 	death_message = "blows up like a balloon!"
 	speak_chance = 2
 	emote_see = list("honks.")

--- a/code/modules/mob/living/simple_animal/abnormality/waw/fire_bird.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/fire_bird.dm
@@ -24,6 +24,7 @@
 	)
 	work_damage_amount = 10
 	work_damage_type = RED_DAMAGE
+	good_hater = TRUE
 	faction = list("hostile", "neutral")
 	can_breach = TRUE
 	start_qliphoth = 3


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
For abnormalities that quiploth drop from goods or can't get goods realistically, this PR makes them able to get understandings goods would give on their normal works.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Convenience for higher pops as with these abnormalities, as well as this was a thing that was planned to be added in the past. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added a new variable
balance: rebalanced good work haters understanding rates
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
