### PR TITLE
Fixes my mistake with KK template

### DIFF
--- a/_maps/templates/syndicate_office/kurokumosake.dmm
+++ b/_maps/templates/syndicate_office/kurokumosake.dmm
@@ -736,16 +736,6 @@
 	},
 /turf/open/floor/wood,
 /area/city/backstreets_room)
-"GO" = (
-/obj/item/clothing/suit/armor/ego_gear/city/kurokumo,
-/obj/item/clothing/suit/armor/ego_gear/city/kurokumo,
-/obj/structure/closet/cabinet{
-	anchored = 1
-	},
-/obj/item/ego_weapon/city/kurokumo,
-/obj/item/ego_weapon/city/kurokumo,
-/turf/open/floor/carpet/black,
-/area/city/backstreets_room)
 "Hf" = (
 /obj/structure/table/wood/poker,
 /obj/item/reagent_containers/food/drinks/bottle/sake{
@@ -781,8 +771,8 @@
 	},
 /obj/item/clothing/suit/armor/ego_gear/city/kurokumo,
 /obj/item/clothing/suit/armor/ego_gear/city/kurokumo,
-/obj/item/ego_weapon/city/kurokumo,
-/obj/item/ego_weapon/city/kurokumo,
+/obj/item/ego_weapon/city/kurokumo/weak,
+/obj/item/ego_weapon/city/kurokumo/weak,
 /turf/open/floor/carpet/black,
 /area/city/backstreets_room)
 "Jz" = (
@@ -842,6 +832,16 @@
 	},
 /turf/open/floor/wood,
 /area/city/backstreets_room)
+"Le" = (
+/obj/item/clothing/suit/armor/ego_gear/city/kurokumo,
+/obj/item/clothing/suit/armor/ego_gear/city/kurokumo,
+/obj/structure/closet/cabinet{
+	anchored = 1
+	},
+/obj/item/ego_weapon/city/kurokumo/weak,
+/obj/item/ego_weapon/city/kurokumo/weak,
+/turf/open/floor/carpet/black,
+/area/city/backstreets_room)
 "Lf" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -896,8 +896,8 @@
 	},
 /obj/item/clothing/suit/armor/ego_gear/city/kurokumo/jacket,
 /obj/item/clothing/suit/armor/ego_gear/city/kurokumo/jacket,
-/obj/item/ego_weapon/city/kurokumo,
-/obj/item/ego_weapon/city/kurokumo,
+/obj/item/ego_weapon/city/kurokumo/weak,
+/obj/item/ego_weapon/city/kurokumo/weak,
 /turf/open/floor/carpet/black,
 /area/city/backstreets_room)
 "Qo" = (
@@ -1093,7 +1093,7 @@ xz
 Ku
 "}
 (2,1,1) = {"
-GO
+Le
 ma
 bi
 Xc
@@ -1103,7 +1103,7 @@ Rj
 bi
 bi
 ma
-GO
+Le
 "}
 (3,1,1) = {"
 uq

--- a/code/game/objects/items/ego_weapons/non_abnormality/weak_edits/city.dm
+++ b/code/game/objects/items/ego_weapons/non_abnormality/weak_edits/city.dm
@@ -115,7 +115,7 @@
 
 //Kurokumo
 /obj/item/ego_weapon/city/kurokumo/weak
-	force = 30
+	force = 52
 	attribute_requirements = list(
 		FORTITUDE_ATTRIBUTE = 60,
 		PRUDENCE_ATTRIBUTE = 60,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Buffs the kurokumo/weak variants to be on standard and replaces the old unusable blades with these variants
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Kurokumo should be playable
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Changed kurokumo/weak damage to 52
fix: Replaced unusable strong variant blades with weak variant
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
