### PR TITLE
Density, bullet, and other miscellaneous fixes

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/aleph/nobody_is.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/nobody_is.dm
@@ -70,6 +70,7 @@
 		"Silky",
 	)
 	var/list/longbeard = list("Beard (Very Long)")
+	var/solo_punish = FALSE
 
 	//Breach Variables
 	var/whip_attack_cooldown
@@ -162,9 +163,12 @@
 			continue
 		potentialmarked += L
 	if(LAZYLEN(potentialmarked)) //It's fine if no one got picked. Probably.
+		solo_punish = FALSE
+		if(LAZYLEN(potentialmarked) < 2)
+			solo_punish = TRUE
 		ReflectChosen(pick(potentialmarked))
 		if(!IsContained())
-			to_chat(chosen, span_warning("You feel uneasy..."))
+			to_chat(chosen, span_warning("You feel the mirror's gaze upon you..."))
 	else
 		ReflectChosen(null)
 
@@ -206,12 +210,19 @@
 		adjusted_chance -= (100 - brainpower) * 0.5
 	return adjusted_chance
 
+/mob/living/simple_animal/hostile/abnormality/nobody_is/AttemptWork(mob/living/carbon/human/user, work_type)
+	if(solo_punish)
+		work_damage_amount = 22
+		return ..()
+	work_damage_amount = initial(work_damage_amount)
+	return ..()
+
 /mob/living/simple_animal/hostile/abnormality/nobody_is/PostWorkEffect(mob/living/carbon/human/user, work_type, pe, work_time)
-	if(Finisher(user)) //Checks if they are the chosen, and disguises as them if they are.
-		return
+	if(!solo_punish)
+		if(Finisher(user)) //Checks if they are the chosen, and disguises as them if they are.
+			return
 	else if(get_attribute_level(user, JUSTICE_ATTRIBUTE) < 80)
 		datum_reference.qliphoth_change(-1)
-	return
 
 /mob/living/simple_animal/hostile/abnormality/nobody_is/FailureEffect(mob/living/carbon/human/user, work_type, pe)
 	. = ..()
@@ -562,7 +573,7 @@
 			grab_victim.deal_damage(strangle_damage, BLACK_DAMAGE)
 		else	//Apply ramping damage
 			playsound(get_turf(src), 'sound/effects/wounds/crackandbleed.ogg', 200, 0, 7)
-			grab_victim.deal_damage((strangle_damage * count), BLACK_DAMAGE)
+			grab_victim.deal_damage((strangle_damage * (3 - count)), BLACK_DAMAGE)
 	count += 1
 	if(grab_victim.sanity_lost) //This should prevent weird things like panics running away halfway through
 		grab_victim.Stun(10) //Immobilize does not stop AI controllers from moving, for some reason.

--- a/code/modules/mob/living/simple_animal/abnormality/he/drifting_fox.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/drifting_fox.dm
@@ -163,6 +163,7 @@
 	maxHealth = 125
 	health = 125
 	density = FALSE
+	status_flags = MUST_HIT_PROJECTILE // Allows projectiles to hit non-dense mob
 	damage_coeff = list(RED_DAMAGE = 1, WHITE_DAMAGE = 0.7, BLACK_DAMAGE = 0.5, PALE_DAMAGE = 2)
 	del_on_death = FALSE
 	ranged = TRUE

--- a/code/modules/mob/living/simple_animal/abnormality/he/red_queen.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/red_queen.dm
@@ -28,10 +28,9 @@
 	observation_prompt = "This abnormality has a notorious reputation for being particularly dry to work with. <br>It's hard to tell what it's thinking or what work it prefers. <br>\
 		What type of work will you attempt?"
 	observation_choices = list(ABNORMALITY_WORK_INSTINCT, ABNORMALITY_WORK_INSIGHT, ABNORMALITY_WORK_ATTACHMENT, ABNORMALITY_WORK_REPRESSION)
-	correct_choices = list() //Matches Red Queen's real preferred work
+	correct_choices = list(ABNORMALITY_WORK_INSTINCT) // Matches Red Queen's real preferred work. This default is set to stop warnings
 	observation_success_message = "You are granted an audience with the red queen. <br>Today, you were able to to satisfy her unpredictable whims"
 	observation_fail_message = "You narrowly dodge the card-guillotine coming for your neck, that was close, let's try something else."
-
 	var/liked
 
 /mob/living/simple_animal/hostile/abnormality/red_queen/Initialize(mapload)
@@ -42,6 +41,7 @@
 
 /mob/living/simple_animal/hostile/abnormality/red_queen/PostSpawn()
 	. = ..()
+	correct_choices = list()
 	correct_choices += liked
 
 /mob/living/simple_animal/hostile/abnormality/red_queen/PostWorkEffect(mob/living/carbon/human/user, work_type, pe)

--- a/code/modules/mob/living/simple_animal/abnormality/waw/nosferatu.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/nosferatu.dm
@@ -249,6 +249,7 @@
 	faction = list("hostile")
 	is_flying_animal = TRUE
 	density = FALSE
+	status_flags = MUST_HIT_PROJECTILE // Lets them be shot
 	speak_emote = list("screeches")
 	attack_verb_continuous = "bites"
 	attack_verb_simple = "bite"

--- a/code/modules/mob/living/simple_animal/abnormality/waw/red_riding_mercenary.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/red_riding_mercenary.dm
@@ -43,7 +43,8 @@ It has now been over four months. Now we get her for real. -Coxswain
 	faction = list("redhood") // I'LL FUCKIN FIGHT YOU TOO, MATE
 	can_breach = TRUE
 	start_qliphoth = 3
