### PR TITLE
Converts hard-coded variables to datums in the fishing subsystem + minor fishing skills cleanup

### DIFF
--- a/ModularTegustation/fishing/code/fish_market.dm
+++ b/ModularTegustation/fishing/code/fish_market.dm
@@ -41,7 +41,8 @@
 
 /obj/machinery/fish_market/ui_interact(mob/user) //Unsure if this can stand on its own as a structure, later on we may fiddle with that to break out of computer variables. -IP
 	. = ..()
-	check_city()
+	if(SSmaptype.maptype in SSmaptype.citymaps)
+		update_stock()
 	if(isliving(user))
 		playsound(src, 'sound/machines/terminal_prompt_confirm.ogg', 50, FALSE)
 	var/dat
@@ -52,7 +53,6 @@
 	var/datum/browser/popup = new(user, "FishingVendor", "FishingVendor", 440, 640)
 	popup.set_content(dat)
 	popup.open()
-	return
 
 /obj/machinery/fish_market/Topic(href, href_list)
 	. = ..()
@@ -82,7 +82,7 @@
 			return TRUE
 
 /obj/machinery/fish_market/attackby(obj/item/I, mob/user, params)
-	if(SSfishing.Uranus == 7)
+	if(SSfishing.IsAligned(/datum/planet/uranus))
 		to_chat(usr, span_notice("Uranus is aligned with earth. All fish points are increaed by 1.5x"))
 	if(istype(I, /obj/item/stack/fish_points))
 		var/obj/item/stack/fish_points/more_points = I
@@ -143,8 +143,8 @@
 	var/fish_weight = (F.weight - F.average_weight) / F.average_weight
 	var/fish_size = (F.size - F.average_size) / F.average_size
 	var/fish_worth_mod = 1 + fish_weight + fish_size
-	if(SSfishing.Uranus == 7)
-		fish_worth_mod*=1.5	//Bonus if uranus is aligned
+	if(SSfishing.IsAligned(/datum/planet/uranus))
+		fish_worth_mod *= 1.5	//Bonus if uranus is aligned
 
 	/*Fish Value based on rarity 2 is
 		the worth of fish that are basic.*/
@@ -159,9 +159,9 @@
 	return round(fish_worth * fish_worth_mod)
 
 
-/obj/machinery/fish_market/proc/check_city()
-	if(SSmaptype.maptype in SSmaptype.citymaps)
-		order_list = list(
+/obj/machinery/fish_market/proc/update_stock()
+	QDEL_LIST(order_list)
+	order_list = list(
 		new /datum/data/extraction_cargo("Discount Quality Suture ",	/obj/item/stack/medical/suture/emergency,			50) = 1,
 		new /datum/data/extraction_cargo("Fishin Starting Pack ",		/obj/item/storage/box/fishing,						200) = 1,
 		new /datum/data/extraction_cargo("Aquarium Rocks ",				/obj/item/aquarium_prop/rocks,						250) = 1,
@@ -223,4 +223,4 @@
 		new /datum/data/extraction_cargo("Fishing Mod (R) ",	/obj/item/workshop_mod/fishing,						200) = 1,
 		new /datum/data/extraction_cargo("Fishing Mod (W) ", 	/obj/item/workshop_mod/fishing/white,				200) = 1,
 		new /datum/data/extraction_cargo("Fishing Mod (B) ", 	/obj/item/workshop_mod/fishing/black,				200) = 1,
-		)
+	)

--- a/ModularTegustation/fishing/code/fishing_items/fishing_net.dm
+++ b/ModularTegustation/fishing/code/fishing_items/fishing_net.dm
@@ -74,7 +74,7 @@
 
 /obj/structure/destructible/fishing_net/proc/SpawnEnemy(turf/dropoff, mob/user)
 	var/spawning = /mob/living/simple_animal/hostile/shrimp
-	if(prob(1) && SSfishing.Mars == 4)
+	if(prob(1) && SSfishing.IsAligned(/datum/planet/mars))
 		spawning = /mob/living/simple_animal/hostile/distortion/shrimp_rambo/easy
 
 	if(prob(5))	//Super rares first

--- a/ModularTegustation/fishing/code/fishing_items/fishing_rod.dm
+++ b/ModularTegustation/fishing/code/fishing_items/fishing_rod.dm
@@ -184,14 +184,14 @@
 		var/size_modifier = rand(1, 4) * 0.1
 		//Size modifier has to be a decimal in order to keep it from making massive fish.
 		//Gets bonuses if mercury is in alignment, and if you're aligned with the mercury god
-		if(SSfishing.Mercury == 2)
-			size_modifier*=1.3
+		if(SSfishing.IsAligned(/datum/planet/mercury))
+			size_modifier *= 1.3
+			to_chat(user, span_nicegreen("[FISHGOD_MERCURY] smiles upon you!."))
+
 		if(user.god_aligned == FISHGOD_MERCURY)
 			size_modifier*=2
 
 		fishie.randomize_weight_and_size(size_modifier)
-		if(SSfishing.Mercury == 2)
-			to_chat(user, span_nicegreen("Lir smiles upon you!."))
 
 		if(user.god_aligned == FISHGOD_URANUS && prob(5))
 			to_chat(user, span_nicegreen("Abena Mansa smiles upon you! You caught some cash!"))

--- a/ModularTegustation/fishing/code/fishing_items/fishing_shrine.dm
+++ b/ModularTegustation/fishing/code/fishing_items/fishing_shrine.dm
@@ -65,49 +65,23 @@
 
 //Godpicking shit
 /obj/structure/fishshrine/proc/pick_god(mob/living/user)
-	var/list/display_names = list("Lir", "Tefnut", "Arnapkapfaaluk", "Susanoo" , "Kukulkan", "Abena Mansa", "Glaucus")
-	if(!display_names.len)
+	var/list/god_names = list()
+	for(var/datum/planet/planet as anything in SSfishing.planets)
+		god_names[planet.god] = planet.god_desc
+
+	for(var/god as anything in SSfishing.sleeping_gods)
+		god_names[god] = "Warning, [god]'s planet has been destroyed, this can negativelly affect you in several situations.\n[SSfishing.sleeping_gods[god]]"
+
+	if(!length(god_names))
 		return
-	var/choice = input(user,"Which god would you like to align yourself with?","Select a god") as null|anything in display_names
+
+	var/choice = input(user, "Which god would you like to align yourself with?", "Select a god") as null|anything in god_names
 	if(!choice || !user.canUseTopic(src, BE_CLOSE, FALSE, NO_TK))
 		to_chat(user, span_notice("You decide to stay a fish athiest for now."))
 		return
 
-	switch(choice)
-		if("Lir")
-			var/confirm = alert("Lir is the God of The Sea, and represents Mercury. Devoting yourself to Lir will give you better fortune with the sizes of fish.", "God Choser", "Devote Yourself", "Take more time")
-			if(confirm == "Devote Yourself")
-				user.god_aligned = FISHGOD_MERCURY
+	if(alert(god_names[choice], "God Choser", "Devote Yourself", "Take more time") != "Devote Yourself")
+		return
 
-		if("Tefnut")
-			var/confirm = alert("Tefnut is the Goddess of moisture, fertility and water, and represents Venus. Devoting yourself to Tefnut will make it less likely for enemies to spawn while catching with nets.", "God Choser", "Devote Yourself", "Take more time")
-			if(confirm == "Devote Yourself")
-				user.god_aligned = FISHGOD_VENUS
-
-		if("Arnapkapfaaluk")
-			var/confirm = alert("Arnapkapfaaluk is the Goddess of aquatic combat, and represents Mars. Devoting yourself to Arnapkapfaaluk will give you strength with fishing weapons.", "God Choser", "Devote Yourself", "Take more time")
-			if(confirm == "Devote Yourself")
-				user.god_aligned = FISHGOD_MARS
-
-		if("Susanoo")
-			var/confirm = alert("Susanoo is the God of harvest and storms, and represents Jupiter. Devoting yourself to Susanoo will make fishing weapons heal on kill.", "God Choser", "Devote Yourself", "Take more time")
-			if(confirm == "Devote Yourself")
-				user.god_aligned = FISHGOD_JUPITER
-
-		if("Kukulkan")
-			var/confirm = alert("Kukulkan is the Serpent Deity, and represents Saturn. Devoting yourself to Kukulkan will decrease the cost of all spells by 1 devotion.", "God Choser", "Devote Yourself", "Take more time")
-			if(confirm == "Devote Yourself")
-				user.god_aligned = FISHGOD_SATURN
-
-		if("Abena Mansa")
-			var/confirm = alert("Abena Mansa is a sea Goddess of gold, and represents Uranus. Devoting yourself to Abena Mansa will make fishing up ahn possible, scaling with your devotion.", "God Choser", "Devote Yourself", "Take more time")
-			if(confirm == "Devote Yourself")
-				user.god_aligned = FISHGOD_URANUS
-
-		if("Glaucus")
-			var/confirm = alert("Glaucus is the God of fishing, and represents Neptune. Devoting yourself to Glaucus will enhance all of your fishing skills.", "God Choser", "Devote Yourself", "Take more time")
-			if(confirm == "Devote Yourself")
-				user.god_aligned = FISHGOD_NEPTUNE
-
-
+	user.god_aligned = choice
 	to_chat(user, span_notice("You devote yourself to [user.god_aligned]."))

--- a/ModularTegustation/fishing/code/fishing_items/fishing_shrine.dm
+++ b/ModularTegustation/fishing/code/fishing_items/fishing_shrine.dm
@@ -30,7 +30,7 @@
 		this_fish_point *= 2
 
 	var/neptune = SSfishing.IsAligned(/datum/planet/neptune)
-	if(neptune) //Big-air bonus for mars being in alignment
+	if(neptune) //If neptune is aligned, double your points
 		this_fish_point *= 2
 
 	qdel(I)

--- a/ModularTegustation/fishing/code/fishing_items/fishing_shrine.dm
+++ b/ModularTegustation/fishing/code/fishing_items/fishing_shrine.dm
@@ -27,23 +27,22 @@
 		if(FISH_RARITY_GOOD_LUCK_FINDING_THIS)
 			this_fish_point = 0.8
 	if(sacrificing.status == FISH_ALIVE)
-		this_fish_point*=2
-	if(SSfishing.Neptune==8)
-		this_fish_point*=2
+		this_fish_point *= 2
+
+	var/neptune = SSfishing.IsAligned(/datum/planet/neptune)
+	if(neptune) //Big-air bonus for mars being in alignment
+		this_fish_point *= 2
+
 	qdel(I)
 	user.devotion+=this_fish_point
-	if(SSfishing.Neptune==8)
-		to_chat(user, span_notice("Neptune is in alignment. Devotion increased by [this_fish_point]. Your devotion to [user.god_aligned] is now [user.devotion]."))
-	else
-		to_chat(user, span_notice("Devotion increased by [this_fish_point]. Your devotion to [user.god_aligned] is now [user.devotion]."))
-
+	to_chat(user, span_notice("[neptune ? "Neptune is in alignment. " : ""]Devotion increased by [this_fish_point]. Your devotion to [user.god_aligned] is now [user.devotion]."))
 
 /obj/structure/fishshrine/attack_hand(mob/living/user)
 	..()
-	if(user.devotion>=1&& user.devotion<5)
+	if(user.devotion >= 1 && user.devotion < 5)
 		to_chat(user, span_notice("The gods look the other way."))
 		return
-	if(user.devotion>=5 && user.god_aligned == FISHGOD_NONE)
+	if(user.devotion >= 5 && user.god_aligned == FISHGOD_NONE)
 		pick_god(user)
 	if(user.god_aligned != FISHGOD_NONE)
 		display_info(user)
@@ -60,22 +59,9 @@
 		if(4)
 			to_chat(user, span_notice("The moon is Full."))
 
-	if(SSfishing.Mercury == 2)
-		to_chat(user, span_notice("Mercury is in alignment with earth."))
-	if(SSfishing.Venus == 3)
-		to_chat(user, span_notice("Venus is in alignment with earth."))
-	if(SSfishing.Mars == 4)
-		to_chat(user, span_notice("Mars is in alignment with earth."))
-	if(SSfishing.Jupiter == 5)
-		to_chat(user, span_notice("Jupiter is in alignment with earth."))
-	if(SSfishing.Saturn == 6)
-		to_chat(user, span_notice("Saturn is in alignment with earth."))
-	if(SSfishing.Uranus == 7)
-		to_chat(user, span_notice("Uranus is in alignment with earth."))
-	if(SSfishing.Neptune == 8)
-		to_chat(user, span_notice("Neptune is in alignment with earth."))
-
-
+	for(var/datum/planet/planet as anything in SSfishing.planets)
+		if(planet.phase == 1)
+			to_chat(user, span_notice("[planet.name] is in alignment with earth."))
 
 //Godpicking shit
 /obj/structure/fishshrine/proc/pick_god(mob/living/user)

--- a/ModularTegustation/tegu_items/workshop/templates/fishing/fishingweapons.dm
+++ b/ModularTegustation/tegu_items/workshop/templates/fishing/fishingweapons.dm
@@ -29,23 +29,22 @@
 	if(!(target.status_flags & GODMODE) && target.stat != DEAD)
 		storelive = TRUE
 
-	if(SSfishing.Mars == 4)	//Big-air bonus for mars being in alignment
-		force*=1.3
+	if(SSfishing.IsAligned(/datum/planet/mars)) //Big-air bonus for mars being in alignment
+		force *= 1.3
 
 	if(!(target.type in aquatic_enemies))
-		force*=0.7
+		force *= 0.7
 	..()
 	if(target.stat == DEAD && storelive)
 		if(user.god_aligned == FISHGOD_JUPITER)
 			user.adjustBruteLoss(-user.maxHealth*0.1)	//Healing for your kill
 			new /obj/effect/temp_visual/heal(get_turf(user), "#FF4444")
 
-		if(SSfishing.Jupiter == 5)
+		if(SSfishing.IsAligned(/datum/planet/jupiter))
 			user.adjustBruteLoss(-user.maxHealth*0.05)	//Healing for your kill
 			new /obj/effect/temp_visual/heal(get_turf(user), "#FF4444")
 
 	force = finishedforce
-
 
 /obj/item/ego_weapon/template/fishing/spear
 	name = "fishing spear template"

--- a/ModularTegustation/tegu_items/workshop/templates/fishing/fishingweapons.dm
+++ b/ModularTegustation/tegu_items/workshop/templates/fishing/fishingweapons.dm
@@ -12,22 +12,23 @@
 	finisheddesc = "A finished harpoon, ready for use. Deals less damage to non-aquatic enemies."
 
 	//Update with aquatic enemies
-	var/list/aquatic_enemies = list(/mob/living/simple_animal/hostile/shrimp,
-			/mob/living/simple_animal/hostile/distortion/shrimp_rambo/easy,
-			/mob/living/simple_animal/hostile/shrimp_soldier,
-			/mob/living/simple_animal/hostile/shrimp_rifleman,
-			/mob/living/simple_animal/hostile/senior_shrimp,)
+	var/list/aquatic_enemies = list(
+		/mob/living/simple_animal/hostile/shrimp,
+		/mob/living/simple_animal/hostile/distortion/shrimp_rambo/easy,
+		/mob/living/simple_animal/hostile/shrimp_soldier,
+		/mob/living/simple_animal/hostile/shrimp_rifleman,
+		/mob/living/simple_animal/hostile/senior_shrimp,
+	)
 
 
 
 /obj/item/ego_weapon/template/fishing/attack(mob/living/target, mob/living/user)
-	var/finishedforce = force
 	var/storelive = FALSE
-	if(user.god_aligned == FISHGOD_MARS)
-		force*=1.3
-
 	if(!(target.status_flags & GODMODE) && target.stat != DEAD)
 		storelive = TRUE
+
+	if(user.god_aligned == FISHGOD_MARS)
+		force *= 1.3
 
 	if(SSfishing.IsAligned(/datum/planet/mars)) //Big-air bonus for mars being in alignment
 		force *= 1.3
@@ -43,8 +44,6 @@
 		if(SSfishing.IsAligned(/datum/planet/jupiter))
 			user.adjustBruteLoss(-user.maxHealth*0.05)	//Healing for your kill
 			new /obj/effect/temp_visual/heal(get_turf(user), "#FF4444")
-
-	force = finishedforce
 
 /obj/item/ego_weapon/template/fishing/spear
 	name = "fishing spear template"

--- a/code/controllers/subsystem/fishing.dm
+++ b/code/controllers/subsystem/fishing.dm
@@ -4,111 +4,128 @@ SUBSYSTEM_DEF(fishing)
 	name = "Fishing"
 	flags = SS_NO_FIRE
 	init_order = INIT_ORDER_DEFAULT
-	var/moonphase = 1	//Four phases, Waning, New, Waxing, and Full
-	var/stopnext		//Do we want to stop the planets until the moon is next full?
+	var/moonphase = 1 //Four phases, Waning, New, Waxing, and Full
+	var/stopnext = FALSE //Do we want to stop the planets until the moon is next full?
 
-	//Sadly, For now each of these are in a separate variable. TODO: deshit this
+	var/list/planets = list()
 
-	//1 Means it's in Alignment.
-	var/Mercury = 1
-	var/Venus = 1
-	var/Mars = 1
-	var/Jupiter = 1
-	var/Saturn = 1
-	var/Uranus = 1
-	var/Neptune = 1
+/datum/controller/subsystem/fishing/Initialize(start_timeofday)
+	if(!(SSmaptype.maptype in SSmaptype.citymaps)) // Don't start if it's not a city map.
+		moonphase = 3	// 3 should be average
+		return ..()
 
+	moonphase = rand(1, 4) // First set a moon phase
 
-/datum/controller/subsystem/fishing/Initialize()
-	..()
-	if(!(SSmaptype.maptype in SSmaptype.citymaps))
-		moonphase = 3	//3 should be average
-		return	//Don't start if it's not a city map.
-
-	//First set a moon phase
-	moonphase = rand(1, 4)
-
-	//then set planet alignments
-	//Each planet takes one more cycle to align
-	//The buffs only take into effect if it is in alignment, and you are devoted to the god
-	Mercury = rand(1,2)		//God is Lir. Buffs the minimum and maximum size of fish.
-	Venus = rand(1,3)		//God is Tefnut. Small chance to fish up a tamed enemy.
-	Mars = rand(1,4)		//God is Arnapkapfaaluk. Buffs the damage of fishing based weapons.
-	Jupiter = rand(1,5)		//God is Susanoo. Heals everyone around you, as well as AOE feeds people
-	Saturn = rand(1,6)		//God is Kukulkan. Buffs aquarium stuff, not only will you heal to full SP on examining fish aquariums, if your aligned god is the same, You feed the fish for significantly longer
-	Uranus = rand(1,7)		//God is Abena Mansa. Fishing gives you a wallet with ahn in it.
-	Neptune = rand(1,8)		//God is Glaucus. Gives massive buffs to all things fishing related when aligned.
+	var/list/planet_datums = subtypesof(/datum/planet)
+	for(var/datum/planet/big_rock as anything in planet_datums) //then set planets and random alignments
+		big_rock = new big_rock()
+		big_rock.phase = rand(1, big_rock.orbit_time)
+		big_rock.linked_subsystem = src
+		planets += big_rock
 
 	addtimer(CALLBACK(src, PROC_REF(Moveplanets)), 7 MINUTES)
+	return ..()
 
 /datum/controller/subsystem/fishing/proc/Moveplanets()
 	addtimer(CALLBACK(src, PROC_REF(Moveplanets)), 7 MINUTES)
-	moonphase+=1		//Moon Phases will affect the power of Moon-based mods.
-	if(moonphase == 5)	//there's only 4
-		moonphase = 1
-
+	moonphase++
 	if(stopnext && moonphase != 4)
 		for(var/mob/M in GLOB.player_list)
 			to_chat(M, span_userdanger("The planets begin to move again."))
 		return
 
-	Mercury+=1
-	if(Mercury == 3)
-		Mercury = 1
+	for(var/datum/planet/big_rock as anything in planets)
+		big_rock.phase++
+		if(big_rock.phase == big_rock.orbit_time + 1)
+			big_rock.phase = 1
 
-	Venus+=1
-	if(Venus == 4)
-		Venus = 1
+/// Takes a planet datum path, If a planet exists and is aligned, returns TRUE. Else returns FALSE
+/datum/controller/subsystem/fishing/proc/IsAligned(datum/planet/planet)
+	if(!ispath(planet))
+		return FALSE
 
-	Mars+=1
-	if(Mars == 5)
-		Mars = 1
-
-	Jupiter+=1
-	if(Jupiter == 6)
-		Jupiter = 1
-
-	Saturn+=1
-	if(Saturn == 7)
-		Saturn = 1
-
-	Uranus+=1
-	if(Uranus == 8)
-		Uranus = 1
-
-	Neptune+=1
-	if(Neptune == 9)
-		Neptune = 1
-
-
-/proc/CheckPlanetAligned(godcheck)
-	switch(godcheck)
-		if(FISHGOD_MERCURY)
-			if(SSfishing.Mercury == 2)
-				return TRUE
-
-		if(FISHGOD_VENUS)
-			if(SSfishing.Venus == 3)
-				return TRUE
-
-		if(FISHGOD_MARS)
-			if(SSfishing.Mars == 4)
-				return TRUE
-
-		if(FISHGOD_JUPITER)
-			if(SSfishing.Jupiter == 5)
-				return TRUE
-
-		if(FISHGOD_SATURN)
-			if(SSfishing.Saturn == 6)
-				return TRUE
-
-		if(FISHGOD_URANUS)
-			if(SSfishing.Uranus == 7)
-				return TRUE
-
-		if(FISHGOD_NEPTUNE)
-			if(SSfishing.Neptune == 8)
-				return TRUE
+	var/datum/planet/found_planet = locate(planet) in planets
+	if(found_planet)
+		if(found_planet.phase == 1)
+			return TRUE
 
 	return FALSE
+
+/// Takes a fish god as argument, if a planet with that god is aligned returns TRUE, FALSE otherwise
+/proc/CheckPlanetAligned(godcheck)
+	for(var/datum/planet/planet as anything in SSfishing.planets)
+		if(godcheck != planet.god)
+			continue
+
+		if(planet.phase == 1)
+			return TRUE
+
+	return FALSE
+
+/// The buffs only take into effect if it is in alignment, and you are devoted to the god
+/datum/planet
+	/// The name of the planet displayed to players
+	var/name = "Funky planet"
+	/**
+	 * orbit_time Controls how long it takes for a planet to get into its alignement with earth, NOT how long it stays in alignement
+	 * Examples:
+	 * - 1 would mean its always aligned
+	 * - 2 would mean it takes 7 minutes to get into orbit, and 7 minutes to get out of alignement
+	 * - 3 would mean it takes 14 minutes to get into orbit, and 7 minutes to get out of alignement
+	 */
+	var/orbit_time = 1
+	/// What place in the orbit are we currently in
+	var/phase = 1
+	/// What god commands this planet
+	var/god = FISHGOD_NONE
+	/// The subsystem we are linked to, for cleanup purposes
+	var/datum/controller/subsystem/fishing/linked_subsystem = null
+
+/datum/planet/Destroy(force, ...)
+	if(linked_subsystem)
+		linked_subsystem.planets -= src
+	return ..()
+
+/// God is Lir. Buffs the minimum and maximum size of fish.
+/datum/planet/mercury
+	name = "Mercury"
+	orbit_time = 2
+	god = FISHGOD_MERCURY
+
+/// God is Tefnut. Small chance to fish up a tamed enemy.
+/datum/planet/venus
+	name = "Venus"
+	orbit_time = 3
+	god = FISHGOD_VENUS
+
+/// God is Arnapkapfaaluk. Buffs the damage of fishing based weapons.
+/// (Please don't laugh at the god's name, he was born with it.)
+/datum/planet/mars
+	name = "Mars"
+	orbit_time = 4
+	god = FISHGOD_MARS
+
+/// God is Susanoo. Heals everyone around you, as well as AOE feeds people
+/datum/planet/jupiter
+	name = "Jupiter"
+	orbit_time = 5
+	god = FISHGOD_JUPITER
+
+/// God is Kukulkan. Buffs aquarium stuff, not only will you heal to full SP on examining fish aquariums.
+/// If your aligned god is the same, You feed the fish for significantly longer
+/datum/planet/saturn
+	name = "Saturn"
+	orbit_time = 6
+	god = FISHGOD_SATURN
+
+/// God is Abena Mansa. Fishing gives you a wallet with ahn in it.
+/datum/planet/uranus
+	name = "Uranus"
+	orbit_time = 7
+	god = FISHGOD_URANUS
+
+/// God is Glaucus. Gives massive buffs to all things fishing related when aligned.
+/datum/planet/neptune
+	name = "Neptune"
+	orbit_time = 8
+	god = FISHGOD_NEPTUNE

--- a/code/controllers/subsystem/fishing.dm
+++ b/code/controllers/subsystem/fishing.dm
@@ -7,7 +7,10 @@ SUBSYSTEM_DEF(fishing)
 	var/moonphase = 1 //Four phases, Waning, New, Waxing, and Full
 	var/stopnext = FALSE //Do we want to stop the planets until the moon is next full?
 
+	/// Gets filled on Initialize() with created datums of planets
 	var/list/planets = list()
+	/// When a planet is destroyed, its god goes into this list.
+	var/list/sleeping_gods = list()
 
 /datum/controller/subsystem/fishing/Initialize(start_timeofday)
 	if(!(SSmaptype.maptype in SSmaptype.citymaps)) // Don't start if it's not a city map.
@@ -78,12 +81,17 @@ SUBSYSTEM_DEF(fishing)
 	var/phase = 1
 	/// What god commands this planet
 	var/god = FISHGOD_NONE
+	/// A general description of what the god's buffs are, showed in the altar
+	var/god_desc = "oh my god!"
 	/// The subsystem we are linked to, for cleanup purposes
 	var/datum/controller/subsystem/fishing/linked_subsystem = null
 
 /datum/planet/Destroy(force, ...)
+	if(god != FISHGOD_NONE)
+		linked_subsystem.sleeping_gods[god] = god_desc
 	if(linked_subsystem)
 		linked_subsystem.planets -= src
+		linked_subsystem = null
 	return ..()
 
 /// God is Lir. Buffs the minimum and maximum size of fish.
@@ -91,12 +99,14 @@ SUBSYSTEM_DEF(fishing)
 	name = "Mercury"
 	orbit_time = 2
 	god = FISHGOD_MERCURY
+	god_desc = "Lir is the God of The Sea, and represents Mercury. Devoting yourself to Lir will give you better fortune with the sizes of fish."
 
 /// God is Tefnut. Small chance to fish up a tamed enemy.
 /datum/planet/venus
 	name = "Venus"
 	orbit_time = 3
 	god = FISHGOD_VENUS
+	god_desc = "Tefnut is the Goddess of moisture, fertility and water, and represents Venus. Devoting yourself to Tefnut will make it less likely for enemies to spawn while catching with nets."
 
 /// God is Arnapkapfaaluk. Buffs the damage of fishing based weapons.
 /// (Please don't laugh at the god's name, he was born with it.)
@@ -104,12 +114,14 @@ SUBSYSTEM_DEF(fishing)
 	name = "Mars"
 	orbit_time = 4
 	god = FISHGOD_MARS
+	god_desc = "Arnapkapfaaluk is the Goddess of aquatic combat, and represents Mars. Devoting yourself to Arnapkapfaaluk will give you strength with fishing weapons."
 
 /// God is Susanoo. Heals everyone around you, as well as AOE feeds people
 /datum/planet/jupiter
 	name = "Jupiter"
 	orbit_time = 5
 	god = FISHGOD_JUPITER
+	god_desc = "Susanoo is the God of harvest and storms, and represents Jupiter. Devoting yourself to Susanoo will make fishing weapons heal on kill."
 
 /// God is Kukulkan. Buffs aquarium stuff, not only will you heal to full SP on examining fish aquariums.
 /// If your aligned god is the same, You feed the fish for significantly longer
@@ -117,15 +129,18 @@ SUBSYSTEM_DEF(fishing)
 	name = "Saturn"
 	orbit_time = 6
 	god = FISHGOD_SATURN
+	god_desc = "Kukulkan is the Serpent Deity, and represents Saturn. Devoting yourself to Kukulkan will decrease the cost of all spells by 1 devotion."
 
 /// God is Abena Mansa. Fishing gives you a wallet with ahn in it.
 /datum/planet/uranus
 	name = "Uranus"
 	orbit_time = 7
 	god = FISHGOD_URANUS
+	god_desc = "Abena Mansa is a sea Goddess of gold, and represents Uranus. Devoting yourself to Abena Mansa will make fishing up ahn possible, scaling with your devotion."
 
 /// God is Glaucus. Gives massive buffs to all things fishing related when aligned.
 /datum/planet/neptune
 	name = "Neptune"
 	orbit_time = 8
 	god = FISHGOD_NEPTUNE
+	god_desc = "Glaucus is the God of fishing, and represents Neptune. Devoting yourself to Glaucus will enhance all of your fishing skills."

--- a/code/game/objects/items/fixerskills/fishing/_fishing.dm
+++ b/code/game/objects/items/fixerskills/fishing/_fishing.dm
@@ -10,20 +10,20 @@
 		return FALSE
 
 	var/mob/living/carbon/human/H = owner
-	var/spend_devotion = devotion_cost
+	var/required_devotion = devotion_cost
 
 	if(H.god_aligned == FISHGOD_SATURN)
-		spend_devotion-=1	//Get one less cost on these spells
+		required_devotion -= 1	//Get one less cost on these spells
 
-	if(H.devotion <spend_devotion)
-		to_chat(H,span_warning("You do not have enough devotion for this spell!"))
+	if(H.devotion < required_devotion)
+		to_chat(H, span_warning("You do not have enough devotion for this spell!"))
 		return FALSE
 
-	if (owner.stat == DEAD)
+	if(owner.stat == DEAD)
 		return FALSE
 
-	H.devotion-=spend_devotion
-	to_chat(H,span_notice("You expend [spend_devotion] devotion. Remaining Devotion: [H.devotion]."))
+	H.devotion -= required_devotion
+	to_chat(H, span_notice("You expend [required_devotion] devotion. Remaining Devotion: [H.devotion]."))
 	StartCooldown()
 	FishEffect(H)
 

--- a/code/game/objects/items/fixerskills/fishing/level1/motion.dm
+++ b/code/game/objects/items/fixerskills/fishing/level1/motion.dm
@@ -13,42 +13,15 @@
 	devotion_cost = 2
 
 /datum/action/cooldown/fishing/planet/FishEffect(mob/living/user)
-	to_chat(user, span_notice("You shift the movement of your aligned planet by 1."))
-	switch(user.god_aligned)
-		if(FISHGOD_MERCURY)
-			SSfishing.Mercury+=1
-			if(SSfishing.Mercury == 3)
-				SSfishing.Mercury = 1
+	for(var/datum/planet/planet as anything in SSfishing.planets)
+		if(user.god_aligned != planet.god)
+			continue
 
-		if(FISHGOD_VENUS)
-			SSfishing.Venus+=1
-			if(SSfishing.Venus == 4)
-				SSfishing.Venus = 1
-
-		if(FISHGOD_MARS)
-			SSfishing.Mars+=1
-			if(SSfishing.Mars == 5)
-				SSfishing.Mars = 1
-
-		if(FISHGOD_JUPITER)
-			SSfishing.Jupiter+=1
-			if(SSfishing.Jupiter == 6)
-				SSfishing.Jupiter = 1
-
-		if(FISHGOD_SATURN)
-			SSfishing.Saturn+=1
-			if(SSfishing.Saturn == 7)
-				SSfishing.Saturn = 1
-
-		if(FISHGOD_URANUS)
-			SSfishing.Uranus+=1
-			if(SSfishing.Uranus == 8)
-				SSfishing.Uranus = 1
-
-		if(FISHGOD_NEPTUNE)
-			SSfishing.Neptune+=1
-			if(SSfishing.Neptune == 9)
-				SSfishing.Neptune = 1
+		planet.phase++
+		if(planet.phase == planet.orbit_time + 1)
+			planet.phase = 1
+		to_chat(user, span_notice("You shift the movement of your aligned planet by 1."))
+		break
 
 //Lunar Motion
 /obj/item/book/granter/action/skill/moonmove
@@ -86,50 +59,24 @@
 	devotion_cost = 4
 
 /datum/action/cooldown/fishing/planet2/FishEffect(mob/living/user)
-	var/list/display_names = list("Mercury", "Venus", "Mars", "Jupiter" , "Saturn", "Uranus", "Neptune")
-	if(!display_names.len)
-		return
-	var/choice = input(user,"Which planet would you like to move?","Planet II") as null|anything in display_names
+	var/list/planet_names = list()
+	for(var/datum/planet/planet as anything in SSfishing.planets)
+		planet_names += planet.name
+
+	var/choice = input(user,"Which planet would you like to move?","Planet II") as null|anything in planet_names
 	if(!choice)
 		to_chat(user, span_notice("You stay your hand."))
 		return
 
-	switch(choice)
-		if("Mercury")
-			SSfishing.Mercury+=1
-			if(SSfishing.Mercury == 3)
-				SSfishing.Mercury = 1
+	var/success = FALSE
+	for(var/datum/planet/planet as anything in SSfishing.planets)
+		if(planet.name != choice)
+			continue
 
-		if("Venus")
-			SSfishing.Venus+=1
-			if(SSfishing.Venus == 4)
-				SSfishing.Venus = 1
+		planet.phase++
+		if(planet.phase == planet.orbit_time + 1)
+			planet.phase = 1
+		success = TRUE
+		break
 
-		if("Mars")
-			SSfishing.Mars+=1
-			if(SSfishing.Mars == 5)
-				SSfishing.Mars = 1
-
-		if("Jupiter")
-			SSfishing.Jupiter+=1
-			if(SSfishing.Jupiter == 6)
-				SSfishing.Jupiter = 1
-
-		if("Saturn")
-			SSfishing.Saturn+=1
-			if(SSfishing.Saturn == 7)
-				SSfishing.Saturn = 1
-
-		if("Uranus")
-			SSfishing.Uranus+=1
-			if(SSfishing.Uranus == 8)
-				SSfishing.Uranus = 1
-
-		if("Neptune")
-			SSfishing.Neptune+=1
-			if(SSfishing.Neptune == 9)
-				SSfishing.Neptune = 1
-
-	to_chat(user, span_nicegreen("[choice] has been moved forwards."))
-
-
+	to_chat(user, success ? span_nicegreen("[choice] has been moved forwards.") : span_userdanger("You lost sight of the planet...?"))

--- a/code/game/objects/items/fixerskills/fishing/level2.dm
+++ b/code/game/objects/items/fixerskills/fishing/level2.dm
@@ -106,51 +106,21 @@
 	for(var/mob/living/M in view(4, get_turf(src)))
 		if(M == owner)
 			continue
+		if(M.god_aligned == initial(M.god_aligned))
+			continue
 
-			//Atheists have no chakra
-		switch(M.god_aligned)
-			if(FISHGOD_MERCURY)
-				if(SSfishing.Mercury <0)	//If your planet is below 0, it was blown out of the sky, and you will die.
-					obliterate(M)
-				if(SSfishing.Mercury != 2)
-					smite(M, user)
+		var/found_planet = FALSE
+		for(var/datum/planet/planet as anything in SSfishing.planets)
+			if(M.god_aligned != planet.god)
+				continue
 
-			if(FISHGOD_VENUS)
-				if(SSfishing.Venus <0)
-					obliterate(M)
-				if(SSfishing.Venus != 3)
-					smite(M, user)
+			found_planet = TRUE
+			if(planet.phase != 1)
+				smite(M, user)
+			break
 
-			if(FISHGOD_MARS)
-				if(SSfishing.Mars <0)
-					obliterate(M)
-				if(SSfishing.Mars != 4)
-					smite(M, user)
-
-			if(FISHGOD_JUPITER)
-				if(SSfishing.Jupiter <0)
-					obliterate(M)
-				if(SSfishing.Jupiter != 5)
-					smite(M, user)
-
-			if(FISHGOD_SATURN)
-				if(SSfishing.Saturn <0)
-					obliterate(M)
-				if(SSfishing.Saturn != 6)
-					smite(M, user)
-
-			if(FISHGOD_URANUS)
-				if(SSfishing.Uranus <0)
-					obliterate(M)
-				if(SSfishing.Uranus != 7)
-					smite(M, user)
-
-			if(FISHGOD_NEPTUNE)
-				if(SSfishing.Neptune <0)
-					obliterate(M)
-				if(SSfishing.Neptune != 8)
-					smite(M, user)
-
+		if(!found_planet) // their planet is dead, and so will they be
+			obliterate(M)
 
 /datum/action/cooldown/fishing/chakra/proc/smite(mob/living/carbon/asshole, mob/living/carbon/user)
 	asshole.apply_damage(user.devotion*SSfishing.moonphase*0.5, WHITE_DAMAGE, null, asshole.run_armor_check(null, WHITE_DAMAGE), spread_damage = TRUE)	//KILL

--- a/code/game/objects/items/fixerskills/fishing/level4.dm
+++ b/code/game/objects/items/fixerskills/fishing/level4.dm
@@ -59,7 +59,8 @@
 /datum/action/cooldown/fishing/supernova/FishEffect(mob/living/user)
 	var/list/planet_names = list()
 	for(var/datum/planet/planet as anything in SSfishing.planets)
-		planet_names += planet.name
+		if(user.god_aligned != planet.god)
+			planet_names += planet.name
 
 	var/choice = input(user, "Which planet would you like to destroy?", "Supernova") as null|anything in planet_names
 	if(!choice)

--- a/code/game/objects/items/fixerskills/fishing/level4.dm
+++ b/code/game/objects/items/fixerskills/fishing/level4.dm
@@ -62,6 +62,10 @@
 		if(user.god_aligned != planet.god)
 			planet_names += planet.name
 
+	if(!length(planet_names))
+		to_chat(user, span_warning("... There is nothing in the sky to detonate... your work is done."))
+		return
+
 	var/choice = input(user, "Which planet would you like to destroy?", "Supernova") as null|anything in planet_names
 	if(!choice)
 		to_chat(user, span_notice("You stay your hand."))

--- a/code/game/objects/items/fixerskills/fishing/level4.dm
+++ b/code/game/objects/items/fixerskills/fishing/level4.dm
@@ -13,36 +13,13 @@
 	devotion_cost = 15
 
 /datum/action/cooldown/fishing/alignment/FishEffect(mob/living/user)
-	to_chat(user, span_notice("You shift your deity's planet to align with earth."))
-	switch(user.god_aligned)
-		if(FISHGOD_MERCURY)
-			if(SSfishing.Mercury>0)	//I never remembered that you could reform planets technically with alignment
-				SSfishing.Mercury=2
+	for(var/datum/planet/planet as anything in SSfishing.planets)
+		if(user.god_aligned != planet.god)
+			continue
 
-		if(FISHGOD_VENUS)
-			if(SSfishing.Venus>0)
-				SSfishing.Venus=3
-
-		if(FISHGOD_MARS)
-			if(SSfishing.Mars>0)
-				SSfishing.Mars=4
-
-		if(FISHGOD_JUPITER)
-			if(SSfishing.Jupiter>0)
-				SSfishing.Jupiter=5
-
-		if(FISHGOD_SATURN)
-			if(SSfishing.Saturn>0)
-				SSfishing.Saturn=6
-
-		if(FISHGOD_URANUS)
-			if(SSfishing.Uranus>0)
-				SSfishing.Uranus=7
-
-		if(FISHGOD_NEPTUNE)
-			if(SSfishing.Neptune>0)
-				SSfishing.Neptune=8
-
+		planet.phase = 1
+		to_chat(user, span_notice("You shift your deity's planet to align with earth."))
+		break
 
 //A Moment in Time
 /obj/item/book/granter/action/skill/planetstop
@@ -80,32 +57,30 @@
 	devotion_cost = 25
 
 /datum/action/cooldown/fishing/supernova/FishEffect(mob/living/user)
-	var/list/display_names = list("Mercury", "Venus", "Mars", "Jupiter" , "Saturn", "Uranus", "Neptune")
-	if(!display_names.len)
-		return
-	var/choice = input(user,"Which planet would you like to destroy?","Supernova") as null|anything in display_names
+	var/list/planet_names = list()
+	for(var/datum/planet/planet as anything in SSfishing.planets)
+		planet_names += planet.name
+
+	var/choice = input(user, "Which planet would you like to destroy?", "Supernova") as null|anything in planet_names
 	if(!choice)
 		to_chat(user, span_notice("You stay your hand."))
 		return
 
-	switch(choice)
-		if("Mercury")
-			SSfishing.Mercury = -100
-		if("Venus")
-			SSfishing.Venus = -100
-		if("Mars")
-			SSfishing.Mars = -100
-		if("Jupiter")
-			SSfishing.Jupiter = -100
-		if("Saturn")
-			SSfishing.Saturn = -100
-		if("Uranus")
-			SSfishing.Uranus = -100
-		if("Neptune")
-			SSfishing.Neptune = -100
+	var/success = FALSE
+	for(var/datum/planet/planet as anything in SSfishing.planets)
+		if(planet.name != choice)
+			continue
 
-	for(var/mob/M in GLOB.player_list)
-		to_chat(M, span_userdanger("You look up in awe. [choice] has been blown from the sky."))
+		qdel(planet) // oh dear
+		success = TRUE
+		break
+
+	if(success)
+		to_chat(user, span_narsiesmall("Death to the false gods."))
+		for(var/mob/M in GLOB.player_list)
+			to_chat(M, span_userdanger("You look up in awe. [choice] has been blown from the sky."))
+	else
+		to_chat(user, span_userdanger("You lost sight of the planet...?"))
 
 //Alignment 2
 /obj/item/book/granter/action/skill/alignment2
@@ -122,27 +97,8 @@
 	devotion_cost = 35
 
 /datum/action/cooldown/fishing/alignment2/FishEffect(mob/living/user)
-	if(SSfishing.Mercury>0)
-		SSfishing.Mercury=2
-
-	if(SSfishing.Venus>0)
-		SSfishing.Venus=3
-
-	if(SSfishing.Mars>0)
-		SSfishing.Mars=4
-
-	if(SSfishing.Jupiter>0)
-		SSfishing.Jupiter=5
-
-	if(SSfishing.Saturn>0)
-		SSfishing.Saturn=6
-
-	if(SSfishing.Uranus>0)
-		SSfishing.Uranus=7
-
-	if(SSfishing.Neptune>0)
-		SSfishing.Neptune=8
+	for(var/datum/planet/planet as anything in SSfishing.planets)
+		planet.phase = 1
 
 	for(var/mob/M in GLOB.player_list)
 		to_chat(M, span_userdanger("You look up in awe. The planets, they're all aligned!"))
-


### PR DESCRIPTION
## About The Pull Request

- Recodes the fishing subsystem to have a list of datums instead of hard-coded variables
- Fish market now checks for the map before the proc, so admins can easily enable the CF/COL fish markets at their demand (let me test things locally easier dammit!)
- Fixed a lot of fish bugs

## Why It's Good For The Game

> Recodes the fishing subsystem to have a list of datums instead of hard-coded variables
- The shitcode and hardcode is real, cleaned it up a good chunk
- This does also allow admins to make custom planets, or copies of pre-existing planets
> Fish market now checks for the map before the proc, so admins can easily enable the CF/COL fish markets at their demand (let me test things locally easier dammit!)
- It just better, also i added a QDEL_LIST() before setting a new list there since quite sure those datums were never being cleared
> Fixed a lot of fish bugs
- Bugs bad, the full list in the changelog

## Changelog
:cl:
code: recoded the fishing subsystem
qol: You can no longer detonate your own god's planet
fix: You can no longer detonate a detonated planet
fix: You can no longer move a detonated planet's phase with "Planet 1" and "Planet 2"
/:cl:
