### PR TITLE
Imperfect Morsel Tweaks

### DIFF
--- a/ModularTegustation/tegu_mobs/lc13_outskirtdwellers.dm
+++ b/ModularTegustation/tegu_mobs/lc13_outskirtdwellers.dm
@@ -21,21 +21,19 @@
 	response_disarm_simple = "gently push aside"
 	verb_ask = "chitters"
 	mob_biotypes = MOB_ORGANIC|MOB_BEAST
-	stop_automated_movement_when_pulled = 1
+	stop_automated_movement_when_pulled = TRUE
 	environment_smash = FALSE
 	density = FALSE
 	maxHealth = 120
 	health = 120
 	speed = 2
-	melee_damage_lower = 0
-	melee_damage_upper = 2
+	melee_damage_lower = 1
+	melee_damage_upper = 3
 	turns_per_move = 2
 	butcher_difficulty = 2
 	buffed = 0
 	death_message = "pops."
-	density = TRUE
-	search_objects = 1
-	tame_chance = 5
+	search_objects = TRUE
 	attack_verb_continuous = "bites"
 	attack_verb_simple = "bite"
 	attack_sound = 'sound/weapons/bite.ogg'
@@ -45,8 +43,7 @@
 	butcher_results = list(/obj/item/food/meat/slab/worm = 1)
 	guaranteed_butcher_results = list(/obj/item/food/meat/slab/worm = 1)
 	silk_results = list(/obj/item/stack/sheet/silk/amber_simple = 1)
-	wanted_objects = list(/obj/effect/decal/cleanable/blood/gibs/, /obj/item/organ, /obj/item/bodypart/head, /obj/item/bodypart/r_arm, /obj/item/bodypart/l_arm, /obj/item/bodypart/l_leg, /obj/item/bodypart/r_leg)
-	food_type = list(/obj/item/organ, /obj/item/bodypart/head, /obj/item/bodypart/r_arm, /obj/item/bodypart/l_arm, /obj/item/bodypart/l_leg, /obj/item/bodypart/r_leg)
+	food_type = list(/obj/effect/decal/cleanable/blood/gibs/, /obj/item/organ, /obj/item/bodypart/head, /obj/item/bodypart/r_arm, /obj/item/bodypart/l_arm, /obj/item/bodypart/l_leg, /obj/item/bodypart/r_leg)
 	var/current_size = RESIZE_DEFAULT_SIZE
 
 /mob/living/simple_animal/hostile/morsel/examine(mob/user)
@@ -57,7 +54,7 @@
 
 /mob/living/simple_animal/hostile/morsel/AttackingTarget()
 	retreat_distance = 0
-	if(is_type_in_typecache(target,wanted_objects)) //we eats
+	if(is_type_in_typecache(target,food_type)) //we eats
 		qdel(target)
 		buffed = (buffed + 1)
 		if(buffed >= 10)
@@ -83,6 +80,12 @@
 	..()
 	if(!target)
 		retreat_distance = 0
+
+//This is so morsel doesnt run to food while your trying to evacuate them.
+/mob/living/simple_animal/hostile/morsel/FindTarget()
+	if(pulledby)
+		return
+	return ..()
 
 /mob/living/simple_animal/hostile/morsel/AttackingTarget()
 	. = ..()
@@ -117,10 +120,16 @@
 	visible_message(span_notice("[src] bites [O] and grinds it into a digestable paste."))
 	playsound(get_turf(user), 'sound/items/eatfood.ogg', 10, 3, 3)
 	buffed = (buffed + 1)
-	adjustBruteLoss(-5)
+	adjustBruteLoss(-15)
 	if(buffed >= 10)
 		PustuleChurn()
 	qdel(O)
+
+/mob/living/simple_animal/hostile/morsel/CanAttack(atom/the_target)
+	if(isobj(the_target))
+		if(is_type_in_typecache(the_target, food_type))
+			return TRUE
+	return ..()
 
 /mob/living/simple_animal/hostile/morsel/proc/PustuleChurn()
 	var/newsize = current_size


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Tweaks ordeal pets based on some observed scenarios.

Scenario 1: A clerk was trying to get a Imperfect Morsel to the elevator but it kept wiggling out of their hands to go after gibs. Even though Morsel is a worm i felt some sympathy for their plight and now made morsel more grabbable, (They will not move to get food when being dragged).

Imperfect Morsel now only checks their foodtype for targets. 
## Why It's Good For The Game
Makes imperfect morsel better, STRONGER,

## Changelog
:cl:
tweak: imperfect morsel
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
