### PR TITLE
Fix Janky Bugs from putting ego armors on other people

### DIFF
--- a/code/modules/clothing/suits/ego_gear/_ego_gear.dm
+++ b/code/modules/clothing/suits/ego_gear/_ego_gear.dm
@@ -36,7 +36,7 @@
 	if(slot_flags & slot) // Equipped to right slot, not just in hands
 		if(!CanUseEgo(H))
 			return FALSE
-		if(equip_slowdown > 0)
+		if(equip_slowdown > 0 && (M == equipper || !equipper))
 			if(!do_after(H, equip_slowdown, target = H))
 				return FALSE
 	return ..()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1024,7 +1024,12 @@
 		to_chat(src, "<span class='notice'>You try to put [what] on [who]...</span>")
 		who.log_message("[key_name(who)] is having [what] put on them by [key_name(src)]", LOG_ATTACK, color="red")
 		log_message("[key_name(who)] is having [what] put on them by [key_name(src)]", LOG_ATTACK, color="red", log_globally=FALSE)
-		if(do_mob(src, who, what.equip_delay_other))
+
+		var/equip_delay = what.equip_delay_other
+		if(istype(what,/obj/item/clothing/suit/armor/ego_gear))
+			var/obj/item/clothing/suit/armor/ego_gear/EGO = what
+			equip_delay = max(EGO.equip_delay_other, EGO.equip_slowdown) //Preventing 0 delay on some ego suits
+		if(do_mob(src, who, equip_delay))
 			if(what && Adjacent(who) && what.mob_can_equip(who, src, final_where, TRUE, TRUE))
 				if(temporarilyRemoveItemFromInventory(what))
 					if(where_list)


### PR DESCRIPTION
## About The Pull Request

Because of how equipping stuff is coded, the progress bar is done 3 fucking times when putting ego armor on other people
This also somehow fixed the inability to put armor on corpses/crit people (idk how that happened)
The changes in living.dm is mostly future proofing somewhat

## Why It's Good For The Game

I CAN FINALLY PUT ARMOR BACK ON CORPSES IN COL/CF

## Changelog
:cl:
balance: makes putting ego armor on others to use the ego delay instead
fix: fixed the triple progress bar shenanigans from putting armor on others
/:cl: