### PR TITLE
Jill no longer sells you air when buying drones[BUGFIX]

### DIFF
--- a/ModularTegustation/tegu_items/representative/research/kcorp.dm
+++ b/ModularTegustation/tegu_items/representative/research/kcorp.dm
@@ -157,6 +157,6 @@
 	corp = K_CORP_REP
 	required_research = /datum/data/lc13research/syringe
 
-/datum/data/lc13research/kguns/ResearchEffect(obj/structure/representative_console/caller)
+/datum/data/lc13research/kdrones/ResearchEffect(obj/structure/representative_console/caller)
 	ItemUnlock(caller.order_list, "K Corp Drone Spawner",	/obj/item/grenade/spawnergrenade/khealing, 600)
 	..()


### PR DESCRIPTION
drones now gained from real research instead of gun research

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Drone research would give nothing as its research effect was attributed to gun research.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Players no longer buy air and dont skip progression by beelining to gun research for drones
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixed Jill giving you drones on gun research instead of drone research
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
