### PR TITLE
Updates oz abnos to be less punishing.

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/he/road_home.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/road_home.dm
@@ -72,6 +72,7 @@
 
 // Modifiers for work chance
 /mob/living/simple_animal/hostile/abnormality/road_home/WorkChance(mob/living/carbon/human/user, chance, work_type)
+	var/newchance = chance
 	if(get_attribute_level(user, JUSTICE_ATTRIBUTE) >= 60) //Apparently the original road home is fortitude but I already made scaredy cat fort and I'm too stubborn to change it.
 		newchance = chance-20
 	return newchance

--- a/code/modules/mob/living/simple_animal/abnormality/he/road_home.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/road_home.dm
@@ -70,9 +70,18 @@
 	///Agents with the "stay home" status effect, they will be driven insane when the home is reached.
 	var/list/agent_friends = list()
 
-/mob/living/simple_animal/hostile/abnormality/road_home/PostWorkEffect(mob/living/carbon/human/user, work_type, pe, work_time)
+// Modifiers for work chance
+/mob/living/simple_animal/hostile/abnormality/road_home/WorkChance(mob/living/carbon/human/user, chance, work_type)
 	if(get_attribute_level(user, JUSTICE_ATTRIBUTE) >= 60) //Apparently the original road home is fortitude but I already made scaredy cat fort and I'm too stubborn to change it.
-		datum_reference.qliphoth_change(-1)
+		newchance = chance-20
+	return newchance
+
+/mob/living/simple_animal/hostile/abnormality/road_home/NeutralEffect(mob/living/carbon/human/user, work_type, pe)
+	. = ..()
+	if(get_attribute_level(user, JUSTICE_ATTRIBUTE) >= 60)
+		if(prob(40))
+			datum_reference.qliphoth_change(-1)
+	return
 
 /mob/living/simple_animal/hostile/abnormality/road_home/FailureEffect(mob/living/carbon/human/user, work_type, pe)
 	. = ..()

--- a/code/modules/mob/living/simple_animal/abnormality/he/scarecrow.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/scarecrow.dm
@@ -106,6 +106,7 @@
 			finishing = FALSE
 
 /mob/living/simple_animal/hostile/abnormality/scarecrow/WorkChance(mob/living/carbon/human/user, chance, work_type)
+	var/newchance = chance
 	if(get_attribute_level(user, PRUDENCE_ATTRIBUTE) >= 60)
 		newchance = chance-20
 	return newchance

--- a/code/modules/mob/living/simple_animal/abnormality/he/scarecrow.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/scarecrow.dm
@@ -105,14 +105,22 @@
 					QDEL_NULL(O)
 			finishing = FALSE
 
+/mob/living/simple_animal/hostile/abnormality/scarecrow/WorkChance(mob/living/carbon/human/user, chance, work_type)
+	if(get_attribute_level(user, PRUDENCE_ATTRIBUTE) >= 60)
+		newchance = chance-20
+	return newchance
+
 /mob/living/simple_animal/hostile/abnormality/scarecrow/FailureEffect(mob/living/carbon/human/user, work_type, pe)
 	. = ..()
 	datum_reference.qliphoth_change(-1)
 	return
 
-/mob/living/simple_animal/hostile/abnormality/scarecrow/PostWorkEffect(mob/living/carbon/human/user, work_type, pe, work_time)
+
+/mob/living/simple_animal/hostile/abnormality/scarecrow/NeutralEffect(mob/living/carbon/human/user, work_type, pe)
+	. = ..()
 	if(get_attribute_level(user, PRUDENCE_ATTRIBUTE) >= 60)
-		datum_reference.qliphoth_change(-1)
+		if(prob(40))
+			datum_reference.qliphoth_change(-1)
 	return
 
 /mob/living/simple_animal/hostile/abnormality/scarecrow/BreachEffect(mob/living/carbon/human/user, breach_type)

