### PR TITLE
Endermage Rcorp Updates: Removal of Friendly Fire from Abnormalities [Done]

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/_abnormality.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_abnormality.dm
@@ -140,6 +140,12 @@
 	// rcorp stuff
 	var/rcorp_team
 
+/mob/living/simple_animal/hostile/abnormality/Login()
+	. = ..()
+	if(!. || !client)
+		return FALSE
+	manual_emote("awakens...")
+
 /mob/living/simple_animal/hostile/abnormality/Initialize(mapload)
 	SHOULD_CALL_PARENT(TRUE)
 	. = ..()

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/melting_love.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/melting_love.dm
@@ -128,6 +128,11 @@
 				L.apply_status_effect(STATUS_EFFECT_SLIMED)
 	return ..()
 
+/mob/living/simple_animal/hostile/abnormality/melting_love/bullet_act(obj/projectile/P)
+	if (P.damage_type == RED_DAMAGE && !ishuman(P.firer))
+		return BULLET_ACT_BLOCK
+	. = ..()
+
 /mob/living/simple_animal/hostile/abnormality/melting_love/Move()
 	. = ..()
 	var/turf/T = get_turf(src)

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -828,6 +828,14 @@
 	walk_to(src, target, minimum_distance, delay)
 
 /mob/living/simple_animal/hostile/proc/AttackingTarget(atom/attacked_target)
+	if(client)
+		if(target == src)
+			to_chat(src, span_warning("You almost attack yourself, but then decide against it."))
+			return
+		if(SSmaptype.maptype == "rcorp" && faction_check_mob(target, FALSE))
+			to_chat(src, span_warning("You almost attack your teammate, but then decide against it."))
+			return
+
 	if(!attacked_target)
 		attacked_target = target
 	if(old_rapid_melee != rapid_melee)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR does 2 very small things.
1. It makes it so abnormalities are unable to melee attack their allies in R-Corp.
2. Whenever you possess an abnormality, That abnormality will do an emote which signals that it's player-controlled.

## Why It's Good For The Game

This PR helps R-Corp by removing a bit of clunkiness from melee fighting as an abno. I don't think having to worry about hitting your allies or yourself is a good way of making playing as an abno more challenging.

Being able to see when your allies become player-controlled can be useful to summoners like ML or CENSORED

## Changelog
:cl:
tweak: hostile mobs will become unable to attack themselves/allies in R-Corp.
tweak: abnos emote when they get possessed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
