### PR TITLE
Fixes K-corp healing drones runtiming every time they hit someone, and them not healing anyone

### DIFF
--- a/ModularTegustation/tegu_items/representative/items/kcorp.dm
+++ b/ModularTegustation/tegu_items/representative/items/kcorp.dm
@@ -108,8 +108,10 @@
 		var/mob/living/H = target
 		H.adjustStaminaLoss(rand(14, 18))
 		if(!defective)
-			to_chat(H, span_nicegreen("You feel your injuries painfully close!"))
 			H.adjustBruteLoss(-20)
+			to_chat(H, span_nicegreen("You feel your injuries painfully close!"))
+			if(prob(25))
+				H.emote("scream")
 	return ..()
 
 // For Asset Reclimation

--- a/ModularTegustation/tegu_items/representative/items/kcorp.dm
+++ b/ModularTegustation/tegu_items/representative/items/kcorp.dm
@@ -81,21 +81,19 @@
 	icon_state = "khealing"
 	icon_living = "khealing"
 	faction = list("kcorp")
-	health = 500	//They're here to help
+	health = 500
 	maxHealth = 500
-	melee_damage_type = STAMINA
 	damage_coeff = list(RED_DAMAGE = 0.4, WHITE_DAMAGE = 0.7, BLACK_DAMAGE = 1.2, PALE_DAMAGE = 1)
-	melee_damage_lower = 14
-	melee_damage_upper = 18
 	robust_searching = TRUE
 	stat_attack = HARD_CRIT
 	del_on_death = TRUE
-	attack_verb_continuous = "jabs"
-	attack_verb_simple = "jabs"
-	attack_sound = 'sound/weapons/bite.ogg'
+	friendly_verb_continuous = "jabs"
+	friendly_verb_simple = "jab"
 	can_patrol = TRUE
 	is_flying_animal = TRUE
 
+	/// If TRUE, will not heal people.
+	var/defective = FALSE
 
 /mob/living/simple_animal/hostile/khealing/CanAttack(atom/the_target)
 	if(!ishuman(the_target))
@@ -106,12 +104,13 @@
 	return FALSE
 
 /mob/living/simple_animal/hostile/khealing/AttackingTarget(atom/attacked_target)
-	..()
-	if(!ishuman(attacked_target))
-		return
-	var/mob/living/H = attacked_target
-	H.adjustBruteLoss(-20)
-
+	if(ishuman(target))
+		var/mob/living/H = target
+		to_chat(H, span_nicegreen("You feel your injuries painfully close!"))
+		H.adjustStaminaLoss(rand(14, 18))
+		if(!defective)
+			H.adjustBruteLoss(-20)
+	return ..()
 
 // For Asset Reclimation
 /obj/item/grenade/spawnergrenade/khealing

--- a/ModularTegustation/tegu_items/representative/items/kcorp.dm
+++ b/ModularTegustation/tegu_items/representative/items/kcorp.dm
@@ -106,9 +106,9 @@
 /mob/living/simple_animal/hostile/khealing/AttackingTarget(atom/attacked_target)
 	if(ishuman(target))
 		var/mob/living/H = target
-		to_chat(H, span_nicegreen("You feel your injuries painfully close!"))
 		H.adjustStaminaLoss(rand(14, 18))
 		if(!defective)
+			to_chat(H, span_nicegreen("You feel your injuries painfully close!"))
 			H.adjustBruteLoss(-20)
 	return ..()
 


### PR DESCRIPTION

## About The Pull Request

- Fixes K-corp drones runtiming due to checking for stamina armor that does not exist every hit
- Fixes K-corp drones never succeeding in their is_human() check due to checking a non-existant entity
- Adds a feedback message about your wounds healing when a drone jabs you
- Adds a defective toggle to K-corp healing drones that makes them mimic their old broken behavior, for fun

## Why It's Good For The Game

> Fixes K-corp drones never succeeding in their is_human() check due to checking a non-existant entity
- The proc is never passed anything under normal circumstances so we were checking the wrong thing, what we want to check is our `target` var with the actual person we are trying to heal

> Fixes K-corp drones runtiming due to checking for stamina armor that does not exist every hit
- Bug fix gud

> Adds a feedback message about your wounds healing when a drone jabs you
- When i fixed the stamina thingy by directly applying the stamina damage instead of checking for armor, we lost the big red text about being jammed in favor of a small blue one, that is very un-noticable
- So now they give a green message about your wounds painfully closing

## Changelog
:cl:
fix: K-corp healing drones no longer break everything.
/:cl:
