### PR TITLE
Very very minor mapfixes with one typo fix sprinkled in

### DIFF
--- a/_maps/map_files/Delta/deltacorp.dmm
+++ b/_maps/map_files/Delta/deltacorp.dmm
@@ -2021,6 +2021,10 @@
 /obj/machinery/door/airlock/glass,
 /turf/open/floor/facility/halls,
 /area/facility_hallway/discipline)
+"eO" = (
+/obj/structure/window/paperframe,
+/turf/open/floor/plating,
+/area/facility_hallway/control)
 "eP" = (
 /obj/effect/turf_decal/tile/neutral{
 	color = "#f8f8f8";
@@ -10744,6 +10748,10 @@
 	},
 /turf/open/floor/plasteel/sepia,
 /area/facility_hallway/training)
+"yQ" = (
+/obj/machinery/smartfridge/extraction_storage/ego_weapon,
+/turf/open/floor/plating,
+/area/facility_hallway/control)
 "yU" = (
 /obj/effect/turf_decal/tile/neutral{
 	color = "#000000";
@@ -17271,6 +17279,14 @@
 	},
 /turf/open/floor/plasteel/sepia,
 /area/department_main/safety)
+"NS" = (
+/obj/machinery/smartfridge/extraction_storage/ego_weapon,
+/turf/closed/indestructible/reinforced{
+	desc = "A huge chunk of wing-grade metal used in various L corporation facilities. Effectively impervious to conventional methods of destruction.";
+	name = "facility wall";
+	opacity = 0
+	},
+/area/department_main/extraction)
 "NT" = (
 /obj/structure/table/wood,
 /obj/machinery/microwave{
@@ -52658,7 +52674,7 @@ lF
 fN
 mA
 mA
-mA
+yQ
 fN
 Vi
 Dp
@@ -56013,7 +56029,7 @@ Tp
 ZC
 XQ
 xk
-Ay
+NS
 LC
 fF
 RG
@@ -57798,7 +57814,7 @@ lF
 fN
 mA
 mA
-mA
+eO
 fN
 Vi
 Zd

--- a/_maps/map_files/Event/laboratory.dmm
+++ b/_maps/map_files/Event/laboratory.dmm
@@ -1174,7 +1174,6 @@
 /area/centcom)
 "eO" = (
 /obj/machinery/door/window,
-/obj/machinery/door/window,
 /obj/machinery/light{
 	dir = 8;
 	pixel_x = -9;

--- a/_maps/map_files/Theta/thetacorp.dmm
+++ b/_maps/map_files/Theta/thetacorp.dmm
@@ -1493,14 +1493,10 @@
 /area/facility_hallway/command)
 "eY" = (
 /obj/structure/filingcabinet/zayininfo{
-	density = 0;
 	pixel_x = -10
 	},
-/obj/structure/filingcabinet/tethinfo{
-	density = 0
-	},
+/obj/structure/filingcabinet/tethinfo,
 /obj/structure/filingcabinet/heinfo{
-	density = 0;
 	pixel_x = 10
 	},
 /turf/open/floor/facility/dark{
@@ -4603,12 +4599,10 @@
 /area/facility_hallway/training)
 "pJ" = (
 /obj/structure/filingcabinet/wawinfo{
-	density = 0;
 	pixel_x = -11
 	},
 /obj/structure/filingcabinet/alephinfo,
 /obj/structure/filingcabinet/toolinfo{
-	density = 0;
 	pixel_x = 10
 	},
 /turf/open/floor/facility/dark{
@@ -9227,14 +9221,6 @@
 	},
 /turf/open/floor/carpet/red,
 /area/department_main/control)
-"FQ" = (
-/obj/structure/chair/wood/wings{
-	dir = 4;
-	pixel_x = 5;
-	pixel_y = 4
-	},
-/turf/open/floor/plasteel/sepia,
-/area/department_main/training)
 "FS" = (
 /obj/structure/window/reinforced/fulltile{
 	armor = list("melee" = 30, "bullet" = 30, "laser" = 20, "energy" = 20, "bomb" = 10, "bio" = 100, "rad" = 100, "fire" = 80, "acid" = 70);
@@ -40838,7 +40824,7 @@ lA
 iG
 XD
 oj
-FQ
+CK
 Ft
 ZZ
 BT

--- a/_maps/templates/fixer_office/protectionfixers.dmm
+++ b/_maps/templates/fixer_office/protectionfixers.dmm
@@ -188,6 +188,7 @@
 /obj/item/grenade/smokebomb,
 /obj/item/disk/nuclear/rcorp,
 /obj/structure/closet/cabinet,
+/obj/structure/window/reinforced/spawner/east,
 /turf/open/floor/pod/dark,
 /area/city/fixers)
 "A" = (
@@ -283,10 +284,6 @@
 	},
 /obj/item/kirbyplants{
 	pixel_y = 17
-	},
-/obj/structure/window/reinforced/spawner/east{
-	resistance_flags = 115;
-	pixel_y = -32
 	},
 /turf/open/floor/pod/dark,
 /area/city/fixers)

--- a/code/modules/projectiles/projectile/ego_bullets/teth.dm
+++ b/code/modules/projectiles/projectile/ego_bullets/teth.dm
@@ -128,7 +128,7 @@
 	damage_type = RED_DAMAGE
 
 /obj/projectile/ego_bullet/ego_luckdraw
-	name = "luck_of_the_draw"
+	name = "luck of the draw"
 	icon_state = "drawcard"
 	damage = 18
 	damage_type = WHITE_DAMAGE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes the pixelshifted window on the protection office template, fixes the two windoors on top of each other on LCL records storage, fixes the D-Corp extraction office not having weapon fridge, fixes the luck of the draw projectiles being named luck_of_the_draw.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The EO having a weapon fridge would be nice and bugfixes dont hurt.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixed D-Corps lack of weapon fridge, pixelshifted directional window on the protection office template, fixed double windoors in the LCL records storage. properly named luck of the draw projectiles.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
