### PR TITLE
Fixes some init hints and amber bugs hard deleting themselfes saving a LOT of hard-delete time

### DIFF
--- a/ModularTegustation/tegu_items/gadgets/unpowered.dm
+++ b/ModularTegustation/tegu_items/gadgets/unpowered.dm
@@ -598,11 +598,11 @@
 	if(!istype(user) || !(user?.mind?.assigned_role in GLOB.service_positions))
 		to_chat(user, span_notice("The Gadget's light flashes red. You aren't a clerk. Check the label before use."))
 		return
-	new /mob/living/simple_animal/hostile/clerkbot(get_turf(user))
+	var/mob/living/simple_animal/hostile/clerkbot/bot = new(get_turf(user))
+	forceMove(bot)
 	to_chat(user, span_nicegreen("The Gadget turns warm and sparks."))
-	qdel(src)
 
-	//Clerkbot spawned by the Clerkbot Spawner
+/// Clerkbot spawned by the Clerkbot Spawner
 /mob/living/simple_animal/hostile/clerkbot
 	name = "A Well Rounded Clerkbot"
 	desc = "Trusted and loyal best friend."
@@ -633,11 +633,12 @@
 	speech_span = SPAN_ROBOT
 
 /mob/living/simple_animal/hostile/clerkbot/Initialize()
-	..()
-	QDEL_IN(src, (120 SECONDS))
 	if(prob(50))
 		icon_state = "clerkbot1"
 		icon_living = "clerkbot1"
+
+	QDEL_IN(src, (120 SECONDS))
+	return ..()
 
 /mob/living/simple_animal/hostile/clerkbot/Login()
 	. = ..()
@@ -646,12 +647,12 @@
 	to_chat(src, "<b>WARNING:THIS CREATURE IS TEMPORARY AND WILL DELETE ITSELF AFTER A GIVEN TIME!</b>")
 
 /mob/living/simple_animal/hostile/clerkbot/Destroy()
-	new /obj/item/clerkbot_gadget(get_turf(src))
+	for(var/obj/item as anything in contents)
+		item.forceMove(get_turf(src))
 	return ..()
 
 /mob/living/simple_animal/hostile/clerkbot/spawn_gibs()
 	new /obj/effect/gibspawner/robot(drop_location(), src)
-
 
 /// Info Page Printer (Does not print info sheets)
 

--- a/code/controllers/subsystem/fishing.dm
+++ b/code/controllers/subsystem/fishing.dm
@@ -23,7 +23,6 @@ SUBSYSTEM_DEF(fishing)
 	for(var/datum/planet/big_rock as anything in planet_datums) //then set planets and random alignments
 		big_rock = new big_rock()
 		big_rock.phase = rand(1, big_rock.orbit_time)
-		big_rock.linked_subsystem = src
 		planets += big_rock
 
 	addtimer(CALLBACK(src, PROC_REF(Moveplanets)), 7 MINUTES)
@@ -83,15 +82,11 @@ SUBSYSTEM_DEF(fishing)
 	var/god = FISHGOD_NONE
 	/// A general description of what the god's buffs are, showed in the altar
 	var/god_desc = "oh my god!"
-	/// The subsystem we are linked to, for cleanup purposes
-	var/datum/controller/subsystem/fishing/linked_subsystem = null
 
 /datum/planet/Destroy(force, ...)
 	if(god != FISHGOD_NONE)
-		linked_subsystem.sleeping_gods[god] = god_desc
-	if(linked_subsystem)
-		linked_subsystem.planets -= src
-		linked_subsystem = null
+		SSfishing.sleeping_gods[god] = god_desc
+	SSfishing.planets -= src
 	return ..()
 
 /// God is Lir. Buffs the minimum and maximum size of fish.

--- a/code/modules/mob/living/simple_animal/hostile/ordeal/amber.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/amber.dm
@@ -45,7 +45,7 @@
 
 /mob/living/simple_animal/hostile/ordeal/amber_bug/death(gibbed)
 	alpha = 255
-	..()
+	return ..()
 
 /mob/living/simple_animal/hostile/ordeal/amber_bug/Life()
 	. = ..()
@@ -103,7 +103,7 @@
 
 /mob/living/simple_animal/hostile/ordeal/amber_bug/proc/BurrowIn(turf/T)
 	if(!T)
-		if(GLOB.xeno_spawn.len)
+		if(length(GLOB.xeno_spawn))
 			T = pick(GLOB.xeno_spawn)
 		else
 			can_burrow_solo = FALSE
@@ -139,8 +139,10 @@
 
 //Amber dawn spawned from dusk
 /mob/living/simple_animal/hostile/ordeal/amber_bug/spawned
+	can_burrow_solo = FALSE
 	butcher_results = list()
 	guaranteed_butcher_results = list()
+	var/mob/living/simple_animal/hostile/ordeal/amber_dusk/bug_mommy
 
 /mob/living/simple_animal/hostile/ordeal/amber_bug/spawned/Initialize()
 	. = ..()
@@ -150,7 +152,12 @@
 	density = FALSE
 	animate(src, alpha = 0, time = 5 SECONDS)
 	QDEL_IN(src, 5 SECONDS)
-	..()
+	return ..()
+
+/mob/living/simple_animal/hostile/ordeal/amber_bug/spawned/Destroy()
+	if(bug_mommy)
+		bug_mommy.spawned_mobs -= src
+	return ..()
 
 // Amber dusk
 /mob/living/simple_animal/hostile/ordeal/amber_dusk
@@ -222,6 +229,9 @@
 
 /mob/living/simple_animal/hostile/ordeal/amber_dusk/Destroy()
 	QDEL_NULL(soundloop)
+	for(var/mob/living/simple_animal/hostile/ordeal/amber_bug/spawned/bug as anything in spawned_mobs)
+		bug.bug_mommy = null
+	spawned_mobs = null
 	return ..()
 
 /mob/living/simple_animal/hostile/ordeal/amber_dusk/Life()
@@ -237,41 +247,38 @@
 		alpha = 255
 	offsets_pixel_x = list("south" = -16, "north" = -16, "west" = -16, "east" = -16)
 	soundloop.stop()
-	listclearnulls(spawned_mobs)
-	for(var/mob/living/simple_animal/hostile/ordeal/amber_bug/AB in spawned_mobs)
-		AB.can_burrow_solo = TRUE
-	..()
+	for(var/mob/living/simple_animal/hostile/ordeal/amber_bug/bug in spawned_mobs)
+		bug.can_burrow_solo = TRUE
+	return ..()
 
 /mob/living/simple_animal/hostile/ordeal/amber_dusk/revive(full_heal, admin_revive)
 	. = ..()
 	offsets_pixel_x = list("south" = -16, "north" = -16, "west" = 0, "east" = -32)
 
 /mob/living/simple_animal/hostile/ordeal/amber_dusk/proc/AttemptBirth()
-	listclearnulls(spawned_mobs)
-	for(var/mob/living/L in spawned_mobs)
-		if(L.stat == DEAD)
-			spawned_mobs -= L
-	var/max_spawn = clamp(GLOB.clients.len * 2, 4, 8)
+	var/max_spawn = clamp(length(GLOB.clients) * 2, 4, 8)
 	if(length(spawned_mobs) >= max_spawn)
 		return FALSE
+
 	burrowing = TRUE
 	playsound(get_turf(src), 'sound/effects/ordeals/amber/dusk_create.ogg', 50, FALSE)
 	SLEEP_CHECK_DEATH(5)
 	visible_message(span_danger("Four smaller bugs emerge from [src]!"))
 	for(var/i = 1 to 4)
-		var/turf/T = get_step(get_turf(src), pick(0, NORTH, SOUTH, EAST, WEST, NORTHEAST, NORTHWEST, SOUTHEAST, SOUTHWEST))
-		if(T.density) // Retry
+		var/turf/Turf = get_step(get_turf(src), pick(0, NORTH, SOUTH, EAST, WEST, NORTHEAST, NORTHWEST, SOUTHEAST, SOUTHWEST))
+		if(Turf.density) // Retry
 			i -= 1
 			continue
-		var/mob/living/simple_animal/hostile/ordeal/amber_bug/spawned/nb = new(T)
-		nb.can_burrow_solo = FALSE
-		spawned_mobs += nb
+
+		var/mob/living/simple_animal/hostile/ordeal/amber_bug/spawned/bug = new(Turf)
+		spawned_mobs += bug
+		bug.bug_mommy = src
 		if(ordeal_reference)
-			nb.ordeal_reference = ordeal_reference
-			ordeal_reference.ordeal_mobs += nb
+			bug.ordeal_reference = ordeal_reference
+			ordeal_reference.ordeal_mobs += bug
+
 	SLEEP_CHECK_DEATH(5)
 	burrowing = FALSE
-	return TRUE
 
 /mob/living/simple_animal/hostile/ordeal/amber_dusk/proc/BurrowIn()
 	burrowing = TRUE
@@ -282,8 +289,8 @@
 	playsound(get_turf(src), 'sound/effects/ordeals/amber/dusk_dig_in.ogg', 50, 1)
 	animate(src, alpha = 0, time = 10)
 	SLEEP_CHECK_DEATH(5)
-	for(var/mob/living/simple_animal/hostile/ordeal/amber_bug/AB in spawned_mobs)
-		addtimer(CALLBACK(AB, PROC_REF(BurrowIn), T))
+	for(var/mob/living/simple_animal/hostile/ordeal/amber_bug/bug as anything in spawned_mobs)
+		addtimer(CALLBACK(bug, PROC_REF(BurrowIn), T))
 	SLEEP_CHECK_DEATH(5)
 	density = FALSE
 	forceMove(T)
@@ -295,6 +302,7 @@
 	density = FALSE
 	for(var/turf/open/OT in range(1, T))
 		new /obj/effect/temp_visual/small_smoke/halfsecond(OT)
+
 	animate(src, alpha = 255, time = 5)
 	playsound(get_turf(src), 'sound/effects/ordeals/amber/dusk_dig_out.ogg', 50, 1)
 	visible_message(span_bolddanger("[src] burrows out from the ground!"))
@@ -305,21 +313,28 @@
 	for(var/mob/living/L in view(1, src))
 		if(!faction_check_mob(L))
 			L.apply_damage(75, RED_DAMAGE, null, L.run_armor_check(null, RED_DAMAGE))
+
 	burrow_cooldown = world.time + burrow_cooldown_time
 	burrowing = FALSE
 
 /mob/living/simple_animal/hostile/ordeal/amber_dusk/spawned
 	butcher_results = list()
 	guaranteed_butcher_results = list()
+	var/mob/living/simple_animal/hostile/ordeal/amber_midnight/bug_daddy
 
 /mob/living/simple_animal/hostile/ordeal/amber_dusk/spawned/Initialize()
-	. = ..()
 	burrow_cooldown = world.time + burrow_cooldown_time
+	return ..()
+
+/mob/living/simple_animal/hostile/ordeal/amber_dusk/spawned/Destroy()
+	if(bug_daddy)
+		bug_daddy.spawned_mobs -= src
+	return ..()
 
 /mob/living/simple_animal/hostile/ordeal/amber_dusk/spawned/death(gibbed)
 	animate(src, alpha = 0, time = 5 SECONDS)
 	QDEL_IN(src, 5 SECONDS)
-	..()
+	return ..()
 
 // Amber midnight
 /mob/living/simple_animal/hostile/ordeal/amber_midnight
@@ -368,12 +383,15 @@
 
 /mob/living/simple_animal/hostile/ordeal/amber_midnight/Destroy()
 	QDEL_NULL(soundloop)
+	for(var/mob/living/simple_animal/hostile/ordeal/amber_dusk/spawned/bug as anything in spawned_mobs)
+		bug.bug_daddy = null
+	spawned_mobs = null
 	return ..()
 
 /mob/living/simple_animal/hostile/ordeal/amber_midnight/death(gibbed)
 	alpha = 255
 	soundloop.stop()
-	..()
+	return ..()
 
 /mob/living/simple_animal/hostile/ordeal/amber_midnight/CanAttack(atom/the_target)
 	return FALSE
@@ -388,30 +406,27 @@
 	if(!burrowing && world.time > burrow_cooldown)
 		AttemptBirth()
 		BurrowIn()
-		return
 
 /mob/living/simple_animal/hostile/ordeal/amber_midnight/proc/AttemptBirth()
-	listclearnulls(spawned_mobs)
-	for(var/mob/living/L in spawned_mobs)
-		if(L.stat == DEAD)
-			spawned_mobs -= L
-	var/max_spawn = clamp(GLOB.clients.len * 0.6, 2, 8)
+	var/max_spawn = clamp(length(GLOB.clients) * 0.6, 2, 8)
 	if(length(spawned_mobs) >= max_spawn)
 		return FALSE
+
 	burrowing = TRUE
 	playsound(get_turf(src), 'sound/effects/ordeals/amber/midnight_create.ogg', 50, FALSE)
 	SLEEP_CHECK_DEATH(2 SECONDS)
 	visible_message(span_danger("Two large bugs emerge from [src]!"))
 	for(var/i = 1 to 2)
 		var/turf/T = get_step(get_turf(src), pick(GLOB.alldirs))
-		var/mob/living/simple_animal/hostile/ordeal/amber_dusk/spawned/nb = new(T)
-		spawned_mobs += nb
+		var/mob/living/simple_animal/hostile/ordeal/amber_dusk/spawned/bug = new(T)
+		spawned_mobs += bug
+		bug.bug_daddy = src
 		if(ordeal_reference)
-			nb.ordeal_reference = ordeal_reference
-			ordeal_reference.ordeal_mobs += nb
+			bug.ordeal_reference = ordeal_reference
+			ordeal_reference.ordeal_mobs += bug
+
 	SLEEP_CHECK_DEATH(2 SECONDS)
 	burrowing = FALSE
-	return TRUE
 
 /mob/living/simple_animal/hostile/ordeal/amber_midnight/proc/BurrowIn()
 	burrowing = TRUE

--- a/code/modules/mob/living/simple_animal/hostile/ordeal/amber.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/amber.dm
@@ -157,6 +157,7 @@
 /mob/living/simple_animal/hostile/ordeal/amber_bug/spawned/Destroy()
 	if(bug_mommy)
 		bug_mommy.spawned_mobs -= src
+	bug_mommy = null
 	return ..()
 
 // Amber dusk
@@ -329,6 +330,7 @@
 /mob/living/simple_animal/hostile/ordeal/amber_dusk/spawned/Destroy()
 	if(bug_daddy)
 		bug_daddy.spawned_mobs -= src
+	bug_daddy = null
 	return ..()
 
 /mob/living/simple_animal/hostile/ordeal/amber_dusk/spawned/death(gibbed)

--- a/code/modules/mob/living/simple_animal/hostile/ordeal/brown/dawn.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/brown/dawn.dm
@@ -211,7 +211,7 @@
 			part.dismember()
 			QDEL_NULL(part)
 			new /obj/effect/gibspawner/generic/silent(get_turf(C))
-		if(C.bodyparts.len <= 1)
+		if(length(C.bodyparts) <= 1)
 			C.gib()
 			return
 	return

--- a/code/modules/mob/living/simple_animal/hostile/ordeal/gold/dusk.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/gold/dusk.dm
@@ -271,22 +271,22 @@
 	)
 
 /mob/living/simple_animal/hostile/ordeal/KHz_corrosion/Initialize()
-	..()
 	var/list/old_speaklist = speak.Copy()
 	speak = list()
-	for(var/i in old_speaklist)
-		for(var/ii in list("A","E","I","O","U","R","S","T"))//All vowels, and the 3 most common consonants
-			i = replacetextEx(i,ii,pick("@","!","$","%","#"))
-		speak.Add(i)
+	for(var/phrase as anything in old_speaklist)
+		for(var/vowel in list("A","E","I","O","U","R","S","T"))//All vowels, and the 3 most common consonants
+			phrase = replacetextEx(phrase, vowel, pick("@","!","$","%","#"))
+		speak.Add(phrase)
+
+	return ..()
 
 /mob/living/simple_animal/hostile/ordeal/KHz_corrosion/Life()
 	. = ..()
-	if(health <= 0)
+	if(!.) // we're dead, lets not speak
 		return
 	if(effect_cooldown <= world.time)
 		whisper("[pick(speak)]")
 		playsound(get_turf(src), "[pick(damage_sounds)]", 25, FALSE)
-		return
 
 /mob/living/simple_animal/hostile/ordeal/KHz_corrosion/say(message, bubble_type, list/spans = list(), sanitize = TRUE, datum/language/language = null, ignore_spam = FALSE, forced = null)
 	..()

--- a/code/modules/mob/living/simple_animal/hostile/ordeal/violet.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/violet.dm
@@ -36,7 +36,7 @@
 			return A
 
 /mob/living/simple_animal/hostile/ordeal/violet_fruit/ListTargets()
-	if(!enemies.len)
+	if(!length(enemies))
 		return list()
 	var/list/see = ..()
 	see &= enemies // Remove all entries that aren't in enemies

--- a/code/modules/ordeals/_ordeal.dm
+++ b/code/modules/ordeals/_ordeal.dm
@@ -95,7 +95,7 @@
 /datum/ordeal/proc/OnMobDeath(mob/living/deadMob)
 	ordeal_mobs.Remove(deadMob)
 	ordeal_mobs = removeNullsFromList(ordeal_mobs)
-	if(!ordeal_mobs.len)
+	if(!length(ordeal_mobs))
 		End()
 	return
 


### PR DESCRIPTION
## About The Pull Request

- Makes clerkbot constructors go inside the clerkbot and pop out when the clerkbot is killed instead of constantly being destroyed/spawned
- Fixes clerkbot initialize hint
- Fixes KHz corrosion initialize hint
- Makes amber bugs hold a reference to their spawning mob, if one exists. And delete themselfes from the spawned_mobs list.
- Fixes some instances of using `.len` instead of `length()`
- Makes single-letter vars in KHz's corrosion into actual var names
- Deletes the linked_subsystem var from fish planets and makes them call SSfishing instead

## Why It's Good For The Game

> Makes clerkbot constructors go inside the clerkbot and pop out when the clerkbot is killed instead of constantly being destroyed/spawned
- Its most likelly cheaper this way, and a bit more how you'd expect it to work in-code
> Fixes clerkbot initialize hint
- guh
> Fixes KHz corrosion initialize hint
- bah
> Makes amber bugs hold a reference to their spawning mob, if one exists. And delete themselfes from the spawned_mobs list.
- Cheaper, they constantly hard-deleted themselfes because the spawning mobs hold a reference to them. Let them rest and save us the like 4-5 times the time they should take to delete.
> Fixes some instances of using `.len` instead of `length()`
> Makes single-letter vars in KHz's corrosion into actual var names
- Shitcode my beloved
> Deletes the linked_subsystem var from fish planets and makes them call SSfishing instead
- If an admin creates a planet, the linked_subsystem is probably never getting set so this is a good chunk safer

## Changelog
:cl:
code: amber bugs now hold a reference to their creating parent, and delete themselfes from the list instead of clearing nulls.
/:cl:
