### PR TITLE
Fixes faelantern lowering qliphoth if you are below 2 temperance regardless of the work

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/teth/faelantern.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/faelantern.dm
@@ -95,13 +95,11 @@
 	QDEL_IN(src, 10 SECONDS)
 
 /mob/living/simple_animal/hostile/abnormality/faelantern/PostWorkEffect(mob/living/carbon/human/user, work_type, pe, work_time, canceled)
-	if(work_type == ABNORMALITY_WORK_REPRESSION && get_modified_attribute_level(user, TEMPERANCE_ATTRIBUTE) > 40)
+	if(work_type == ABNORMALITY_WORK_REPRESSION && get_modified_attribute_level(user, TEMPERANCE_ATTRIBUTE) >= 40)
 		datum_reference.qliphoth_change(-1)
 		return
-	if(get_modified_attribute_level(user, TEMPERANCE_ATTRIBUTE) < 40)
+	if(work_type != ABNORMALITY_WORK_REPRESSION && get_modified_attribute_level(user, TEMPERANCE_ATTRIBUTE) < 40)
 		datum_reference.qliphoth_change(-1)
-		return
-	return
 
 /mob/living/simple_animal/hostile/abnormality/faelantern/FailureEffect(mob/living/carbon/human/user, work_type, pe)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

- Fixes faelantern lowering its qliphoth if you are below 2 temperance, on any work
(The original intent was that you can only do repression if you have 1 temperance)

- Fixes a wrong check, making it so if you are exactly on point with your temperance at 40 you can work repression without lowering faelantern's qliphoth

## Why It's Good For The Game

> Fixes faelantern lowering its qliphoth if you are below 2 temperance, on any work
> Fixes a wrong check, making it so if you are exactly on point with your temperance at 40 you can work repression without lowering faelantern's qliphoth
- Bug bad, very bad in this case

## Changelog
:cl:
fix: faelantern no longer lowers its qliphoth on all works if you are below 2 temperance
/:cl:
