### PR TITLE
Shock Work Fix

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/he/shock_centipede.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/shock_centipede.dm
@@ -79,7 +79,7 @@
 
 	var/tailattack_range = 5
 
-	var/repression_change_qlip_1 = 30
+	var/repression_change_qlip_1_2 = 50
 
 
 /* Work effects */
@@ -108,8 +108,8 @@
 	return TRUE
 
 /mob/living/simple_animal/hostile/abnormality/shock_centipede/ChanceWorktickOverride(mob/living/carbon/human/user, work_chance, init_work_chance, work_type)
-	if((datum_reference?.qliphoth_meter == 1 || datum_reference?.qliphoth_meter == 2) && work_type != ABNORMALITY_WORK_REPRESSION)
-		return repression_change_qlip_1
+	if((datum_reference?.qliphoth_meter == 1 || datum_reference?.qliphoth_meter == 2) && work_type == ABNORMALITY_WORK_REPRESSION)
+		return repression_change_qlip_1_2
 	else
 		return work_chance
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes it so if you do Repression work on Shock Centipede while it's counter is at 1 or 2, it's rates drop down to 50%

## Why It's Good For The Game

Makes the Shock Centipede work as it is supposed to.

## Changelog
:cl:
fix: fixed shock centipede's work rates


<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
