### PR TITLE
Corrects Fbird's obs choices

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/waw/fire_bird.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/fire_bird.dm
@@ -42,7 +42,7 @@
 	observation_prompt = "You can only hunt it wearing a thick blindfold, but even through the fabric you can track it by the light that manages to seep through and by the heat it radiates. <br>\
 		In your hands you carry a bow nocked with an arrow, it's your last one. <br>\
 		You've been pursuing your prey for days, you..."
-	observation_choices = list("Fire an arrow", "Take off your blindfold", "Do nothing") //awaiting extra answers functionality //"Take off your blindfold" should be a third option
+	observation_choices = list("Fire an arrow", "Take off your blindfold", "Do nothing")
 	correct_choices = list("Do nothing", "Take off your blindfold")
 	observation_success_message = "You watch and wait as the light and heat pass until only cold and darkness reign in the forest. <br>\
 		Feeling safe, you remove your blindfold and find on the ground one of its radiant feathers. <br>\
@@ -65,7 +65,7 @@
 	var/dash_damage = 220
 	var/list/been_hit = list()
 
-/mob/living/simple_animal/hostile/abnormality/fire_bird/ObservationResult(mob/living/carbon/human/user, condition, answer) //special answer for cake result
+/mob/living/simple_animal/hostile/abnormality/fire_bird/ObservationResult(mob/living/carbon/human/user, condition, answer) //borrowed from Bottle of Tears
 	if(answer == "Take off your blindfold")
 		observation_success_message = observation_success_message_2
 	else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
It's supposed to have two right answers
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Mistakes are bad
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Firebird now has two right answers, as its supposed to
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