--- a/code/modules/mob/living/simple_animal/abnormality/he/scaredy_cat.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/scaredy_cat.dm
@@ -82,10 +82,24 @@
 	RegisterSignal(SSdcs, COMSIG_GLOB_MOB_DEATH, PROC_REF(OnMobDeath))
 	RegisterSignal(SSdcs, COMSIG_GLOB_ABNORMALITY_BREACH, PROC_REF(OnAbnoBreach))
 
-/mob/living/simple_animal/hostile/abnormality/scaredy_cat/PostWorkEffect(mob/living/carbon/human/user, work_type, pe, work_time)
+/mob/living/simple_animal/hostile/abnormality/scaredy_cat/WorkChance(mob/living/carbon/human/user, chance, work_type)
+	if(get_attribute_level(user, FORTITUDE_ATTRIBUTE) >= 60)
+		newchance = chance-20
+	return newchance
+
+/mob/living/simple_animal/hostile/abnormality/scaredy_cat/NeutralEffect(mob/living/carbon/human/user, work_type, pe)
+	. = ..()
+	if(get_attribute_level(user, FORTITUDE_ATTRIBUTE) >= 60)
+		if(prob(40))
+			datum_reference.qliphoth_change(-1)
+	return
+
+/mob/living/simple_animal/hostile/abnormality/scaredy_cat/FailureEffect(mob/living/carbon/human/user, work_type, pe)
+	. = ..()
 	if(get_attribute_level(user, FORTITUDE_ATTRIBUTE) >= 60)
 		datum_reference.qliphoth_change(-1)
 	return
+
 
 /mob/living/simple_animal/hostile/abnormality/scaredy_cat/BreachEffect(mob/living/carbon/human/user, breach_type)
 	protect_cooldown = world.time + protect_cooldown_time //to avoid him teleporting twice for no reason on breach

--- a/code/modules/mob/living/simple_animal/abnormality/he/scaredy_cat.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/scaredy_cat.dm
@@ -83,6 +83,7 @@
 	RegisterSignal(SSdcs, COMSIG_GLOB_ABNORMALITY_BREACH, PROC_REF(OnAbnoBreach))
 
 /mob/living/simple_animal/hostile/abnormality/scaredy_cat/WorkChance(mob/living/carbon/human/user, chance, work_type)
+	var/newchance = chance
 	if(get_attribute_level(user, FORTITUDE_ATTRIBUTE) >= 60)
 		newchance = chance-20
 	return newchance

--- a/code/modules/mob/living/simple_animal/abnormality/he/woodsman.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/woodsman.dm
@@ -325,6 +325,7 @@
 
 
 /mob/living/simple_animal/hostile/abnormality/woodsman/WorkChance(mob/living/carbon/human/user, chance, work_type)
+	var/newchance = chance
 	if (get_attribute_level(user, TEMPERANCE_ATTRIBUTE) >= 60)
 		newchance = chance-20
 	return newchance

--- a/code/modules/mob/living/simple_animal/abnormality/he/woodsman.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/woodsman.dm
@@ -323,9 +323,17 @@
 	icon_state = icon_living
 	can_act = TRUE
 
-/mob/living/simple_animal/hostile/abnormality/woodsman/PostWorkEffect(mob/living/carbon/human/user, work_type, pe, work_time)
+
+/mob/living/simple_animal/hostile/abnormality/woodsman/WorkChance(mob/living/carbon/human/user, chance, work_type)
 	if (get_attribute_level(user, TEMPERANCE_ATTRIBUTE) >= 60)
-		datum_reference.qliphoth_change(-1)
+		newchance = chance-20
+	return newchance
+
+/mob/living/simple_animal/hostile/abnormality/woodsman/NeutralEffect(mob/living/carbon/human/user, work_type, pe)
+	. = ..()
+	if (get_attribute_level(user, TEMPERANCE_ATTRIBUTE) >= 60)
+		if(prob(40))
+			datum_reference.qliphoth_change(-1)
 	return
 
 /mob/living/simple_animal/hostile/abnormality/woodsman/FailureEffect(mob/living/carbon/human/user, work_type, pe)

--- a/code/modules/paperwork/records/info/he.dm
+++ b/code/modules/paperwork/records/info/he.dm
@@ -28,7 +28,8 @@
 	abno_type = /mob/living/simple_animal/hostile/abnormality/scarecrow
 	abno_code = "F-01-87"
 	abno_info = list(
-		"When an employee with Prudence Level 3 or higher finished their work, the Qliphoth Counter lowered.",
+		"Employees with Prudence Level 3 or higher had a workrate reduction when working on F-01-87.",
+		"When an employee with Prudence Level 3 or higher finished their work with a neutral work result, the Qliphoth Counter lowered at a normal chance.",
 		"When the work result was Bad, the Qliphoth Counter lowered.",
 		"When Scarecrow Searching for Wisdom was escaping and killed an employee, it sucked their brain out to recover its HP.")
 
@@ -114,8 +115,9 @@
 	abno_type = /mob/living/simple_animal/hostile/abnormality/woodsman
 	abno_code = "F-05-32"
 	abno_info = list(
+		"Employees with Temperance Level 3 or higher had a workrate reduction when working on F-05-32.",
+		"When an employee with Temperance Level 3 or higher finished their work with a neutral work result, the Qliphoth Counter lowered at a normal chance.",
 		"When the work result was Bad, the Qliphoth Counter lowered.",
-		"When an employee with Temperance Level 3 or higher completed their work, the Qliphoth Counter lowered.",
 		"When an employee attempts work while the Qliphoth Counter is at 1, they will immediately die. Then, the Abnormality will escape.",
 		"Whenever a body, living or dead, was placed into the Warm-Hearted Woodsman’s chest while the Qliphoth Counter was at 1, the Qliphoth Counter increased.",
 		"WARNING: When a body was placed into the Warm-Hearted Woodsman’s chest when the Qliphoth Counter was not at 1, it breached immediately.")
@@ -148,9 +150,11 @@
 	abno_type = /mob/living/simple_animal/hostile/abnormality/scaredy_cat
 	abno_code = "F-02-126"
 	abno_info = list(
+		"Employees with Fortitude Level 3 or higher had a workrate reduction when working on F-02-126.",
+		"When an employee with Fortitude Level 3 or higher finished their work with a neutral work result, the Qliphoth Counter lowered at a normal chance.",
+		"When an employee with Fortitude Level 3 or higher finished their work with a bad work result, the Qliphoth Counter lowered.",
 		"When another Abnormality breached containment, the Qliphoth Counter lowered.",
 		"When another \"Oz\" Abnormality breached containment, the Qliphoth Counter dropped to 0.",
-		"When an employee with Fortitude Level 3 or higher completed their work, the Qliphoth Counter lowered.",
 		"When another Abnormality was suppressed, the Qliphoth Counter increased.",
 		"When the Qliphoth Counter reached 0, Scaredy Cat teleported out of the Containment Unit to protect another breached Abnormality.",
 		"Scaredy Cat could not be fully suppressed as long as the Abnormality it protected was alive.",
@@ -259,7 +263,8 @@
 	abno_type = /mob/living/simple_animal/hostile/abnormality/road_home
 	abno_code = "F-01-136"
 	abno_info = list(
-		"When an employee with Justice Level 3 or higher completed their work, the Qliphoth Counter lowered.",
+		"Employees with Justice Level 3 or higher had a workrate reduction when working on F-01-136.",
+		"When an employee with Justice Level 3 or higher finished their work with a neutral work result, the Qliphoth Counter lowered at a normal chance.",
 		"When the work result was Bad, the Qliphoth Counter lowered.",
 		"When the Road Home breached containment, a house landed in a random department, dealing massive white damage around it.",
 		"The Road Home also teleported to another department, and tried to make a golden road to the house.",


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Working with your stats above the cap will no longer lower qliphoth.
Instead, you get a lowered workrate. 
If you get a neutral on these abnos, while above the cap, the Counter has a 40% chance to lower.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This should let you work Oz abnos later into the round to avoid breaches, and while it still punishes you, it won't punish you nearly as hard
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: rebalanced Oz abnos breaching.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
