### PR TITLE
Liu section 1 and section 2 swap places in their roaming routes.

### DIFF
--- a/code/modules/jobs/job_types/trusted_players/association/roaming.dm
+++ b/code/modules/jobs/job_types/trusted_players/association/roaming.dm
@@ -28,8 +28,8 @@
 		You are a fixer that recently blew into town to assist the local offices in their endeavors."
 
 	var/list/associations = list("zwei","shi5", "liu5", "seven")
-	var/list/uncommon_associations = list("shi2", "cinq", "liu2")
-	var/list/rare_associations = list("hana", "liu1")
+	var/list/uncommon_associations = list("shi2", "cinq", "liu1")
+	var/list/rare_associations = list("hana", "liu2")
 
 /datum/job/associateroaming/after_spawn(mob/living/carbon/human/H, mob/M)
 	//Not fear immune you're basically some goober
@@ -70,16 +70,16 @@
 			weapon = /obj/item/ego_weapon/city/cinq
 
 		if("liu1")
-			armor = /obj/item/ego_weapon/city/liu/fire/fist
-			weapon = /obj/item/clothing/suit/armor/ego_gear/city/liu
+			armor = /obj/item/clothing/suit/armor/ego_gear/city/liu
+			weapon = /obj/item/ego_weapon/city/liu/fire/fist
 
 		if("liu2")
 			armor = /obj/item/clothing/suit/armor/ego_gear/city/liuvet/section2
 			weapon = /obj/item/ego_weapon/city/liu/fire/spear
 
 		if("liu5")
-			armor = /obj/item/ego_weapon/city/liu/fist
-			weapon = /obj/item/clothing/suit/armor/ego_gear/city/liu/section5
+			armor = /obj/item/clothing/suit/armor/ego_gear/city/liu/section5
+			weapon = /obj/item/ego_weapon/city/liu/fist
 
 		if("seven")
 			armor = /obj/item/clothing/suit/armor/ego_gear/city/seven


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Swaps Liu 1 and Liu 2 making Liu 2 rare and Liu 1 uncommon.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The rarity system is meant to make less players spawn as overall strong offices, the Liu1 roaming has normal Liu armor and a fire fist, the Liu2 roaming has veteran armor which is better in everyway and the fire spear which not only has more range but also does more damage than the fire fist.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: swaps liu2 and liu1 in rarity
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
