### PR TITLE
Adds melee damage to guns

### DIFF
--- a/ModularTegustation/tegu_items/extraction/egosurgery.dm
+++ b/ModularTegustation/tegu_items/extraction/egosurgery.dm
@@ -9,7 +9,7 @@
 	var/maximum_energy = 5
 	var/target_item = null
 	var/current_progress = 0
-	var/random_sound_list = list( //Random surgery sound for every step
+	var/random_sound_list = list( // Random surgery sound for every step
 	'sound/items/jaws_pry.ogg',
 	'sound/items/drill_use.ogg',
 	'sound/items/welder.ogg',
@@ -24,8 +24,8 @@
 	. = ..()
 	RegisterSignal(SSdcs, COMSIG_GLOB_WORK_COMPLETED, PROC_REF(WorkCharge))
 	RegisterSignal(SSdcs, COMSIG_GLOB_ORDEAL_END, PROC_REF(OrdealCharge))
-	if(SSlobotomy_corp.next_ordeal_level > 2) //next_ordeal_level is 2 at roundstart
-		maximum_energy = (5 + (5 * (SSlobotomy_corp.next_ordeal_level - 2))) //The math is weird on this - next_ordeal_level is the ordeal AFTER the one about to spawn, so 2 higher.
+	if(SSlobotomy_corp.next_ordeal_level > 2) // next_ordeal_level is 2 at roundstart
+		maximum_energy = (5 + (5 * (SSlobotomy_corp.next_ordeal_level - 2))) // The math is weird on this - next_ordeal_level is the ordeal AFTER the one about to spawn, so 2 higher.
 
 /obj/item/extraction/upgrade_tool/Destroy()
 	UnregisterSignal(SSdcs, COMSIG_GLOB_WORK_COMPLETED)
@@ -59,7 +59,7 @@
 /obj/item/extraction/upgrade_tool/pre_attack(atom/A, mob/living/user, params)
 	. = ..()
 	if(!tool_checks(user))
-		return FALSE //You can't do any special interactions
+		return FALSE // You can't do any special interactions
 	if(energy < 1)
 		to_chat(user, span_warning("The [src] is out of energy!"))
 		return FALSE
@@ -85,14 +85,14 @@
 
 	if(istype(A, /obj/item/ego_weapon))
 		var/obj/item/ego_weapon/theweapon = A
-		if(theweapon.force_multiplier >= 1.09) //Should prevent weirdness with numbers like 19.9999
+		if(theweapon.force_multiplier >= 1.09) // Should prevent weirdness with numbers like 19.9999
 			to_chat(user, span_warning("You can't modify this any further!"))
 			return
 		target_item = theweapon
 		ToolPrepare(user)
 	else if(istype(A, /obj/item/gun/ego_gun))
 		var/obj/item/gun/ego_gun/thegun = A
-		if(thegun.projectile_damage_multiplier >= 1.09) //Should prevent weirdness with numbers like 19.9999
+		if(thegun.projectile_damage_multiplier >= 1.09) // Should prevent weirdness with numbers like 19.9999
 			to_chat(user, span_warning("You can't modify this any further!"))
 			return
 		target_item = thegun
@@ -113,7 +113,7 @@
 	if(!target_item)
 		return
 	to_chat(user, span_warning("You continue to attempt to modify [target_item]!"))
-	playsound(get_turf(user), "[pick(random_sound_list)]", 50, TRUE) //I should probably give each sound custom text but its funnier to leave it to the player's imagination
+	playsound(get_turf(user), "[pick(random_sound_list)]", 50, TRUE) // I should probably give each sound custom text but its funnier to leave it to the player's imagination
 
 /obj/item/extraction/upgrade_tool/proc/ToolProgress(mob/user)
 	if(!target_item)
@@ -135,11 +135,15 @@
 		return
 	if(istype(target_item, /obj/item/ego_weapon))
 		var/obj/item/ego_weapon/theweapon = target_item
-		theweapon.force_multiplier = (clamp(theweapon.force_multiplier + 0.05, 0, 1.2))
+		theweapon.force_multiplier = (clamp(theweapon.force_multiplier + 0.05, 0, 1.2)) // Add 0.05 or 5% to the force multiplier
 
 	else if(istype(target_item, /obj/item/gun/ego_gun))
 		var/obj/item/gun/ego_gun/thegun = target_item
-		thegun.projectile_damage_multiplier = (clamp(thegun.projectile_damage_multiplier + 0.05, 0, 1.2))
+		var/old_multiplier = thegun.force_multiplier
+		thegun.force_multiplier = (clamp(thegun.force_multiplier + 0.05, 0, 1.2))
+		var/difference = thegun.force_multiplier - old_multiplier
+		if(difference > 0)
+			thegun.projectile_damage_multiplier *= (1 + difference) // Sure we COULD just set it equal to force_multiplier but that would break some guns
 	to_chat(user, span_warning("You successfully improve [target_item]!"))
 	target_item = null
 	current_progress = 0

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -276,9 +276,7 @@
 	if(I.force)
 		var/justice_mod = 1 + (get_modified_attribute_level(user, JUSTICE_ATTRIBUTE)/100)
 		var/damage = I.force * justice_mod
-		if(istype(I, /obj/item/ego_weapon))
-			var/obj/item/ego_weapon/theweapon = I
-			damage *= theweapon.force_multiplier
+		damage *= I.force_multiplier
 		apply_damage(damage, I.damtype, white_healable = TRUE)
 		if(I.damtype in list(RED_DAMAGE, BLACK_DAMAGE, PALE_DAMAGE))
 			if(prob(33))
@@ -301,9 +299,7 @@
 		log_combat(user, src, "attacked", I)
 		var/justice_mod = 1 + (get_modified_attribute_level(user, JUSTICE_ATTRIBUTE)/100)
 		var/damage = I.force * justice_mod
-		if(istype(I, /obj/item/ego_weapon))
-			var/obj/item/ego_weapon/theweapon = I
-			damage *= theweapon.force_multiplier
+		damage *= I.force_multiplier
 		take_damage(damage, I.damtype, attack_dir = get_dir(src, user))
 		return TRUE
 

--- a/code/datums/ai/sanity/_sanityloss_controller.dm
+++ b/code/datums/ai/sanity/_sanityloss_controller.dm
@@ -734,9 +734,7 @@
 	..()
 	retaliate(user)
 	var/aggro = I.force
-	if(istype(I, /obj/item/ego_weapon))
-		var/obj/item/ego_weapon/EW = I
-		aggro *= EW.force_multiplier
+	aggro *= I.force_multiplier
 	if(ishuman(user))
 		aggro *= 1 + get_modified_attribute_level(user, JUSTICE_ATTRIBUTE) * 0.01
 	RegisterAggroValue(user, aggro, I.damtype)
@@ -779,9 +777,7 @@
 			var/mob/living/carbon/human/H = I.thrownby
 			retaliate(H)
 			var/aggro = I.throwforce * (1 + get_modified_attribute_level(H, JUSTICE_ATTRIBUTE) * 0.01)
-			if(istype(I, /obj/item/ego_weapon))
-				var/obj/item/ego_weapon/EW = I
-				aggro *= EW.force_multiplier
+			aggro *= I.force_multiplier
 			RegisterAggroValue(H, aggro, I.damtype)
 	return
 

--- a/code/datums/components/fullauto.dm
+++ b/code/datums/components/fullauto.dm
@@ -117,6 +117,8 @@
 		return
 	if(get_dist(source.mob, _target) < 2) //Adjacent clicking.
 		return
+	if(source.mob.next_move > world.time) //Too busy doing something else to fire
+		return
 
 	if(isnull(location)) //Clicking on a screen object.
 		if(_target.plane != CLICKCATCHER_PLANE) //The clickcatcher is a special case. We want the click to trigger then, under it.

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -202,6 +202,11 @@ GLOBAL_VAR_INIT(embedpocalypse, FALSE) // if true, all items will be able to emb
 	/// What Color its swing animation is
 	var/swingcolor
 
+	/// How many deciseconds between attacks, times ten.
+	var/attack_speed = 1
+	/// A multiplier added to force through various means. Used primarily for weapon upgrades.
+	var/force_multiplier = 1
+
 /obj/item/Initialize()
 
 	if(attack_verb_continuous)
@@ -353,6 +358,11 @@ GLOBAL_VAR_INIT(embedpocalypse, FALSE) // if true, all items will be able to emb
 /obj/item/ui_act(action, list/params)
 	add_fingerprint(usr)
 	return ..()
+
+/obj/item/attack(mob/M, mob/user)
+	. = ..()
+	if(attack_speed && attack_speed != 1)
+		user.changeNext_move(CLICK_CD_MELEE * attack_speed)
 
 /obj/item/attack_hand(mob/user)
 	. = ..()

--- a/code/game/objects/items/ego_weapons/_ego_weapon.dm
+++ b/code/game/objects/items/ego_weapons/_ego_weapon.dm
@@ -10,9 +10,7 @@
 	drag_slowdown = 1
 	swingstyle = WEAPONSWING_SMALLSWEEP
 	var/list/attribute_requirements = list()
-	var/attack_speed = 1
 	var/special
-	var/force_multiplier = 1
 
 	/// Is CleanUp proc running?
 	var/cleaning = FALSE
@@ -36,8 +34,6 @@
 	if(!CanUseEgo(user))
 		return FALSE
 	. = ..()
-	if(attack_speed && attack_speed != 1)
-		user.changeNext_move(CLICK_CD_MELEE * attack_speed)
 
 	if(charge && attack_charge_gain)
 		HandleCharge(1, target)

--- a/code/game/objects/items/ego_weapons/non_abnormality/fullstop.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/fullstop.dm
@@ -4,6 +4,7 @@
 	desc = "a template for fullstop."
 	icon_state = "fullstop"
 	inhand_icon_state = "fullstop"
+	force = 14
 	ammo_type = /obj/item/ammo_casing/caseless/fullstop	//Does 10 damage
 	weapon_weight = WEAPON_HEAVY
 	fire_sound = 'sound/weapons/gun/rifle/shot_alt.ogg'
@@ -17,6 +18,7 @@
 	desc = "A heavy rifle. Guns like these are expensive in the City. You could buy a whole other weapon of good quality with the money for this one's bullets."
 	icon_state = "fullstop"
 	inhand_icon_state = "fullstop"
+	force = 20
 	fire_sound = 'sound/weapons/gun/rifle/shot_alt.ogg'
 	shotsleft = 30
 	autofire = 0.12 SECONDS
@@ -33,6 +35,8 @@
 	desc = "A fullstop pistol. Looks familiar."
 	icon_state = "fullstoppistol"
 	inhand_icon_state = "fullstopsniper"
+	force = 12
+	attack_speed = 0.5
 	shotsleft = 17
 	fire_delay = 5
 	reloadtime = 1.3 SECONDS
@@ -48,6 +52,7 @@
 	desc = "A sniper rifle. Despite the cost and heavy regulations, you could still kill someone stealthily from a good distance with this."
 	icon_state = "fullstopsniper"
 	inhand_icon_state = "fullstopsniper"
+	force = 20
 	fire_sound = 'sound/weapons/gun/sniper/shot.ogg'
 	zoom_amt = 10 //Long range, enough to see in front of you, but no tiles behind you.
 	zoomable = TRUE
@@ -67,6 +72,8 @@
 	desc = "An expensive pistol. Keep your hands steady. It's not over yet."
 	icon_state = "fullstopdeagle"
 	inhand_icon_state = "fullstopdeagle"
+	force = 17
+	attack_speed = 0.5
 	weapon_weight = WEAPON_LIGHT
 	fire_sound = 'sound/weapons/gun/rifle/shot_alt.ogg'
 	projectile_damage_multiplier = 4

--- a/code/game/objects/items/ego_weapons/non_abnormality/kcorp.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/kcorp.dm
@@ -95,6 +95,7 @@
 	inhand_icon_state = "kpistol"
 	lefthand_file = 'ModularTegustation/Teguicons/lc13_left.dmi'
 	righthand_file = 'ModularTegustation/Teguicons/lc13_right.dmi'
+	force = 8
 	ammo_type = /obj/item/ammo_casing/caseless/ego_kcorp
 	fire_delay = 5
 	shotsleft = 12
@@ -109,6 +110,7 @@
 	desc = "A lime green machinepistol used by Kcorp."
 	icon_state = "ksmg"
 	inhand_icon_state = "ksmg"
+	force = 17
 	fire_sound = 'sound/weapons/gun/smg/mp7.ogg'
 	autofire = 0.08 SECONDS
 	fire_delay = 1
@@ -127,6 +129,7 @@
 	desc = "A short grenade launcher used by Kcorp."
 	icon_state = "kgrenade"
 	inhand_icon_state = "kgrenade"
+	force = 17
 	ammo_type = /obj/item/ammo_casing/caseless/ego_knade
 	fire_delay = 7
 	shotsleft = 6

--- a/code/game/objects/items/ego_weapons/non_abnormality/lcorp_melee.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/lcorp_melee.dm
@@ -44,7 +44,7 @@
 
 /obj/item/ego_weapon/city/lcorp/proc/IncreaseAttributes(mob/living/user, obj/item/egoshard/egoshard)
 	damtype = egoshard.damage_type
-	force = (egoshard.base_damage) //base damage
+	force = egoshard.base_damage //base damage
 	for(var/atr in attribute_requirements)
 		attribute_requirements[atr] = egoshard.stat_requirement
 	to_chat(user, span_warning("The requirements to equip [src] have increased!"))
@@ -65,6 +65,7 @@
 	name = "l-corp combat baton"
 	icon_state = "baton"
 	desc = "A baton issued by L-Corp to those who cannot utilize E.G.O."
+	swingstyle = WEAPONSWING_LARGESWEEP
 	hitsound = 'sound/weapons/fixer/generic/baton1.ogg'
 	force = 22
 
@@ -84,6 +85,7 @@
 	name = "l-corp club"
 	icon_state = "club"
 	desc = "A heavy club issued by L-Corp to those who cannot utilize E.G.O."
+	swingstyle = WEAPONSWING_LARGESWEEP
 	hitsound = 'sound/weapons/fixer/generic/club2.ogg'
 	force = 35 //Still less DPS, replaces baseball bat
 	attack_speed = 1.6

--- a/code/game/objects/items/ego_weapons/non_abnormality/lcorp_ranged.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/lcorp_ranged.dm
@@ -56,6 +56,7 @@
 
 /obj/item/gun/ego_gun/city/lcorp/proc/IncreaseAttributes(mob/living/user, obj/item/egoshard/egoshard)
 	damtype = egoshard.damage_type
+	force = (egoshard.base_damage * 0.7) //70% of base damage which is to be expected of guns. Currently all guns override this with their own values.
 	tier = egoshard.tier
 	for(var/atr in attribute_requirements)
 		attribute_requirements[atr] = egoshard.stat_requirement
@@ -116,6 +117,8 @@
 	inhand_icon_state = "pistol"
 	special = "This weapon has pinpoint accuracy when dual wielded."
 	ammo_type = /obj/item/ammo_casing/caseless/lcorp/pistol
+	attack_speed = 0.5
+	force = 6
 	fire_delay = 10
 	shotsleft = 7
 	reloadtime = 2.1 SECONDS
@@ -134,6 +137,10 @@
 	damage = 11
 	damage_tier = list(11,20,30,55,90)
 
+/obj/item/gun/ego_gun/city/lcorp/pistol/IncreaseAttributes(mob/living/user, obj/item/egoshard/egoshard)
+	..()
+	force = (egoshard.base_damage * 0.42) // 2 attacks per attack cycle due to being a pistol
+
 /obj/item/gun/ego_gun/city/lcorp/automatic_pistol
 	name = "l-corp automatic pistol"
 	desc = "A rapid-fire pistol issued by L-Corp to those who cannot utilize E.G.O."
@@ -141,6 +148,8 @@
 	inhand_icon_state = "automatic"
 	w_class = WEIGHT_CLASS_NORMAL
 	ammo_type = /obj/item/ammo_casing/caseless/lcorp/automatic
+	attack_speed = 0.5
+	force = 6
 	fire_sound = 'sound/weapons/gun/pistol/shot.ogg'
 	vary_fire_sound = FALSE
 	shotsleft = 20
@@ -157,6 +166,10 @@
 	damage = 2
 	damage_tier = list(2,4,6,9,15)
 
+/obj/item/gun/ego_gun/city/lcorp/automatic_pistol/IncreaseAttributes(mob/living/user, obj/item/egoshard/egoshard)
+	..()
+	force = (egoshard.base_damage * 0.42) // 2 attacks per attack cycle due to being a pistol
+
 ///////////////////
 //CLERK EQUIPMENT//
 ///////////////////
@@ -170,6 +183,8 @@
 	worn_icon_state = "gun"
 	lefthand_file = 'icons/mob/inhands/weapons/guns_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/guns_righthand.dmi'
+	attack_speed = 0.5
+	force = 6
 	w_class = WEIGHT_CLASS_NORMAL
 	ammo_type = /obj/item/ammo_casing/caseless/ego_clerk
 	burst_size = 1

--- a/code/game/objects/items/ego_weapons/non_abnormality/limbus_labs.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/limbus_labs.dm
@@ -6,6 +6,8 @@
 	inhand_icon_state = "lccb_pistol"
 	icon = 'icons/obj/limbus_weapons.dmi'
 	fire_sound = 'sound/weapons/gun/pistol/shot.ogg'
+	force = 8
+	attack_speed = 0.5
 	weapon_weight = WEAPON_LIGHT
 	ammo_type = /obj/item/ammo_casing/caseless/fullstop
 	shotsleft = 13
@@ -19,6 +21,8 @@
 	icon_state = "lccb_burstpistol"
 	inhand_icon_state = "lccb_pistol"
 	icon = 'icons/obj/limbus_weapons.dmi'
+	force = 8
+	attack_speed = 0.5
 	fire_sound = 'sound/weapons/gun/pistol/shot.ogg'
 	weapon_weight = WEAPON_LIGHT
 	ammo_type = /obj/item/ammo_casing/caseless/fullstop
@@ -35,6 +39,8 @@
 	inhand_icon_state = "lccb_magnum"
 	icon = 'icons/obj/limbus_weapons.dmi'
 	fire_sound = 'sound/weapons/gun/pistol/shot.ogg'
+	force = 8
+	attack_speed = 0.5
 	weapon_weight = WEAPON_HEAVY
 	ammo_type = /obj/item/ammo_casing/caseless/fullstop
 	projectile_damage_multiplier = 6 //60 damage per bullet
@@ -49,6 +55,7 @@
 	icon_state = "lccb_smg"
 	inhand_icon_state = "lccb_smg"
 	icon = 'icons/obj/limbus_weapons.dmi'
+	force = 14
 	fire_sound = 'sound/weapons/gun/smg/mp7.ogg'
 	ammo_type = /obj/item/ammo_casing/caseless/fullstop
 	spread = 30
@@ -63,6 +70,7 @@
 	icon_state = "lccb_shotgun"
 	inhand_icon_state = "lccb_shotgun"
 	icon = 'icons/obj/limbus_weapons.dmi'
+	force = 14
 	ammo_type = /obj/item/ammo_casing/caseless/thumbshell //Does 8 shells at 5 damage, total 40
 	projectile_damage_multiplier = 0.5 //5 damage per bullet
 	fire_delay = 10

--- a/code/game/objects/items/ego_weapons/non_abnormality/rats.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/rats.dm
@@ -35,7 +35,7 @@
 	desc = "It's a brick."
 	special = "Fits into an EGO belt."
 	icon_state = "ratbrick"
-	force = 5
+	force = 6
 	throwforce = 50
 	attack_speed = 0.8
 	attack_verb_continuous = list("bricks", "smashes", "shatters")
@@ -87,9 +87,11 @@
 		return TRUE
 
 /obj/item/gun/ego_gun/pistol/rats/afterattack(atom/target, mob/living/user, flag, params)
+	if(flag && (user.a_intent == INTENT_HARM || forced_melee)) // Don't want to take damage when just using melee
+		return ..()
 	if(prob(50))
 		to_chat(user,span_warning("You pinch your fingers in the weapon."))
 		user.apply_damage(10, RED_DAMAGE, null, user.run_armor_check(null, BLACK_DAMAGE))
 		return FALSE
-	..()
+	return ..()
 

--- a/code/game/objects/items/ego_weapons/non_abnormality/shrimp.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/shrimp.dm
@@ -6,6 +6,8 @@
 	icon = 'ModularTegustation/Teguicons/lc13_weapons.dmi'
 	icon_state = "sodaminigun"
 	inhand_icon_state = "sodaminigun"
+	force = 31
+	attack_speed = 1.8
 	ammo_type = /obj/item/ammo_casing/caseless/ego_soda
 	weapon_weight = WEAPON_HEAVY
 	drag_slowdown = 3
@@ -28,6 +30,7 @@
 	icon = 'ModularTegustation/Teguicons/lc13_weapons.dmi'
 	icon_state = "sodaassault"
 	inhand_icon_state = "sodaassault"
+	force = 11
 	ammo_type = /obj/item/ammo_casing/caseless/ego_soda
 	weapon_weight = WEAPON_HEAVY
 	burst_size = 3
@@ -40,6 +43,8 @@
 	icon = 'ModularTegustation/Teguicons/lc13_weapons.dmi'
 	icon_state = "sodaminigun"
 	inhand_icon_state = "sodaminigun"
+	force = 105
+	attack_speed = 1.7
 	ammo_type = /obj/item/ammo_casing/caseless/ego_soda
 	weapon_weight = WEAPON_HEAVY
 	drag_slowdown = 2

--- a/code/game/objects/items/ego_weapons/non_abnormality/thumb.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/thumb.dm
@@ -5,7 +5,7 @@
 	icon_state = "thumb_soldato"
 	inhand_icon_state = "thumb_soldato"
 	force = 30
-	var/attack_speed = 1.5
+	attack_speed = 1.5
 	ammo_type = /obj/item/ammo_casing/caseless/fullstop	//Does 10 damage
 	weapon_weight = WEAPON_HEAVY
 	fire_sound = 'sound/weapons/gun/rifle/shot_alt.ogg'
@@ -25,7 +25,6 @@
 	..()
 	if(shotsleft < initial(shotsleft))
 		shotsleft += 1
-	user.changeNext_move(CLICK_CD_MELEE * attack_speed)
 
 //Capo
 /obj/item/gun/ego_gun/city/thumb/capo

--- a/code/modules/mob/living/simple_animal/abnormality/_auxiliary_modes/joke/ego_guns.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_auxiliary_modes/joke/ego_guns.dm
@@ -6,6 +6,7 @@
 	special = "Use this weapon in your hand when wearing matching armor to create food for people nearby."
 	icon = 'code/modules/mob/living/simple_animal/abnormality/_auxiliary_modes/joke/!icons/ego_weapons.dmi'
 	icon_state = "mcrib"
+	force = 6
 	ammo_type = /obj/item/ammo_casing/caseless/ego_mcrib
 	burst_size = 1
 	fire_delay = 10

--- a/code/modules/mob/living/simple_animal/abnormality/_tools/zayin/promise.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_tools/zayin/promise.dm
@@ -51,6 +51,7 @@
 	I.forceMove(src)
 	if(prob(successrate))
 		SuccessEffect()
+		I.force_multiplier += 0.1
 		I.projectile_damage_multiplier += 0.1
 		I.forceMove(get_turf(src))
 	else

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -42,6 +42,7 @@
 	var/semicd = 0						//cooldown handler
 	var/weapon_weight = WEAPON_LIGHT
 	var/dual_wield_spread = 24			//additional spread when dual wielding
+	var/forced_melee = FALSE			//forced to melee attack. Currently only used for the ego_gun subtype
 
 	/// Just 'slightly' snowflakey way to modify projectile damage for projectiles fired from this gun.
 	var/projectile_damage_multiplier = 1
@@ -203,7 +204,7 @@
 	if(flag) //It's adjacent, is the user, or is on the user's person
 		if(target in user.contents) //can't shoot stuff inside us.
 			return
-		if(!ismob(target) || user.a_intent == INTENT_HARM) //melee attack
+		if(!ismob(target) || user.a_intent == INTENT_HARM || forced_melee) //melee attack
 			return
 		if(target == user && user.zone_selected != BODY_ZONE_PRECISE_MOUTH) //so we can't shoot ourselves (unless mouth selected)
 			return
@@ -382,7 +383,7 @@
 	semicd = FALSE
 
 /obj/item/gun/attack(mob/M as mob, mob/user)
-	if(user.a_intent == INTENT_HARM) //Flogging
+	if(user.a_intent == INTENT_HARM || forced_melee) //Flogging
 		if(bayonet)
 			M.attackby(bayonet, user)
 			return

--- a/code/modules/projectiles/guns/ego_gun.dm
+++ b/code/modules/projectiles/guns/ego_gun.dm
@@ -29,6 +29,25 @@
 /obj/item/gun/ego_gun/examine(mob/user)
 	. = ..()
 	. += EgoAttackInfo(user)
+	switch(attack_speed)
+		if(-INFINITY to 0.39)
+			. += span_notice("This weapon has a very fast attack speed.")
+
+		if(0.4 to 0.69) // nice
+			. += span_notice("This weapon has a fast attack speed.")
+
+		if(0.7 to 0.99)
+			. += span_notice("This weapon attacks slightly faster than normal.")
+
+		if(1.01 to 1.49)
+			. += span_notice("This weapon attacks slightly slower than normal.")
+
+		if(1.5 to 1.99)
+			. += span_notice("This weapon has a slow attack speed.")
+
+		if(2 to INFINITY)
+			. += span_notice("This weapon attacks extremely slow.")
+	. += GunAttackInfo(user)
 	if(special)
 		. += "<span class='notice'>[special]</span>"
 	if(reloadtime)
@@ -90,6 +109,11 @@
 		to_chat(usr, display_text)
 
 /obj/item/gun/ego_gun/proc/EgoAttackInfo(mob/user)
+	if(force_multiplier != 1)
+		return span_notice("It deals [round(force * force_multiplier, 0.1)] [damtype] damage in melee. (+ [(force_multiplier - 1) * 100]%)")
+	return span_notice("It deals [force] [damtype] damage in melee.")
+
+/obj/item/gun/ego_gun/proc/GunAttackInfo(mob/user)
 	if(chambered && chambered.BB)
 		if(projectile_damage_multiplier != 1)
 			return "<span class='notice'>Its bullets deal [round((chambered.BB.damage * projectile_damage_multiplier), 0.1)] [chambered.BB.damage_type] damage. (+ [(projectile_damage_multiplier - 1) * 100]%)</span>"
@@ -167,8 +191,20 @@
 		playsound(src, 'sound/weapons/gun/general/bolt_rack.ogg', 50, TRUE)
 		shotsleft = initial(shotsleft)
 	is_reloading = FALSE
+	forced_melee = FALSE //no longer forced to resort to melee
 
-//Examine text for pistols.
+/obj/item/gun/ego_gun/attack(mob/M as mob, mob/user)
+	if(!CanUseEgo(user))
+		return FALSE
+	if(!can_shoot())
+		forced_melee = TRUE // Forces us to melee
+	return ..()
+
+//Pistols... There's really nothing attached to the default type except examine and attack speed
+/obj/item/gun/ego_gun/pistol
+	attack_speed = 0.5
+	force = 6
+
 /obj/item/gun/ego_gun/pistol/examine(mob/user)
 	. = ..()
 	. += "<span class='notice'>This weapon fits in an ego weapon belt.</span>"

--- a/code/modules/projectiles/guns/ego_gun/aleph.dm
+++ b/code/modules/projectiles/guns/ego_gun/aleph.dm
@@ -8,6 +8,9 @@
 	icon_state = "star"
 	inhand_icon_state = "star"
 	special = "This gun scales with remaining SP."
+	force = 33
+	damtype = WHITE_DAMAGE
+	attack_speed = 0.5
 	ammo_type = /obj/item/ammo_casing/caseless/ego_star
 	weapon_weight = WEAPON_HEAVY
 	spread = 5
@@ -40,6 +43,8 @@
 	icon_state = "adoration"
 	inhand_icon_state = "adoration"
 	special = "Use in hand to swap between AOE, DOT and shotgun modes."
+	force = 56
+	damtype = BLACK_DAMAGE
 	ammo_type = /obj/item/ammo_casing/caseless/ego_adoration
 	weapon_weight = WEAPON_HEAVY
 	fire_sound = 'sound/effects/attackblob.ogg'
@@ -82,6 +87,8 @@
 	desc = "Having decided to trust its own intuition, the jester spake the names of everyone it had met on that path with each step it took."
 	icon_state = "nihil"
 	inhand_icon_state = "nihil"
+	force = 56
+	damtype = BLACK_DAMAGE
 	ammo_type = /obj/item/ammo_casing/caseless/ego_nihil
 	weapon_weight = WEAPON_HEAVY
 	fire_sound = 'sound/weapons/fixer/generic/energy1.ogg'
@@ -153,6 +160,8 @@
 	icon_state = "pink"
 	inhand_icon_state = "pink"
 	special = "This weapon has a scope, and fires projectiles with zero travel time. Damage dealt is increased when hitting targets further away. Middle mouse button click/alt click to zoom in that direction."
+	force = 56
+	damtype = WHITE_DAMAGE
 	ammo_type = /obj/item/ammo_casing/caseless/pink
 	weapon_weight = WEAPON_HEAVY
 	fire_sound = 'sound/abnormalities/armyinblack/pink.ogg'
@@ -229,6 +238,7 @@
 	icon_state = "arcadia"
 	inhand_icon_state = "arcadia"
 	special = "Use in hand to load bullets."
+	force = 56
 	ammo_type = /obj/item/ammo_casing/caseless/arcadia
 	weapon_weight = WEAPON_HEAVY
 	spread = 5
@@ -264,6 +274,8 @@
 	desc = "You will be judged; as I have."
 	icon_state = "judge"
 	inhand_icon_state = "judge"
+	force = 56
+	damtype = WHITE_DAMAGE
 	weapon_weight = WEAPON_MEDIUM	//Cannot be dual wielded
 	recoil = 2
 	fire_sound_volume = 30

--- a/code/modules/projectiles/guns/ego_gun/he.dm
+++ b/code/modules/projectiles/guns/ego_gun/he.dm
@@ -4,12 +4,13 @@
 	icon_state = "prank"
 	worn_icon_state = "prank"
 	inhand_icon_state = "prank"
+	force = 20
+	damtype = BLACK_DAMAGE
 	ammo_type = /obj/item/ammo_casing/caseless/ego_prank
 	weapon_weight = WEAPON_HEAVY
 	fire_delay = 5
 	shotsleft = 10
 	reloadtime = 1.4 SECONDS
-	damtype = BLACK_DAMAGE
 	fire_sound = 'sound/weapons/gun/rifle/shot_alt.ogg'
 	attribute_requirements = list(
 							TEMPERANCE_ATTRIBUTE = 40
@@ -20,6 +21,7 @@
 	desc = "A magnum pistol featuring excellent burst firing potential."
 	icon_state = "gaze"
 	inhand_icon_state = "gaze"
+	force = 12
 	ammo_type = /obj/item/ammo_casing/caseless/ego_gaze
 	fire_delay = 10
 	shotsleft = 8
@@ -40,6 +42,8 @@
 	special = "Use in hand to turn on homing mode. This mode fires slower, but homes in on a random target within 15 metres.	\
 			WARNING: This feature is not accurate."
 	ammo_type =	/obj/item/ammo_casing/caseless/ego_galaxy
+	force = 20
+	damtype = BLACK_DAMAGE
 	fire_delay = 15
 	fire_sound = 'sound/magic/wand_teleport.ogg'
 	weapon_weight = WEAPON_MEDIUM
@@ -72,6 +76,8 @@
 	special = "This weapon will sometimes jam. \
 			Use this weapon in hand to unjam it. \
 			this weapon fires faster and in a bigger burst for 15 seconds after being unjammed."
+	force = 20
+	damtype = WHITE_DAMAGE
 	ammo_type = /obj/item/ammo_casing/caseless/ego_unrequited
 	fire_delay = 3
 	burst_size = 3
@@ -143,6 +149,9 @@
 	icon_state = "harmony"
 	inhand_icon_state = "harmony"
 	special = "This weapon fires bouncing, piercing shots."
+	force = 30
+	damtype = WHITE_DAMAGE
+	attack_speed = 1.8
 	ammo_type = /obj/item/ammo_casing/caseless/ego_harmony
 	fire_sound = 'sound/weapons/ego/harmony1.ogg'
 	vary_fire_sound = FALSE
@@ -161,6 +170,7 @@
 	desc = "It's an old wooden longrifle."
 	icon_state = "transmission"
 	inhand_icon_state = "transmission"
+	force = 20
 	ammo_type = /obj/item/ammo_casing/caseless/ego_transmission
 	weapon_weight = WEAPON_HEAVY
 	fire_delay = 5
@@ -176,6 +186,8 @@
 	desc = "Nothing beats the classics."
 	icon_state = "song"
 	inhand_icon_state = "song"
+	force = 20
+	damtype = WHITE_DAMAGE
 	ammo_type = /obj/item/ammo_casing/caseless/ego_song
 	fire_sound = 'sound/weapons/gun/pistol/shot_alt.ogg'
 	weapon_weight = WEAPON_MEDIUM
@@ -193,6 +205,8 @@
 	icon_state = "songmini"
 	inhand_icon_state = "songmini"
 	special = "This weapon fires 3 pellets."
+	force = 12
+	damtype = WHITE_DAMAGE
 	ammo_type = /obj/item/ammo_casing/caseless/ego_songmini
 	fire_sound = 'sound/weapons/gun/revolver/shot_light.ogg'
 	shotsleft = 16
@@ -208,6 +222,8 @@
 	desc = "Hair has grown on the crossbow as if to express that the woman’s dejection will never be forgotten."
 	icon_state = "screamingwedge"
 	inhand_icon_state = "screamingwedge"
+	force = 20
+	damtype = WHITE_DAMAGE
 	ammo_type = /obj/item/ammo_casing/caseless/ego_wedge
 	weapon_weight = WEAPON_HEAVY
 	fire_delay = 10
@@ -226,6 +242,7 @@
 	lefthand_file = 'icons/mob/inhands/weapons/guns_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/guns_righthand.dmi'
 	special = "This weapon fires dice that deal varying amounts of damage."
+	force = 12
 	ammo_type = /obj/item/ammo_casing/caseless/ego_swindle
 	weapon_weight = WEAPON_HEAVY
 	fire_delay = 5
@@ -242,6 +259,8 @@
 	icon_state = "ringing"
 	inhand_icon_state = "ringing"
 	special = "This weapon can be used as a megaphone."
+	force = 20
+	damtype = BLACK_DAMAGE
 	ammo_type = /obj/item/ammo_casing/caseless/ego_ringing
 	weapon_weight = WEAPON_HEAVY
 	autofire = 0.15 SECONDS
@@ -279,6 +298,8 @@
 	icon_state = "syrinx"
 	inhand_icon_state = "syrinx"
 	special = "This weapon fires slow bullets with limited range."
+	force = 20
+	damtype = WHITE_DAMAGE
 	ammo_type = /obj/item/ammo_casing/caseless/ego_syrinx
 	weapon_weight = WEAPON_MEDIUM
 	spread = 40
@@ -296,6 +317,8 @@
 	desc = "Though I can't guide you... I can offer a warm embrace."
 	icon_state = "ardor_star"
 	inhand_icon_state = "ardor_star"
+	force = 30
+	attack_speed = 1.8
 	ammo_type = /obj/item/ammo_casing/caseless/ego_ardor
 	weapon_weight = WEAPON_HEAVY
 	fire_sound = 'sound/weapons/gun/sniper/shot.ogg'

--- a/code/modules/projectiles/guns/ego_gun/special.dm
+++ b/code/modules/projectiles/guns/ego_gun/special.dm
@@ -3,6 +3,7 @@
 	desc = "A gun used by shrimp corp, apparently."
 	icon_state = "sodarifle"
 	inhand_icon_state = "sodalong"
+	force = 14 // These guns don't have any stat requirements so they won't do high damage
 	ammo_type = /obj/item/ammo_casing/caseless/ego_shrimprifle
 	weapon_weight = WEAPON_HEAVY
 	fire_delay = 3
@@ -14,6 +15,8 @@
 	icon_state = "sodashotgun"
 	inhand_icon_state = "sodalong"
 	special = "This weapon fires 3 pellets."
+	force = 18
+	attack_speed = 1.3
 	ammo_type = /obj/item/ammo_casing/caseless/ego_shrimpshotgun
 	weapon_weight = WEAPON_HEAVY
 	fire_delay = 10
@@ -24,6 +27,7 @@
 	desc = "A gun used by shrimp corp, apparently."
 	icon_state = "sodasmg"
 	inhand_icon_state = "soda"
+	force = 14
 	ammo_type = /obj/item/ammo_casing/caseless/ego_soda
 	weapon_weight = WEAPON_HEAVY
 	spread = 8
@@ -67,6 +71,8 @@
 	fire_delay = 1
 	autofire = 0.5 SECONDS
 	special = "This weapon heals humans that it hits."
+	force = 56
+	damtype = BLACK_DAMAGE
 	weapon_weight = WEAPON_HEAVY
 	ammo_type = /obj/item/ammo_casing/caseless/ego_hatred
 	fire_sound = 'sound/abnormalities/hatredqueen/attack.ogg'

--- a/code/modules/projectiles/guns/ego_gun/teth.dm
+++ b/code/modules/projectiles/guns/ego_gun/teth.dm
@@ -9,6 +9,8 @@
 	icon_state = "match"
 	inhand_icon_state = "match"
 	special = "This weapon does AOE damage."
+	force = 23
+	attack_speed = 1.8
 	ammo_type = /obj/item/ammo_casing/caseless/ego_match
 	weapon_weight = WEAPON_HEAVY
 	fire_delay = 15
@@ -22,6 +24,7 @@
 	the weapon has high firepower despite its small size."
 	icon_state = "beak"
 	inhand_icon_state = "beak"
+	force = 14
 	ammo_type = /obj/item/ammo_casing/caseless/ego_beak
 	weapon_weight = WEAPON_MEDIUM
 	spread = 10
@@ -35,6 +38,7 @@
 	desc = "A heavy revolver that fires at a surprisingly fast rate, and is deadly accurate."
 	icon_state = "beakmagnum"
 	inhand_icon_state = "beakmagnum"
+	force = 8
 	special = "This weapon has pinpoint accuracy when dual wielded."
 	ammo_type = /obj/item/ammo_casing/caseless/ego_beakmagnum
 	fire_delay = 10
@@ -51,6 +55,8 @@
 	icon_state = "noise"
 	inhand_icon_state = "noise"
 	special = "This weapon fires 5 pellets."
+	force = 14
+	damtype = WHITE_DAMAGE
 	ammo_type = /obj/item/ammo_casing/caseless/ego_noise
 	weapon_weight = WEAPON_HEAVY
 	fire_delay = 10
@@ -63,6 +69,8 @@
 	desc = "A classic blue revolver, that gives you feelings of loneliness."
 	icon_state = "solitude"
 	inhand_icon_state = "solitude"
+	force = 8
+	damtype = WHITE_DAMAGE
 	ammo_type = /obj/item/ammo_casing/caseless/ego_solitude
 	fire_delay = 10
 	shotsleft = 5
@@ -77,6 +85,8 @@
 	When throbbing emotions surge up from time to time, it's best to simply cover the face."
 	icon_state = "shy"
 	inhand_icon_state = "shy"
+	force = 8
+	damtype = BLACK_DAMAGE
 	ammo_type = /obj/item/ammo_casing/caseless/ego_shy
 	fire_sound = 'sound/effects/meatslap.ogg'
 	vary_fire_sound = FALSE
@@ -89,6 +99,8 @@
 	desc = "And when the crying stops, dawn will break."
 	icon_state = "dream"
 	inhand_icon_state = "dream"
+	force = 14
+	damtype = WHITE_DAMAGE
 	ammo_type = /obj/item/ammo_casing/caseless/ego_dream
 	weapon_weight = WEAPON_HEAVY
 	fire_sound = "dreamy_gun"
@@ -99,12 +111,13 @@
 	desc = "The pain of creation! The pain! The pain!"
 	icon_state = "page"
 	inhand_icon_state = "page"
+	force = 14
+	damtype = BLACK_DAMAGE
 	ammo_type = /obj/item/ammo_casing/caseless/ego_page
 	weapon_weight = WEAPON_HEAVY
 	fire_delay = 5
 	shotsleft = 10
 	reloadtime = 1.4 SECONDS
-	damtype = BLACK_DAMAGE
 	fire_sound = 'sound/weapons/gun/rifle/shot_alt.ogg'
 
 /obj/item/gun/ego_gun/snapshot
@@ -113,6 +126,8 @@
 	icon_state = "snapshot"
 	inhand_icon_state = "snapshot"
 	special = "This weapon fires a hitscan beam."
+	force = 14
+	damtype = WHITE_DAMAGE
 	ammo_type = /obj/item/ammo_casing/caseless/ego_snapshot
 	weapon_weight = WEAPON_HEAVY
 	fire_delay = 10
@@ -124,11 +139,12 @@
 	icon_state = "wishing_cairn"
 	inhand_icon_state = "wishing_cairn"
 	special = "This weapon has a combo system with a short range."
+	force = 14
+	damtype = BLACK_DAMAGE
 	ammo_type = /obj/item/ammo_casing/caseless/ego_wishing
 	weapon_weight = WEAPON_HEAVY
 	fire_delay = 3
 	burst_size = 2
-	damtype = BLACK_DAMAGE
 	fire_sound = 'sound/abnormalities/pagoda/throw.ogg'
 	var/ammo2 = /obj/item/ammo_casing/caseless/ego_wishing2
 
@@ -148,6 +164,7 @@
 	icon_state = "aspiration"
 	inhand_icon_state = "aspiration"
 	special = "This weapon fires a hitscan beam at the cost of health. \n Upon hitting an ally, this weapon heals the target,"
+	force = 14
 	ammo_type = /obj/item/ammo_casing/caseless/ego_aspiration
 	weapon_weight = WEAPON_HEAVY
 	autofire = 0.5 SECONDS
@@ -170,6 +187,8 @@
 	inhand_x_dimension = 64
 	inhand_y_dimension = 64
 	special = "This weapon fires 4 pellets."
+	force = 18
+	attack_speed = 1.3
 	ammo_type = /obj/item/ammo_casing/caseless/ego_patriot
 	weapon_weight = WEAPON_HEAVY
 	fire_delay = 12

--- a/code/modules/projectiles/guns/ego_gun/waw.dm
+++ b/code/modules/projectiles/guns/ego_gun/waw.dm
@@ -4,6 +4,9 @@
 	icon_state = "correctional"
 	inhand_icon_state = "correctional"
 	special = "This weapon fires 6 pellets."
+	force = 33
+	damtype = BLACK_DAMAGE
+	attack_speed = 1.3
 	ammo_type = /obj/item/ammo_casing/caseless/ego_correctional
 	weapon_weight = WEAPON_HEAVY
 	fire_delay = 7
@@ -22,13 +25,13 @@
 	The projectiles relive the legacy of the kingdom as they travel toward the target."
 	icon_state = "hornet"
 	inhand_icon_state = "hornet"
+	force = 28
 	ammo_type = /obj/item/ammo_casing/caseless/ego_hornet
 	weapon_weight = WEAPON_HEAVY
 	fire_sound = 'sound/weapons/gun/rifle/leveraction.ogg'
 	fire_delay = 2
 	shotsleft = 10
 	reloadtime = 1.4 SECONDS
-	damtype = RED_DAMAGE
 	attribute_requirements = list(
 							FORTITUDE_ATTRIBUTE = 80
 							)
@@ -41,6 +44,8 @@
 	icon_state = "hatred"
 	inhand_icon_state = "hatred"
 	special = "This weapon heals humans that it hits."
+	force = 28
+	damtype = BLACK_DAMAGE
 	ammo_type = /obj/item/ammo_casing/caseless/ego_hatred
 	weapon_weight = WEAPON_HEAVY
 	fire_delay = 15
@@ -51,7 +56,7 @@
 							JUSTICE_ATTRIBUTE = 60
 							)
 
-/obj/item/gun/ego_gun/hatred/EgoAttackInfo(mob/user)
+/obj/item/gun/ego_gun/hatred/GunAttackInfo(mob/user)
 	if(chambered && chambered.BB)
 		return "<span class='notice'>Its bullets deal [chambered.BB.damage] randomly chosen damage.</span>"
 	return
@@ -77,6 +82,8 @@
 	special = "This weapon fires extremely slowly. \
 		This weapon pierces all targets. \
 		This weapon gets a firespeed bonus when wearing the matching armor."
+	force = 28
+	damtype = BLACK_DAMAGE
 	ammo_type = /obj/item/ammo_casing/caseless/ego_magicbullet
 	weapon_weight = WEAPON_HEAVY
 	fire_delay = 30	//Put on the armor, jackass.
@@ -115,6 +122,8 @@
 	icon_state = "solemnlament"
 	inhand_icon_state = "solemnlament"
 	special = "Firing both solemn lament and solemn vow at the same time will increase damage by 1.5x"
+	force = 17
+	damtype = WHITE_DAMAGE
 	ammo_type = /obj/item/ammo_casing/caseless/ego_solemnlament
 	fire_delay = 5
 	shotsleft = 18
@@ -150,6 +159,8 @@
 	icon_state = "solemnvow"
 	inhand_icon_state = "solemnvow"
 	special = "Firing both solemn lament and solemn vow at the same time will increase damage by 1.5x"
+	force = 17
+	damtype = BLACK_DAMAGE
 	ammo_type = /obj/item/ammo_casing/caseless/ego_solemnvow
 	fire_delay = 5
 	shotsleft = 18
@@ -183,6 +194,7 @@
 	desc = "Courtesy of the 16th Ego rifleman's brigade."
 	icon_state = "loyalty"
 	inhand_icon_state = "loyalty"
+	force = 28
 	ammo_type = /obj/item/ammo_casing/caseless/ego_loyalty
 	weapon_weight = WEAPON_HEAVY
 	spread = 26
@@ -202,6 +214,8 @@
 	icon_state = "executive"
 	inhand_icon_state = "executive"
 	special = "This gun scales with justice."
+	force = 12
+	damtype = PALE_DAMAGE
 	burst_size = 1
 	fire_delay = 5
 	shotsleft = 10
@@ -220,6 +234,7 @@
 	desc = "With steel in one hand and gunpowder in the other, there's nothing to fear in this place."
 	icon_state = "crimsonscar"
 	inhand_icon_state = "crimsonscar"
+	force = 17
 	ammo_type = /obj/item/ammo_casing/caseless/ego_crimson
 	weapon_weight = WEAPON_MEDIUM
 	special = "This weapon fires 3 pellets."
@@ -238,6 +253,8 @@
 	icon_state = "ecstasy"
 	inhand_icon_state = "ecstasy"
 	special = "This weapon fires slow bullets with limited range."
+	force = 28
+	damtype = WHITE_DAMAGE
 	ammo_type = /obj/item/ammo_casing/caseless/ego_ecstasy
 	weapon_weight = WEAPON_MEDIUM
 	spread = 40
@@ -256,6 +273,7 @@
 	icon_state = "praetorian"
 	inhand_icon_state = "executive"
 	special = "This weapon fires IFF bullets."
+	force = 28
 	ammo_type = /obj/item/ammo_casing/caseless/ego_praetorian
 	fire_sound = 'sound/weapons/gun/pistol/tp17.ogg'
 	autofire = 0.12 SECONDS
@@ -273,6 +291,8 @@
 	icon_state = "magic_pistol"
 	inhand_icon_state = "magic_pistol"
 	special = "This weapon pierces all targets. This weapon fires faster with the matching armor"
+	force = 17
+	damtype = BLACK_DAMAGE
 	ammo_type = /obj/item/ammo_casing/caseless/ego_magicpistol
 	fire_delay = 6
 	shotsleft = 7
@@ -303,6 +323,7 @@
 	desc = "There are no clocks to alert the arrival times."
 	icon_state = "laststop"
 	inhand_icon_state = "laststop"
+	force = 17
 	ammo_type = /obj/item/ammo_casing/caseless/ego_laststop
 	weapon_weight = WEAPON_HEAVY
 	fire_delay = 5
@@ -318,6 +339,7 @@
 	desc = "Go ahead and rattle 'em boys."
 	icon_state = "intentions"
 	inhand_icon_state = "intentions"
+	force = 17
 	ammo_type = /obj/item/ammo_casing/caseless/ego_intentions
 	weapon_weight = WEAPON_MEDIUM
 	spread = 40
@@ -335,6 +357,8 @@
 			The arrowhead is dull and sprouts flowers of vivid color wherever it strikes."
 	icon_state = "aroma"
 	inhand_icon_state = "aroma"
+	force = 28
+	damtype = WHITE_DAMAGE
 	ammo_type = /obj/item/ammo_casing/caseless/ego_aroma
 	weapon_weight = WEAPON_HEAVY
 	fire_delay = 25
@@ -350,6 +374,8 @@
 	icon_state = "assonance"
 	inhand_icon_state = "assonance"
 	special = "This weapon fires a hitscan beam. \nUpon hitting an enemy, this weapon heals a nearby Discord weapon user."
+	force = 28
+	damtype = WHITE_DAMAGE
 	ammo_type = /obj/item/ammo_casing/caseless/ego_assonance
 	weapon_weight = WEAPON_HEAVY
 	fire_delay = 5
@@ -369,7 +395,7 @@
 	inhand_icon_state = "featherofhonor"
 	ammo_type = /obj/item/ammo_casing/caseless/ego_feather
 	weapon_weight = WEAPON_HEAVY
-	special = "This weapon deals 42 white in melee."
+	special = "This weapon is highly effective in melee."
 	force = 42
 	damtype = WHITE_DAMAGE
 	fire_delay = 12
@@ -383,6 +409,8 @@
 	desc = "A chunk of the naked nest inigrated with a launching mechanism."
 	icon_state = "exuviae"
 	inhand_icon_state = "exuviae"
+	force = 33
+	attack_speed = 1.3
 	ammo_type = /obj/item/ammo_casing/caseless/ego_exuviae
 	weapon_weight = WEAPON_HEAVY
 	special = "Upon hit the targets RED vulnerability is increased by 0.2."
@@ -401,6 +429,8 @@
 	icon_state = "warring"
 	inhand_icon_state = "warring"
 	special = "This weapon can unleash a special attack by loading a second arrow."
+	force = 28
+	damtype = BLACK_DAMAGE
 	ammo_type = /obj/item/ammo_casing/caseless/ego_warring
 	weapon_weight = WEAPON_HEAVY
 	fire_delay = 0//it caused some jank, like failing to charge after the do-after
@@ -474,8 +504,12 @@
 	desc = "Time for a feast! Enjoy the blood-red night imbued with madness to your heart’s content!"
 	icon_state = "banquet"
 	inhand_icon_state = "banquet"
-	special = "This weapon uses HP to fire."
+	special = "This weapon uses HP to reload and heals you on a melee hit."
+	force = 36
+	damtype = BLACK_DAMAGE
+	attack_speed = 1.8
 	ammo_type = /obj/item/ammo_casing/caseless/ego_banquet
+	weapon_weight = WEAPON_MEDIUM
 	fire_delay = 13
 	shotsleft = 7
 	reloadtime = 1.6 SECONDS
@@ -485,12 +519,32 @@
 							TEMPERANCE_ATTRIBUTE = 60
 	)
 
-/obj/item/gun/ego_gun/banquet/before_firing(atom/target,mob/user)
-	if(ishuman(user))
-		var/mob/living/carbon/human/H = user
-		H.adjustBruteLoss(15)
+/obj/item/gun/ego_gun/banquet/attack(mob/living/target, mob/living/carbon/human/user)
+	if(!CanUseEgo(user))
+		return
+	if(!(target.status_flags & GODMODE) && target.stat != DEAD)
+		var/heal_amt = force*0.10
+		if(isanimal(target))
+			var/mob/living/simple_animal/S = target
+			if(S.damage_coeff.getCoeff(damtype) > 0)
+				heal_amt *= S.damage_coeff.getCoeff(damtype)
+			else
+				heal_amt = 0
+		user.adjustBruteLoss(-heal_amt)
 	..()
-	return
+
+/obj/item/gun/ego_gun/banquet/reload_ego(mob/user)
+	is_reloading = TRUE
+	to_chat(user,span_notice("You start loading a new magazine."))
+	playsound(src, 'sound/weapons/gun/general/slide_lock_1.ogg', 50, TRUE)
+	if(do_after(user, reloadtime, src)) //gotta reload
+		playsound(src, 'sound/weapons/gun/general/bolt_rack.ogg', 50, TRUE)
+		if(isliving(user))
+			var/mob/living/the_gunner = user
+			the_gunner.adjustBruteLoss(3 * (initial(shotsleft) - shotsleft)) // Lose 3 * shots spent in hp
+		shotsleft = initial(shotsleft)
+	is_reloading = FALSE
+	forced_melee = FALSE //no longer forced to resort to melee
 
 /obj/item/gun/ego_gun/blind_rage
 	name = "Blind Fire"
@@ -498,6 +552,8 @@
 	icon_state = "blind_gun"
 	special = "This weapon fires burning bullets. Watch out for friendly fire!"
 	ammo_type = /obj/item/ammo_casing/caseless/ego_blind_rage
+	force = 28
+	damtype = BLACK_DAMAGE
 	weapon_weight = WEAPON_HEAVY
 	fire_delay = 8
 	shotsleft = 8
@@ -514,6 +570,8 @@
 			The arrowhead is dull and sprouts flowers of vivid color wherever it strikes."
 	icon_state = "wife"
 	inhand_icon_state = "wife"
+	force = 28
+	damtype = WHITE_DAMAGE
 	ammo_type = /obj/item/ammo_casing/caseless/ego_bride
 	weapon_weight = WEAPON_HEAVY
 	fire_delay = 5
@@ -524,11 +582,13 @@
 							FORTITUDE_ATTRIBUTE = 80
 	)
 
-/obj/item/gun/ego_gun/hookah
+/obj/item/gun/ego_gun/hookah //TODO: Seems like lots of these are placeholder. remind me to finish this weapon if you are reading this.
 	name = "lethargy"
 	desc = "Courtesy of the 16th Ego rifleman's brigade."
 	icon_state = "loyalty"
 	inhand_icon_state = "loyalty"
+	force = 20
+	damtype = PALE_DAMAGE
 	ammo_type = /obj/item/ammo_casing/caseless/ego_hookah
 	weapon_weight = WEAPON_HEAVY
 	spread = 20
@@ -547,6 +607,8 @@
 	desc = "If no one had come in to get me, I would have stayed in that room, not even realizing the passing time."
 	icon_state = "innocence_gun"
 	inhand_icon_state = "innocence_gun"
+	force = 17
+	damtype = WHITE_DAMAGE
 	ammo_type = /obj/item/ammo_casing/caseless/ego_innocence
 	fire_sound = 'sound/abnormalities/orangetree/ding.ogg'
 	vary_fire_sound = TRUE
@@ -566,6 +628,8 @@
 	worn_icon_state = "hypocrisy"
 	special = "Use this weapon in hand to place a trap that inflicts \
 		50 RED damage and alerts the user of the area it was triggered."
+	force = 28
+	damtype = WHITE_DAMAGE
 	ammo_type = /obj/item/ammo_casing/caseless/ego_hypocrisy
 	weapon_weight = WEAPON_HEAVY
 	fire_delay = 25

--- a/code/modules/projectiles/guns/ego_gun/zayin.dm
+++ b/code/modules/projectiles/guns/ego_gun/zayin.dm
@@ -1,9 +1,11 @@
+// All zayin pistols use the default 6 force for ego_gun pistols
 /obj/item/gun/ego_gun/pistol/tough
 	name = "tough pistol"
 	desc = "A glock reminiscent of a certain detective who fought evil for 25 years, losing hair as time went by."
 	special = "Use this weapon in your hand when wearing matching armor to turn others nearby bald."
 	icon_state = "bald"
 	inhand_icon_state = "bald"
+	damtype = WHITE_DAMAGE
 	ammo_type = /obj/item/ammo_casing/caseless/ego_tough
 	burst_size = 1
 	fire_delay = 10
@@ -173,6 +175,7 @@
 	special = "If you are wearing the matching armor, fired shots will heal friendlies on hit."
 	icon_state = "nightshade"
 	inhand_icon_state = "nightshade"
+	damtype = BLACK_DAMAGE
 	ammo_type = /obj/item/ammo_casing/caseless/ego_nightshade
 	burst_size = 1
 	fire_delay = 10
@@ -264,6 +267,7 @@
 	desc = "A pistol painted in a refreshing orange. Whenever this EGO is used, a faint scent of orange wafts through the air."
 	icon_state = "oceanic"
 	inhand_icon_state = "oceanic"
+	damtype = WHITE_DAMAGE
 	ammo_type = /obj/item/ammo_casing/caseless/ego_oceanic
 	burst_size = 1
 	fire_delay = 5

--- a/code/modules/spells/ability_types/realized.dm
+++ b/code/modules/spells/ability_types/realized.dm
@@ -1018,16 +1018,8 @@
 		return FALSE
 	if(!is_type_in_list(I, ego_list))
 		return FALSE
-	if(istype(I, /obj/item/ego_weapon))
-		var/obj/item/ego_weapon/egoweapon = I
-		if(egoweapon.force_multiplier < 1.2)
-			to_chat(user, span_notice("You must use a weapon with a damage multiplier of 20% or higher!"))
-			return FALSE
-		Reload(I, user)
-		return TRUE
-	if(istype(I, /obj/item/gun/ego_gun))
-		var/obj/item/gun/ego_gun/egogun = I
-		if(egogun.projectile_damage_multiplier < 1.2)
+	if(istype(I, /obj/item/ego_weapon) || istype(I, /obj/item/gun/ego_gun))
+		if(I.force_multiplier < 1.2)
 			to_chat(user, span_notice("You must use a weapon with a damage multiplier of 20% or higher!"))
 			return FALSE
 		Reload(I, user)
