### PR TITLE
Scraps duds, fixes Dealer description and adds final observation

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/teth/dealerdamned.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/dealerdamned.dm
@@ -1,6 +1,6 @@
 /mob/living/simple_animal/hostile/abnormality/dealerdamned
 	name = "Dealer of the Damned"
-	desc = "A floating playing card with what appears to be a cursor acting as its hand."
+	desc = "A towering figure with a revolver for a head. It's seated in front of a poker table."
 	icon = 'ModularTegustation/Teguicons/64x64.dmi'
 	icon_state = "dealerdamned"
 	maxHealth = 400
@@ -18,7 +18,6 @@
 	speak_emote = list("states")
 	pet_bonus = "waves"
 
-	//Forsaken gift is just a placeholder so it doesn't bug tf out when I compile
 	ego_list = list(
 		/datum/ego_datum/weapon/luckdraw,
 		/datum/ego_datum/armor/luckdraw,
@@ -30,6 +29,13 @@
 	var/has_flipped
 	var/static/gambled_prior = list()
 	var/work_count = 0
+
+	observation_prompt = "You awaken to a building flooded with stimulation; guests mingle and drink as slot machines whirr and blare their tunes, drowning out the mourning of those who have lost it all. <br>\
+	Amidst all this, you find yourself sat in front of a poker table, already in the middle of a game. The Dealer turns to you, eagerly awaiting your next move."
+	observation_choices = list("Call", "Fold")
+	correct_choices = list("Call")
+	observation_success_message = "You call, confident your hand is enough to win. However, you lose, beat by none other than a Royal Flush. Despite this loss, you continue to play, confident your luck will eventually turn around..."
+	observation_fail_message = "You fold, wishing to cling to what little remains of your wealth. Despite lacking any facial features, you can feel the Dealer's disappointment..."
 
 //Coinflip V1; Expect Jank
 /mob/living/simple_animal/hostile/abnormality/dealerdamned/funpet(mob/petter)

--- a/code/modules/projectiles/ammunition/ego_ammunition/zayin.dm
+++ b/code/modules/projectiles/ammunition/ego_ammunition/zayin.dm
@@ -37,9 +37,3 @@
 	name = "oceanic casing"
 	desc = "A oceanica casing."
 	projectile_type = /obj/projectile/ego_bullet/ego_oceanic
-
-/obj/item/ammo_casing/caseless/ego_dud
-	name = "dud casing"
-	desc = "A dud casing."
-	projectile_type = /obj/projectile/ego_bullet/ego_dud
-	pellets = 0

--- a/code/modules/projectiles/projectile/ego_bullets/zayin.dm
+++ b/code/modules/projectiles/projectile/ego_bullets/zayin.dm
@@ -57,12 +57,3 @@
 	name = "oceanic"
 	damage = 11		//Worse than tough lol
 	damage_type = WHITE_DAMAGE
-
-/obj/projectile/ego_bullet/ego_dud
-	name = "dud"
-	damage = 1
-	damage_type = RED_DAMAGE
-
-/obj/projectile/ego_bullet/ego_dud/Initialize()
-	qdel(src)
-	..()


### PR DESCRIPTION
As the title states, this adds a Final Observation to DotD and changes its description to match its current sprite. This also gets rid of the unimplemented and nonfunctional dud rounds originally intended for use with Death Dealer.

Hopefully this version of the PR doesn't fucking break everything this time.
## About The Pull Request

Adds final observation for Dealer of the Damned, as well as changing its description to match its current sprite.
Removes the unimplemented Dud rounds intended to be used with Death Dealer.
## Why It's Good For The Game

Dud rounds weren't being used, and Dealer lacked a Final Observation. Its description also matched the devsprite rather than its final appearance.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added final observation for DotD
del: Removed Dud rounds
tweak: Tweaked DotD description

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
