### PR TITLE
Moves the brain attributes into the body fabricator file for modularity, saves it on death instead of constantly re-saving it every life tick

### DIFF
--- a/ModularTegustation/lc13_machinery.dm
+++ b/ModularTegustation/lc13_machinery.dm
@@ -329,23 +329,20 @@
 	var/stored_temperance = 0
 	var/stored_justice = 0
 
-/mob/living/carbon/human/death(gibbed)
-	var/obj/item/organ/brain/B = getorganslot(ORGAN_SLOT_BRAIN)
-	if(B) // make sure it does exist before adding the thingies
-		B.sync_stats(src)
+/obj/item/organ/brain/Remove(mob/living/carbon/C, special = 0, no_id_transfer = FALSE)
+	if(C)
+		stored_fortitude = get_raw_level(C, FORTITUDE_ATTRIBUTE)
+		stored_prudence = get_raw_level(C, PRUDENCE_ATTRIBUTE)
+		stored_temperance = get_raw_level(C, TEMPERANCE_ATTRIBUTE)
+		stored_justice = get_raw_level(C, JUSTICE_ATTRIBUTE)
 	. = ..()
-
-/obj/item/organ/brain/proc/sync_stats(mob/living/carbon/human/H) //Syncs stuff for torso fabricator
-	stored_fortitude = get_raw_level(H, FORTITUDE_ATTRIBUTE)
-	stored_prudence = get_raw_level(H, PRUDENCE_ATTRIBUTE)
-	stored_temperance = get_raw_level(H, TEMPERANCE_ATTRIBUTE)
-	stored_justice = get_raw_level(H, JUSTICE_ATTRIBUTE)
 
 /datum/job/after_spawn(mob/living/H, mob/M, latejoin = FALSE)
 	. = ..()
 	var/obj/item/organ/brain/B = H.getorganslot(ORGAN_SLOT_BRAIN)
-	if(length(B.initial_traits) == 0)
-		B.initial_traits = H.status_traits
+	if(B)
+		if(length(B.initial_traits) == 0)
+			B.initial_traits = H.status_traits
 
 /*---------------\
 |Body Preservation Unit|

--- a/ModularTegustation/lc13_machinery.dm
+++ b/ModularTegustation/lc13_machinery.dm
@@ -331,7 +331,7 @@
 
 /mob/living/carbon/human/death(gibbed)
 	var/obj/item/organ/brain/B = getorganslot(ORGAN_SLOT_BRAIN)
-	if(stat != DEAD && B) // make sure it does exist before adding the thingies
+	if(B) // make sure it does exist before adding the thingies
 		B.sync_stats(src)
 	. = ..()
 

--- a/ModularTegustation/lc13_machinery.dm
+++ b/ModularTegustation/lc13_machinery.dm
@@ -321,6 +321,32 @@
 
 #undef ANIMATE_FABRICATOR_ACTIVE
 
+// here we add some vars to the brain to hold the attributes/traits of a mob
+/obj/item/organ/brain
+	var/list/initial_traits = list()
+	var/stored_fortitude = 0
+	var/stored_prudence = 0
+	var/stored_temperance = 0
+	var/stored_justice = 0
+
+/mob/living/carbon/human/death(gibbed)
+	var/obj/item/organ/brain/B = getorganslot(ORGAN_SLOT_BRAIN)
+	if(stat != DEAD && B) // make sure it does exist before adding the thingies
+		B.sync_stats(src)
+	. = ..()
+
+/obj/item/organ/brain/proc/sync_stats(mob/living/carbon/human/H) //Syncs stuff for torso fabricator
+	stored_fortitude = get_raw_level(H, FORTITUDE_ATTRIBUTE)
+	stored_prudence = get_raw_level(H, PRUDENCE_ATTRIBUTE)
+	stored_temperance = get_raw_level(H, TEMPERANCE_ATTRIBUTE)
+	stored_justice = get_raw_level(H, JUSTICE_ATTRIBUTE)
+
+/datum/job/after_spawn(mob/living/H, mob/M, latejoin = FALSE)
+	. = ..()
+	var/obj/item/organ/brain/B = H.getorganslot(ORGAN_SLOT_BRAIN)
+	if(length(B.initial_traits) == 0)
+		B.initial_traits = H.status_traits
+
 /*---------------\
 |Body Preservation Unit|
 \---------------*/

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -40,12 +40,6 @@
 		/datum/brain_trauma/severe/narcolepsy
 		)
 
-	var/list/initial_traits = list()
-	var/stored_fortitude = 0
-	var/stored_prudence = 0
-	var/stored_temperance = 0
-	var/stored_justice = 0
-
 /obj/item/organ/brain/Insert(mob/living/carbon/C, special = 0,no_id_transfer = FALSE)
 	..()
 
@@ -431,10 +425,3 @@
 		qdel(X)
 		amount_cured++
 	return amount_cured
-
-/obj/item/organ/brain/proc/sync_stats(mob/living/carbon/human/H) //Syncs stuff for torso fabricator
-	stored_fortitude = get_raw_level(H, FORTITUDE_ATTRIBUTE)
-	stored_prudence = get_raw_level(H, PRUDENCE_ATTRIBUTE)
-	stored_temperance = get_raw_level(H, TEMPERANCE_ATTRIBUTE)
-	stored_justice = get_raw_level(H, JUSTICE_ATTRIBUTE)
-

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -50,10 +50,6 @@
 	//Update our name based on whether our face is obscured/disfigured
 	name = get_visible_name()
 
-	var/obj/item/organ/brain/B = getorganslot(ORGAN_SLOT_BRAIN)
-	if(stat != DEAD && B)
-		B.sync_stats(src)
-
 	if(stat != DEAD)
 		return TRUE
 


### PR DESCRIPTION

## About The Pull Request

- Moves the brain attributes into the torso fabricator file
- Makes the brain attributes only save when the user is killed, instead of saving every life tick


## Why It's Good For The Game

> Moves the brain attributes into the torso fabricator file
- I like modularity :3
> Makes the brain attributes only save when the user is killed, instead of saving every life tick
- Saving it every life tick is wastefull, its better to just do so when the user is killed. Afterall the torso fabricator should **NEVER** have a brain inserted into it before that brain's host dies

## Changelog
:cl:
code: the brain now only saves attributes to itself when the user dies, since it does not need to do it before the user dies.
/:cl:
