### PR TITLE
col ncorp nerf

### DIFF
--- a/ModularTegustation/ego_weapons/melee/non_abnormality/ncorp.dm
+++ b/ModularTegustation/ego_weapons/melee/non_abnormality/ncorp.dm
@@ -195,13 +195,14 @@
 	icon_state = "messingnagel"
 	force = 18
 	damtype = RED_DAMAGE
+	swingstyle = WEAPONSWING_THRUST
 
 	attack_verb_continuous = list("jabs", "stabs")
 	attack_verb_simple = list("jab", "stab")
 	hitsound = 'sound/weapons/fixer/generic/nail1.ogg'
-	var/nails
+//	var/nails
 
-/obj/item/ego_weapon/city/ncorp_brassnail/attack(mob/living/target, mob/living/user)
+/*/obj/item/ego_weapon/city/ncorp_brassnail/attack(mob/living/target, mob/living/user)
 	..()
 	nails++
 	if(nails>=5)
@@ -217,7 +218,7 @@
 
 	I.force += I.force* nails *0.1
 	nails = 0
-	to_chat(user, span_notice("You transfer [nails] nails to your hammer, increasing it's damage."))
+	to_chat(user, span_notice("You transfer [nails] nails to your hammer, increasing it's damage."))*/
 
 /obj/item/ego_weapon/city/ncorp_brassnail/big
 	name = "Elektrumnagel"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes the Gold Nail's Nail ability.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
N-Corp on COL is already overtuned to hell, this will de-bug one of their bugged weapons.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: N-Corp gold nails no longer deal shitloads of damage
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
