### PR TITLE
Domain Expansion: Sephirah Griefing

### DIFF
--- a/code/modules/jobs/job_types/trusted_players/sephirah.dm
+++ b/code/modules/jobs/job_types/trusted_players/sephirah.dm
@@ -115,7 +115,7 @@ GLOBAL_LIST_INIT(sephirah_names, list(
 
 		//Literally being griefed.
 		SSlobotomy_corp.lob_points += 1
-		minor_announce("Due to a lack of resources; a random abnormality has been chosen and LOB points have been deposited in your account. \
+		minor_announce("Due to a lack of resources; a random abnormality has been chosen and LOB point has been deposited in your account. \
 				Extraction Headquarters apologizes for the inconvenience", "Extraction Alert:", TRUE)
 		return
 
@@ -230,15 +230,15 @@ GLOBAL_LIST_EMPTY(SephirahBullet)
 /mob/living/carbon/human/proc/BulletAuth()
 	set name = "Authorize Execution Bullets"
 	set category = "Sephirah"
-	GLOB.SephirahBullet|= src.ckey
-	if(GLOB.SephirahBullet.len == 2)
+	GLOB.SephirahBullet |= src.ckey
+	if(length(GLOB.SephirahBullet) == 2)
 		minor_announce("The facility's manager has been deemed trustworthy of our new Execution Bullet pilot program. \
 			Execution bullets will be delivered immediately.", "Disciplinary Alert:", TRUE)
 		GLOB.execution_enabled = TRUE
 
 	else
 		to_chat(src, span_notice("Your superiors have been notified of your authorization. Reminder that execution bullets require authorization of 2 sephirah."))
-		message_admins("<span class='notice'>A sephirah ([src.ckey]) has given an authorization for execution bullets..</span>")
+		message_admins(span_notice("A sephirah ([src.ckey]) has given an authorization for execution bullets."))
 
 /mob/living/carbon/human/proc/Announcement()
 	set name = "Make Announcement"

--- a/code/modules/jobs/job_types/trusted_players/sephirah.dm
+++ b/code/modules/jobs/job_types/trusted_players/sephirah.dm
@@ -23,9 +23,14 @@
 	. = ..()
 	//You're a fucking robot.
 	ADD_TRAIT(outfit_owner, TRAIT_SANITYIMMUNE, JOB_TRAIT)
+	//Okay maybe don't JUST let them grief.
+	add_verb(outfit_owner, /mob/living/carbon/human/proc/QuestComplete)
 
-	//Let'em Grief
+	//NOW Let'em Grief
+	add_verb(outfit_owner, /mob/living/carbon/human/proc/GameInfo)
+	add_verb(outfit_owner, /mob/living/carbon/human/proc/Announcement)
 	add_verb(outfit_owner, /mob/living/carbon/human/proc/RandomAbno)
+	add_verb(outfit_owner, /mob/living/carbon/human/proc/RandomSelection)
 	add_verb(outfit_owner, /mob/living/carbon/human/proc/NextAbno)
 	add_verb(outfit_owner, /mob/living/carbon/human/proc/SlowGame)
 	add_verb(outfit_owner, /mob/living/carbon/human/proc/QuickenGame)
@@ -33,7 +38,7 @@
 	add_verb(outfit_owner, /mob/living/carbon/human/proc/WorkMeltDecrease)
 	add_verb(outfit_owner, /mob/living/carbon/human/proc/MeltIncrease)
 	add_verb(outfit_owner, /mob/living/carbon/human/proc/MeltDecrease)
-	add_verb(outfit_owner, /mob/living/carbon/human/proc/GameInfo)
+	add_verb(outfit_owner, /mob/living/carbon/human/proc/BulletAuth)
 	// a TGUI menu that SHOULD contain all the above actions
 	var/datum/action/sephirah_game_panel/new_action = new(outfit_owner.mind || outfit_owner)
 	new_action.Grant(outfit_owner)
@@ -87,6 +92,14 @@ GLOBAL_LIST_INIT(sephirah_names, list(
 /*************************************************/
 //Sephirah Gamemaster commands.
 
+/mob/living/carbon/human/proc/QuestComplete()
+	set name = "Reward Custom Quest"
+	set category = "Sephirah.Events"
+	SSlobotomy_corp.lob_points += 1
+	minor_announce("The local sephirah have decided that the facility's, and by extention, the manager's, performance have been exemplary. \
+				1 LOB point has been deposited into the account of your manager", "Central Command Alert:", TRUE)
+	return
+
 /mob/living/carbon/human/proc/RandomAbno()
 	set name = "Randomize Current Abnormality"
 	set category = "Sephirah.Events"
@@ -101,10 +114,23 @@ GLOBAL_LIST_INIT(sephirah_names, list(
 		SSabnormality_queue.ClearChoices()
 
 		//Literally being griefed.
-		SSlobotomy_corp.available_box += 500
-		minor_announce("Due to a lack of resources; a random abnormality has been chosen and PE has been deposited in your account. \
+		SSlobotomy_corp.lob_points += 1
+		minor_announce("Due to a lack of resources; a random abnormality has been chosen and LOB points have been deposited in your account. \
 				Extraction Headquarters apologizes for the inconvenience", "Extraction Alert:", TRUE)
 		return
+
+/mob/living/carbon/human/proc/RandomSelection()
+	set name = "Randomize Abnormality Selection"
+	set category = "Sephirah.Events"
+
+	SSabnormality_queue.next_abno_spawn = world.time + SSabnormality_queue.next_abno_spawn_time + ((min(16, SSabnormality_queue.spawned_abnos) - 6) * 6) SECONDS
+	SSabnormality_queue.PickAbno()
+
+	//Literally being griefed.
+	SSlobotomy_corp.lob_points += 0.25
+	minor_announce("Extraction has made an error in which abnormalities your manager was to select. Extraction apologizes profusely, \
+			and the actual set of [GetFacilityUpgradeValue(UPGRADE_ABNO_QUEUE_COUNT)] abnormalities has been sent to your manager's console.", "Extraction Alert:", TRUE)
+	return
 
 //See next abnormality
 /mob/living/carbon/human/proc/NextAbno()
@@ -198,7 +224,27 @@ GLOBAL_VAR_INIT(Sephirahmeltmodifier, 0)
 	to_chat(src, span_notice("One less abnormality will melt per event."))
 	message_admins("<span class='notice'>A sephirah ([src.ckey]) has made less abnormalities melt per event.</span>")
 
+//Execution barrets
+GLOBAL_LIST_EMPTY(SephirahBullet)
 
+/mob/living/carbon/human/proc/BulletAuth()
+	set name = "Authorize Execution Bullets"
+	set category = "Sephirah"
+	GLOB.SephirahBullet|= src.ckey
+	if(GLOB.SephirahBullet.len == 2)
+		minor_announce("The facility's manager has been deemed trustworthy of our new Execution Bullet pilot program. \
+			Execution bullets will be delivered immediately.", "Disciplinary Alert:", TRUE)
+		GLOB.execution_enabled = TRUE
+
+	else
+		to_chat(src, span_notice("Your superiors have been notified of your authorization. Reminder that execution bullets require authorization of 2 sephirah."))
+		message_admins("<span class='notice'>A sephirah ([src.ckey]) has given an authorization for execution bullets..</span>")
+
+/mob/living/carbon/human/proc/Announcement()
+	set name = "Make Announcement"
+	set category = "Sephirah"
+	var/input = stripped_input(src,"What do you want announce?", ,"Test Announcement")
+	minor_announce("[input]" , "Official Sephirah announcement from: [src.name]")
 
 //See next abnormality
 /mob/living/carbon/human/proc/GameInfo()

--- a/code/modules/jobs/job_types/trusted_players/sephirah.dm
+++ b/code/modules/jobs/job_types/trusted_players/sephirah.dm
@@ -320,8 +320,20 @@ GLOBAL_LIST_EMPTY(SephirahBullet)
 	var/mob/living/carbon/human/hooman = owner
 
 	switch(action) // maybe change labels?
+		if("Make announcement")
+			hooman.Announcement()
+
+		if("Complete quest")
+			hooman.QuestComplete()
+
 		if("Randomize abnormality")
 			hooman.RandomAbno()
+
+		if("Randomize selection")
+			hooman.RandomSelection()
+
+		if("Authorize execution bullets")
+			hooman.BulletAuth()
 
 		if("Slow abnormality arrival")
 			hooman.SlowGame()
@@ -340,3 +352,5 @@ GLOBAL_LIST_EMPTY(SephirahBullet)
 
 		if("Decrease abnormality per meltdown")
 			hooman.MeltDecrease()
+
+

--- a/tgui/packages/tgui/interfaces/SephirahPanel.js
+++ b/tgui/packages/tgui/interfaces/SephirahPanel.js
@@ -62,15 +62,54 @@ const ButtonPanel = (props, context) => {
     <Section title="Avaible actions">
       <Box mt="0.5em">
         <LabeledList>
+          <Collapsible title="Complete quest">
+            <LabeledList.Item
+              labelWrap
+              label="Reward the facility for completing a custom quest that you set out earlier this shift."
+              buttons={
+                <Button
+                  content={'Complete quest'}
+                  color={'green'}
+                  onClick={() => act('Complete quest')}
+                />
+              }
+            />
+          </Collapsible>
+          <Collapsible title="Make announcement">
+            <LabeledList.Item
+              labelWrap
+              label="Allows you to make a global announcement."
+              buttons={
+                <Button
+                  content={'Make announcement'}
+                  color={'green'}
+                  onClick={() => act('Make announcement')}
+                />
+              }
+            />
+          </Collapsible>
           <Collapsible title="Randomize abnormality">
             <LabeledList.Item
               labelWrap
-              label="Randomizes the current abnormality, only works if the abnormality has not yet been randomized at its current state"
+              label="Randomizes the current abnormality, only works if the abnormality has not yet been randomized at its current state. Gives the manager 1 LOB."
               buttons={
                 <Button
                   content={'Randomize abnormality'}
                   color={'green'}
                   onClick={() => act('Randomize abnormality')}
+                />
+              }
+            />
+          </Collapsible>
+          <Collapsible title="Randomize selection">
+            <LabeledList.Item
+              labelWrap
+              label="Randomizes the current abnormality selection. Gives the manager 1 LOB."
+              buttons={
+                <Button
+                  content={'RRandomize selection'}
+                  color={'green'}
+                  onClick={() => act('Randomize selection')}
                 />
               }
             />
@@ -159,6 +198,19 @@ const ButtonPanel = (props, context) => {
                   content={'Decrease abnormality per meltdown'}
                   color={'green'}
                   onClick={() => act('Decrease abnormality per meltdown')}
+                />
+              }
+            />
+          </Collapsible>
+          <Collapsible title="Authorize execution bullets">
+            <LabeledList.Item
+              labelWrap
+              label="Put your vote in to authorize execution bullets for the manager. 2 Sephirah have to agree for this to pass."
+              buttons={
+                <Button
+                  content={'Authorize execution bullets'}
+                  color={'red'}
+                  onClick={() => act('Authorize execution bullets')}
                 />
               }
             />


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a few new sephirah mechanics

### Quest Complettion
They now can issue RP quests and complete them to give the players 1 LOB (This can be changed)

### Announcement
Sephirah can now make announcements similar to the captain

### Random Abnormality
Random abno now gives you 1 LOB instead of a shitload of PE

### Random Selection
New option to replace the current 3 with a new 3 abnos

### Execution Bullet Auth
2 Sephirahs can now authorize the manajuh to use execution bullets.


To do:
Add to the TGUI panel
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
More sephirah tools. 
More are incoming
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added more sephirah commands
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
