### PR TITLE
Makes the one singular violin in CC light enough to be picked up by the average clerk

### DIFF
--- a/_maps/map_files/Beta/betacorp.dmm
+++ b/_maps/map_files/Beta/betacorp.dmm
@@ -9608,12 +9608,10 @@
 /area/department_main/discipline)
 "Vu" = (
 /obj/structure/table/wood/fancy/blue,
-/obj/item/instrument/violin{
-	anchored = 1
-	},
 /obj/effect/turf_decal/siding/yellow/corner{
 	dir = 4
 	},
+/obj/item/instrument/violin,
 /turf/open/floor/wood,
 /area/department_main/command)
 "Vv" = (


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Unanchors the Bravo violin in CC, none of the other instruments are anchored.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Musical instrument variety
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Unanchors randomly anchored violin in bravo
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
