### PR TITLE
Fixes Two Friendly Shrimps having the same code path

### DIFF
--- a/ModularTegustation/ego_weapons/ranged/zayin.dm
+++ b/ModularTegustation/ego_weapons/ranged/zayin.dm
@@ -101,12 +101,12 @@
 	if(istype(S))
 		var/shrimpcount
 		while(shrimpcount < 2)
-			new /mob/living/simple_animal/hostile/shrimp/friendly(get_turf(user))
+			new /mob/living/simple_animal/hostile/shrimp/grieving(get_turf(user))
 			shrimpcount += 1
 	user.playsound_local(get_turf(user), 'sound/abnormalities/wellcheers/shrimptaps.ogg', 50, 0)
 
 //friendly spawned shrimp
-/mob/living/simple_animal/hostile/shrimp/friendly
+/mob/living/simple_animal/hostile/shrimp/grieving
 	name = "wellcheers obituary serviceman"
 	desc = "A shrimp that appears to be grieving. A moment of silence, please."
 	icon_state = "wellcheers_funeral"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The Soda Zayin Fish are renamed in code to make it so the realization spawns it's special shrimps.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bug fixes
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixed Wellcheers not getting buff shrimp
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
