### PR TITLE
Changes the Manager Bullet Suicide so you can Execution Bullet Yourself

### DIFF
--- a/ModularTegustation/tegu_items/gadgets/manager_bullets.dm
+++ b/ModularTegustation/tegu_items/gadgets/manager_bullets.dm
@@ -32,8 +32,15 @@
 
 /obj/item/managerbullet/suicide_act(mob/living/carbon/user)
 	. = ..()
-	user.visible_message(span_suicide("[user] holds the bullet in front of them, with the desire to shield themselves from oxygen! It looks like [user.p_theyre()] trying to commit suicide!"))
-	return OXYLOSS
+	user.visible_message(span_suicide("[user] holds the bullet in front of them, and sets the bullet's setting to 'Execute'! It looks like [user.p_theyre()] trying to commit suicide!"))
+	if(ishuman(user))
+		var/mob/living/carbon/human/H = user
+		H.unequip_everything()
+		H.Stun(10)
+	playsound(get_turf(user), 'ModularTegustation/Tegusounds/weapons/guns/manager_bullet_fire.ogg', 10, 0, 3)
+	new /obj/effect/temp_visual/execute_bullet(get_turf(user))
+	QDEL_IN(user, 1)
+	return MANUAL_SUICIDE
 
 
 /datum/status_effect/interventionshield


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
What the title says
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It is a funnier suicide than what was there before
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: tweaked manager bullet suicide
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
