### PR TITLE
Makes Clown Smiling at You Explode into Foam like SS13 clown mobs

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/waw/clown_smiling.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/clown_smiling.dm
@@ -187,7 +187,8 @@
 	playsound(get_turf(src), 'sound/abnormalities/clownsmiling/announcedead.ogg', 75, 1)
 	for(var/mob/living/L in view(5, src))
 		if(!faction_check_mob(L))
-			L.deal_damage(50, RED_DAMAGE)
+			L.deal_damage(25, RED_DAMAGE)
+	new /obj/effect/particle_effect/foam in get_turf(src)
 	gib()
 
 //Clown picture-related code


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Reduces explosion damage by half but makes foam that slips people around it
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It is funny
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added foam to Clown Smiling At Me's explosion
balance: Reduced explosion damage
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
