### PR TITLE
Makes scouts no longer shoot air bullets at you, instead they menacingly stare you down

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/ordeal/indigo/dawn.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/indigo/dawn.dm
@@ -58,3 +58,7 @@
 	ranged = 1
 	retreat_distance = 3
 	minimum_distance = 1
+
+/mob/living/simple_animal/hostile/ordeal/indigo_dawn/OpenFire(atom/A)
+	visible_message(span_danger("<b>[src]</b> menacingly stares at [A]!"))
+	ranged_cooldown = world.time + ranged_cooldown_time


### PR DESCRIPTION

## About The Pull Request

Gives scounts an `OpenFire()` override

## Why It's Good For The Game

They kept doing messages about firing at someone, whilst firing nothing, so this PR makes them stare at the person menacingly instead.

## Changelog
:cl:
tweak: indigo dawn scouts no longer shoot at you with nothingness, instead they stare at your menacingly now
/:cl:
