### PR TITLE
E.G.O. telepads (Extraction officer update)

### DIFF
--- a/ModularTegustation/tegu_items/extraction/egotelepad.dm
+++ b/ModularTegustation/tegu_items/extraction/egotelepad.dm
@@ -1,0 +1,43 @@
+/obj/structure/return_pad
+	name = "E.G.O. return pad"
+	desc = "A device developed in a partnership with W-Corp for safe and insant transportation of E.G.O. to the extraction department."
+	icon = 'icons/obj/telescience.dmi'
+	icon_state = "qpad-idle"
+	var/obj/structure/extraction_belt/linked_structure
+	var/available_teleports = 3
+	var/ready = FALSE
+
+/obj/structure/return_pad/Initialize()
+	. = ..()
+	QDEL_IN(src, 45 SECONDS)
+	addtimer(CALLBACK(src, PROC_REF(Warmup)), 1 SECONDS)
+
+/obj/structure/return_pad/Destroy()
+	linked_structure = null
+	return ..()
+
+/obj/structure/return_pad/attackby(obj/item/I, mob/user, params)
+	if(istype(I, /obj/item/clothing/suit/armor/ego_gear) || istype(I, /obj/item/gun/ego_gun/pistol) || istype(I, /obj/item/ego_weapon) || istype(I, /obj/item/gun/ego_gun))
+		TryTeleport(I)
+		return
+	return ..()
+
+/obj/structure/return_pad/proc/Warmup() // This proc basically exists so that people don't accidently toss items in it the instant it spawns
+	ready = TRUE
+
+/obj/structure/return_pad/proc/TryTeleport(obj/item/I)
+	if(!linked_structure)
+		visible_message(span_warning("ERROR - NO LINKED STRUCTURE!"))
+		qdel(src)
+		return
+	if(!ready)
+		visible_message(span_warning("ERROR - Warming up. Please wait one second."))
+		return
+	flick("qpad-beam", src)
+	playsound(get_turf(src), 'sound/weapons/emitter2.ogg', 25, TRUE)
+	playsound(get_turf(linked_structure), 'sound/weapons/emitter2.ogg', 25, TRUE)
+	do_teleport(I, get_turf(linked_structure),null,TRUE,null,null,null,null,TRUE, channel = TELEPORT_CHANNEL_FREE) // Don't want anything interrupting it
+	available_teleports -= 1
+	if(!available_teleports)
+		visible_message(span_warning("[src] fizzles out and disappears!"))
+		qdel(src)

--- a/lobotomy-corp13.dme
+++ b/lobotomy-corp13.dme
@@ -4120,6 +4120,7 @@
 #include "ModularTegustation\tegu_items\extraction\_extraction.dm"
 #include "ModularTegustation\tegu_items\extraction\egodelivery.dm"
 #include "ModularTegustation\tegu_items\extraction\egosurgery.dm"
+#include "ModularTegustation\tegu_items\extraction\egotelepad.dm"
 #include "ModularTegustation\tegu_items\extraction\key.dm"
 #include "ModularTegustation\tegu_items\extraction\lock.dm"
 #include "ModularTegustation\tegu_items\extraction\toolextractor.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a highly requested feature for the EO that allows players to send E.G.O. back to the extraction department when receiving new E.G.O. In addition, extraction officers can now use their handheld device to simply plop out E.G.O. from their department when they are away.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Convenience and sanity. Might not be great for balance.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added E.G.O. Telepads
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
