### PR TITLE
Jbird now uses livinginrange when the mode is R-Corp

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/waw/judgement_bird.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/judgement_bird.dm
@@ -106,21 +106,6 @@
 			new /obj/effect/temp_visual/judgement(get_turf(L))
 			L.deal_damage(judgement_damage, PALE_DAMAGE)
 
-			if(L.stat == DEAD)	//Gotta fucking check again in case it kills you. Real moment
-				if(!IsCombatMap())
-					var/turf/T = get_turf(L)
-					if(locate(/obj/structure/jbird_noose) in T)
-						T = pick_n_take(T.reachableAdjacentTurfs())//if a noose is on this tile, it'll still create another one. You probably shouldn't be letting this many people die to begin with
-						L.forceMove(T)
-					var/obj/structure/jbird_noose/N = new(get_turf(L))
-					N.buckle_mob(L)
-					playsound(get_turf(L), 'sound/abnormalities/judgementbird/kill.ogg', 75, 0, 7)
-					playsound(get_turf(L), 'sound/abnormalities/judgementbird/hang.ogg', 100, 0, 7)
-					var/mob/living/simple_animal/hostile/runawaybird/V = new(get_turf(L))
-					birdlist+=V
-					V = new(get_turf(L))
-					birdlist+=V
-
 		icon_state = icon_living
 		judging = FALSE
 		return

--- a/code/modules/mob/living/simple_animal/abnormality/waw/judgement_bird.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/judgement_bird.dm
@@ -97,7 +97,7 @@
 	playsound(get_turf(src), 'sound/abnormalities/judgementbird/pre_ability.ogg', 50, 0, 2)
 	SLEEP_CHECK_DEATH(2 SECONDS)
 	playsound(get_turf(src), 'sound/abnormalities/judgementbird/ability.ogg', 75, 0, 7)
-	for(var/mob/living/L in urange(judgement_range, src))
+	for(var/mob/living/L in livinginrange(judgement_range, src))
 		if(faction_check_mob(L, FALSE))
 			continue
 		if(L.stat == DEAD)

--- a/code/modules/mob/living/simple_animal/abnormality/waw/judgement_bird.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/judgement_bird.dm
@@ -97,31 +97,60 @@
 	playsound(get_turf(src), 'sound/abnormalities/judgementbird/pre_ability.ogg', 50, 0, 2)
 	SLEEP_CHECK_DEATH(2 SECONDS)
 	playsound(get_turf(src), 'sound/abnormalities/judgementbird/ability.ogg', 75, 0, 7)
-	for(var/mob/living/L in livinginrange(judgement_range, src))
-		if(faction_check_mob(L, FALSE))
-			continue
-		if(L.stat == DEAD)
-			continue
-		new /obj/effect/temp_visual/judgement(get_turf(L))
-		L.deal_damage(judgement_damage, PALE_DAMAGE)
+	if(SSmaptype.maptype == "rcorp")
+		for(var/mob/living/L in livinginrange(judgement_range, src))
+			if(faction_check_mob(L, FALSE))
+				continue
+			if(L.stat == DEAD)
+				continue
+			new /obj/effect/temp_visual/judgement(get_turf(L))
+			L.deal_damage(judgement_damage, PALE_DAMAGE)
 
