### PR TITLE
Makes the shrimp tongue no longer change "krill" into "kreel"

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/shrimp.dm
+++ b/code/modules/mob/living/carbon/human/species_types/shrimp.dm
@@ -56,14 +56,16 @@
 	message = replacetext(message, "confusing", "conchfusing")
 	message = replacetext(message, "complicated", "clampified")
 	message = replacetext(message, "self", "shellf")
-	message = replacetext(message, "kill", "krill") // Krill yourshellf... or skrill issue
 	message = replacetext(message, "about", "a-boat")
-	message = replacetext(message, "real", "reel")
 	message = replacetext(message, "cap", "carp")
 	message = replacetext(message, "god", "cod")
 	message = replacetext(message, "calamity", "clamity")
 	message = replacetext(message, "help", "kelp")
 	message = replacetext(message, "not", "naught")
-	message = replacetext(message, "ill", "eel")
 	message = replacetext(message, "sophisticated", "sofishticated")
+	message = replacetext(message, "kill", "%1") // Krill yourshellf... or skrill issue
+	message = replacetext(message, "real", "reel")
+	message = replacetext(message, "ill", "eel")
+	message = replacetext(message, "%1", "krill") // earlier on we added a symbol so it dosen't get messed up by ill regex, we fix it here
+
 	speech_args[SPEECH_MESSAGE] = message


### PR DESCRIPTION

## About The Pull Request

Makes kill get turned into "%1", that then gets turned into "krill"
This protects any "kill" sections from being turned into "keel", without using any if() statements or double-regexing

## Why It's Good For The Game

Its probably the best solution for this, that allows both "ill" and "kill" to be turned correctly in a single message
Also its annoying to see it actually replace krill

## Changelog
:cl:
fix: The shrimp tongue is now properly telling people to krill themselfes
/:cl:
