### PR TITLE
Reindeers no longer kill everyone when crossing beams

### DIFF
--- a/code/modules/projectiles/guns/misc/medbeam.dm
+++ b/code/modules/projectiles/guns/misc/medbeam.dm
@@ -117,13 +117,19 @@
 				return FALSE
 		for(var/obj/effect/ebeam/medical/B in turf)// Don't cross the str-beams!
 			if(B.owner.origin != current_beam.origin)
-				explosion(B.loc,0,0,5,8)
+				if(isliving(user))
+					var/mob/living/living_user = user
+					to_chat(living_user, span_userdanger("You feel the power of two beams tearing you apart!"))
+					living_user.gib()
 				qdel(dummy)
 				return FALSE
 
 		for(var/obj/effect/ebeam/mindwhip/B in turf)// Don't cross the str-beams!
 			if(B.owner.origin != current_beam.origin)
-				explosion(B.loc,0,0,5,8)
+				if(isliving(user))
+					var/mob/living/living_user = user
+					to_chat(living_user, span_userdanger("You feel the power of two beams tearing you apart!"))
+					living_user.gib()
 				qdel(dummy)
 				return FALSE
 	qdel(dummy)

--- a/code/modules/projectiles/guns/misc/reindeer.dm
+++ b/code/modules/projectiles/guns/misc/reindeer.dm
@@ -86,6 +86,7 @@
 	if(!isliving(target))
 		return
 
+	user.Immobilize(1 SECONDS)
 	current_target = target
 	active = TRUE
 	current_beam = user.Beam(current_target, icon_state="drainbeam", time = 10 MINUTES, maxdistance = max_range, beam_type = /obj/effect/ebeam/medical)
@@ -134,13 +135,19 @@
 				return FALSE
 		for(var/obj/effect/ebeam/medical/B in turf)// Don't cross the str-beams!
 			if(B.owner.origin != current_beam.origin)
-				explosion(B.loc,0,0,5,8)
+				if(isliving(user))
+					var/mob/living/living_user = user
+					to_chat(living_user, span_userdanger("You feel the power of two beams tearing you apart!"))
+					living_user.gib()
 				qdel(dummy)
 				return FALSE
 
 		for(var/obj/effect/ebeam/mindwhip/B in turf)// Don't cross the str-beams!
 			if(B.owner.origin != current_beam.origin)
-				explosion(B.loc,0,0,5,8)
+				if(isliving(user))
+					var/mob/living/living_user = user
+					to_chat(living_user, span_userdanger("You feel the power of two beams tearing you apart!"))
+					living_user.gib()
 				qdel(dummy)
 				return FALSE
 	qdel(dummy)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Reindeer beams now gib the user instead of calling explosion
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Reindeer beam crossing has been the reason why R-Corp loses literally 90% of the time.

Almost every single loss from R-Corp has been because reindeer have killed 10+ people in a push.
While extremely funny, stupid reindeer players do lose the entire round singlehandedly.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Reindeers now just kill each other.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
