### PR TITLE
Zwei Batons now powered by duracell batteries instead of potato batteries

### DIFF
--- a/code/game/objects/items/ego_weapons/non_abnormality/zwei.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/zwei.dm
@@ -135,7 +135,7 @@
 	T.Jitter(20)
 	T.set_confusion(max(10, T.get_confusion()))
 	T.stuttering = max(8, T.stuttering)
-	T.adjustStaminaLoss(force, TRUE, TRUE)
+	T.adjustStaminaLoss(force*2, TRUE, TRUE)
 
 	SEND_SIGNAL(T, COMSIG_LIVING_MINOR_SHOCK)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Doubled the stamina damage done by Zwei batons as to deal with the fact that fortitude scales stamina, taking 4 hits to stun a 130 stat and 3 to stun a 100 stat.

https://github.com/user-attachments/assets/52aae772-3db9-46e1-8845-63b5200d3dd1


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The Zwei Baton did so little stamina (33.3 stamina) that it would on most cases kill players before actually stunning them making it highly inefficient as a non-lethal weapon, a 80 stat association member would do 288 RED by the fourth hit of the Zwei Baton as an example.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Doubled stamina damage done by zwei baton
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
