### PR TITLE
Skill cleanup and quite a lot of fixes

### DIFF
--- a/code/game/objects/items/fixerskills/level1/defensive.dm
+++ b/code/game/objects/items/fixerskills/level1/defensive.dm
@@ -7,9 +7,9 @@
 	custom_premium_price = 600
 
 /datum/action/cooldown/hunkerdown
-	cooldown_time = 30 SECONDS
 	icon_icon = 'icons/hud/screen_skills.dmi'
 	button_icon_state = "hunkerdown"
+	cooldown_time = 30 SECONDS
 
 
 /datum/action/cooldown/hunkerdown/Trigger()

--- a/code/game/objects/items/fixerskills/level1/defensive.dm
+++ b/code/game/objects/items/fixerskills/level1/defensive.dm
@@ -49,7 +49,7 @@
 	custom_premium_price = 600
 
 /datum/action/cooldown/firstaid
-	cooldown_time = 60 SECONDS
+	cooldown_time = 1 MINUTES
 	icon_icon = 'icons/hud/screen_skills.dmi'
 	button_icon_state = "firstaid"
 
@@ -88,7 +88,7 @@
 	custom_premium_price = 600
 
 /datum/action/cooldown/meditation
-	cooldown_time = 60 SECONDS
+	cooldown_time = 1 MINUTES
 	icon_icon = 'icons/hud/screen_skills.dmi'
 	button_icon_state = "meditation"
 

--- a/code/game/objects/items/fixerskills/level1/defensive.dm
+++ b/code/game/objects/items/fixerskills/level1/defensive.dm
@@ -7,7 +7,7 @@
 	custom_premium_price = 600
 
 /datum/action/cooldown/hunkerdown
-	cooldown_time = 300
+	cooldown_time = 30 SECONDS
 	icon_icon = 'icons/hud/screen_skills.dmi'
 	button_icon_state = "hunkerdown"
 
@@ -49,7 +49,7 @@
 	custom_premium_price = 600
 
 /datum/action/cooldown/firstaid
-	cooldown_time = 600
+	cooldown_time = 60 SECONDS
 	icon_icon = 'icons/hud/screen_skills.dmi'
 	button_icon_state = "firstaid"
 
@@ -58,7 +58,8 @@
 	. = ..()
 	if(!.)
 		return FALSE
-	if (ishuman(owner))
+
+	if(ishuman(owner))
 		var/mob/living/carbon/human/human = owner
 		human.physiology.red_mod *= 0.8
 		human.physiology.white_mod *= 0.8
@@ -87,7 +88,7 @@
 	custom_premium_price = 600
 
 /datum/action/cooldown/meditation
-	cooldown_time = 600
+	cooldown_time = 60 SECONDS
 	icon_icon = 'icons/hud/screen_skills.dmi'
 	button_icon_state = "meditation"
 
@@ -114,4 +115,3 @@
 	human.physiology.pale_mod /= 0.8
 	human.adjustSanityLoss(-30) //Heals you
 	new /obj/effect/temp_visual/heal(get_turf(owner), "#6E6EFF")
-

--- a/code/game/objects/items/fixerskills/level1/healing.dm
+++ b/code/game/objects/items/fixerskills/level1/healing.dm
@@ -10,11 +10,12 @@
 	icon_icon = 'icons/hud/screen_skills.dmi'
 	button_icon_state = "healing"
 	name = "Healing"
-	cooldown_time = 300
+	cooldown_time = 30 SECONDS
 	var/healamount = 20
 
 /datum/action/cooldown/healing/Trigger()
-	if(!..())
+	. = ..()
+	if(!.)
 		return FALSE
 
 	if (owner.stat == DEAD)
@@ -39,11 +40,12 @@
 	icon_icon = 'icons/hud/screen_skills.dmi'
 	button_icon_state = "soothing"
 	name = "Soothing"
-	cooldown_time = 300
+	cooldown_time = 30 SECONDS
 	var/healamount = 20
 
 /datum/action/cooldown/soothing/Trigger()
-	if(!..())
+	. = ..()
+	if(!.)
 		return FALSE
 
 	if (owner.stat == DEAD)
@@ -69,11 +71,12 @@
 	icon_icon = 'icons/hud/screen_skills.dmi'
 	button_icon_state = "curing"
 	name = "Curing"
-	cooldown_time = 300
+	cooldown_time = 30 SECONDS
 	var/healamount = 10
 
 /datum/action/cooldown/curing/Trigger()
-	if(!..())
+	. = ..()
+	if(!.)
 		return FALSE
 
 	if (owner.stat == DEAD)

--- a/code/game/objects/items/fixerskills/level1/healing.dm
+++ b/code/game/objects/items/fixerskills/level1/healing.dm
@@ -7,9 +7,9 @@
 	custom_premium_price = 600
 
 /datum/action/cooldown/healing
+	name = "Healing"
 	icon_icon = 'icons/hud/screen_skills.dmi'
 	button_icon_state = "healing"
-	name = "Healing"
 	cooldown_time = 30 SECONDS
 	var/healamount = 20
 
@@ -37,9 +37,9 @@
 	custom_premium_price = 600
 
 /datum/action/cooldown/soothing
+	name = "Soothing"
 	icon_icon = 'icons/hud/screen_skills.dmi'
 	button_icon_state = "soothing"
-	name = "Soothing"
 	cooldown_time = 30 SECONDS
 	var/healamount = 20
 
@@ -68,9 +68,9 @@
 	custom_premium_price = 600
 
 /datum/action/cooldown/curing
+	name = "Curing"
 	icon_icon = 'icons/hud/screen_skills.dmi'
 	button_icon_state = "curing"
-	name = "Curing"
 	cooldown_time = 30 SECONDS
 	var/healamount = 10
 

--- a/code/game/objects/items/fixerskills/level1/movement.dm
+++ b/code/game/objects/items/fixerskills/level1/movement.dm
@@ -17,11 +17,12 @@
 	icon_icon = 'icons/hud/screen_skills.dmi'
 	button_icon_state = "dash"
 	name = "Dash"
-	cooldown_time = 30
+	cooldown_time = 3 SECONDS
 	var/direction = 1
 
 /datum/action/cooldown/dash/Trigger()
-	if(!..())
+	. = ..()
+	if(!.)
 		return FALSE
 
 	if (owner.stat == DEAD)
@@ -59,7 +60,7 @@
 	custom_premium_price = 600
 
 /datum/action/cooldown/assault
-	cooldown_time = 200
+	cooldown_time = 20 SECONDS
 	icon_icon = 'icons/hud/screen_skills.dmi'
 	button_icon_state = "assault"
 
@@ -87,7 +88,7 @@
 	custom_premium_price = 600
 
 /datum/action/cooldown/retreat
-	cooldown_time = 200
+	cooldown_time = 20 SECONDS
 	icon_icon = 'icons/hud/screen_skills.dmi'
 	button_icon_state = "retreat"
 

--- a/code/game/objects/items/fixerskills/level1/movement.dm
+++ b/code/game/objects/items/fixerskills/level1/movement.dm
@@ -46,9 +46,9 @@
 			return TRUE
 
 /datum/action/cooldown/dash/back
+	name = "Backstep"
 	icon_icon = 'icons/hud/screen_skills.dmi'
 	button_icon_state = "backstep"
-	name = "Backstep"
 	direction = -1
 
 //Assault
@@ -88,10 +88,9 @@
 	custom_premium_price = 600
 
 /datum/action/cooldown/retreat
-	cooldown_time = 20 SECONDS
 	icon_icon = 'icons/hud/screen_skills.dmi'
 	button_icon_state = "retreat"
-
+	cooldown_time = 20 SECONDS
 
 /datum/action/cooldown/retreat/Trigger()
 	. = ..()

--- a/code/game/objects/items/fixerskills/level1/scavenger.dm
+++ b/code/game/objects/items/fixerskills/level1/scavenger.dm
@@ -7,9 +7,9 @@
 	custom_premium_price = 600
 
 /datum/action/cooldown/smokedash
+	name = "Smokedash"
 	icon_icon = 'icons/hud/screen_skills.dmi'
 	button_icon_state = "smokedash"
-	name = "Smokedash"
 	cooldown_time = 30 SECONDS
 
 /datum/action/cooldown/smokedash/Trigger()
@@ -42,9 +42,9 @@
 	custom_premium_price = 600
 
 /datum/action/cooldown/skulk
+	name = "Skulk"
 	icon_icon = 'icons/hud/screen_skills.dmi'
 	button_icon_state = "smkulk"
-	name = "Skulk"
 	cooldown_time = 30 SECONDS
 
 /datum/action/cooldown/skulk/Trigger()

--- a/code/game/objects/items/fixerskills/level1/scavenger.dm
+++ b/code/game/objects/items/fixerskills/level1/scavenger.dm
@@ -10,10 +10,11 @@
 	icon_icon = 'icons/hud/screen_skills.dmi'
 	button_icon_state = "smokedash"
 	name = "Smokedash"
-	cooldown_time = 300
+	cooldown_time = 30 SECONDS
 
 /datum/action/cooldown/smokedash/Trigger()
-	if(!..())
+	. = ..()
+	if(!.)
 		return FALSE
 
 	if (owner.stat == DEAD)
@@ -44,10 +45,11 @@
 	icon_icon = 'icons/hud/screen_skills.dmi'
 	button_icon_state = "smkulk"
 	name = "Skulk"
-	cooldown_time = 300
+	cooldown_time = 30 SECONDS
 
 /datum/action/cooldown/skulk/Trigger()
-	if(!..())
+	. = ..()
+	if(!.)
 		return FALSE
 
 	if (owner.stat == DEAD)

--- a/code/game/objects/items/fixerskills/level2/butcher.dm
+++ b/code/game/objects/items/fixerskills/level2/butcher.dm
@@ -10,10 +10,11 @@
 	icon_icon = 'icons/hud/screen_skills.dmi'
 	button_icon_state = "butcher"
 	name = "Butcher"
-	cooldown_time = 20
+	cooldown_time = 2 SECONDS
 
 /datum/action/cooldown/butcher/Trigger()
-	if(!..())
+	. = ..()
+	if(!.)
 		return FALSE
 
 	if (owner.stat == DEAD)

--- a/code/game/objects/items/fixerskills/level2/butcher.dm
+++ b/code/game/objects/items/fixerskills/level2/butcher.dm
@@ -13,7 +13,7 @@
 
 /datum/action/cooldown/butcher
 	name = "Butcher"
-	desc = "Instantly butcher all dead opponents in a 5x5 range around you. If you are holding an object that can butcher more efficiently than your skill absorb it into the skill."
+	desc = "Instantly butcher all dead opponents in a 5x5 range around you. If you are holding an object that can butcher more efficiently than your skill, absorb the object into the skill."
 	icon_icon = 'icons/hud/screen_skills.dmi'
 	button_icon_state = "butcher"
 	cooldown_time = 2 SECONDS

--- a/code/game/objects/items/fixerskills/level2/butcher.dm
+++ b/code/game/objects/items/fixerskills/level2/butcher.dm
@@ -12,10 +12,10 @@
 	)
 
 /datum/action/cooldown/butcher
-	icon_icon = 'icons/hud/screen_skills.dmi'
-	button_icon_state = "butcher"
 	name = "Butcher"
 	desc = "Instantly butcher all dead opponents in a 5x5 range around you. If you are holding an object that can butcher more efficiently than your skill absorb it into the skill."
+	icon_icon = 'icons/hud/screen_skills.dmi'
+	button_icon_state = "butcher"
 	cooldown_time = 2 SECONDS
 	check_flags = AB_CHECK_CONSCIOUS
 	var/datum/component/butchering/butcher_component

--- a/code/game/objects/items/fixerskills/level2/butcher.dm
+++ b/code/game/objects/items/fixerskills/level2/butcher.dm
@@ -58,9 +58,9 @@
 	if(our_strong_butchering >= their_weak_effectiveness)
 		return
 
-	to_chat(owner, span_nicegreen("You absorb [potential_knife] into the [name] ability, empowering its butchering effectiveness!"))
 	butcher_component.effectiveness = meat_machine.effectiveness
 	butcher_component.bonus_modifier = meat_machine.bonus_modifier
+	to_chat(owner, span_nicegreen("You absorb [potential_knife] into the [name] ability, empowering its butchering effectiveness!"))
 	qdel(potential_knife)
 
 	var/difference = floor((their_weak_effectiveness - our_strong_butchering) / 5)

--- a/code/game/objects/items/fixerskills/level2/butcher.dm
+++ b/code/game/objects/items/fixerskills/level2/butcher.dm
@@ -17,7 +17,6 @@
 	icon_icon = 'icons/hud/screen_skills.dmi'
 	button_icon_state = "butcher"
 	cooldown_time = 2 SECONDS
-	check_flags = AB_CHECK_CONSCIOUS
 	var/datum/component/butchering/butcher_component
 
 /datum/action/cooldown/butcher/New()

--- a/code/game/objects/items/fixerskills/level2/butcher.dm
+++ b/code/game/objects/items/fixerskills/level2/butcher.dm
@@ -5,24 +5,64 @@
 	name = "Level 2 Skill: Butcher"
 	level = 2
 	custom_premium_price = 1200
+	remarks = list(
+		"So there is 1 pair of gloves in the backstreets that can make me a butchering god...? huh.",
+		"To butcher the meat properly you have to understand the meat... what a bunch of nonsense.",
+		"District 23 is the perfect place to practice butchering and get butchered at the same time...",
+	)
 
 /datum/action/cooldown/butcher
 	icon_icon = 'icons/hud/screen_skills.dmi'
 	button_icon_state = "butcher"
 	name = "Butcher"
+	desc = "Instantly butcher all dead opponents in a 5x5 range around you. If you are holding an object that can butcher more efficiently than your skill absorb it into the skill."
 	cooldown_time = 2 SECONDS
+	check_flags = AB_CHECK_CONSCIOUS
+	var/datum/component/butchering/butcher_component
+
+/datum/action/cooldown/butcher/New()
+	. = ..()
+	AddComponent(/datum/component/butchering)
+	butcher_component = src.GetComponent(/datum/component/butchering)
+
+/datum/action/cooldown/butcher/Destroy()
+	butcher_component = null
+	return ..()
 
 /datum/action/cooldown/butcher/Trigger()
 	. = ..()
 	if(!.)
-		return FALSE
+		return
+	if(owner.stat != CONSCIOUS)
+		to_chat(owner, span_warning("You need to not be bleeding out on the floor to butcher creatures!"))
+		return
 
-	if (owner.stat == DEAD)
-		return FALSE
+	absorb_knife() // if our owner is holding a thing that can butcher better than we do, lets assume its form
 
-	//Compile people around you
-	for(var/mob/living/M in view(2, get_turf(src)))
-		if(M.stat == DEAD && !ishuman(M))
-			M.gib()
+	for(var/mob/living/the_meal in view(2, get_turf(src))) // For conviniency, do it in a range
+		if(the_meal.stat == DEAD && !ishuman(the_meal) && (the_meal.butcher_results || the_meal.guaranteed_butcher_results))
+			butcher_component.Butcher(owner, the_meal)
 	StartCooldown()
 
+/datum/action/cooldown/butcher/proc/absorb_knife()
+	var/obj/potential_knife = owner.get_active_held_item()
+	if(!potential_knife)
+		return
+
+	var/datum/component/butchering/meat_machine = potential_knife.GetComponent(/datum/component/butchering)
+	if(!meat_machine)
+		return
+
+	var/their_weak_effectiveness = meat_machine.effectiveness + meat_machine.bonus_modifier
+	var/our_strong_butchering = butcher_component.effectiveness + butcher_component.bonus_modifier
+	if(our_strong_butchering >= their_weak_effectiveness)
+		return
+
+	to_chat(owner, span_nicegreen("You absorb [potential_knife] into the [name] ability, empowering its butchering effectiveness!"))
+	butcher_component.effectiveness = meat_machine.effectiveness
+	butcher_component.bonus_modifier = meat_machine.bonus_modifier
+	qdel(potential_knife)
+
+	var/difference = floor((their_weak_effectiveness - our_strong_butchering) / 5)
+	for(var/i in 1 to difference)
+		name = "[name]+"

--- a/code/game/objects/items/fixerskills/level2/confusion.dm
+++ b/code/game/objects/items/fixerskills/level2/confusion.dm
@@ -10,10 +10,11 @@
 	icon_icon = 'icons/hud/screen_skills.dmi'
 	button_icon_state = "confusion"
 	name = "Confusion"
-	cooldown_time = 500
+	cooldown_time = 50 SECONDS
 
 /datum/action/cooldown/confusion/Trigger()
-	if(!..())
+	. = ..()
+	if(!.)
 		return FALSE
 
 	if (owner.stat == DEAD)

--- a/code/game/objects/items/fixerskills/level2/confusion.dm
+++ b/code/game/objects/items/fixerskills/level2/confusion.dm
@@ -7,9 +7,9 @@
 	custom_premium_price = 1200
 
 /datum/action/cooldown/confusion
+	name = "Confusion"
 	icon_icon = 'icons/hud/screen_skills.dmi'
 	button_icon_state = "confusion"
-	name = "Confusion"
 	cooldown_time = 50 SECONDS
 
 /datum/action/cooldown/confusion/Trigger()

--- a/code/game/objects/items/fixerskills/level2/flashbang.dm
+++ b/code/game/objects/items/fixerskills/level2/flashbang.dm
@@ -10,10 +10,11 @@
 	icon_icon = 'icons/hud/screen_skills.dmi'
 	button_icon_state = "solarflare"
 	name = "Solar Flare"
-	cooldown_time = 500
+	cooldown_time = 50 SECONDS
 
 /datum/action/cooldown/solarflare/Trigger()
-	if(!..())
+	. = ..()
+	if(!.)
 		return FALSE
 
 	if (owner.stat == DEAD)

--- a/code/game/objects/items/fixerskills/level2/flashbang.dm
+++ b/code/game/objects/items/fixerskills/level2/flashbang.dm
@@ -7,9 +7,9 @@
 	custom_premium_price = 1200
 
 /datum/action/cooldown/solarflare
+	name = "Solar Flare"
 	icon_icon = 'icons/hud/screen_skills.dmi'
 	button_icon_state = "solarflare"
-	name = "Solar Flare"
 	cooldown_time = 50 SECONDS
 
 /datum/action/cooldown/solarflare/Trigger()

--- a/code/game/objects/items/fixerskills/level2/lifesteal.dm
+++ b/code/game/objects/items/fixerskills/level2/lifesteal.dm
@@ -10,11 +10,12 @@
 	icon_icon = 'icons/hud/screen_skills.dmi'
 	button_icon_state = "lifesteal"
 	name = "Lifesteal"
-	cooldown_time = 100
+	cooldown_time = 10 SECONDS
 	var/damageamount = 10
 
 /datum/action/cooldown/lifesteal/Trigger()
-	if(!..())
+	. = ..()
+	if(!.)
 		return FALSE
 
 	if (owner.stat == DEAD)

--- a/code/game/objects/items/fixerskills/level2/lifesteal.dm
+++ b/code/game/objects/items/fixerskills/level2/lifesteal.dm
@@ -19,6 +19,7 @@
 	if(!.)
 		return FALSE
 	if(owner.stat > SOFT_CRIT)
+		to_chat(owner, span_userdanger("You are too weak to steal life from people around you..."))
 		return FALSE
 
 	var/mob/living/carbon/human/skilluser = owner

--- a/code/game/objects/items/fixerskills/level2/lifesteal.dm
+++ b/code/game/objects/items/fixerskills/level2/lifesteal.dm
@@ -7,9 +7,10 @@
 	custom_premium_price = 1200
 
 /datum/action/cooldown/lifesteal
+	name = "Lifesteal"
+	desc = "Steal health and sanity from everyone alive around you in a 5x5 tile radious."
 	icon_icon = 'icons/hud/screen_skills.dmi'
 	button_icon_state = "lifesteal"
-	name = "Lifesteal"
 	cooldown_time = 10 SECONDS
 	var/damageamount = 10
 
@@ -17,22 +18,23 @@
 	. = ..()
 	if(!.)
 		return FALSE
-
-	if (owner.stat == DEAD)
+	if(owner.stat > SOFT_CRIT)
 		return FALSE
 
 	var/mob/living/carbon/human/skilluser = owner
 
-	//Compile people around you
-	for(var/mob/living/M in view(2, get_turf(src)))
-		new /obj/effect/temp_visual/cult/sparks (get_turf(M))
-		M.adjustBruteLoss(10)	//Healing for those around.
-		skilluser.adjustBruteLoss(-4)	//Healing for those around.
+	for(var/mob/living/victim in oview(2, get_turf(src)))
+		if(victim.stat == DEAD) // what are you going to take from them?
+			continue
 
-	for(var/mob/living/carbon/human/M in view(2, get_turf(src)))
-		M.adjustSanityLoss(10)	//Healing for those around.
-		skilluser.adjustSanityLoss(-4)	//Healing for those around.
+		new /obj/effect/temp_visual/cult/sparks(get_turf(victim))
+		victim.adjustBruteLoss(10)
+		skilluser.adjustBruteLoss(-4)
+		if(ishuman(victim))
+			var/mob/living/carbon/human/double_victim = victim
+			double_victim.adjustSanityLoss(10)
+			skilluser.adjustSanityLoss(-4)
 
+	owner.visible_message(span_userdanger("tiny cuts form on everyone around [owner], their blood flowing to [owner]'s injuries!"), span_warning("You absorb life from everyone around you!"))
 	new /obj/effect/temp_visual/heal(get_turf(skilluser), "#E2ED4A")
 	StartCooldown()
-

--- a/code/game/objects/items/fixerskills/level2/lockpick.dm
+++ b/code/game/objects/items/fixerskills/level2/lockpick.dm
@@ -10,10 +10,11 @@
 	icon_icon = 'icons/hud/screen_skills.dmi'
 	button_icon_state = "lockpick"
 	name = "Lockpick"
-	cooldown_time = 600
+	cooldown_time = 1 MINUTES
 
 /datum/action/cooldown/lockpick/Trigger()
-	if(!..())
+	. = ..()
+	if(!.)
 		return FALSE
 
 	if (owner.stat == DEAD)

--- a/code/game/objects/items/fixerskills/level2/lockpick.dm
+++ b/code/game/objects/items/fixerskills/level2/lockpick.dm
@@ -7,9 +7,9 @@
 	custom_premium_price = 1200
 
 /datum/action/cooldown/lockpick
+	name = "Lockpick"
 	icon_icon = 'icons/hud/screen_skills.dmi'
 	button_icon_state = "lockpick"
-	name = "Lockpick"
 	cooldown_time = 1 MINUTES
 
 /datum/action/cooldown/lockpick/Trigger()

--- a/code/game/objects/items/fixerskills/level2/shockwave.dm
+++ b/code/game/objects/items/fixerskills/level2/shockwave.dm
@@ -20,6 +20,6 @@
 		to_chat(owner, span_warning("Throwing everything away from you would be difficult in this state."))
 		return
 
-	owner.visible_message(span_userdanger("[owner] throws away everything around them!"), span_warning("You throw everything away from you!"))
 	goonchem_vortex(get_turf(owner), 1, 13)
+	owner.visible_message(span_userdanger("[owner] throws away everything around them!"), span_warning("You throw everything away from you!"))
 	StartCooldown()

--- a/code/game/objects/items/fixerskills/level2/shockwave.dm
+++ b/code/game/objects/items/fixerskills/level2/shockwave.dm
@@ -6,17 +6,20 @@
 	custom_premium_price = 1200
 
 /datum/action/cooldown/shockwave
-	icon_icon = 'icons/hud/screen_skills.dmi'
 	name = "Shockwave"
+	desc = "Throw everything in a 13 meter radious away from you."
+	icon_icon = 'icons/hud/screen_skills.dmi'
 	button_icon_state = "shockwave"
 	cooldown_time = 15 SECONDS
 
 /datum/action/cooldown/shockwave/Trigger()
 	. = ..()
 	if(!.)
-		return FALSE
+		return
+	if(owner.stat != CONSCIOUS)
+		to_chat(owner, span_warning("Throwing everything away from you would be difficult in this state."))
+		return
 
-	if (owner.stat)
-		return FALSE
-	goonchem_vortex(get_turf(src), 1, 13)
+	owner.visible_message(span_userdanger("[owner] throws away everything around them!"), span_warning("You throw everything away from you!"))
+	goonchem_vortex(get_turf(owner), 1, 13)
 	StartCooldown()

--- a/code/game/objects/items/fixerskills/level2/shockwave.dm
+++ b/code/game/objects/items/fixerskills/level2/shockwave.dm
@@ -9,7 +9,7 @@
 	icon_icon = 'icons/hud/screen_skills.dmi'
 	name = "Shockwave"
 	button_icon_state = "shockwave"
-	cooldown_time = 150
+	cooldown_time = 15 SECONDS
 
 /datum/action/cooldown/shockwave/Trigger()
 	. = ..()

--- a/code/game/objects/items/fixerskills/level3/bulletproof.dm
+++ b/code/game/objects/items/fixerskills/level3/bulletproof.dm
@@ -8,6 +8,7 @@
 /datum/action/innate/bulletproof
 	name = "Bulletproof"
 	icon_icon = 'icons/hud/screen_skills.dmi'
+	button_icon_state = "shield_off"
 	var/datum/martial_art/bulletproof/MA = new /datum/martial_art/bulletproof
 
 /datum/action/innate/bulletproof/Activate()

--- a/code/game/objects/items/fixerskills/level4/dismember.dm
+++ b/code/game/objects/items/fixerskills/level4/dismember.dm
@@ -10,10 +10,11 @@
 	icon_icon = 'icons/hud/screen_skills.dmi'
 	button_icon_state = "dismember"
 	name = "Dismember"
-	cooldown_time = 6000
+	cooldown_time = 10 MINUTES
 
 /datum/action/cooldown/dismember/Trigger()
-	if(!..())
+	. = ..()
+	if(!.)
 		return FALSE
 
 	if (owner.stat == DEAD)

--- a/code/game/objects/items/fixerskills/level4/dismember.dm
+++ b/code/game/objects/items/fixerskills/level4/dismember.dm
@@ -7,9 +7,9 @@
 	custom_premium_price = 2400
 
 /datum/action/cooldown/dismember
+	name = "Dismember"
 	icon_icon = 'icons/hud/screen_skills.dmi'
 	button_icon_state = "dismember"
-	name = "Dismember"
 	cooldown_time = 10 MINUTES
 
 /datum/action/cooldown/dismember/Trigger()

--- a/code/game/objects/items/fixerskills/level4/healing.dm
+++ b/code/game/objects/items/fixerskills/level4/healing.dm
@@ -10,14 +10,17 @@
 	icon_icon = 'icons/hud/screen_skills.dmi'
 	button_icon_state = "reraise"
 	name = "Re-Raise"
-	cooldown_time = 6000
+	cooldown_time = 10 MINUTES
 	var/healamount = 15
 
 /datum/action/cooldown/reraise/Trigger()
-	if(!..())
+	. = ..()
+	if(!.)
 		return FALSE
+
 	if(owner.stat != DEAD)
 		return FALSE
+
 	var/mob/living/carbon/human/human = owner
 	if(human.revive(full_heal = TRUE, admin_revive = TRUE))
 		human.grab_ghost(force = TRUE) // even suicides

--- a/code/game/objects/items/fixerskills/level4/healing.dm
+++ b/code/game/objects/items/fixerskills/level4/healing.dm
@@ -7,11 +7,10 @@
 	custom_premium_price = 2400
 
 /datum/action/cooldown/reraise
+	name = "Re-Raise"
 	icon_icon = 'icons/hud/screen_skills.dmi'
 	button_icon_state = "reraise"
-	name = "Re-Raise"
 	cooldown_time = 10 MINUTES
-	var/healamount = 15
 
 /datum/action/cooldown/reraise/Trigger()
 	. = ..()

--- a/code/game/objects/items/fixerskills/level4/kys.dm
+++ b/code/game/objects/items/fixerskills/level4/kys.dm
@@ -7,9 +7,9 @@
 	custom_premium_price = 2400
 
 /datum/action/cooldown/nuke
+	name = "Nuke"
 	icon_icon = 'icons/hud/screen_skills.dmi'
 	button_icon_state = "nuke"
-	name = "Nuke"
 	cooldown_time = 20 MINUTES
 
 /datum/action/cooldown/nuke/Trigger()

--- a/code/game/objects/items/fixerskills/level4/kys.dm
+++ b/code/game/objects/items/fixerskills/level4/kys.dm
@@ -10,10 +10,11 @@
 	icon_icon = 'icons/hud/screen_skills.dmi'
 	button_icon_state = "nuke"
 	name = "Nuke"
-	cooldown_time = 12000
+	cooldown_time = 20 MINUTES
 
 /datum/action/cooldown/nuke/Trigger()
-	if(!..())
+	. = ..()
+	if(!.)
 		return FALSE
 
 	if (owner.stat == DEAD)

--- a/code/game/objects/items/fixerskills/level4/status_effects.dm
+++ b/code/game/objects/items/fixerskills/level4/status_effects.dm
@@ -8,7 +8,7 @@
 /datum/action/cooldown/timestop
 	icon_icon = 'icons/hud/screen_skills.dmi'
 	button_icon_state = "timestop"
-	cooldown_time = 6000
+	cooldown_time = 10 MINUTES
 	var/timestop_range = 2
 	var/timestop_duration = 15
 

--- a/code/game/objects/items/fixerskills/level4/team.dm
+++ b/code/game/objects/items/fixerskills/level4/team.dm
@@ -7,9 +7,9 @@
 	custom_premium_price = 2400
 
 /datum/action/cooldown/warbanner
+	name = "Warbanner"
 	icon_icon = 'icons/hud/screen_skills.dmi'
 	button_icon_state = "warbanner"
-	name = "Warbanner"
 	cooldown_time = 3 MINUTES
 	var/list/affected = list()
 	var/range = 2
@@ -64,9 +64,9 @@
 	custom_premium_price = 2400
 
 /datum/action/cooldown/warcry
+	name = "Warcry"
 	icon_icon = 'icons/hud/screen_skills.dmi'
 	button_icon_state = "warcry"
-	name = "Warcry"
 	cooldown_time = 3 MINUTES
 	var/list/affected = list()
 	var/range = 2

--- a/code/game/objects/items/fixerskills/level4/team.dm
+++ b/code/game/objects/items/fixerskills/level4/team.dm
@@ -10,13 +10,14 @@
 	icon_icon = 'icons/hud/screen_skills.dmi'
 	button_icon_state = "warbanner"
 	name = "Warbanner"
-	cooldown_time = 1800
+	cooldown_time = 3 MINUTES
 	var/list/affected = list()
 	var/range = 2
 	var/affect_self = TRUE
 
 /datum/action/cooldown/warbanner/Trigger()
-	if(!..())
+	. = ..()
+	if(!.)
 		return FALSE
 
 	if (owner.stat == DEAD)
@@ -66,13 +67,14 @@
 	icon_icon = 'icons/hud/screen_skills.dmi'
 	button_icon_state = "warcry"
 	name = "Warcry"
-	cooldown_time = 1800
+	cooldown_time = 3 MINUTES
 	var/list/affected = list()
 	var/range = 2
 	var/affect_self = TRUE
 
 /datum/action/cooldown/warcry/Trigger()
-	if(!..())
+	. = ..()
+	if(!.)
 		return FALSE
 
 	if (owner.stat == DEAD)


### PR DESCRIPTION
## About The Pull Request

- Cleans up skills to use the SECONDS and MINUTES defines instead of doing all time in miliseconds.
- Makes the code do `. = ..(); if(!.){return}` instead of `if(..()){return}`.
- Removes the re-raise skill var called 'healamount' as its never used.
====
- Butchering skill now relies on the butcher component and can absorb knives to enhance its butchering ability as long as the knife is better than the skill at it.
- Fixes lifesteal stealing life from yourself (tongue twister moment)
- Makes lifesteal no longer able to be cast if you are unable to crawl.
- Makes lifesteal no longer take life from corpses (ooo you like eating corpses dont you?)
- Fixes shockwave not working by making it call `owner` instead of `src`.

## Why It's Good For The Game

> Cleans up skills to use the SECONDS and MINUTES defines instead of doing all time in miliseconds.
> Makes the code do `. = ..(); if(!.){return}` instead of `if(..()){return}`.
> Removes the re-raise skill var called 'healamount' as its never used.
- its painfull to see man.

> Butchering skill now relies on the butcher component and can absorb knives to enhance its butchering ability as long as the knife is better than the skill at it.
- I think its much more fun this way, gives feedback about how many creatures you butchered, and to other who butchered them. Also adds progression into it instead of trading speed for efficiency, you can now have both!

> Makes lifesteal no longer able to be cast if you are unable to crawl.
- I feel like its better if people who are knocked out cannot life-steal themselfes into safety again.

> Makes lifesteal no longer take life from corpses (ooo you like eating corpses dont you?)
-  Why was this a thing in the first place, a full-heal every 15 seconds because of 30 corpses on the same tile should not be a thing

> Fixes shockwave not working by making it call `owner` instead of `src`.
> Fixes lifesteal stealing life from yourself (tongue twister moment)
- Its good for skills to work, and work as intended.

## Changelog
:cl:
balance: The butcher skill was majorly re-worked code side, and can now absorb knives.
balance: The lifesteal skill no longer works if you are past soft-crit, and no longer works on corpses
fix: The shockwave skill now works as intended.
fix: The lifesteal skill now does not steal your own life.
/:cl:
