### PR TITLE
[SERIOUSLY DNM] EGO weapons no longer fit into your belt slot.

### DIFF
--- a/ModularTegustation/ego_weapons/_ego_weapon.dm
+++ b/ModularTegustation/ego_weapons/_ego_weapon.dm
@@ -6,7 +6,6 @@
 	lefthand_file = 'icons/mob/inhands/weapons/ego_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/ego_righthand.dmi'
 	w_class = WEIGHT_CLASS_BULKY			//No more stupid 10 egos in bag
-	slot_flags = ITEM_SLOT_BELT
 	drag_slowdown = 1
 	swingstyle = WEAPONSWING_SMALLSWEEP
 	var/list/attribute_requirements = list()

--- a/code/modules/jobs/job_types/agent.dm
+++ b/code/modules/jobs/job_types/agent.dm
@@ -127,13 +127,16 @@
 	jobtype = /datum/job/agent
 
 	head = /obj/item/clothing/head/beret/tegu/lobotomy/agent
-	belt = /obj/item/pda/security
+	belt = /obj/item/storage/belt/ego
 	ears = /obj/item/radio/headset/alt
 	glasses = /obj/item/clothing/glasses/sunglasses
 	uniform = /obj/item/clothing/under/suit/lobotomy
 	shoes = /obj/item/clothing/shoes/laceup
 	gloves = /obj/item/clothing/gloves/color/black
 	implants = list(/obj/item/organ/cyberimp/eyes/hud/security)
+	l_pocket = /obj/item/pda/security
+
+	pda_slot = ITEM_SLOT_LPOCKET
 
 	backpack_contents = list(
 		/obj/item/melee/classic_baton,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
# This PR is for testing purposes only, and not to be merged.

## About The Pull Request
EGO weapons no longer fit into your belt slot.
the EGO belt (small arms belt) itself is not affected.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Motherfuckers always run around with 3 EGO weapons. This is not intended. 
You should be allowed 2 full sized EGO weapons, it is what our game is balanced around.

This PR removes one of your EGO slots, and forces you into just 1 EGO stored like in lobotomy corp, with some high skill agents able to become LC Ryoshu with 2 EGO.

Belts are unaffected, but may be changed in the future to instead take up one slot instead of 2
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: EGO no longer fits in belt slot
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
