### PR TITLE
Wcorp Shieldweapons now block all damage types.

### DIFF
--- a/ModularTegustation/ego_weapons/melee/non_abnormality/wcorp.dm
+++ b/ModularTegustation/ego_weapons/melee/non_abnormality/wcorp.dm
@@ -211,6 +211,7 @@
 
 /datum/status_effect/interventionshield/wcorp
 	statuseffectvisual = icon('ModularTegustation/Teguicons/tegu_effects.dmi', "pale_shield")
+	respectivedamage = list(RED_DAMAGE, WHITE_DAMAGE, BLACK_DAMAGE, PALE_DAMAGE)
 
 /obj/item/ego_weapon/city/wcorp/shield
 	name = "w-corp type-C shieldblade"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
W-Corp Shield weapons now block all damagetypes.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Technically a bugfix. This is a holdover from when all the Wcorp enemies did red damage.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Wcorp Shieldweapons now block all damage types.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
