### PR TITLE
Makes the SSlobotomy and SSlobotomy_queue subsystems sleep on combat mode, reworks the automatic round-end notification for everyone dying and adds it to R-corp

### DIFF
--- a/ModularTegustation/tegu_items/wcorp/enemies.dm
+++ b/ModularTegustation/tegu_items/wcorp/enemies.dm
@@ -9,8 +9,8 @@ GLOBAL_VAR_INIT(wcorp_boss_spawn, FALSE)
 	var/spawntype
 
 /obj/effect/landmark/wavespawn/Initialize()
-	..()
 	addtimer(CALLBACK(src, PROC_REF(tryspawn)), 3 MINUTES, TIMER_STOPPABLE)
+	return ..()
 
 //Wave increases.
 /obj/effect/landmark/wavespawn/proc/tryspawn()
@@ -245,12 +245,3 @@ GLOBAL_VAR_INIT(wcorp_boss_spawn, FALSE)
 	var/mob/living/simple_animal/hostile/H = new spawntype(get_turf(src))
 	H.can_patrol = TRUE
 	H.patrol_cooldown_time = 10 SECONDS
-	//If no one is alive, End round
-	for(var/mob/living/carbon/human/L in GLOB.player_list)
-		if(L.z != z)
-			continue
-		if(L.stat != DEAD)
-			return
-	SSticker.force_ending = 1
-	to_chat(world, span_userdanger("All W-Corp staff is dead! Round automatically ending."))
-

--- a/code/controllers/subsystem/abnormality_queue.dm
+++ b/code/controllers/subsystem/abnormality_queue.dm
@@ -47,10 +47,14 @@ SUBSYSTEM_DEF(abnormality_queue)
 	var/current_milestone = 1
 
 /datum/controller/subsystem/abnormality_queue/Initialize(timeofday)
+	rooms_start = length(GLOB.abnormality_room_spawners)
+	if(!rooms_start)
+		flags |= SS_NO_FIRE
+		return ..() // Sleepy time
+
 	RegisterSignal(SSdcs, COMSIG_GLOB_ORDEAL_END, PROC_REF(OnOrdealEnd))
-	rooms_start = GLOB.abnormality_room_spawners.len
 	next_abno_spawn_time -= min(2, rooms_start * 0.05) MINUTES // 20 rooms will decrease wait time by 1 Minute
-	..()
+	return ..()
 
 /datum/controller/subsystem/abnormality_queue/fire()
 	if(world.time >= next_abno_spawn)
@@ -170,7 +174,7 @@ SUBSYSTEM_DEF(abnormality_queue)
 	return TRUE
 
 /datum/controller/subsystem/abnormality_queue/proc/HandleStartingAbnormalities()
-	var/player_count = GLOB.clients.len
+	var/player_count = length(GLOB.clients)
 	var/i
 	for(i=1 to round(clamp(player_count, 5, 30) / 5))
 		sleep(15 SECONDS) // Allows manager to select abnormalities if he is fast enough.

--- a/code/controllers/subsystem/lobotomy_corp.dm
+++ b/code/controllers/subsystem/lobotomy_corp.dm
@@ -101,7 +101,10 @@ SUBSYSTEM_DEF(lobotomy_corp)
 	var/auto_restart_in_progress = FALSE
 
 /datum/controller/subsystem/lobotomy_corp/Initialize(timeofday)
-	. = ..()
+	if(SSmaptype.maptype in SSmaptype.combatmaps) // sleep
+		flags |= SS_NO_FIRE
+		return ..()
+
 	RegisterSignal(SSdcs, COMSIG_GLOB_MOB_DEATH, PROC_REF(OnMobDeath))
 	addtimer(CALLBACK(src, PROC_REF(SetGoal)), 5 MINUTES)
 	addtimer(CALLBACK(src, PROC_REF(InitializeOrdeals)), 60 SECONDS)
@@ -109,8 +112,10 @@ SUBSYSTEM_DEF(lobotomy_corp)
 	for(var/F in subtypesof(/datum/facility_upgrade))
 		upgrades += new F
 
+	return ..()
+
 /datum/controller/subsystem/lobotomy_corp/proc/SetGoal()
-	var/player_mod = GLOB.player_list.len * 0.2
+	var/player_mod = length(GLOB.player_list) * 0.2
 	box_goal = clamp(round(7500 * player_mod), 3000, 36000)
 	return TRUE
 
@@ -256,7 +261,7 @@ SUBSYSTEM_DEF(lobotomy_corp)
 	if((TETH_LEVEL in qliphoth_meltdown_affected) && ROUNDTIME >= 60 MINUTES)
 		qliphoth_meltdown_affected -= TETH_LEVEL
 	qliphoth_meter = 0
-	var/abno_amount = all_abnormality_datums.len
+	var/abno_amount = length(all_abnormality_datums)
 	var/player_count = AvailableAgentCount()
 	var/total_count = AvailableAgentCount(suppressioncount = TRUE)
 	var/suppression_modifier = 1
@@ -316,10 +321,10 @@ SUBSYSTEM_DEF(lobotomy_corp)
 		meltdown_occured += computer
 	if(LAZYLEN(meltdown_occured))
 		var/text_info = ""
-		for(var/y = 1 to meltdown_occured.len)
+		for(var/y = 1 to length(meltdown_occured))
 			var/obj/machinery/computer/abnormality/computer = meltdown_occured[y]
 			text_info += computer.datum_reference.name
-			if(y != meltdown_occured.len)
+			if(y != length(meltdown_occured))
 				text_info += ", "
 		text_info += "."
 		// Announce next ordeal

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -116,7 +116,8 @@
 		addtimer(CALLBACK(src, PROC_REF(send_intercept), 0), rand(waittime_l, waittime_h))
 	generate_station_goals()
 
-	addtimer(CALLBACK(SSabnormality_queue, TYPE_PROC_REF(/datum/controller/subsystem/abnormality_queue, HandleStartingAbnormalities)), ABNORMALITY_DELAY)
+	if(name != "Combat Mode") // Is this a bit shitcodey? Yeah, it is.
+		addtimer(CALLBACK(SSabnormality_queue, TYPE_PROC_REF(/datum/controller/subsystem/abnormality_queue, HandleStartingAbnormalities)), ABNORMALITY_DELAY)
 
 	gamemode_ready = TRUE
 	return TRUE

--- a/code/game/gamemodes/management/event/combat.dm
+++ b/code/game/gamemodes/management/event/combat.dm
@@ -52,6 +52,7 @@ GLOBAL_VAR_INIT(wcorp_enemy_faction, "") //decides which faction WCorp will be u
 						addtimer(CALLBACK(src, PROC_REF(drawround)), 40 MINUTES)
 						to_chat(world, span_userdanger("Round will end in a draw after 40 minutes."))
 				addtimer(CALLBACK(src, PROC_REF(rcorp_announce)), 3 MINUTES)
+				RegisterSignal(SSdcs, COMSIG_GLOB_MOB_DEATH, PROC_REF(CheckLiving))
 
 			//Limbus Labs
 			if("limbus_labs")
@@ -82,25 +83,43 @@ GLOBAL_VAR_INIT(wcorp_enemy_faction, "") //decides which faction WCorp will be u
 					if(4)
 						GLOB.wcorp_enemy_faction = "shrimp"
 
+				RegisterSignal(SSdcs, COMSIG_GLOB_MOB_DEATH, PROC_REF(CheckLiving))
+
+/// Automatically ends the shift if no humanoid players are alive
+/datum/game_mode/combat/proc/CheckLiving()
+	for(var/mob/living/carbon/human/hooman in GLOB.human_list)
+		if(hooman.stat != DEAD && hooman.ckey)
+			return
+
+	if(SSticker.force_ending == TRUE) // they lost another way before we could do it, how rude.
+		message_admins("round already ended!")
+		return
+
+	SSticker.force_ending = TRUE
+	if(SSmaptype.maptype == "wcorp")
+		to_chat(world, span_userdanger("All W-Corp staff is dead! Round automatically ending."))
+	else
+		to_chat(world, span_userdanger("Every player has perished. Abnormalities have won."))
+
 //Win cons
 /datum/game_mode/combat/proc/loseround()
-	SSticker.force_ending = 1
+	SSticker.force_ending = TRUE
 	to_chat(world, span_userdanger("Players have taken too long! Round automatically ending."))
 
 /datum/game_mode/combat/proc/winround()
-	SSticker.force_ending = 1
+	SSticker.force_ending = TRUE
 	to_chat(world, span_userdanger("Players have survived! Round automatically ending."))
 
 /datum/game_mode/combat/proc/drawround()
-	SSticker.force_ending = 1
+	SSticker.force_ending = TRUE
 	to_chat(world, span_userdanger("Players have taken too long! Round ending in a Draw."))
 
 /datum/game_mode/combat/proc/endround()
-	SSticker.force_ending = 1
+	SSticker.force_ending = TRUE
 	to_chat(world, span_userdanger("Shift has ended."))
 
 /datum/game_mode/combat/proc/endroundRcorp(text)
-	SSticker.force_ending = 1
+	SSticker.force_ending = TRUE
 	to_chat(world, span_userdanger(text))
 
 /datum/game_mode/combat/proc/roundendwarning()

--- a/code/game/gamemodes/management/event/combat.dm
+++ b/code/game/gamemodes/management/event/combat.dm
@@ -92,7 +92,6 @@ GLOBAL_VAR_INIT(wcorp_enemy_faction, "") //decides which faction WCorp will be u
 			return
 
 	if(SSticker.force_ending == TRUE) // they lost another way before we could do it, how rude.
-		message_admins("round already ended!")
 		return
 
 	SSticker.force_ending = TRUE


### PR DESCRIPTION

## About The Pull Request

- Replaces .len things with length() in our subsystems
- Makes the SSlobotomy and SSlobotomy_queue subsystems sleep on combat mode
- Makes our subsystems properly return the initialize thingy instead of doing `..()` and leaving it at dat
- The abnormality queue is no longer asked to spawn abnormalities whilst there's combat mode on
- Reworks the W-corp's round-ending landmark thingy to a gamemode thingy, whilst de-shittifying it and adding it to R-corp

## Why It's Good For The Game

> Replaces .len things with length() in our subsystems
- its better
> Makes the SSlobotomy and SSlobotomy_queue subsystems sleep on combat mode
- We dont really need them, not to my knowledge anyway. And thats some processing saved.
> Makes our subsystems properly return the initialize thingy instead of doing `..()` and leaving it at dat
- Most other subsystems do it, so lets fall into the line
> The abnormality queue is no longer asked to spawn abnormalities whilst there's combat mode on
- It gives an annoying message and an un-needed call, lets not.
> Reworks the W-corp's round-ending landmark thingy to a gamemode thingy, whilst de-shittifying it and adding it to R-corp
- no more "you have lost x24", now only a single message remains. And this also adds support for any future gamemodes that want it (cough cough, Railroad)
- Also added it to R-corp since yeah, if every person is dead lets not keep them fighting

## Changelog
:cl:
tweak: R-corp now auto-loses if all R-corp members are dead
fix: fixed the game screaming 24 times at you if everyone dies in W-corp
code: LC subsystems now sleep whilst on combat mode, making the game probably run a bit better
/:cl:
