### PR TITLE
Removes Box of L corp Debug tools from J Corp Lootbox pool

### DIFF
--- a/ModularTegustation/tegu_items/representative/items/jcorp.dm
+++ b/ModularTegustation/tegu_items/representative/items/jcorp.dm
@@ -19,7 +19,7 @@
 	icon_state = "jcorplootbox[rand(1,3)]"
 
 /obj/item/a_gift/jcorp/get_gift_type()
-	var/list/banned_items = subtypesof(/obj/item/lc_debug) + subtypesof(/obj/item/reagent_containers/glass/bottle) + subtypesof(/obj/item/uplink)
+	var/list/banned_items = subtypesof(/obj/item/lc_debug) + subtypesof(/obj/item/reagent_containers/glass/bottle) + subtypesof(/obj/item/uplink) + subtypesof(/obj/item/storage/box/lc_debugtools)
 	if(!GLOB.possible_gifts.len)
 		var/list/gift_types_list = subtypesof(/obj/item)
 		for(var/V in gift_types_list)

--- a/ModularTegustation/tegu_items/representative/items/jcorp.dm
+++ b/ModularTegustation/tegu_items/representative/items/jcorp.dm
@@ -19,7 +19,7 @@
 	icon_state = "jcorplootbox[rand(1,3)]"
 
 /obj/item/a_gift/jcorp/get_gift_type()
-	var/list/banned_items = subtypesof(/obj/item/lc_debug) + subtypesof(/obj/item/reagent_containers/glass/bottle) + subtypesof(/obj/item/uplink) + subtypesof(/obj/item/storage/box/lc_debugtools)
+	var/list/banned_items = subtypesof(/obj/item/lc_debug) + subtypesof(/obj/item/reagent_containers/glass/bottle) + subtypesof(/obj/item/uplink) + /obj/item/storage/box/lc_debugtools
 	if(!GLOB.possible_gifts.len)
 		var/list/gift_types_list = subtypesof(/obj/item)
 		for(var/V in gift_types_list)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes a quite big oversight of J Corp Lootboxes and prevents the debug box itself from being impossible to get from it.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Some of the LC13 debug tools can break the games in multiple ways. This was intended but I forgot to include the box itself.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: removed LC13 debug box from being possible to get from lootboxes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