@@ -1069,6 +1061,7 @@
 
 		else if(ispath(ego, /obj/item/gun/ego_gun))
 			var/obj/item/gun/ego_gun/egogun = new ego(get_turf(user))
+			egogun.force_multiplier = 1.20
 			egogun.projectile_damage_multiplier = 1.20
 			egogun.name = "shimmering [egogun.name]"
 			egogun.set_light(3, 6, "#D4FAF37")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

MAJOR code refractors : 
- attack_speed has been moved up to the /item level, which means that guns can now have a set attack speed
- force_multiplier has been moved up to the /item level. There's pretty much no reason not to. This allows the melee damage of guns to be upgraded through various means.
- Things that previously only improved bullet damage multipliers for guns now also update the force multiplier.

Gun Changes :

- All ego guns now deal approximately 70% of the melee damage you would expect from a melee weapon of the same tier.
- All ego guns now deal a damage type matching the bullet they fire.
- Pistols have a 0.5 attack speed by default.
- All guns now have melee damage statistics as part of their examine text.
- All automatic weapons now check if you are able to attack before firing. This prevents people from firing automatic weapons while simultaneously bashing something with them.

Individual weapon changes :

- Banquet is now a medium sized gun, and has lifesteal on melee hits. It now only consumes health to reload rather than per shot.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Guns have to reload and players don't like being a useless wet noodle when that happens.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: all guns now have a melee damage type
balance: all guns now have actual melee damage numbers
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
