### PR TITLE
Improves Simple Smile's Work Rates

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/teth/simple_smile.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/simple_smile.dm
@@ -101,7 +101,7 @@
 
 	for(var/attribute in stats)
 		if(get_attribute_level(user, attribute)>= 40)
-			chance_modifier *= 0.85
+			chance_modifier *= 0.8
 			lucky_counter += 1
 
 	return chance * chance_modifier

--- a/code/modules/mob/living/simple_animal/abnormality/teth/simple_smile.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/simple_smile.dm
@@ -28,10 +28,10 @@
 	retreat_distance = 3
 	minimum_distance = 1
 	work_chances = list(
-		ABNORMALITY_WORK_INSTINCT = 80,
-		ABNORMALITY_WORK_INSIGHT = 80,
-		ABNORMALITY_WORK_ATTACHMENT = 80,
-		ABNORMALITY_WORK_REPRESSION = 80,
+		ABNORMALITY_WORK_INSTINCT = 85,
+		ABNORMALITY_WORK_INSIGHT = 85,
+		ABNORMALITY_WORK_ATTACHMENT = 85,
+		ABNORMALITY_WORK_REPRESSION = 85,
 	)
 	work_damage_amount = 5
 	work_damage_type = BLACK_DAMAGE
@@ -101,7 +101,7 @@
 
 	for(var/attribute in stats)
 		if(get_attribute_level(user, attribute)>= 40)
-			chance_modifier *= 0.7
+			chance_modifier *= 0.85
 			lucky_counter += 1
 
 	return chance * chance_modifier


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes Simple Smile's workrates to have an 85% base chance and decrease by 20% instead of 80% and 30% respectively
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Simple Smile's workrates have been quite outdated throughout the changes we have gotten. With the slower pace of the game, it would be way less plausable for people to have 1 in all. Hopefully this will help make Simple smile better.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: rebalanced Gone With a Simple Smile
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
