### PR TITLE
Allow Wcorp Vest to be Removed from Armor Fridges

### DIFF
--- a/code/modules/clothing/suits/ego_gear/non_abnormality/wcorp.dm
+++ b/code/modules/clothing/suits/ego_gear/non_abnormality/wcorp.dm
@@ -1,6 +1,6 @@
 //Wcorp
 /obj/item/clothing/suit/armor/ego_gear/wcorp
-	name = "\improper w corp armor vest"
+	name = "w corp armor vest"
 	desc = "A light armor vest worn by W corp. It's light as a feather."
 	icon_state = "w_corp"
 	armor = list(RED_DAMAGE = 30, WHITE_DAMAGE = 30, BLACK_DAMAGE = 30, PALE_DAMAGE = 30)
@@ -14,7 +14,7 @@
 							)
 
 /obj/item/clothing/head/ego_hat/wcorp
-	name = "\improper w-corp cap"
+	name = "w-corp cap"
 	desc = "A ball cap worn by w-corp."
 	icon_state = "what"
 	perma = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
W corp vest was unable to be removed from the armor fridge because of the \improper in its name. The improper is removed for functionality.

In vv i went to edit the variable for name to see if that was the issue. 
![Screenshot 2024-08-21 173355](https://github.com/user-attachments/assets/d830f293-44d6-4c56-a898-3576d2d1b69c)
the mproper was still in the name but i couldnt see it in the variable.

One day we will have smart fridges that work on item type rather than name.

## Changelog
:cl:
fix: W corp vest name.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
