### PR TITLE
Jangsan now 100% scarier towards R-Corp infantry

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/he/jangsan.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/jangsan.dm
@@ -145,7 +145,7 @@
 		for(var/attribute in stats)
 			if(get_attribute_level(user, attribute)< 61)
 				weak_counter += 1
-			if(get_attribute_level(user, attribute)>= 80)
+			if(get_attribute_level(user, attribute)>= 60) //This doesnt matter for rca
 				strong_counter += 1
 		return
 	else

--- a/code/modules/mob/living/simple_animal/abnormality/he/jangsan.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/jangsan.dm
@@ -141,12 +141,20 @@
 /mob/living/simple_animal/hostile/abnormality/jangsan/proc/StatCheck(mob/living/carbon/human/user)
 	strong_counter = 0 //Counts how many stats are at or above 60 AKA level 3 or higher
 	weak_counter = 0 //Counts how many stats are below 40 AKA level 1
-	for(var/attribute in stats)
-		if(get_attribute_level(user, attribute)< 40)
-			weak_counter += 1
-		if(get_attribute_level(user, attribute)>= 60)
-			strong_counter += 1
-	return
+	if(SSmaptype.maptype == "rcorp") //Buff for Jangsan for the R-Corp mode
+		for(var/attribute in stats)
+			if(get_attribute_level(user, attribute)< 61)
+				weak_counter += 1
+			if(get_attribute_level(user, attribute)>= 80)
+				strong_counter += 1
+		return
+	else
+		for(var/attribute in stats)
+			if(get_attribute_level(user, attribute)< 40)
+				weak_counter += 1
+			if(get_attribute_level(user, attribute)>= 60)
+				strong_counter += 1
+		return
 
 //Too weak and it kills you
 /mob/living/simple_animal/hostile/abnormality/jangsan/PostWorkEffect(mob/living/carbon/human/user, work_type, pe, work_time)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Jangsans fear counter now buffed to kill those who have 60 stats or lower, meaning Jangsan can kill a rabbit, but not a raven as he needs all stats below 4 to use his fear.

https://github.com/user-attachments/assets/a45bcca9-c3ae-4b25-a7a2-c51c4ff4349d


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Jangsan among all the easytanks is considered one of the weakest he is bulletproof like porccubus and warden but lacks their speed or range to fend off those who simply swap weapons, the other tanks which share his slot possess either healing or aoe attacks to fend off attackers this makes Jangsan a bigger threat which can be countered by ravens and captains who can pull their teammates out of danger and attack freely.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Jangsan now checks if the player has all his stats below 61 on rca.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
