### PR TITLE
Makes bottle of tears no longer consider your temperance buff, when taking away your justice

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/zayin/bottle.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/bottle.dm
@@ -162,9 +162,9 @@
 	if(temperance >= (fortitude + prudence + justice) / 1.5) // If your temperance is at least twice your average stat, you aren't hurt, but lose temperance.
 		var/raw_temperance = get_raw_level(user, TEMPERANCE_ATTRIBUTE)
 		to_chat(user, span_userdanger("The room is filling with water... but you feel oddly unconcerned."))
-		user.adjust_attribute_level(TEMPERANCE_ATTRIBUTE, 20 - raw_temperance)
+		user.adjust_attribute_level(TEMPERANCE_ATTRIBUTE, 20 - floor(raw_temperance))
 		// This is a PERMANENT stat change, VERY significant. But it can happen only once per round. You're The Protagonist, after all.
-		var/stat_change = raw_temperance - 20
+		var/stat_change = floor(raw_temperance - 20)
 		user.adjust_attribute_buff(JUSTICE_ATTRIBUTE, stat_change) // Gain benefit from what you lost.
 		addtimer(CALLBACK(src, PROC_REF(DecayProtagonistBuff), user, stat_change), 20 SECONDS) // Short grace period. 10s of this happens while you're asleep.
 	else
@@ -181,16 +181,16 @@
 
 	user.adjustBruteLoss(-((user.maxHealth - fortitude) * 0.25)) // If you didn't die instantly, heal up some.
 
-/mob/living/simple_animal/hostile/abnormality/bottle/proc/DecayProtagonistBuff(mob/living/carbon/human/buffed, justice = 0)
+/mob/living/simple_animal/hostile/abnormality/bottle/proc/DecayProtagonistBuff(mob/living/carbon/human/buffed, given_justice = 0)
 	// Goes faster when the buff is higher, so you don't have an overwhelming buff for an overwhelming length of time.
-	if(!buffed)
+	if(!buffed || given_justice == 0)
 		return FALSE
-	var/factor = justice / 10
+	var/factor = given_justice / 10
 	var/timing = 10 + max(0, (100 - factor * factor))
 	buffed.adjust_attribute_buff(JUSTICE_ATTRIBUTE, -1)
 	if(prob(10))
 		buffed.adjust_attribute_level(JUSTICE_ATTRIBUTE, 1) // 10% chance for justice buff to become real justice as it decays.
-	addtimer(CALLBACK(src, PROC_REF(DecayProtagonistBuff), buffed, justice - 1), timing)
+	addtimer(CALLBACK(src, PROC_REF(DecayProtagonistBuff), buffed, given_justice - 1), timing)
 
 /mob/living/simple_animal/hostile/abnormality/bottle/BreachEffect(mob/living/carbon/human/user, breach_type)
 	if(breach_type == BREACH_PINK)

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/bottle.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/bottle.dm
@@ -160,11 +160,11 @@
 	var/temperance = get_attribute_level(user, TEMPERANCE_ATTRIBUTE)
 	var/justice = get_attribute_level(user, JUSTICE_ATTRIBUTE)
 	if(temperance >= (fortitude + prudence + justice) / 1.5) // If your temperance is at least twice your average stat, you aren't hurt, but lose temperance.
+		var/raw_temperance = get_raw_level(user, TEMPERANCE_ATTRIBUTE)
 		to_chat(user, span_userdanger("The room is filling with water... but you feel oddly unconcerned."))
-		user.adjust_attribute_level(TEMPERANCE_ATTRIBUTE, 20 - temperance)
+		user.adjust_attribute_level(TEMPERANCE_ATTRIBUTE, 20 - raw_temperance)
 		// This is a PERMANENT stat change, VERY significant. But it can happen only once per round. You're The Protagonist, after all.
-		var/stat_change = 0
-		stat_change = temperance - 20
+		var/stat_change = raw_temperance - 20
 		user.adjust_attribute_buff(JUSTICE_ATTRIBUTE, stat_change) // Gain benefit from what you lost.
 		addtimer(CALLBACK(src, PROC_REF(DecayProtagonistBuff), user, stat_change), 20 SECONDS) // Short grace period. 10s of this happens while you're asleep.
 	else
@@ -176,7 +176,6 @@
 	user.AdjustSleeping(10 SECONDS)
 	if(user.stat == DEAD)
 		animate(user, alpha = 0, time = 2 SECONDS)
-		to_chat(user.client, span_userdanger("You have died from the bottle, and your body is now a part of the endless sea."))
 		QDEL_IN(user, 3.5 SECONDS)
 		return
 
@@ -184,7 +183,7 @@
 
 /mob/living/simple_animal/hostile/abnormality/bottle/proc/DecayProtagonistBuff(mob/living/carbon/human/buffed, justice = 0)
 	// Goes faster when the buff is higher, so you don't have an overwhelming buff for an overwhelming length of time.
-	if(justice <= 0 || !buffed)
+	if(!buffed)
 		return FALSE
 	var/factor = justice / 10
 	var/timing = 10 + max(0, (100 - factor * factor))


### PR DESCRIPTION

## About The Pull Request

- Makes it so bottle takes in your temperance + buff in the check (what it has always done), and only your temperance without buffs on the actual justice buff part
- Removes the message i earlier inserted about becoming a part of an endless sea

## Why It's Good For The Game

- Makes it so bottle takes in your temperance + buff in the check (what it has always done), and only your temperance without buffs on the actual justice buff part
> Its supposed to leave you at 20 temperance in the end, if you had viva you instead get left at 0 and get a massive buff thats WAY over what it should be. Ending at a negative justice buff
- Removes the message i earlier inserted about becoming a part of an endless sea
> It was supposed to show that you failed the check, it does not do that clear enough. My bad

## Changelog
:cl:
fix: Bottle no longer looks at your temperance buff and goes "yeah, lets buff his justice 3 times more because he had viva"
/:cl:
