### PR TITLE
Fixes Gluttony Peccatulum from One hit gibbing abnormalities, and adds more peccatulum to the spawnpool

### DIFF
--- a/code/modules/jobs/job_types/labs/command/assetprot.dm
+++ b/code/modules/jobs/job_types/labs/command/assetprot.dm
@@ -44,6 +44,9 @@
 	var/list/peccetulum = list(
 		/mob/living/simple_animal/hostile/ordeal/sin_gloom,
 		/mob/living/simple_animal/hostile/ordeal/sin_gluttony,
+		/mob/living/simple_animal/hostile/ordeal/sin_pride,
+		/mob/living/simple_animal/hostile/ordeal/sin_lust,
+		/mob/living/simple_animal/hostile/ordeal/sin_wrath
 	)
 
 	message_admins("<span class='notice'>Asset Protection ([src.ckey]) has spawned Peccetulum.</span>")

--- a/code/modules/mob/living/simple_animal/hostile/ordeal/brown/dawn.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/brown/dawn.dm
@@ -186,9 +186,9 @@
 
 /mob/living/simple_animal/hostile/ordeal/sin_gluttony/AttackingTarget()
 	. = ..()
-	if(. && isliving(target))
+	if(. && isliving(target) && SSmaptype.maptype != "limbus_labs")
 		var/mob/living/L = target
-		if(L.stat != DEAD && SSmaptype.maptype != "limbus_labs")
+		if(L.stat != DEAD)
 			if(L.health <= HEALTH_THRESHOLD_DEAD && HAS_TRAIT(L, TRAIT_NODEATH))
 				devour(L)
 		else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
What title says
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bug fix and more variety
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added more spawns to Asset Protection spawn pool
fix: fixed Gluttony Peccatulum gibbing abnormalities in LCL
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
