### PR TITLE
Fixes the runtime of civilians spawning with a tier 0 skill book + optimizations and cleanup

### DIFF
--- a/code/game/objects/items/fixerskills/fishing/_fishing.dm
+++ b/code/game/objects/items/fixerskills/fishing/_fishing.dm
@@ -1,19 +1,20 @@
 /datum/action/cooldown/fishing
-	icon_icon = 'icons/hud/screen_fishing.dmi'
-	button_icon_state = "sacredword"
 	name = "Sacred Word"
-	cooldown_time = 300
+	button_icon_state = "sacredword"
+	icon_icon = 'icons/hud/screen_fishing.dmi'
+	cooldown_time = 30 SECONDS
 	var/devotion_cost = 0
 
 /datum/action/cooldown/fishing/Trigger()
-	if(!..())
+	. = ..()
+	if(!.)
 		return FALSE
 
 	var/mob/living/carbon/human/H = owner
 	var/required_devotion = devotion_cost
 
 	if(H.god_aligned == FISHGOD_SATURN)
-		required_devotion -= 1	//Get one less cost on these spells
+		required_devotion--	//Get one less cost on these spells
 
 	if(H.devotion < required_devotion)
 		to_chat(H, span_warning("You do not have enough devotion for this spell!"))

--- a/code/game/objects/items/fixerskills/fishing/level1/arcane.dm
+++ b/code/game/objects/items/fixerskills/fishing/level1/arcane.dm
@@ -1,15 +1,15 @@
 //Scry
 /obj/item/book/granter/action/skill/scry
-	granted_action = /datum/action/cooldown/fishing/scry
-	actionname = "Scry"
 	name = "Level 1 Skill: Scry"
+	actionname = "Scry"
+	granted_action = /datum/action/cooldown/fishing/scry
 	level = 1
 	custom_premium_price = 600
 
 /datum/action/cooldown/fishing/scry
-	button_icon_state = "scry"
 	name = "Scry"
-	cooldown_time = 300
+	button_icon_state = "scry"
+	cooldown_time = 30 SECONDS
 	devotion_cost = 1
 
 /datum/action/cooldown/fishing/scry/FishEffect(mob/living/user)
@@ -24,97 +24,59 @@
 		if(4)
 			to_chat(user, span_notice("The moon is Full."))
 
-	if(CheckPlanetAligned(FISHGOD_MERCURY))
-		to_chat(user, span_notice("Mercury is in alignment with earth."))
-	if(CheckPlanetAligned(FISHGOD_VENUS))
-		to_chat(user, span_notice("Venus is in alignment with earth."))
-	if(CheckPlanetAligned(FISHGOD_MARS))
-		to_chat(user, span_notice("Mars is in alignment with earth."))
-	if(CheckPlanetAligned(FISHGOD_JUPITER))
-		to_chat(user, span_notice("Jupiter is in alignment with earth."))
-	if(CheckPlanetAligned(FISHGOD_SATURN))
-		to_chat(user, span_notice("Saturn is in alignment with earth."))
-	if(CheckPlanetAligned(FISHGOD_URANUS))
-		to_chat(user, span_notice("Uranus is in alignment with earth."))
-	if(CheckPlanetAligned(FISHGOD_NEPTUNE))
-		to_chat(user, span_notice("Neptune is in alignment with earth."))
-
-
+	for(var/datum/planet/planet as anything in SSfishing.planets)
+		if(planet.phase == 1)
+			to_chat(user, span_notice("[planet.name] is in alignment with earth."))
 
 //Sacred Word
 /obj/item/book/granter/action/skill/sacredword
-	granted_action = /datum/action/cooldown/fishing/sacredword
-	actionname = "Sacred Word"
 	name = "Level 1 Skill: Sacred Word"
+	actionname = "Sacred Word"
+	granted_action = /datum/action/cooldown/fishing/sacredword
 	level = 1
 	custom_premium_price = 600
 
 /datum/action/cooldown/fishing/sacredword
-	button_icon_state = "sacredword"
 	name = "Sacred Word"
-	cooldown_time = 6000
+	button_icon_state = "sacredword"
+	cooldown_time = 10 MINUTES
 	devotion_cost = 0
 
 /datum/action/cooldown/fishing/sacredword/FishEffect(mob/living/user)
-	switch(user.god_aligned)
-		if(FISHGOD_MERCURY)
-			if(CheckPlanetAligned(FISHGOD_MERCURY))
-				user.devotion+=4
-				to_chat(user, span_notice("Lir hears your words."))
+	for(var/datum/planet/planet as anything in SSfishing.planets)
+		if(user.god_aligned != planet.god)
+			continue
 
-		if(FISHGOD_VENUS)
-			if(CheckPlanetAligned(FISHGOD_VENUS))
-				user.devotion+=6
-				to_chat(user, span_notice("Tefnut hears your words."))
-
-		if(FISHGOD_MARS)
-			if(CheckPlanetAligned(FISHGOD_MARS))
-				user.devotion+=8
-				to_chat(user, span_notice("Arnapkapfaaluk hears your words."))
-
-		if(FISHGOD_JUPITER)
-			if(CheckPlanetAligned(FISHGOD_JUPITER))
-				user.devotion+=10
-				to_chat(user, span_notice("Susanoo hears your words."))
-
-		if(FISHGOD_SATURN)
-			if(CheckPlanetAligned(FISHGOD_SATURN))
-				user.devotion+=12
-				to_chat(user, span_notice("Kukulkan hears your words."))
-
-		if(FISHGOD_URANUS)
-			if(CheckPlanetAligned(FISHGOD_URANUS))
-				user.devotion+=14
-				to_chat(user, span_notice("Abena Mansa hears your words."))
-
-		if(FISHGOD_NEPTUNE)
-			if(CheckPlanetAligned(FISHGOD_NEPTUNE))
-				user.devotion+=16
-				to_chat(user, span_notice("Glaucus hears your words."))
-		else
+		if(planet.phase != 1)
 			to_chat(user, span_notice("Your planet is misaligned. Your prayer goes unanswered."))
+			return
 
+		user.devotion += (planet.orbit_time * 2)
+		to_chat(user, span_notice("[user.god_aligned] hears your words."))
+		return
+
+	to_chat(user, span_danger("... but silence is the only listener.")) // Your planet is done broke
 
 //Commune
 /obj/item/book/granter/action/skill/commune
-	granted_action = /datum/action/cooldown/fishing/commune
-	actionname = "Commune"
 	name = "Level 1 Skill: Commune"
+	actionname = "Commune"
+	granted_action = /datum/action/cooldown/fishing/commune
 	level = 1
 	custom_premium_price = 600
 
 /datum/action/cooldown/fishing/commune
-	button_icon_state = "commune"
 	name = "Commune"
-	cooldown_time = 100
+	button_icon_state = "commune"
+	cooldown_time = 10 SECONDS
 	devotion_cost = 1
 
 /datum/action/cooldown/fishing/commune/FishEffect(mob/living/user)
-	if(user.god_aligned == FISHGOD_NONE)	//Athiests can't commune because they don't have a soul
+	if(user.god_aligned == FISHGOD_NONE) // Athiests can't commune because they don't have a soul
 		to_chat(user, span_userdanger("YOU HAVE NO GOD."))
 
 	var/input = stripped_input(user,"What do you want to send to others that follow your god?", ,"Commune")
-	message_admins("<span class='notice'>A fisherman ([user.ckey]) has used commune with the following message: [input].</span>")
+	message_admins("A fisherman ([user.ckey]) has used commune with the following message: [input].")
 	for(var/mob/living/M in GLOB.player_list)
 		if(M.god_aligned == user.god_aligned)
 			to_chat(M, span_userdanger("You have a message for you: [input]"))

--- a/code/game/objects/items/fixerskills/fishing/level1/arcane.dm
+++ b/code/game/objects/items/fixerskills/fishing/level1/arcane.dm
@@ -1,4 +1,3 @@
-//Scry
 /obj/item/book/granter/action/skill/scry
 	name = "Level 1 Skill: Scry"
 	actionname = "Scry"
@@ -28,7 +27,6 @@
 		if(planet.phase == 1)
 			to_chat(user, span_notice("[planet.name] is in alignment with earth."))
 
-//Sacred Word
 /obj/item/book/granter/action/skill/sacredword
 	name = "Level 1 Skill: Sacred Word"
 	actionname = "Sacred Word"
@@ -57,7 +55,6 @@
 
 	to_chat(user, span_danger("... but silence is the only listener.")) // Your planet is done broke
 
-//Commune
 /obj/item/book/granter/action/skill/commune
 	name = "Level 1 Skill: Commune"
 	actionname = "Commune"

--- a/code/game/objects/items/fixerskills/fishing/level1/arcane.dm
+++ b/code/game/objects/items/fixerskills/fishing/level1/arcane.dm
@@ -75,7 +75,7 @@
 	if(user.god_aligned == FISHGOD_NONE) // Athiests can't commune because they don't have a soul
 		to_chat(user, span_userdanger("YOU HAVE NO GOD."))
 
-	var/input = stripped_input(user,"What do you want to send to others that follow your god?", ,"Commune")
+	var/input = stripped_input(user, "What do you want to send to others that follow your god?", "Fish communion", "Commune")
 	message_admins("A fisherman ([user.ckey]) has used commune with the following message: [input].")
 	for(var/mob/living/M in GLOB.player_list)
 		if(M.god_aligned == user.god_aligned)

--- a/code/game/objects/items/fixerskills/fishing/level1/healing.dm
+++ b/code/game/objects/items/fixerskills/fishing/level1/healing.dm
@@ -8,8 +8,8 @@
 	custom_premium_price = 600
 
 /datum/action/cooldown/fishing/prayer
-	button_icon_state = "lunar"
 	name = "Lunar Prayer"
+	button_icon_state = "lunar"
 	cooldown_time = 30 SECONDS
 	devotion_cost = 3
 
@@ -33,8 +33,8 @@
 	custom_premium_price = 600
 
 /datum/action/cooldown/fishing/love
-	button_icon_state = "love"
 	name = "God's Love"
+	button_icon_state = "love"
 	cooldown_time = 30 SECONDS
 	devotion_cost = 3
 	var/healamount = 1

--- a/code/game/objects/items/fixerskills/fishing/level1/healing.dm
+++ b/code/game/objects/items/fixerskills/fishing/level1/healing.dm
@@ -1,21 +1,21 @@
 
 //Prayer
 /obj/item/book/granter/action/skill/prayer
-	granted_action = /datum/action/cooldown/fishing/prayer
-	actionname = "Lunar Prayer"
 	name = "Level 1 Skill: Lunar Prayer"
+	actionname = "Lunar Prayer"
+	granted_action = /datum/action/cooldown/fishing/prayer
 	level = 1
 	custom_premium_price = 600
 
 /datum/action/cooldown/fishing/prayer
 	button_icon_state = "lunar"
 	name = "Lunar Prayer"
-	cooldown_time = 300
+	cooldown_time = 30 SECONDS
 	devotion_cost = 3
 
 /datum/action/cooldown/fishing/prayer/FishEffect(mob/living/user)
 	var/healamount = 5
-	healamount*=SSfishing.moonphase
+	healamount *= SSfishing.moonphase
 	for(var/mob/living/carbon/human/H in view(2, get_turf(src)))
 		if(H.stat >= HARD_CRIT)
 			continue
@@ -26,21 +26,21 @@
 
 //God's love
 /obj/item/book/granter/action/skill/love
-	granted_action = /datum/action/cooldown/fishing/love
-	actionname = "God's Love"
 	name = "Level 1 Skill: The God's Love"
+	actionname = "God's Love"
+	granted_action = /datum/action/cooldown/fishing/love
 	level = 1
 	custom_premium_price = 600
 
 /datum/action/cooldown/fishing/love
 	button_icon_state = "love"
 	name = "God's Love"
-	cooldown_time = 300
+	cooldown_time = 30 SECONDS
 	devotion_cost = 3
 	var/healamount = 1
 
 /datum/action/cooldown/fishing/love/FishEffect(mob/living/user)
-	healamount+=1
+	healamount++
 	var/givehealing = TOUGHER_TIMES_SPECIFIC(healamount,0.02)
 	for(var/mob/living/carbon/human/H in view(2, get_turf(src)))
 		if(H.stat >= HARD_CRIT)

--- a/code/game/objects/items/fixerskills/fishing/level1/joke.dm
+++ b/code/game/objects/items/fixerskills/fishing/level1/joke.dm
@@ -1,15 +1,14 @@
-//Detect Fish
-//A useless skill, made to be funny
+/// A useless* skill, made to be funny
 /obj/item/book/granter/action/skill/detect
-	granted_action = /datum/action/cooldown/fishing/detect
-	actionname = "Detect Fish"
 	name = "Level 1 Skill: Detect Fish"
+	actionname = "Detect Fish"
+	granted_action = /datum/action/cooldown/fishing/detect
 	level = 1
 	custom_premium_price = 600
 
 /datum/action/cooldown/fishing/detect
-	button_icon_state = "detect"
 	name = "Detect Fish"
+	button_icon_state = "detect"
 	cooldown_time = 30 SECONDS
 	devotion_cost = 1
 
@@ -24,37 +23,34 @@
 	to_chat(user, span_notice("There's no fish nearby."))
 
 
-//Fish Lockpick
-//Opens any fish-shaped lock
+/// Opens any fish-shaped lock
 /obj/item/book/granter/action/skill/fishlockpick
-	granted_action = /datum/action/cooldown/fishing/fishlockpick
-	actionname = "Fish Lockpick"
 	name = "Level 1 Skill: Fish Lockpick"
+	actionname = "Fish Lockpick"
+	granted_action = /datum/action/cooldown/fishing/fishlockpick
 	level = 1
 	custom_premium_price = 600
 
 /datum/action/cooldown/fishing/fishlockpick
-	button_icon_state = "fishlockpick"
 	name = "Fish Lockpick"
+	button_icon_state = "fishlockpick"
 	cooldown_time = 30 SECONDS
 	devotion_cost = 1
 
 /datum/action/cooldown/fishing/fishlockpick/FishEffect(mob/living/user)
 	to_chat(user, span_notice("All nearby fish-shaped locks have been opened."))
 
-
-//Fish Telepathy
-//Commune with the fish. Basically fishing
+/// Commune with the fish. Basically fishing
 /obj/item/book/granter/action/skill/fishtelepathy
-	granted_action = /datum/action/cooldown/fishing/fishtelepathy
-	actionname = "Fish Telepathy"
 	name = "Level 1 Skill: Fish Telepathy"
+	actionname = "Fish Telepathy"
+	granted_action = /datum/action/cooldown/fishing/fishtelepathy
 	level = 1
 	custom_premium_price = 600
 
 /datum/action/cooldown/fishing/fishtelepathy
-	button_icon_state = "fishtelepathy"
 	name = "Fish Telepathy"
+	button_icon_state = "fishtelepathy"
 	cooldown_time = 40 SECONDS
 	devotion_cost = 1
 
@@ -68,9 +64,7 @@
 			return
 	to_chat(user, span_notice("There's no fish nearby."))
 
-
 /datum/action/cooldown/fishing/fishtelepathy/proc/Recall(mob/living/carbon/human/user)
 	to_chat(user, span_notice("The fish have crucial news for you:"))
 	to_chat(user, span_notice("Glub."))
 	user.devotion += 2
-

--- a/code/game/objects/items/fixerskills/fishing/level1/joke.dm
+++ b/code/game/objects/items/fixerskills/fishing/level1/joke.dm
@@ -10,7 +10,7 @@
 /datum/action/cooldown/fishing/detect
 	button_icon_state = "detect"
 	name = "Detect Fish"
-	cooldown_time = 300
+	cooldown_time = 30 SECONDS
 	devotion_cost = 1
 
 /datum/action/cooldown/fishing/detect/FishEffect(mob/living/user)
@@ -36,7 +36,7 @@
 /datum/action/cooldown/fishing/fishlockpick
 	button_icon_state = "fishlockpick"
 	name = "Fish Lockpick"
-	cooldown_time = 300
+	cooldown_time = 30 SECONDS
 	devotion_cost = 1
 
 /datum/action/cooldown/fishing/fishlockpick/FishEffect(mob/living/user)
@@ -55,7 +55,7 @@
 /datum/action/cooldown/fishing/fishtelepathy
 	button_icon_state = "fishtelepathy"
 	name = "Fish Telepathy"
-	cooldown_time = 400
+	cooldown_time = 40 SECONDS
 	devotion_cost = 1
 
 /datum/action/cooldown/fishing/fishtelepathy/FishEffect(mob/living/user)
@@ -72,5 +72,5 @@
 /datum/action/cooldown/fishing/fishtelepathy/proc/Recall(mob/living/carbon/human/user)
 	to_chat(user, span_notice("The fish have crucial news for you:"))
 	to_chat(user, span_notice("Glub."))
-	user.devotion+=2
+	user.devotion += 2
 

--- a/code/game/objects/items/fixerskills/fishing/level1/motion.dm
+++ b/code/game/objects/items/fixerskills/fishing/level1/motion.dm
@@ -1,14 +1,13 @@
-//Planetary Momentum
 /obj/item/book/granter/action/skill/planet
-	granted_action = /datum/action/cooldown/fishing/planet
-	actionname = "Planet"
 	name = "Level 1 Skill: Planet"
+	actionname = "Planet"
+	granted_action = /datum/action/cooldown/fishing/planet
 	level = 1
 	custom_premium_price = 600
 
 /datum/action/cooldown/fishing/planet
-	button_icon_state = "planet"
 	name = "Planet"
+	button_icon_state = "planet"
 	cooldown_time = 10 MINUTES
 	devotion_cost = 2
 
@@ -23,38 +22,35 @@
 		to_chat(user, span_notice("You shift the movement of your aligned planet by 1."))
 		break
 
-//Lunar Motion
 /obj/item/book/granter/action/skill/moonmove
-	granted_action = /datum/action/cooldown/fishing/moonmove
-	actionname = "Lunar Motion"
 	name = "Level 1 Skill: Lunar Motion"
+	actionname = "Lunar Motion"
+	granted_action = /datum/action/cooldown/fishing/moonmove
 	level = 1
 	custom_premium_price = 600
 
 /datum/action/cooldown/fishing/moonmove
-	button_icon_state = "moonmove"
 	name = "Lunar Motion"
+	button_icon_state = "moonmove"
 	cooldown_time = 10 MINUTES
 	devotion_cost = 3
 
 /datum/action/cooldown/fishing/moonmove/FishEffect(mob/living/user)
 	to_chat(user, span_notice("You shift the moon forwards by one phase."))
-	SSfishing.moonphase+=1		//Moon Phases will affect the power of Moon-based mods.
-	if(SSfishing.moonphase == 5)	//there's only 4
+	SSfishing.moonphase++
+	if(SSfishing.moonphase == 5) // there's only 4
 		SSfishing.moonphase = 1
 
-
-//Targeted Planet
 /obj/item/book/granter/action/skill/planet2
-	granted_action = /datum/action/cooldown/fishing/planet2
-	actionname = "Planet II"
 	name = "Level 1 Skill: Plane II"
+	actionname = "Planet II"
+	granted_action = /datum/action/cooldown/fishing/planet2
 	level = 1
 	custom_premium_price = 600
 
 /datum/action/cooldown/fishing/planet2
-	button_icon_state = "planet2"
 	name = "Planet II"
+	button_icon_state = "planet2"
 	cooldown_time = 10 MINUTES
 	devotion_cost = 4
 

--- a/code/game/objects/items/fixerskills/fishing/level1/motion.dm
+++ b/code/game/objects/items/fixerskills/fishing/level1/motion.dm
@@ -9,7 +9,7 @@
 /datum/action/cooldown/fishing/planet
 	button_icon_state = "planet"
 	name = "Planet"
-	cooldown_time = 6000
+	cooldown_time = 10 MINUTES
 	devotion_cost = 2
 
 /datum/action/cooldown/fishing/planet/FishEffect(mob/living/user)
@@ -34,7 +34,7 @@
 /datum/action/cooldown/fishing/moonmove
 	button_icon_state = "moonmove"
 	name = "Lunar Motion"
-	cooldown_time = 6000
+	cooldown_time = 10 MINUTES
 	devotion_cost = 3
 
 /datum/action/cooldown/fishing/moonmove/FishEffect(mob/living/user)
@@ -55,7 +55,7 @@
 /datum/action/cooldown/fishing/planet2
 	button_icon_state = "planet2"
 	name = "Planet II"
-	cooldown_time = 6000
+	cooldown_time = 10 MINUTES
 	devotion_cost = 4
 
 /datum/action/cooldown/fishing/planet2/FishEffect(mob/living/user)

--- a/code/game/objects/items/fixerskills/fishing/level2.dm
+++ b/code/game/objects/items/fixerskills/fishing/level2.dm
@@ -9,7 +9,7 @@
 /datum/action/cooldown/fishing/smite
 	button_icon_state = "smite"
 	name = "Smite the Heretics"
-	cooldown_time = 300
+	cooldown_time = 30 SECONDS
 	devotion_cost = 7
 
 /datum/action/cooldown/fishing/smite/FishEffect(mob/living/user)
@@ -17,9 +17,9 @@
 	for(var/mob/living/M in view(4, get_turf(src)))
 		if(M.god_aligned != M.god_aligned)
 			//Deal a fuckload of damage to athiests
-			if(M.god_aligned == FISHGOD_NONE)
+			if(M.god_aligned == initial(M.god_aligned))
 				var/damagedealing = clamp(user.devotion, 1, 50)
-				M.apply_damage(damagedealing*2, WHITE_DAMAGE, null, M.run_armor_check(null, WHITE_DAMAGE), spread_damage = TRUE)	//KILL
+				M.apply_damage(damagedealing * 2, WHITE_DAMAGE, null, M.run_armor_check(null, WHITE_DAMAGE), spread_damage = TRUE)	//KILL
 				if(ishuman(M))
 					to_chat(target, span_userdanger("The gods have punished you for your sins!"), confidential = TRUE)
 				return
@@ -30,9 +30,6 @@
 				M.apply_damage(damagedealing, WHITE_DAMAGE, null, M.run_armor_check(null, WHITE_DAMAGE), spread_damage = TRUE)	//KILL
 				if(ishuman(M))
 					to_chat(target, span_userdanger("[user.god_aligned] has punished you for your sins!"), confidential = TRUE)
-
-
-
 
 //Lunar Might
 /obj/item/book/granter/action/skill/might
@@ -45,7 +42,7 @@
 /datum/action/cooldown/fishing/might
 	button_icon_state = "might"
 	name = "Lunar Might"
-	cooldown_time = 300
+	cooldown_time = 30 SECONDS
 	devotion_cost = 7
 	var/stat_hold = 0
 
@@ -59,7 +56,6 @@
 	var/mob/living/carbon/human/H = owner
 	H.adjust_attribute_bonus(JUSTICE_ATTRIBUTE, -stat_hold)
 
-
 //Awe the Weak
 /obj/item/book/granter/action/skill/awe
 	granted_action = /datum/action/cooldown/fishing/awe
@@ -71,7 +67,7 @@
 /datum/action/cooldown/fishing/awe
 	button_icon_state = "awe"
 	name = "Awe the Weak"
-	cooldown_time = 300
+	cooldown_time = 30 SECONDS
 	devotion_cost = 8
 
 /datum/action/cooldown/fishing/awe/FishEffect(mob/living/user)
@@ -82,10 +78,8 @@
 		if(M.god_aligned == FISHGOD_NONE)
 			//Stun the non-believers.
 			to_chat(M, span_userdanger("You are in awe of [user]'s devotion to [user.god_aligned]!"), confidential = TRUE)
-			M.Immobilize(15)
+			M.Immobilize(1.5 SECONDS)
 	StartCooldown()
-
-
 
 //Chakra Misalignment
 /obj/item/book/granter/action/skill/chakra
@@ -98,7 +92,7 @@
 /datum/action/cooldown/fishing/chakra
 	button_icon_state = "chakra"
 	name = "Chakra Misalignment"
-	cooldown_time = 300
+	cooldown_time = 30 SECONDS
 	devotion_cost = 12
 
 /datum/action/cooldown/fishing/chakra/FishEffect(mob/living/user)
@@ -109,28 +103,25 @@
 		if(M.god_aligned == initial(M.god_aligned))
 			continue
 
-		var/found_planet = FALSE
 		for(var/datum/planet/planet as anything in SSfishing.planets)
 			if(M.god_aligned != planet.god)
 				continue
 
-			found_planet = TRUE
 			if(planet.phase != 1)
 				smite(M, user)
-			break
+			return
 
-		if(!found_planet) // their planet is dead, and so will they be
-			obliterate(M)
+		obliterate(M) // their planet is dead, and so will they be
 
 /datum/action/cooldown/fishing/chakra/proc/smite(mob/living/carbon/asshole, mob/living/carbon/user)
-	asshole.apply_damage(user.devotion*SSfishing.moonphase*0.5, WHITE_DAMAGE, null, asshole.run_armor_check(null, WHITE_DAMAGE), spread_damage = TRUE)	//KILL
+	asshole.apply_damage(user.devotion * SSfishing.moonphase * 0.5, WHITE_DAMAGE, null, asshole.run_armor_check(null, WHITE_DAMAGE), spread_damage = TRUE)	//KILL
 	if(ishuman(asshole))
 		to_chat(asshole, span_userdanger("You feel your chakra rend itself!"), confidential = TRUE)
 
 /datum/action/cooldown/fishing/chakra/proc/obliterate(mob/living/carbon/H)
 	to_chat(H, span_userdanger("YOUR CHAKRA IS SPLITTING YOUR BODY!"), confidential = TRUE)
 	new /obj/effect/temp_visual/human_horizontal_bisect(get_turf(H))
-	H.set_lying_angle(360) //gunk code I know, but it is the simplest way to override gib_animation() without touching other code. Also looks smoother.
+	H.set_lying_angle(NORTH) //gunk code I know, but it is the simplest way to override gib_animation() without touching other code. Also looks smoother.
 	H.gib()
 
 
@@ -146,7 +137,7 @@
 /datum/action/cooldown/fishing/splitter
 	button_icon_state = "splitter"
 	name = "Greater Fish - Vertical"
-	cooldown_time = 100
+	cooldown_time = 10 SECONDS
 	devotion_cost = 7
 
 /datum/action/cooldown/fishing/splitter/FishEffect(mob/living/user)
@@ -157,8 +148,8 @@
 		if(M.stat >= SOFT_CRIT)
 			to_chat(M, span_userdanger("YOU'RE FIN-ISHED!"), confidential = TRUE)
 			new /obj/effect/temp_visual/human_horizontal_bisect(get_turf(M))
-			M.set_lying_angle(360)
+			M.set_lying_angle(NORTH)
 
-			//Spawn salmon and toss it all over the place
-			new /obj/item/food/fish/fresh_water/salmon(M.loc)
+			// Fesh
+			new /obj/item/food/fish/fresh_water/salmon(get_turf(M))
 			M.gib()

--- a/code/game/objects/items/fixerskills/fishing/level2.dm
+++ b/code/game/objects/items/fixerskills/fishing/level2.dm
@@ -64,12 +64,12 @@
 	devotion_cost = 8
 
 /datum/action/cooldown/fishing/awe/FishEffect(mob/living/user)
-	for(var/mob/living/M in view(5, get_turf(src)))
-		if(M == owner)
+	for(var/mob/living/victim in view(5, get_turf(src)))
+		if(victim == owner)
 			continue
-		if(M.god_aligned == FISHGOD_NONE) // Stun the non-believers.
-			to_chat(M, span_userdanger("You are in awe of [user]'s devotion to [user.god_aligned]!"), confidential = TRUE)
-			M.Immobilize(1.5 SECONDS)
+		if(victim.god_aligned == FISHGOD_NONE) // Stun the non-believers.
+			to_chat(victim, span_userdanger("You are in awe of [user]'s devotion to [user.god_aligned]!"), confidential = TRUE)
+			victim.Immobilize(1.5 SECONDS)
 
 	StartCooldown()
 
@@ -90,15 +90,15 @@
 	for(var/mob/living/victim in view(4, get_turf(user)))
 		if(victim == owner)
 			continue
-		if(M.god_aligned == FISHGOD_NONE)
+		if(victim.god_aligned == FISHGOD_NONE)
 			continue
 
 		for(var/datum/planet/planet as anything in SSfishing.planets)
-			if(M.god_aligned != planet.god)
+			if(victim.god_aligned != planet.god)
 				continue
 
 			if(planet.phase != 1)
-				smite(M, user)
+				smite(victim, user)
 			return
 
 		obliterate(M) // their planet is dead, and so will they be
@@ -131,14 +131,14 @@
 
 /datum/action/cooldown/fishing/splitter/FishEffect(mob/living/user)
 	//Compile people around you in crit
-	for(var/mob/living/M in view(2, get_turf(src)))
-		if(M == owner)
+	for(var/mob/living/future_fish in view(2, get_turf(src)))
+		if(future_fish == owner)
 			continue
-		if(M.stat >= SOFT_CRIT)
-			to_chat(M, span_userdanger("YOU'RE FIN-ISHED!"), confidential = TRUE)
-			new /obj/effect/temp_visual/human_horizontal_bisect(get_turf(M))
-			M.set_lying_angle(NORTH)
+		if(future_fish.stat >= SOFT_CRIT)
+			to_chat(future_fish, span_userdanger("YOU'RE FIN-ISHED!"), confidential = TRUE)
+			new /obj/effect/temp_visual/human_horizontal_bisect(get_turf(future_fish))
+			future_fish.set_lying_angle(NORTH)
 
 			// Fesh
-			new /obj/item/food/fish/fresh_water/salmon(get_turf(M))
-			M.gib()
+			new /obj/item/food/fish/fresh_water/salmon(get_turf(future_fish))
+			future_fish.gib()

--- a/code/game/objects/items/fixerskills/fishing/level2.dm
+++ b/code/game/objects/items/fixerskills/fishing/level2.dm
@@ -14,22 +14,19 @@
 
 /datum/action/cooldown/fishing/smite/FishEffect(mob/living/user)
 	//Compile people around you
-	for(var/mob/living/M in view(4, get_turf(src)))
-		if(M.god_aligned != M.god_aligned)
-			//Deal a fuckload of damage to athiests
-			if(M.god_aligned == initial(M.god_aligned))
-				var/damagedealing = clamp(user.devotion, 1, 50)
-				M.apply_damage(damagedealing * 2, WHITE_DAMAGE, null, M.run_armor_check(null, WHITE_DAMAGE), spread_damage = TRUE)	//KILL
-				if(ishuman(M))
-					to_chat(target, span_userdanger("The gods have punished you for your sins!"), confidential = TRUE)
-				return
+	for(var/mob/living/sinner in view(4, get_turf(src)))
+		if(user.god_aligned == sinner.god_aligned)
+			continue
 
-			//Deal some damage if they don't share the same god
-			if(M.god_aligned != user.god_aligned)
-				var/damagedealing = clamp(user.devotion, 1, 50)
-				M.apply_damage(damagedealing, WHITE_DAMAGE, null, M.run_armor_check(null, WHITE_DAMAGE), spread_damage = TRUE)	//KILL
-				if(ishuman(M))
-					to_chat(target, span_userdanger("[user.god_aligned] has punished you for your sins!"), confidential = TRUE)
+		var/damage = clamp(user.devotion, 1, 50)
+		if(sinner.god_aligned == FISHGOD_NONE) //Deal a fuckload of damage to athiests
+			damage *= 2
+
+		sinner.deal_damage(damage, WHITE_DAMAGE) //KILL
+		if(ishuman(user))
+			to_chat(sinner, span_userdanger("[user.god_aligned] has punished you for your sins using [user] as a conduit!"))
+		else
+			to_chat(sinner, span_userdanger("The gods have punished you for your sins using [user] as a conduit!"))
 
 //Lunar Might
 /obj/item/book/granter/action/skill/might
@@ -100,7 +97,7 @@
 	for(var/mob/living/M in view(4, get_turf(src)))
 		if(M == owner)
 			continue
-		if(M.god_aligned == initial(M.god_aligned))
+		if(M.god_aligned == FISHGOD_NONE)
 			continue
 
 		for(var/datum/planet/planet as anything in SSfishing.planets)

--- a/code/game/objects/items/fixerskills/fishing/level2.dm
+++ b/code/game/objects/items/fixerskills/fishing/level2.dm
@@ -1,19 +1,17 @@
-//Smite the Heretic
 /obj/item/book/granter/action/skill/smite
-	granted_action = /datum/action/cooldown/fishing/smite
-	actionname = "Smite the Heretics"
 	name = "Level 2 Skill: Smite the Heretics"
+	actionname = "Smite the Heretics"
+	granted_action = /datum/action/cooldown/fishing/smite
 	level = 2
 	custom_premium_price = 1200
 
 /datum/action/cooldown/fishing/smite
-	button_icon_state = "smite"
 	name = "Smite the Heretics"
+	button_icon_state = "smite"
 	cooldown_time = 30 SECONDS
 	devotion_cost = 7
 
 /datum/action/cooldown/fishing/smite/FishEffect(mob/living/user)
-	//Compile people around you
 	for(var/mob/living/sinner in view(4, get_turf(src)))
 		if(user.god_aligned == sinner.god_aligned)
 			continue
@@ -28,17 +26,16 @@
 		else
 			to_chat(sinner, span_userdanger("The gods have punished you for your sins using [user] as a conduit!"))
 
-//Lunar Might
 /obj/item/book/granter/action/skill/might
-	granted_action = /datum/action/cooldown/fishing/might
-	actionname = "Lunar Might"
 	name = "Level 2 Skill: Lunar Might"
+	actionname = "Lunar Might"
+	granted_action = /datum/action/cooldown/fishing/might
 	level = 2
 	custom_premium_price = 1200
 
 /datum/action/cooldown/fishing/might
-	button_icon_state = "might"
 	name = "Lunar Might"
+	button_icon_state = "might"
 	cooldown_time = 30 SECONDS
 	devotion_cost = 7
 	var/stat_hold = 0
@@ -53,49 +50,45 @@
 	var/mob/living/carbon/human/H = owner
 	H.adjust_attribute_bonus(JUSTICE_ATTRIBUTE, -stat_hold)
 
-//Awe the Weak
 /obj/item/book/granter/action/skill/awe
-	granted_action = /datum/action/cooldown/fishing/awe
-	actionname = "Awe the Weak"
 	name = "Level 2 Skill: Awe the Weak"
+	actionname = "Awe the Weak"
+	granted_action = /datum/action/cooldown/fishing/awe
 	level = 2
 	custom_premium_price = 1200
 
 /datum/action/cooldown/fishing/awe
-	button_icon_state = "awe"
 	name = "Awe the Weak"
+	button_icon_state = "awe"
 	cooldown_time = 30 SECONDS
 	devotion_cost = 8
 
 /datum/action/cooldown/fishing/awe/FishEffect(mob/living/user)
-	//Compile people around you
 	for(var/mob/living/M in view(5, get_turf(src)))
 		if(M == owner)
 			continue
-		if(M.god_aligned == FISHGOD_NONE)
-			//Stun the non-believers.
+		if(M.god_aligned == FISHGOD_NONE) // Stun the non-believers.
 			to_chat(M, span_userdanger("You are in awe of [user]'s devotion to [user.god_aligned]!"), confidential = TRUE)
 			M.Immobilize(1.5 SECONDS)
+
 	StartCooldown()
 
-//Chakra Misalignment
 /obj/item/book/granter/action/skill/chakra
-	granted_action = /datum/action/cooldown/fishing/chakra
-	actionname = "Chakra Misalignment"
 	name = "Level 2 Skill: Chakra Misalignment"
+	actionname = "Chakra Misalignment"
+	granted_action = /datum/action/cooldown/fishing/chakra
 	level = 2
 	custom_premium_price = 1200
 
 /datum/action/cooldown/fishing/chakra
-	button_icon_state = "chakra"
 	name = "Chakra Misalignment"
+	button_icon_state = "chakra"
 	cooldown_time = 30 SECONDS
 	devotion_cost = 12
 
 /datum/action/cooldown/fishing/chakra/FishEffect(mob/living/user)
-	//Compile people around you
-	for(var/mob/living/M in view(4, get_turf(src)))
-		if(M == owner)
+	for(var/mob/living/victim in view(4, get_turf(user)))
+		if(victim == owner)
 			continue
 		if(M.god_aligned == FISHGOD_NONE)
 			continue
@@ -118,22 +111,21 @@
 /datum/action/cooldown/fishing/chakra/proc/obliterate(mob/living/carbon/H)
 	to_chat(H, span_userdanger("YOUR CHAKRA IS SPLITTING YOUR BODY!"), confidential = TRUE)
 	new /obj/effect/temp_visual/human_horizontal_bisect(get_turf(H))
-	H.set_lying_angle(NORTH) //gunk code I know, but it is the simplest way to override gib_animation() without touching other code. Also looks smoother.
+	H.set_lying_angle(NORTH) // gunk code I know, but it is the simplest way to override gib_animation() without touching other code. Also looks smoother.
 	H.gib()
 
-
-//Salmon Splitter
-//Explode someone into fish
+/// Salmon Splitter
+/// Explode someone dead into fish
 /obj/item/book/granter/action/skill/splitter
-	granted_action = /datum/action/cooldown/fishing/splitter
-	actionname = "Greater Fish - Vertical"
 	name = "Level 2 Skill: Greater Fish - Vertical"
+	actionname = "Greater Fish - Vertical"
+	granted_action = /datum/action/cooldown/fishing/splitter
 	level = 2
 	custom_premium_price = 1200
 
 /datum/action/cooldown/fishing/splitter
-	button_icon_state = "splitter"
 	name = "Greater Fish - Vertical"
+	button_icon_state = "splitter"
 	cooldown_time = 10 SECONDS
 	devotion_cost = 7
 

--- a/code/game/objects/items/fixerskills/fishing/level2.dm
+++ b/code/game/objects/items/fixerskills/fishing/level2.dm
@@ -101,7 +101,7 @@
 				smite(victim, user)
 			return
 
-		obliterate(M) // their planet is dead, and so will they be
+		obliterate(victim) // their planet is dead, and so will they be
 
 /datum/action/cooldown/fishing/chakra/proc/smite(mob/living/carbon/asshole, mob/living/carbon/user)
 	asshole.apply_damage(user.devotion * SSfishing.moonphase * 0.5, WHITE_DAMAGE, null, asshole.run_armor_check(null, WHITE_DAMAGE), spread_damage = TRUE)	//KILL

--- a/code/game/objects/items/fixerskills/fishing/level4.dm
+++ b/code/game/objects/items/fixerskills/fishing/level4.dm
@@ -9,7 +9,7 @@
 /datum/action/cooldown/fishing/alignment
 	button_icon_state = "alignment"
 	name = "alignment"
-	cooldown_time = 6000
+	cooldown_time = 10 MINUTES
 	devotion_cost = 15
 
 /datum/action/cooldown/fishing/alignment/FishEffect(mob/living/user)
@@ -32,7 +32,7 @@
 /datum/action/cooldown/fishing/planetstop
 	button_icon_state = "planetstop"
 	name = "planetstop"
-	cooldown_time = 18000
+	cooldown_time = 30 MINUTES
 	devotion_cost = 12
 
 /datum/action/cooldown/fishing/planetstop/FishEffect(mob/living/user)
@@ -53,7 +53,7 @@
 /datum/action/cooldown/fishing/supernova
 	button_icon_state = "supernova"
 	name = "supernova"
-	cooldown_time = 12000
+	cooldown_time = 20 MINUTES
 	devotion_cost = 25
 
 /datum/action/cooldown/fishing/supernova/FishEffect(mob/living/user)
@@ -98,7 +98,7 @@
 /datum/action/cooldown/fishing/alignment2
 	button_icon_state = "alignment2"
 	name = "Alignment II"
-	cooldown_time = 18000
+	cooldown_time = 30 MINUTES
 	devotion_cost = 35
 
 /datum/action/cooldown/fishing/alignment2/FishEffect(mob/living/user)

--- a/code/game/objects/items/fixerskills/fishing/level4.dm
+++ b/code/game/objects/items/fixerskills/fishing/level4.dm
@@ -1,14 +1,13 @@
-//Align
 /obj/item/book/granter/action/skill/alignment
-	granted_action = /datum/action/cooldown/fishing/alignment
-	actionname = "Alignment"
 	name = "Level 4 Skill: Alignment"
+	actionname = "Alignment"
+	granted_action = /datum/action/cooldown/fishing/alignment
 	level = 4
 	custom_premium_price = 2400
 
 /datum/action/cooldown/fishing/alignment
+	name = "Alignment"
 	button_icon_state = "alignment"
-	name = "alignment"
 	cooldown_time = 10 MINUTES
 	devotion_cost = 15
 
@@ -21,17 +20,16 @@
 		to_chat(user, span_notice("You shift your deity's planet to align with earth."))
 		break
 
-//A Moment in Time
 /obj/item/book/granter/action/skill/planetstop
-	granted_action = /datum/action/cooldown/fishing/planetstop
-	actionname = "A Moment in Time"
 	name = "Level 4 Skill: A Moment in Time"
+	actionname = "A Moment in Time"
+	granted_action = /datum/action/cooldown/fishing/planetstop
 	level = 4
 	custom_premium_price = 2400
 
 /datum/action/cooldown/fishing/planetstop
+	name = "A Moment in Time"
 	button_icon_state = "planetstop"
-	name = "planetstop"
 	cooldown_time = 30 MINUTES
 	devotion_cost = 12
 
@@ -41,18 +39,16 @@
 	for(var/mob/M in GLOB.player_list)
 		to_chat(M, span_userdanger("The planets have stopped moving."))
 
-
-//Supernova
 /obj/item/book/granter/action/skill/supernova
-	granted_action = /datum/action/cooldown/fishing/supernova
-	actionname = "Supernova"
 	name = "Level 4 Skill: Supernova"
+	actionname = "Supernova"
+	granted_action = /datum/action/cooldown/fishing/supernova
 	level = 4
 	custom_premium_price = 2400
 
 /datum/action/cooldown/fishing/supernova
+	name = "Supernova"
 	button_icon_state = "supernova"
-	name = "supernova"
 	cooldown_time = 20 MINUTES
 	devotion_cost = 25
 
@@ -89,15 +85,15 @@
 
 //Alignment 2
 /obj/item/book/granter/action/skill/alignment2
-	granted_action = /datum/action/cooldown/fishing/alignment2
-	actionname = "Alignment II"
 	name = "Level 4 Skill: Alignment II"
+	actionname = "Alignment II"
+	granted_action = /datum/action/cooldown/fishing/alignment2
 	level = 4
 	custom_premium_price = 2400
 
 /datum/action/cooldown/fishing/alignment2
-	button_icon_state = "alignment2"
 	name = "Alignment II"
+	button_icon_state = "alignment2"
 	cooldown_time = 30 MINUTES
 	devotion_cost = 35
 

--- a/code/game/objects/items/fixerskills/level1/healing.dm
+++ b/code/game/objects/items/fixerskills/level1/healing.dm
@@ -79,7 +79,7 @@
 	if(!.)
 		return FALSE
 
-	if (owner.stat == DEAD)
+	if(owner.stat == DEAD)
 		return FALSE
 
 	for(var/mob/living/carbon/human/H in view(2, get_turf(src)))

--- a/code/game/objects/items/fixerskills/level4/dismember.dm
+++ b/code/game/objects/items/fixerskills/level4/dismember.dm
@@ -17,7 +17,7 @@
 	if(!.)
 		return FALSE
 
-	if (owner.stat == DEAD)
+	if(owner.stat == DEAD)
 		return FALSE
 
 	//Compile people around you

--- a/code/game/objects/items/fixerskills/skills.dm
+++ b/code/game/objects/items/fixerskills/skills.dm
@@ -5,7 +5,7 @@
 	var/mob/living/carbon/human/user
 
 	//To do: Refactor.
-	var/list/datum/action/actions_levels = list(
+	var/static/list/datum/action/actions_levels = list(
 		/datum/action/cooldown/dash = 1,
 		/datum/action/cooldown/dash/back = 1,
 		/datum/action/cooldown/smokedash = 1,

--- a/code/modules/jobs/job_types/city/civilian.dm
+++ b/code/modules/jobs/job_types/city/civilian.dm
@@ -17,7 +17,7 @@ Civilian
 	allow_bureaucratic_error = FALSE
 	maptype = list("city", "fixers")
 	paycheck = 170
-
+	var/static/list/possible_books = null
 
 /datum/job/civilian/equip(mob/living/carbon/human/H, visualsOnly = FALSE, announce = TRUE, latejoin = FALSE, datum/outfit/outfit_override = null, client/preference_source)
 	//Don't dupe money.
@@ -25,26 +25,15 @@ Civilian
 		paycheck = 50
 	else
 		paycheck = initial(paycheck)
-	..()
-
-
-/proc/add_skill_book(mob/living/carbon/human/H)
-	if (prob(50))
-		var/level = get_civilian_level(H)
-		var/list/temp = list()
-		for (var/T in subtypesof(/obj/item/book/granter/action/skill))
-			var/obj/item/book/granter/action/skill/book = new T
-			if (book.level == level)
-				temp.Add(book)
-		var/obj/item/book/granter/action/skill/random_book = pick(temp)
-		H.equip_to_slot_or_del(random_book,ITEM_SLOT_BACKPACK, TRUE)
+	return ..()
 
 /proc/get_civilian_level(mob/living/carbon/human/user)
 	var/collective_levels = 0
 	for(var/a in user.attributes)
-		var/datum/attribute/atr = user.attributes[a]
-		collective_levels += atr.level
-	var/level = collective_levels / 4
+		var/datum/attribute/attribute = user.attributes[a]
+		collective_levels += attribute.level
+
+	var/level = collective_levels / length(user.attributes)
 	if (level < 40)
 		return 0
 	else if (level >= 40 && level < 60 )
@@ -69,7 +58,7 @@ Civilian
 		var/statgeneration3 = rand(110)
 
 		var/stattotal = min(statgeneration1, statgeneration2)
-		stattotal = 20+min(stattotal, statgeneration3)
+		stattotal = 20 + min(stattotal, statgeneration3)
 
 		roundstart_attributes = list(
 									FORTITUDE_ATTRIBUTE = stattotal,
@@ -77,7 +66,7 @@ Civilian
 									TEMPERANCE_ATTRIBUTE = stattotal,
 									JUSTICE_ATTRIBUTE = stattotal
 									)
-		SScityevents.generated+=M.ckey
+		SScityevents.generated += M.ckey
 	else
 		roundstart_attributes = list(
 									FORTITUDE_ATTRIBUTE = 20,
@@ -85,8 +74,20 @@ Civilian
 									TEMPERANCE_ATTRIBUTE = 20,
 									JUSTICE_ATTRIBUTE = 20
 									)
-	..()
-	add_skill_book(H)
+	. = ..()
+	if(prob(50))
+		if(!possible_books) // Since possible_books is a static var, we dont know if its generated or not. If its not then generate it
+			possible_books = list(list(), list(), list(), list())
+			for(var/obj/item/book/granter/action/skill/book as anything in subtypesof(/obj/item/book/granter/action/skill))
+				possible_books[book.level] += book
+
+		var/player_level = get_civilian_level(H)
+		if(!length(possible_books[player_level]))
+			return
+
+		var/book_path = pick(possible_books[player_level])
+		var/obj/item/book/granter/action/skill/random_book = new book_path
+		H.equip_to_slot_or_del(random_book, ITEM_SLOT_BACKPACK, TRUE)
 
 /datum/outfit/job/civilian
 	name = "Civilan"

--- a/code/modules/jobs/job_types/city/civilian.dm
+++ b/code/modules/jobs/job_types/city/civilian.dm
@@ -77,11 +77,11 @@ Civilian
 	. = ..()
 	if(prob(50))
 		if(!possible_books) // Since possible_books is a static var, we dont know if its generated or not. If its not then generate it
-			possible_books = list(list(), list(), list(), list())
+			possible_books = list(list(), list(), list(), list(), list())
 			for(var/obj/item/book/granter/action/skill/book as anything in subtypesof(/obj/item/book/granter/action/skill))
-				possible_books[book.level] += book
+				possible_books[book.level + 1] += book // we add 1 here to account for level 0 fixers, they get the first index
 
-		var/player_level = get_civilian_level(H)
+		var/player_level = get_civilian_level(H) + 1
 		if(!length(possible_books[player_level]))
 			return
 

--- a/code/modules/jobs/job_types/city/civilian.dm
+++ b/code/modules/jobs/job_types/city/civilian.dm
@@ -86,7 +86,7 @@ Civilian
 			return
 
 		var/book_path = pick(possible_books[player_level])
-		var/obj/item/book/granter/action/skill/random_book = new book_path
+		var/obj/item/book/granter/action/skill/random_book = new book_path()
 		H.equip_to_slot_or_del(random_book, ITEM_SLOT_BACKPACK, TRUE)
 
 /datum/outfit/job/civilian


### PR DESCRIPTION

## About The Pull Request

- Reworks a good chunk of code surrounding civilians skill books spawning in, making the game no longer try to spawn non-existant books
- Brings fishing skills up to the coding standard for skills

## Why It's Good For The Game

> Reworks a good chunk of code surrounding civilians skill books spawning in, making the game no longer try to spawn non-existant books
- Made a good chunk of non-map runtimes on COL/CF rounds. Using a static var we can now also generate the list once and never again, saving a lil bit of processing at the cost of memory.
> Brings fishing skills up to the coding standard for skills
- "Give me 300 of this, 18000 of that" <-- statements made by the utterly deranged

## Changelog
:cl:
code: Fixed runtimes relating to civilians spawning in with level 0 skill books
/:cl:
