### PR TITLE
Adds ERA Stat Req Buff to Other Applicable Armors

### DIFF
--- a/code/game/objects/items/ego_weapons/non_abnormality/black_silence.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/black_silence.dm
@@ -33,6 +33,21 @@
 	var/list/unlocked_list = list()
 	var/iff = TRUE
 
+
+/obj/item/ego_weapon/black_silence_gloves/examine(mob/user)
+	. = ..()
+	if(user.mind)
+		if(user.mind.assigned_role in list("Disciplinary Officer", "Emergency Response Agent")) //These guys get a bonus to equipping gacha.
+			. += span_notice("Due to your abilities, you get a -20 reduction to stat requirements when equipping this weapon.")
+
+/obj/item/ego_weapon/black_silence_gloves/CanUseEgo(mob/living/user)
+	if(user.mind)
+		if(user.mind.assigned_role in list("Disciplinary Officer", "Emergency Response Agent")) //These guys get a bonus to equipping gacha.
+			equip_bonus = 20
+		else
+			equip_bonus = 0
+	. = ..()
+
 /obj/item/ego_weapon/black_silence_gloves/equipped(mob/user, slot)
 	. = ..()
 	if(!user)

--- a/code/game/objects/items/ego_weapons/non_abnormality/kcorp.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/kcorp.dm
@@ -103,6 +103,20 @@
 	fire_sound = 'sound/weapons/gun/pistol/shot.ogg'
 	fire_sound_volume = 70
 
+/obj/item/gun/ego_gun/pistol/kcorp/examine(mob/user)
+	. = ..()
+	if(user.mind)
+		if(user.mind.assigned_role in list("Disciplinary Officer", "Emergency Response Agent")) //These guys get a bonus to equipping gacha.
+			. += span_notice("Due to your abilities, you get a -20 reduction to stat requirements when equipping this weapon.")
+
+/obj/item/gun/ego_gun/pistol/kcorp/CanUseEgo(mob/living/user)
+	if(user.mind)
+		if(user.mind.assigned_role in list("Disciplinary Officer", "Emergency Response Agent")) //These guys get a bonus to equipping gacha.
+			equip_bonus = 20
+		else
+			equip_bonus = 0
+	. = ..()
+
 
 // Guns below
 /obj/item/gun/ego_gun/pistol/kcorp/smg

--- a/code/modules/clothing/suits/ego_gear/non_abnormality/index.dm
+++ b/code/modules/clothing/suits/ego_gear/non_abnormality/index.dm
@@ -26,6 +26,21 @@
 							)
 	alternative_styles = list("index_proxy_open", "index_proxy_closed")
 
+/obj/item/clothing/suit/armor/ego_gear/adjustable/index_proxy/examine(mob/user)
+	. = ..()
+	if(user.mind)
+		if(user.mind.assigned_role in list("Disciplinary Officer", "Emergency Response Agent")) //These guys get a bonus to equipping gacha.
+			. += span_notice("Due to your abilities, you get a -20 reduction to stat requirements when equipping this armor.")
+
+/obj/item/clothing/suit/armor/ego_gear/adjustable/index_proxy/CanUseEgo(mob/living/user)
+	if(user.mind)
+		if(user.mind.assigned_role in list("Disciplinary Officer", "Emergency Response Agent")) //These guys get a bonus to equipping gacha.
+			equip_bonus = 20
+		else
+			equip_bonus = 0
+	. = ..()
+
+
 /obj/item/clothing/suit/armor/ego_gear/city/index_mess
 	name = "index messenger armor"
 	desc = "Armor worn by index messengers."

--- a/code/modules/clothing/suits/ego_gear/non_abnormality/ucorp.dm
+++ b/code/modules/clothing/suits/ego_gear/non_abnormality/ucorp.dm
@@ -1,7 +1,9 @@
 //Peqod Crew
-/obj/item/clothing/suit/armor/ego_gear/pequod_captain
+/obj/item/clothing/suit/armor/ego_gear/city/pequod_captain
 	name = "pequod captain's uniform"
 	desc = "A worn and rugged uniform worn by veteran fixers in U corp."
+	icon = 'icons/obj/clothing/ego_gear/suits.dmi'
+	worn_icon = 'icons/mob/clothing/ego_gear/suit.dmi'
 	icon_state = "pequod_ahab"
 	armor = list(RED_DAMAGE = 30, WHITE_DAMAGE = 30, BLACK_DAMAGE = 30, PALE_DAMAGE = 30)
 	slowdown = -0.1
@@ -12,3 +14,4 @@
 							TEMPERANCE_ATTRIBUTE = 55,
 							JUSTICE_ATTRIBUTE = 55
 							)
+

--- a/code/modules/clothing/suits/ego_gear/non_abnormality/ucorp.dm
+++ b/code/modules/clothing/suits/ego_gear/non_abnormality/ucorp.dm
@@ -14,4 +14,3 @@
 							TEMPERANCE_ATTRIBUTE = 55,
 							JUSTICE_ATTRIBUTE = 55
 							)
-

--- a/code/modules/clothing/suits/ego_gear/non_abnormality/wcorp.dm
+++ b/code/modules/clothing/suits/ego_gear/non_abnormality/wcorp.dm
@@ -13,6 +13,21 @@
 							JUSTICE_ATTRIBUTE = 55
 							)
 
+/obj/item/clothing/suit/armor/ego_gear/wcorp/examine(mob/user)
+	. = ..()
+	if(user.mind)
+		if(user.mind.assigned_role in list("Disciplinary Officer", "Emergency Response Agent")) //These guys get a bonus to equipping gacha.
+			. += span_notice("Due to your abilities, you get a -20 reduction to stat requirements when equipping this armor.")
+
+/obj/item/clothing/suit/armor/ego_gear/wcorp/CanUseEgo(mob/living/user)
+	if(user.mind)
+		if(user.mind.assigned_role in list("Disciplinary Officer", "Emergency Response Agent")) //These guys get a bonus to equipping gacha.
+			equip_bonus = 20
+		else
+			equip_bonus = 0
+	. = ..()
+
+
 /obj/item/clothing/head/ego_hat/wcorp
 	name = "w-corp cap"
 	desc = "A ball cap worn by w-corp."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds the ERA lower stats for Black Silence Gloves, Index Proxy armor, K corp guns, W corp vest, and the Pequod armor.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes oversights.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixed some non-EGO weapons not giving the ERA stat req decrease
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
