### PR TITLE
Multiple Armor Slowdown

### DIFF
--- a/code/modules/clothing/suits/ego_gear/_ego_gear.dm
+++ b/code/modules/clothing/suits/ego_gear/_ego_gear.dm
@@ -60,6 +60,17 @@
 			return
 		neckwear.Destroy()
 
+/obj/item/clothing/suit/armor/ego_gear/pickup(mob/user)
+	. = ..()
+	if(!user.has_movespeed_modifier(/datum/movespeed_modifier/too_many_armors) && ishuman(user))
+		var/obj/item/clothing/suit/armor/equipped_armor = user.get_item_by_slot(ITEM_SLOT_OCLOTHING)
+		if(istype(equipped_armor, /obj/item/clothing/suit/armor/ego_gear))
+			if((SSmaptype.maptype in SSmaptype.citymaps) || (SSmaptype.maptype in SSmaptype.combatmaps))
+				return
+			else
+				if(user.mind.assigned_role != "Extraction Officer")
+					user.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/too_many_armors)
+
 /obj/item/clothing/suit/armor/ego_gear/dropped(mob/user)
 	. = ..()
 	if(hat)
@@ -72,6 +83,8 @@
 		if(!istype(neckwear, neck))
 			return
 		neckwear.Destroy()
+	if(user.has_movespeed_modifier(/datum/movespeed_modifier/too_many_armors))
+		user.remove_movespeed_modifier(/datum/movespeed_modifier/too_many_armors)
 
 /obj/item/clothing/suit/armor/ego_gear/proc/CanUseEgo(mob/living/carbon/human/user)
 	if(!ishuman(user))
@@ -144,3 +157,7 @@
 	var/mob/living/carbon/human/H = usr
 	H.update_inv_wear_suit()
 	H.update_body()
+
+/datum/movespeed_modifier/too_many_armors
+	variable = TRUE
+	multiplicative_slowdown = 3.3 //Roughly 1/3 speed for holding too many armors

--- a/code/modules/clothing/suits/ego_gear/_ego_gear.dm
+++ b/code/modules/clothing/suits/ego_gear/_ego_gear.dm
@@ -68,7 +68,8 @@
 			if((SSmaptype.maptype in SSmaptype.citymaps) || (SSmaptype.maptype in SSmaptype.combatmaps))
 				return
 			else
-				if(user.mind.assigned_role != "Extraction Officer")
+				var/slowdown_free_roles = list("Clerk", "Agent Support Clerk", "Facility Support Clerk", "Extraction Officer")
+				if(!(user.mind.assigned_role in slowdown_free_roles))
 					user.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/too_many_armors)
 
 /obj/item/clothing/suit/armor/ego_gear/dropped(mob/user)

--- a/code/modules/clothing/suits/ego_gear/_ego_gear.dm
+++ b/code/modules/clothing/suits/ego_gear/_ego_gear.dm
@@ -161,4 +161,4 @@
 
 /datum/movespeed_modifier/too_many_armors
 	variable = TRUE
-	multiplicative_slowdown = 3.3 //Roughly 1/3 speed for holding too many armors
+	multiplicative_slowdown = 1.5 //Roughly 1/3 speed for holding too many armors

--- a/code/modules/clothing/suits/ego_gear/_ego_gear.dm
+++ b/code/modules/clothing/suits/ego_gear/_ego_gear.dm
@@ -63,8 +63,8 @@
 /obj/item/clothing/suit/armor/ego_gear/pickup(mob/user)
 	. = ..()
 	if(!user.has_movespeed_modifier(/datum/movespeed_modifier/too_many_armors) && ishuman(user))
-		var/obj/item/clothing/suit/armor/equipped_armor = user.get_item_by_slot(ITEM_SLOT_OCLOTHING)
-		if(istype(equipped_armor, /obj/item/clothing/suit/armor/ego_gear))
+		var/obj/item/clothing/suit/armor/ego_gear/equipped_armor = user.get_item_by_slot(ITEM_SLOT_OCLOTHING)
+		if(istype(equipped_armor))
 			if((SSmaptype.maptype in SSmaptype.citymaps) || (SSmaptype.maptype in SSmaptype.combatmaps))
 				return
 			else

--- a/code/modules/clothing/suits/ego_gear/_ego_gear.dm
+++ b/code/modules/clothing/suits/ego_gear/_ego_gear.dm
@@ -68,7 +68,7 @@
 			if((SSmaptype.maptype in SSmaptype.citymaps) || (SSmaptype.maptype in SSmaptype.combatmaps))
 				return
 			else
-				var/slowdown_free_roles = list("Clerk", "Agent Support Clerk", "Facility Support Clerk", "Extraction Officer")
+				var/list/slowdown_free_roles = list("Clerk", "Agent Support Clerk", "Facility Support Clerk", "Extraction Officer")
 				if(!(user.mind.assigned_role in slowdown_free_roles))
 					user.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/too_many_armors)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
In the Main Lobotomy Corporation 13 mode, holding an armor while wearing another armor slows you down if you aren't an Extraction Officer. The slowdown will end when you are back to 1 armor in your inventory. It shouldn't impact sidemodes.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Discourages people from constantly having two armors on them to switch on a whim.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: rebalanced having multiple armors on a person
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