-		if(L.stat == DEAD)	//Gotta fucking check again in case it kills you. Real moment
-			if(!IsCombatMap())
-				var/turf/T = get_turf(L)
-				if(locate(/obj/structure/jbird_noose) in T)
-					T = pick_n_take(T.reachableAdjacentTurfs())//if a noose is on this tile, it'll still create another one. You probably shouldn't be letting this many people die to begin with
-					L.forceMove(T)
-				var/obj/structure/jbird_noose/N = new(get_turf(L))
-				N.buckle_mob(L)
-				playsound(get_turf(L), 'sound/abnormalities/judgementbird/kill.ogg', 75, 0, 7)
-				playsound(get_turf(L), 'sound/abnormalities/judgementbird/hang.ogg', 100, 0, 7)
-				var/mob/living/simple_animal/hostile/runawaybird/V = new(get_turf(L))
-				birdlist+=V
-				V = new(get_turf(L))
-				birdlist+=V
+			if(L.stat == DEAD)	//Gotta fucking check again in case it kills you. Real moment
+				if(!IsCombatMap())
+					var/turf/T = get_turf(L)
+					if(locate(/obj/structure/jbird_noose) in T)
+						T = pick_n_take(T.reachableAdjacentTurfs())//if a noose is on this tile, it'll still create another one. You probably shouldn't be letting this many people die to begin with
+						L.forceMove(T)
+					var/obj/structure/jbird_noose/N = new(get_turf(L))
+					N.buckle_mob(L)
+					playsound(get_turf(L), 'sound/abnormalities/judgementbird/kill.ogg', 75, 0, 7)
+					playsound(get_turf(L), 'sound/abnormalities/judgementbird/hang.ogg', 100, 0, 7)
+					var/mob/living/simple_animal/hostile/runawaybird/V = new(get_turf(L))
+					birdlist+=V
+					V = new(get_turf(L))
+					birdlist+=V
 
-	icon_state = icon_living
-	judging = FALSE
+		icon_state = icon_living
+		judging = FALSE
+		return
+	else
+		for(var/mob/living/L in urange(judgement_range, src))
+			if(faction_check_mob(L, FALSE))
+				continue
+			if(L.stat == DEAD)
+				continue
+			new /obj/effect/temp_visual/judgement(get_turf(L))
+			L.deal_damage(judgement_damage, PALE_DAMAGE)
+
+			if(L.stat == DEAD)	//Gotta fucking check again in case it kills you. Real moment
+				if(!IsCombatMap())
+					var/turf/T = get_turf(L)
+					if(locate(/obj/structure/jbird_noose) in T)
+						T = pick_n_take(T.reachableAdjacentTurfs())//if a noose is on this tile, it'll still create another one. You probably shouldn't be letting this many people die to begin with
+						L.forceMove(T)
+					var/obj/structure/jbird_noose/N = new(get_turf(L))
+					N.buckle_mob(L)
+					playsound(get_turf(L), 'sound/abnormalities/judgementbird/kill.ogg', 75, 0, 7)
+					playsound(get_turf(L), 'sound/abnormalities/judgementbird/hang.ogg', 100, 0, 7)
+					var/mob/living/simple_animal/hostile/runawaybird/V = new(get_turf(L))
+					birdlist+=V
+					V = new(get_turf(L))
+					birdlist+=V
+
+		icon_state = icon_living
+		judging = FALSE
+		return
 
 /mob/living/simple_animal/hostile/abnormality/judgement_bird/NeutralEffect(mob/living/carbon/human/user, work_type, pe)
 	. = ..()

--- a/code/modules/mob/living/simple_animal/abnormality/waw/judgement_bird.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/judgement_bird.dm
@@ -98,7 +98,7 @@
 	SLEEP_CHECK_DEATH(2 SECONDS)
 	playsound(get_turf(src), 'sound/abnormalities/judgementbird/ability.ogg', 75, 0, 7)
 	if(SSmaptype.maptype == "rcorp")
-		for(var/mob/living/L in livinginrange(judgement_range, src))
+		for(var/mob/living/L in livinginrange(judgement_range, src)) //abomination made so jbird pierces rhinos solely in rcorp
 			if(faction_check_mob(L, FALSE))
 				continue
 			if(L.stat == DEAD)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
urange does not pierce rhinos, livinginrange does, piercing is needed on a abno which is in the piercing slot
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes judgement bird fulfill its purpose in other modes
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: jbird range check now chooses between livinginrange or urange depending if its rcorp or not
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
