### PR TITLE
Nerf Gold Dawn Beanstalk Corrosion Damage

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/ordeal/gold/dawn.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/gold/dawn.dm
@@ -48,8 +48,8 @@
 	health = 220
 	melee_reach = 2 //Spear = long range
 	melee_damage_type = BLACK_DAMAGE
-	melee_damage_lower = 10
-	melee_damage_upper = 13
+	melee_damage_lower = 7
+	melee_damage_upper = 10
 	attack_sound = 'sound/weapons/ego/spear1.ogg'
 	death_sound = 'sound/effects/limbus_death.ogg'
 	attack_verb_continuous = "stabs"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Reduces the damage that beanstalk corrosions do by 3
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Considering they had the same damage output as Steel dawns but tended to spawn in higher numbers, they were too strong with that and having a range of 2 to the point where they kind of made overshadow the actual bosses of the ordeal.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: rebalanced beanstalk corrosion damage
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
