### PR TITLE
Snow queen and crumbling armor final observation adjustments

### DIFF
--- a/code/modules/mob/living/carbon/human/ego_gifts.dm
+++ b/code/modules/mob/living/carbon/human/ego_gifts.dm
@@ -596,8 +596,8 @@
 /datum/ego_gifts/frostcrown
 	name = "The Winters Kiss"
 	icon_state = "frostcrown"
-	fortitude_bonus = 6
-	prudence_bonus = 6
+	fortitude_bonus = 2
+	prudence_bonus = 2
 	slot = HAT
 
 /datum/ego_gifts/fury

--- a/code/modules/mob/living/simple_animal/abnormality/he/snow_queen.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/snow_queen.dm
@@ -60,8 +60,6 @@
 		/datum/ego_datum/armor/frostsplinter,
 	)
 	gift_type = /datum/ego_gifts/frostcrown
-	//Gift is rewarded at the end of a duel with Snow Queen.
-	gift_chance = 100
 	abnormality_origin = ABNORMALITY_ORIGIN_LOBOTOMY
 	var/can_act = TRUE
 	//The purpose of this variable is to prevent people from ghosting in the arena and making snow queen unworkable.

--- a/code/modules/mob/living/simple_animal/abnormality/teth/crumbling_armor.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/crumbling_armor.dm
@@ -41,11 +41,23 @@
 	var/numbermarked
 	var/meltdown_cooldown //no spamming the meltdown effect
 	var/meltdown_cooldown_time = 30 SECONDS
+	var/armor_dispensed
+
+// Hacky code to make the final observation check for a gift type without actually having it as a gift type
+/mob/living/simple_animal/hostile/abnormality/crumbling_armor/FinalObservation(mob/living/carbon/human/user)
+	gift_type = /datum/ego_gifts/recklessCourage
+	..()
+	gift_type = null
 
 /mob/living/simple_animal/hostile/abnormality/crumbling_armor/ObservationResult(mob/living/carbon/human/user, condition)
 	. = ..()
 	if(condition)
-		new /obj/item/clothing/suit/armor/ego_gear/he/crumbling_armor(get_turf(user))
+		var/datum/ego_gifts/recklessCourage/R = new
+		user.Apply_Gift(R)
+		if(!armor_dispensed) // You only get one of these. Ever.
+			new /obj/item/clothing/suit/armor/ego_gear/he/crumbling_armor(get_turf(user))
+			armor_dispensed = TRUE
+	datum_reference.observation_ready = FALSE
 
 /mob/living/simple_animal/hostile/abnormality/crumbling_armor/SuccessEffect(mob/living/carbon/human/user, work_type, pe)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes adjustments to the final observation of crumbling armor, and fixes a bug related to snow queen.

- BUGFIX: Crumbling armor's final observation now properly resets when completed.
- Crumbling armor now only ever dispenses one special armor. Ever. This means players can no longer print them by the dozens.
- To compensate, crumbling armor will now dispense the weakest version of its special interaction gift when final observation is complete, without the downsides. The gift enhances justice by 10 but lowers fortitude by 5. This is still really good.
- BUGFIX: Snow queen now no longer has a 100% gift chance. I don't know why abnormalities with no gift are coded to have this in the first place.
- Adjusted snow queen's "normal" gift by lowering its stats by about two thirds. It had stats far beyond what it should have.

## Why It's Good For The Game
Game is more balanced I guess
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: adjusted crumbling armor's final observation
balance: snow queen's hat gift has been lowered from 6/6 to 2/2
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
