### PR TITLE
Der Freischutz has replaced his rubber bullets with magic bullets for rca

### DIFF
--- a/ModularTegustation/tegu_items/rcorp/!abno_overwrites.dm
+++ b/ModularTegustation/tegu_items/rcorp/!abno_overwrites.dm
@@ -67,3 +67,10 @@
 		jump_damage = 100
 		jump_aoe = 2
 	return ..()
+
+//Der Freischutz gets 233% more damage
+//This is to account for the fact his attack is highly choreographed and cannot pierce walls
+/mob/living/simple_animal/hostile/abnormality/der_freischutz/Initialize()
+	if(SSmaptype.maptype == "rcorp")
+		bullet_damage = 200
+	return ..()

--- a/code/modules/mob/living/simple_animal/abnormality/he/der_freischutz.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/der_freischutz.dm
@@ -49,6 +49,7 @@
 	var/bullet_cooldown_time = 7 SECONDS
 	var/bullet_fire_delay = 1.5 SECONDS
 	var/bullet_max_range = 50
+	var/bullet_damage = 80
 
 	//PLAYABLES ATTACKS (action in this case)
 	attack_action_types = list(/datum/action/innate/abnormality_attack/toggle/der_freischutz_zoom)
@@ -149,6 +150,7 @@
 	B.original = end_turf
 	B.preparePixelProjectile(end_turf, start_turf)
 	B.range = bullet_max_range
+	B.damage = bullet_damage
 	B.fire()
 	new /datum/beam(start_turf.Beam(end_turf, "magic_bullet_tracer", time = 3 SECONDS))
 	IconChange(firing = FALSE)
@@ -267,4 +269,3 @@
 			for(var/obj/effect/frei_magic/Port in portals)
 				Port.fade_out()
 	return
-


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Raises Der Fresichutz black damage to 200 on rca 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
His attacks are highly choreographed when he does hit he only does 30 black to the rabbits.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Der Freischutz has 200 damage on rca
code: Der Freischutz bullet damage var
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
