### PR TITLE
Express train makes use of TOUGHER_TIMES() to scale it's timer higher the more people there are

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/waw/express_train.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/express_train.dm
@@ -48,8 +48,21 @@
 	meltdown_timer = world.time + meltdown_tick
 	return ..()
 
+/mob/living/simple_animal/hostile/abnormality/express_train/proc/Tick_Update()
+	var/player_count
+	for(var/mob/living/carbon/human/H in GLOB.player_list)	//Way harder to get a list of living humans.
+		if(H.stat != DEAD)
+			player_count+=1
+
+	//Here's what the scaling looks like:
+	//The more players you have, the less time you have to press the button.
+	//At 20 players, you have 55 seconds, 10 players, you have 64 Seconds, at 1 player you get 82 Seconds.
+	//At infinite players, you get 40 seconds.
+	meltdown_tick = 1000 - 600*TOUGHER_TIMES(player_count)
+
 /mob/living/simple_animal/hostile/abnormality/express_train/Life()
 	if(meltdown_timer < world.time && !datum_reference?.working)
+		Tick_Update()	//update the tick
 		if(datum_reference.qliphoth_meter)
 			meltdown_timer = world.time + meltdown_tick
 			datum_reference.qliphoth_change(-1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Train now has more time between lights the less players you have.
The absolute minimum is 400 time; 40 seconds.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This is experimental, and exists to get feedback.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Express Train to Hell now uses Tougher_times()
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
