### PR TITLE
Spider bud now slaps you for destroying its cocoons, cocoons are more naturally spread across the cell.

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/teth/spider_bud.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/spider_bud.dm
@@ -50,6 +50,9 @@
 	if(get_attribute_level(user, PRUDENCE_ATTRIBUTE) >= 40 && work_type != ABNORMALITY_WORK_INSIGHT)
 		return
 
+	turn_into_burger(user)
+
+/mob/living/simple_animal/hostile/abnormality/spider/proc/turn_into_burger(mob/living/carbon/human/user, skip_waiting = FALSE)
 	icon_state = "spider_open"
 	if(GODMODE in user.status_flags)
 		manual_emote("stares at [user], visibly annoyed.")
@@ -62,7 +65,9 @@
 	user.forceMove(casing)
 
 	user.death()
-	SLEEP_CHECK_DEATH(5 SECONDS)
+	if(!skip_waiting)
+		SLEEP_CHECK_DEATH(4 SECONDS)
+
 	icon_state = "spider_closed"
 	datum_reference.max_boxes += 2
 
@@ -76,11 +81,7 @@
 	. = ..()
 	pixel_x = rand(-16, 16)
 	pixel_y = rand(-10, 20)
-	icon_state = pick(
-		"cocoon_large1",
-		"cocoon_large2",
-		"cocoon_large3",
-	)
+	icon_state = "cocoon_large[rand(1, 3)]"
 
 /obj/structure/spider/cocoon/spider_bud/Destroy()
 	if(!istype(spooder))
@@ -88,12 +89,17 @@
 
 	spooder.datum_reference.max_boxes -= 2
 	for(var/mob/living/carbon/human/sinner in oview(2, src))
+		if(sinner.stat == DEAD || isnull(sinner.ckey))
+			continue
+
 		if(!spooder.metagame_list[sinner.ckey])
 			spooder.metagame_list += sinner.ckey
 			spooder.metagame_list[sinner.ckey] = 0
 
 		spooder.metagame_list[sinner.ckey] += 1
 		sinner.deal_damage(50 * spooder.metagame_list[sinner.ckey], RED_DAMAGE)
-		to_chat(sinner, span_userdanger("As you destroy the cocoon, tiny spiders swarm you and tear out some of your flesh before returning to [spooder]!"))
+		to_chat(sinner, span_userdanger("As the cocoon breaks tiny spiders swarm you and tear out some of your flesh before returning to [spooder]!"))
+		if(sinner.stat == DEAD) // if they are dead after our attack, burger them
+			spooder.turn_into_burger(sinner, TRUE)
 
 	return ..()

--- a/code/modules/mob/living/simple_animal/abnormality/teth/spider_bud.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/spider_bud.dm
@@ -56,7 +56,7 @@
 	icon_state = "spider_open"
 	if(GODMODE in user.status_flags)
 		manual_emote("stares at [user], visibly annoyed.")
-		SLEEP_CHECK_DEATH(5 SECONDS)
+		SLEEP_CHECK_DEATH(3 SECONDS)
 		icon_state = "spider_closed"
 		return
 
@@ -66,7 +66,7 @@
 
 	user.death()
 	if(!skip_waiting)
-		SLEEP_CHECK_DEATH(4 SECONDS)
+		SLEEP_CHECK_DEATH(3 SECONDS)
 
 	icon_state = "spider_closed"
 	datum_reference.max_boxes += 2

--- a/code/modules/paperwork/records/info/teth.dm
+++ b/code/modules/paperwork/records/info/teth.dm
@@ -15,7 +15,9 @@
 		"Employees with Prudence Level 1 squashed the spiderlings. Spider Bud turned those who harmed its children into cocoons.",
 		"When cleaning the unit as a part of Insight Work, the employee was quickly turned into a cocoon by Spider Bud.",
 		"For each person encased in a cocoon, Spider Bud's max PE available from work was increased by 2.",
-		"Employees were entirely unable to get a good work result from spider bud.",)
+		"Employees were entirely unable to get a good work result from spider bud, unless very special circumstances arose",
+		"Employees that destroyed or closelly watched a destruction of a cocoon made by Spider Bud had reported tiny spiders coming out of the cocoon and biting them, in rare cases this resulted in the employees death",
+	)
 
 //Scorched girl
 /obj/item/paper/fluff/info/teth/match


### PR DESCRIPTION

## About The Pull Request

Spider cocoons are now randomy spread across the cell via making their pixel_x and pixel_y positions semi-random.
Spider bud now slaps you for 50 red damage, multiplied by the amount of times you closelly watched a cocoon get destroyed, if you die to that attack you also get cocooned.

## Why It's Good For The Game

> Spider cocoons are now randomy spread across the cell via making their pixel_x and pixel_y positions semi-random
- This makes it look much more natural and adds the fun thing of cocoons not overlaying onto eachother when someone is dying a LOT to spider bud.
> Spider bud now slaps you for 50 red damage, multiplied by the amount of times you closelly watched a cocoon get destroyed, if you die to that attack you also get cocooned.
- Its kinda weird it just sits there, doing nothing as you destroy the cocoons. This makes it so its possible to retrieve your body 1-2 times, but more than that is gonna not be a good idea

## Changelog
:cl:
tweak: Spider bud no longer likes you breaking their cocoons
/:cl:
