### PR TITLE
Fixes workshop gautlets not checking if a target is qdeleted before its thrown, making a runtime

### DIFF
--- a/ModularTegustation/tegu_items/workshop/templates/gauntlet.dm
+++ b/ModularTegustation/tegu_items/workshop/templates/gauntlet.dm
@@ -17,26 +17,25 @@
 	if(specialmod)
 		specialmod.ActivateEffect(src, special_count, target, user)
 
-	if(do_after(user, attack_speed*5, target))
-
-		to_chat(target, span_userdanger("[user] punches you with everything they got!!"))
-		to_chat(user, span_danger("You throw your entire body into this punch!"))
-		var/punch_damage = force
-		//I gotta regrab  justice here
-		var/userjust = (get_modified_attribute_level(user, JUSTICE_ATTRIBUTE))
-		var/justicemod = 1 + userjust/100
-		punch_damage *= justicemod
-
-		if(ishuman(target))
-			punch_damage = 50
-
-		target.apply_damage(punch_damage, damtype, null, target.run_armor_check(null, damtype), spread_damage = TRUE)		//MASSIVE fuckoff punch
-
-		playsound(src, 'sound/weapons/resonator_blast.ogg', 50, TRUE)
-		var/atom/throw_target = get_edge_target_turf(target, user.dir)
-		if(target && !target?.anchored)
-			target.throw_at(throw_target, 2, 4, user)		//Bigass knockback.
-
-	else
+	if(!do_after(user, attack_speed * 5, target))
 		to_chat(user, "<span class='spider'><b>Your attack was interrupted!</b></span>")
 		return
+
+	to_chat(target, span_userdanger("[user] punches you with everything they got!!"))
+	to_chat(user, span_danger("You throw your entire body into this punch!"))
+
+	var/punch_damage = force
+	//I gotta regrab  justice here
+	var/userjust = (get_modified_attribute_level(user, JUSTICE_ATTRIBUTE))
+	var/justicemod = 1 + userjust/100
+	punch_damage *= justicemod
+
+	if(ishuman(target))
+		punch_damage = 50
+
+	target.apply_damage(punch_damage, damtype, null, target.run_armor_check(null, damtype), spread_damage = TRUE)		//MASSIVE fuckoff punch
+
+	playsound(src, 'sound/weapons/resonator_blast.ogg', 50, TRUE)
+	var/atom/throw_target = get_edge_target_turf(target, user.dir)
+	if(target.anchored && !QDELETED(target))
+		target.throw_at(throw_target, 2, 4, user) //Bigass knockback.


### PR DESCRIPTION

## About The Pull Request

Title

## Why It's Good For The Game

Bug bad, fills up our runtime log.

## Changelog
:cl:
fix: Workshop gautlets no longer throw a runtime when trying to throw a qdeleted object
/:cl:
