### PR TITLE
Fixes some initialize hints

### DIFF
--- a/ModularTegustation/tegu_items/associations/!overwrites.dm
+++ b/ModularTegustation/tegu_items/associations/!overwrites.dm
@@ -1,5 +1,5 @@
 /mob/living/simple_animal/hostile/ordeal/steel_dawn/steel_noon/Initialize()
-	..()
+	. = ..()
 	if(SSmaptype.maptype in SSmaptype.citymaps)
 		maxHealth = 500
 		health = 500

--- a/code/modules/mob/living/simple_animal/distortion/myth/another_day_work.dm
+++ b/code/modules/mob/living/simple_animal/distortion/myth/another_day_work.dm
@@ -147,7 +147,7 @@
 
 /obj/item/ego_weapon/waging/Initialize()
 	RegisterSignal(src, COMSIG_PROJECTILE_ON_HIT, PROC_REF(projectile_hit))
-	..()
+	return ..()
 
 /obj/item/ego_weapon/waging/afterattack(atom/target, mob/living/user, proximity_flag, clickparams)
 	if(!CanUseEgo(user))


### PR DESCRIPTION

## About The Pull Request

- Fixes waging and steel noons not returning initialize hints

## Why It's Good For The Game

Because it makes quiet errors

## Changelog
:cl:
code: waging and steel noon now return init hints, this is of no significance whatsoever
/:cl:
