### PR TITLE
RCA Officer Skills and Payload Changes

### DIFF
--- a/code/modules/jobs/job_types/rcorp/command.dm
+++ b/code/modules/jobs/job_types/rcorp/command.dm
@@ -37,6 +37,15 @@
 		rank_title = "JCDR"
 		trusted_only = FALSE
 
+/datum/job/rcorp_captain/commander/after_spawn(mob/living/carbon/human/H, mob/M)
+	. = ..()
+	ADD_TRAIT(H, TRAIT_COMBATFEAR_IMMUNE, JOB_TRAIT)
+	var/datum/action/G = new /datum/action/cooldown/warbanner/captain
+	G.Grant(H)
+
+	G = new /datum/action/cooldown/warcry/captain
+	G.Grant(H)
+
 /datum/job/rcorp_captain/commander/announce(mob/living/carbon/human/H)
 	..()
 	switch(rank_title)

--- a/code/modules/jobs/job_types/rcorp/fifthpack/officer.dm
+++ b/code/modules/jobs/job_types/rcorp/fifthpack/officer.dm
@@ -28,6 +28,11 @@
 /datum/job/supportofficer/after_spawn(mob/living/carbon/human/H, mob/M)
 	. = ..()
 	ADD_TRAIT(H, TRAIT_COMBATFEAR_IMMUNE, JOB_TRAIT)
+	var/datum/action/G = new /datum/action/cooldown/warbanner/captain
+	G.Grant(H)
+
+	G = new /datum/action/cooldown/warcry/captain
+	G.Grant(H)
 
 
 /datum/outfit/job/supportofficer

--- a/code/modules/jobs/job_types/rcorp/officer.dm
+++ b/code/modules/jobs/job_types/rcorp/officer.dm
@@ -30,6 +30,11 @@
 /datum/job/juniorofficer/after_spawn(mob/living/carbon/human/H, mob/M)
 	. = ..()
 	ADD_TRAIT(H, TRAIT_COMBATFEAR_IMMUNE, JOB_TRAIT)
+	var/datum/action/G = new /datum/action/cooldown/warbanner/captain
+	G.Grant(H)
+
+	G = new /datum/action/cooldown/warcry/captain
+	G.Grant(H)
 
 /datum/outfit/job/officer
 	name = "Operations Officer"

--- a/code/modules/mob/payload/payload.dm
+++ b/code/modules/mob/payload/payload.dm
@@ -50,6 +50,10 @@
 			pixel_x = -16
 			base_pixel_x = -16
 
+			//Moves at 1/3rd speed to give R-Corp a fighting chance; Abnos can play significantly more agressively
+			base_delay_amount = 28
+			minimum_delay_amount = 12
+
 /mob/payload/proc/GetPath()
 	if(!target)
 		switch(team)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
- RCA Senior Officers and Junior Officer get Warbanner/Warcry, the Captains do not.
- Abno payload is now half speed.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
RCA officers get nothing special over captains, now they have more effective tools to encourage teamplay.
Abnos are significantly more aggressive than rcorp, and they can push the payload very well. This forces them to be much more of a sitting duck while they push; rounds should last more than 5 mins now on abno payload.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: RCA Command gets skills
balance: RCA payload rebalance
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
