### PR TITLE
Fixes memories temperance check

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/he/better_memories.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/better_memories.dm
@@ -59,10 +59,9 @@
 
 // Those with low temperance will find a memory in the pile.
 /mob/living/simple_animal/hostile/abnormality/better_memories/PostWorkEffect(mob/living/carbon/human/user, work_type, pe, work_time)
-	if(get_attribute_level(user, TEMPERANCE_ATTRIBUTE) <= 60)
+	if(get_attribute_level(user, TEMPERANCE_ATTRIBUTE) < 60)
 		datum_reference.qliphoth_change(-1)
 		user.apply_status_effect(MEMORY_DEBUFF)
-	return
 
 // Better memories can have 3 seperate minions who will terroize the facility. Code modified from luna.dm
 /mob/living/simple_animal/hostile/abnormality/better_memories/ZeroQliphoth(mob/living/carbon/human/user)


### PR DESCRIPTION

## About The Pull Request

Makes memories check of `usertemp >= 60` into `usertemp > 60`

## Why It's Good For The Game

Its a level 3 temperance check that fails if the user is at preciselly level 3, not great

## Changelog
:cl:
fix: Memories from a better time no longer fails the temperance check if the user is at preciselly 60 temperance
/:cl:
