### PR TITLE
Reworks how the possession blacklist is handled, Admins can now disable possessing on individual abnormalities.

### DIFF
--- a/ModularTegustation/misc_procs.dm
+++ b/ModularTegustation/misc_procs.dm
@@ -9,7 +9,6 @@
 /datum/proc/try_take_abnormality(mob/dead/observer/possessing_player, mob/abnormality)
 	if(!SSlobotomy_corp.enable_possession) // uhhhh, how did you even access this proc?
 		to_chat(usr, span_userdanger("Abnormality possession is not enabled!"))
-		message_admins(span_adminnotice("[possessing_player.key] has accessed the try_take_abnormality proc whilst possession is disabled."))
 		return
 
 	if(!possessing_player.ckey) // safety check

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -637,7 +637,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	// LOBOTOMYCORPORATION ADDITION START
 	if(!SSlobotomy_corp.enable_possession)
 		to_chat(usr, span_userdanger("Abnormality possession is not enabled!"))
-		return
+		return FALSE
 
 	if(possession_cooldown >= world.time)
 		to_chat(src, span_userdanger("You are under a cooldown for possessing for [(possession_cooldown - world.time) / 10] more seconds!"))

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -3,10 +3,6 @@ GLOBAL_LIST_EMPTY(ghost_images_simple) //this is a list of all ghost images as t
 
 GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 
-GLOBAL_LIST_INIT(unpossessable_mobs, list( // LOBOTOMYCORPORATION ADDITION -- abnormality blacklist
-	/mob/living/simple_animal/hostile/abnormality/punishing_bird,
-))
-
 /mob/dead/observer
 	name = "ghost"
 	desc = "It's a g-g-g-g-ghooooost!" //jinkies!
@@ -638,27 +634,34 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	set name = "Possess!"
 	set desc= "Take over the body of a mindless creature!"
 
+	// LOBOTOMYCORPORATION ADDITION START
+	if(!SSlobotomy_corp.enable_possession)
+		to_chat(usr, span_userdanger("Abnormality possession is not enabled!"))
+		return
+
+	if(possession_cooldown >= world.time)
+		to_chat(src, span_userdanger("You are under a cooldown for possessing for [(possession_cooldown - world.time) / 10] more seconds!"))
+		return FALSE
+	// LOBOTOMYCORPORATION ADDITION END
+
 	var/list/possessible = list()
 	for(var/mob/living/L in GLOB.alive_mob_list)
-		if(istype(L,/mob/living/carbon/human/dummy) || !get_turf(L)) //Haha no.
-			continue
 		// LOBOTOMYCORPORATION ADDITION START
-		if(!SSlobotomy_corp.enable_possession)
-			message_admins(span_adminnotice("[src.key] has accessed the mob/dead/observer/verb/possess() whilst abnormality possession is not enabled!"))
-			return
-		if(is_type_in_list(L, GLOB.unpossessable_mobs))
+		if(isabnormalitymob(L))
+			var/mob/living/simple_animal/hostile/abnormality/abnormality = L
+			if(abnormality.do_not_possess)
+				continue
+
+		if(istype(L, /mob/living/carbon/human/dummy) || !get_turf(L)) //Haha no.
 			continue
 		// LOBOTOMYCORPORATION ADDITION END
+
 		if(!(L in GLOB.player_list) && !L.mind)
 			possessible += L
 
 	var/mob/living/target = input("Your new life begins today!", "Possess Mob", null, null) as null|anything in sortNames(possessible)
 
 	if(!target)
-		return FALSE
-
-	if(possession_cooldown >= world.time)
-		to_chat(src, span_userdanger("You are under a cooldown for possessing for [(possession_cooldown - world.time) * 10] more seconds!"))
 		return FALSE
 
 	if(ismegafauna(target))
@@ -721,16 +724,14 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		to_chat(usr, span_userdanger("Abnormality possession is not enabled!"))
 		return ..()
 
-	if(is_type_in_list(over, GLOB.unpossessable_mobs))
-		to_chat(usr, span_userdanger("This abnormality is blacklisted from being possessed!"))
-		return ..()
+	if(isabnormalitymob(over))
+		var/mob/living/simple_animal/hostile/abnormality/abnormality = over
+		if(abnormality.do_not_possess)
+			to_chat(usr, span_userdanger("This abnormality is blacklisted from being possessed!"))
+			return ..()
 
 	if(possession_cooldown >= world.time)
-		to_chat(src, span_userdanger("You are under a cooldown for possessing for [(possession_cooldown - world.time) * 10] more seconds!"))
-		return ..()
-
-	if(!isobserver(usr)) // safety check
-		to_chat(usr, span_userdanger("you are not an observer despite being an observer, silly. You cant possess abnormalities!"))
+		to_chat(src, span_userdanger("You are under a cooldown for possessing for [(possession_cooldown - world.time) / 10] more seconds!"))
 		return ..()
 
 	if(!usr.client) // who are we talking to again...? whatever

--- a/code/modules/mob/living/simple_animal/abnormality/_abnormality.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_abnormality.dm
@@ -96,6 +96,9 @@
 	var/core_icon = ""
 	var/core_enabled = TRUE
 
+	/// If an abnormality should not be possessed even if possessibles are enabled, mainly for admins.
+	var/do_not_possess = FALSE
+
 	// secret skin variables ahead
 
 	/// Toggles if the abnormality has a secret form and can spawn naturally

--- a/code/modules/mob/living/simple_animal/abnormality/teth/punishing_bird.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/punishing_bird.dm
@@ -63,6 +63,8 @@
 	correct_choices = list("Little bird", "Punishing bird")
 	observation_success_message = "The small bird accepts whatever name you decide to give it. Its nature can never change now."
 
+	do_not_possess = TRUE
+
 	var/list/enemies = list()
 	var/list/pecking_targets = list()
 	var/list/already_punished = list()


### PR DESCRIPTION

## About The Pull Request

- Changes the global forbidden abnormality possession blacklist into a var on every abnormality that gets checked instead
- Moves some if() checks around into better spots
- Removes the admin message if someone tries to possess whilst possession is not enabled

## Why It's Good For The Game

> Changes the global forbidden abnormality possession blacklist into a var on every abnormality that gets checked instead
- This way, admins can disable any abnormality they are preparing for adminbus and dont want a ghost entering into. Also cleaner
> Moves some if() checks around into better spots
- Please, let me bury the history of me making the code check if possession is enabled in SSlobotomy subsystem EVERY time it checks if a mob is valid to possess, god the inefficiency
> Removes the admin message if someone tries to possess whilst possession is not enabled
- It's not really needed, no harm is being done

## Changelog
:cl:
admin: you can now disable possession on individual abnormality's by changing their `do_not_possess` var
/:cl:
