### PR TITLE
REDUCE LAG AND DESTROY AUTO PATROL CLEANBOTS [DONE]

### DIFF
--- a/code/__DEFINES/robots.dm
+++ b/code/__DEFINES/robots.dm
@@ -6,7 +6,7 @@
 #define BOT_STEP_DELAY 4 //Delay between movemements
 #define BOT_STEP_MAX_RETRIES 5 //Maximum times a bot will retry to step from its position
 
-#define DEFAULT_SCAN_RANGE		7	//default view range for finding targets.
+#define DEFAULT_SCAN_RANGE		5	//default view range for finding targets.
 
 //Mode defines. If you add a new one make sure you update mode_name in /mob/living/simple_animal/bot
 #define BOT_IDLE 			0	// idle

--- a/code/modules/mob/living/simple_animal/bot/cleanbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/cleanbot.dm
@@ -17,7 +17,7 @@
 	window_name = "Automatic Station Cleaner v1.4"
 	pass_flags = PASSMOB | PASSFLAPS
 	path_image_color = "#993299"
-	auto_patrol = TRUE // Let's get going, naturally!
+	auto_patrol = FALSE // Let's get going, naturally!
 	path_hud = null // No patrol visual. Literally all that was required.
 
 	var/blood = 1

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -38,7 +38,7 @@
 
 
 //These vars are related to how mobs locate and target
-	var/robust_searching = 0 //By default, mobs have a simple searching method, set this to 1 for the more scrutinous searching (stat_attack, stat_exclusive, etc), should be disabled on most mobs
+	var/robust_searching = FALSE //By default, mobs have a simple searching method, set this to 1 for the more scrutinous searching (stat_attack, stat_exclusive, etc), should be disabled on most mobs
 	var/vision_range = 9 //How big of an area to search for targets in, a vision of 9 attempts to find targets as soon as they walk into screen view
 	var/aggro_vision_range = 9 //If a mob is aggro, we search in this radius. Defaults to 9 to keep in line with original simple mob aggro radius
 	var/search_objects = 0 //If we want to consider objects when searching around, set this to 1. If you want to search for objects while also ignoring mobs until hurt, set it to 2. To completely ignore mobs, even when attacked, set it to 3
@@ -83,6 +83,9 @@
 		move_to_delay - 2 = speed. */
 	UpdateSpeed()
 	. = ..()
+	if(SSmaptype.maptype in SSmaptype.citymaps)
+		if(vision_range > 7)
+			vision_range = 8
 
 	if(!targets_from)
 		targets_from = src

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -84,8 +84,7 @@
 	UpdateSpeed()
 	. = ..()
 	if(SSmaptype.maptype in SSmaptype.citymaps)
-		if(vision_range > 7)
-			vision_range = 8
+		vision_range = min(vision_range, 8)
 
 	if(!targets_from)
 		targets_from = src

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -30,7 +30,7 @@
 	///Use this to temporarely stop random movement or to if you write special movement code for animals.
 	var/stop_automated_movement = 0
 	///Does the mob wander around when idle?
-	var/wander = 1
+	var/wander = FALSE
 	///When set to 1 this stops the animal from moving when someone is pulling it.
 	var/stop_automated_movement_when_pulled = 1
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Reduces lag by making mobs a bit more nearsighted on city maps by reducing their vision range to 7-10 and disabling wander for all creatures. I hate wander. Bot vision range was reduced from 7 to 5 and cleanbot patrol was turned off.

Quick testing showed no runtimes.

## Why It's Good For The Game
Doing this during the last city map seemed to improve preformance.

## Changelog
:cl:
tweak: _DEFINES\robots.dm DEFAULT_SCAN_RANGE
tweak: set cleanbot auto patrol to FALSE
tweak: auto set vision range to 8 on city maps if more than 7
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