-	density = FALSE //Prevents red from getting stuck unable to reach her target
+	density = FALSE // Prevents red from getting stuck unable to reach her target
+	status_flags = MUST_HIT_PROJECTILE // Allows projectiles to hit even though she's not dense.
 	ego_list = list(
 		/datum/ego_datum/weapon/crimson,
 		/datum/ego_datum/weapon/crimson/gun,

--- a/code/modules/mob/living/simple_animal/hostile/ordeal/gold/dusk.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/gold/dusk.dm
@@ -60,10 +60,10 @@
 
 /mob/living/simple_animal/hostile/ordeal/centipede_corrosion/proc/Pulse()//Periodic weak AOE attack, gain charge constantly
 	pulse_cooldown = world.time + pulse_cooldown_time
-	playsound(get_turf(src), 'sound/weapons/fixer/generic/energy2.ogg', 10, FALSE, 3)
 	AdjustCharge(1)
 	if(charge_level < 5 || broken)
 		return
+	playsound(get_turf(src), 'sound/weapons/fixer/generic/energy2.ogg', 10, FALSE, 3)
 	var/turf/orgin = get_turf(src)
 	var/list/all_turfs = RANGE_TURFS(5, orgin)
 	for(var/i = 0 to 2)
@@ -82,12 +82,11 @@
 	new /obj/effect/temp_visual/smash_effect(T)
 	HurtInTurf(T, list(), 5, BLACK_DAMAGE, check_faction = TRUE, hurt_mechs = TRUE)
 	for(var/mob/living/simple_animal/hostile/ordeal/thunderbird_corrosion/TB in T)
-		if(TB.charged)
+		if(TB.charge_level >= TB.charge_level_cap)
 			continue
-		TB.charged = TRUE
+		TB.AdjustCharge(4)
 		playsound(get_turf(TB), 'sound/weapons/fixer/generic/energy3.ogg', 75, FALSE, 3)
 		TB.visible_message(span_warning("[TB] absorbs the arcing electricity!"))
-		new /obj/effect/temp_visual/healing/no_dam(get_turf(TB))
 
 /mob/living/simple_animal/hostile/ordeal/centipede_corrosion/proc/AdjustCharge(addition)
 	if(addition > 0 && charge_level < charge_level_cap)
@@ -171,16 +170,24 @@
 	ranged = TRUE
 	projectiletype = /obj/projectile/thunder_tomahawk
 	projectilesound = 'sound/abnormalities/thunderbird/tbird_peck.ogg'
-	var/charged = FALSE
 	var/list/spawned_mobs = list()
 	var/datum/beam/current_beam = null
 	var/recharge_cooldown
 	var/recharge_cooldown_time = 10 SECONDS
+	var/charge_level = 0
+	var/charge_level_cap = 20
 
+/mob/living/simple_animal/hostile/ordeal/thunderbird_corrosion/proc/AdjustCharge(addition)
+	if(addition > 0 && charge_level < charge_level_cap)
+		new /obj/effect/temp_visual/healing/charge(get_turf(src))
+	charge_level = clamp(charge_level + addition, 0, charge_level_cap)
 
-/mob/living/simple_animal/hostile/ordeal/thunderbird_corrosion/proc/Recharge(atom/A)
+/mob/living/simple_animal/hostile/ordeal/thunderbird_corrosion/proc/Recharge(atom/A) // Recharging the centipede
 	if(recharge_cooldown >= world.time)
 		return FALSE
+	if(charge_level < 10)
+		return FALSE
+	AdjustCharge(-10)
 	recharge_cooldown = world.time + recharge_cooldown_time
 	current_beam = Beam(A, icon_state="lightning[rand(1,12)]", time = 3 SECONDS)
 
@@ -189,11 +196,11 @@
 	if(!isliving(target))
 		return
 	var/mob/living/L = target
-	if(charged)
-		L.deal_damage(15, BLACK_DAMAGE)
+	if(charge_level) // We deal up to 20 more damage, 1 for every point of charge.
+		L.deal_damage(charge_level, BLACK_DAMAGE)
 		playsound(get_turf(src), 'sound/weapons/fixer/generic/energyfinisher1.ogg', 75, 1)
 		to_chat(L,span_danger("The [src] unleashes its charge!"))
-		charged = FALSE
+		AdjustCharge(-charge_level)
 	if(!ishuman(target))
 		return
 	var/mob/living/carbon/human/H = target

--- a/code/modules/paperwork/records/info/aleph.dm
+++ b/code/modules/paperwork/records/info/aleph.dm
@@ -228,7 +228,8 @@
 		"When an employee whose Justice was lower than Level 4 completed the work, the Qliphoth Counter decreased.",
 		"When the work result was Bad, the Qliphoth Counter lowered.",
 		"An employee in the facility will be reflected upon the mirror on the face of Nobody Is.",
-		"When the selected employee completed work, they were assimilated into the abnormality.")
+		"When only one employee with the clearance to work on abnormalities was present in the facility, work damage increased.",
+		"Otherwise, when the selected employee completed work, they were assimilated into the abnormality.",)
 	abno_breach_damage_count = "Extreme" // Once it transforms its over
 	abno_resistances = list(
 		RED_DAMAGE = "Endured/Endured/Resistant",


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes it so that several mobs are hit by stray bullets instead of the bullets passing over.
Suppresses debug warnings related to red queen's final observation.
Fixes math on the strangle attack from nobody is and added a "solo mode" mechanic to the abnormality.
Very minor changes to gold dusk, mostly visual.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes weird jank
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: drifting fox umbrellas can now be hit by bullets
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
