### PR TITLE
Fixes Will You Play's Last Worker check

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/he/will_you_play.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/will_you_play.dm
@@ -37,7 +37,6 @@
 		say("You again? Fine. We'll play again.")
 	else
 		say("I'll go fer scissors. How 'bout you?")
-	last_worked = user
 	return TRUE
 
 
@@ -126,3 +125,4 @@
 				user.adjust_attribute_level(A, 1)
 			continue
 		user.adjust_attribute_level(A, statgain)
+	last_worked = user


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes Will You Play's last worker check occur after the work instead of upon starting
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It interferes with WYP's bonus from winning.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixed WYP last player check
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
