### PR TITLE
Adds time until the next abnormality arrives progress bar to the sephirah menu, frees sephirah menu buttons

### DIFF
--- a/ModularTegustation/tegu_items/debug_items.dm
+++ b/ModularTegustation/tegu_items/debug_items.dm
@@ -206,7 +206,8 @@
  */
 /obj/item/lc_debug/sephirah_action_granter
 	name = "debug sephirah action granter"
-	desc = "A strange wooden sign with the words\"THE ROBITS GRIFF ME!!!\" inscribed upon it"
+	desc = "A strange wooden sign with the words \"THE ROBITS GRIFF ME!!!\" inscribed upon it"
+	icon = 'icons/obj/items_and_weapons.dmi'
 	icon_state = "picket"
 
 /obj/item/lc_debug/sephirah_action_granter/examine(mob/user)

--- a/code/controllers/subsystem/abnormality_queue.dm
+++ b/code/controllers/subsystem/abnormality_queue.dm
@@ -29,6 +29,8 @@ SUBSYSTEM_DEF(abnormality_queue)
 	var/rooms_start = 0
 	/// Amount of times PostSpawn() proc has been called. Kept separate from times_fired because admins love to call fire() manually
 	var/spawned_abnos = 0
+	/// When an abnormality spawns, the time it spawned is here. Purelly used for sephirahs TGUI console
+	var/previous_abno_spawn = 0
 	// I am using this all because default subsystem waiting and next_fire is done in a very... interesting way.
 	/// World time at which new abnormality will be spawned
 	var/next_abno_spawn = INFINITY
@@ -62,9 +64,10 @@ SUBSYSTEM_DEF(abnormality_queue)
 
 /datum/controller/subsystem/abnormality_queue/proc/SpawnAbno()
 	// Earlier in the game, abnormalities will spawn faster and then slow down a bit
+	previous_abno_spawn = world.time
 	next_abno_spawn = world.time + next_abno_spawn_time + ((min(16, spawned_abnos) - 6) * 9) SECONDS
 
-	if(!LAZYLEN(GLOB.abnormality_room_spawners))
+	if(!length(GLOB.abnormality_room_spawners))
 		return
 
 	var/obj/effect/spawner/abnormality_room/choice = pick(GLOB.abnormality_room_spawners)
@@ -108,7 +111,7 @@ SUBSYSTEM_DEF(abnormality_queue)
 		available_levels = list(TETH_LEVEL)
 
 	// Roll the abnos from available levels
-	if(!ispath(queued_abnormality) && LAZYLEN(possible_abnormalities))
+	if(!ispath(queued_abnormality) && length(possible_abnormalities))
 		PickAbno()
 
 /datum/controller/subsystem/abnormality_queue/proc/PostSpawn()
@@ -138,15 +141,15 @@ SUBSYSTEM_DEF(abnormality_queue)
 		to_chat(person, span_notice("You feel stronger than before."))
 
 /datum/controller/subsystem/abnormality_queue/proc/PickAbno()
-	if(!LAZYLEN(available_levels))
+	if(!length(available_levels))
 		return FALSE
 	/// List of threat levels that we will pick
 	var/list/picking_levels = list()
 	for(var/threat in available_levels)
-		if(!LAZYLEN(possible_abnormalities[threat]))
+		if(!length(possible_abnormalities[threat]))
 			continue
 		picking_levels |= threat
-	if(!LAZYLEN(picking_levels))
+	if(!length(picking_levels))
 		return FALSE
 
 	// There we select the abnormalities
@@ -154,7 +157,7 @@ SUBSYSTEM_DEF(abnormality_queue)
 	var/pick_count = GetFacilityUpgradeValue(UPGRADE_ABNO_QUEUE_COUNT)
 	var/list/picked_levs = list()
 	for(var/i = 1 to pick_count)
-		if(!LAZYLEN(possible_abnormalities))
+		if(!length(possible_abnormalities))
 			break
 		var/lev = pick(picking_levels)
 		// If we have more options to fill and we have multiple available levels - force them in.
@@ -164,11 +167,11 @@ SUBSYSTEM_DEF(abnormality_queue)
 			// And pick again
 			lev = pick(picking_levels)
 		picked_levs |= lev
-		if(!LAZYLEN(possible_abnormalities[lev] - picking_abnormalities))
+		if(!length(possible_abnormalities[lev] - picking_abnormalities))
 			continue
 		var/chosen_abno = PickWeightRealNumber(possible_abnormalities[lev] - picking_abnormalities)
 		picking_abnormalities += chosen_abno
-	if(!LAZYLEN(picking_abnormalities))
+	if(!length(picking_abnormalities))
 		return FALSE
 	queued_abnormality = pick(picking_abnormalities)
 	return TRUE
@@ -198,7 +201,7 @@ SUBSYSTEM_DEF(abnormality_queue)
 	var/list/picking_abno = list()
 
 	for(var/level in available_levels)
-		if(!LAZYLEN(possible_abnormalities[level]))
+		if(!length(possible_abnormalities[level]))
 			continue
 		picking_abno |= possible_abnormalities[level]
 

--- a/code/modules/jobs/job_types/trusted_players/sephirah.dm
+++ b/code/modules/jobs/job_types/trusted_players/sephirah.dm
@@ -294,19 +294,17 @@ GLOBAL_LIST_EMPTY(SephirahBullet)
 	var/mob/living/simple_animal/hostile/abnormality/queued_abno = SSabnormality_queue.queued_abnormality
 	data["queued_abno"] = initial(queued_abno.name)
 
-	/* Scrapped due to difficulty -- to be implemented
 	// START OF ARRIVAL INFORMATION
 	var/safe_abnormality_delay
-	if(SSabnormality_queue.next_abno_spawn != INFINITY) // happens when starting abnormalities are being selected, or things break
-		safe_abnormality_delay = SSabnormality_queue.next_abno_spawn
+	if(SSabnormality_queue.next_abno_spawn != INFINITY) // Happens when starting abnormalities are being selected, or things break
+		safe_abnormality_delay = floor(SSabnormality_queue.next_abno_spawn)
 	else
-		safe_abnormality_delay = ABNORMALITY_DELAY
+		safe_abnormality_delay = ABNORMALITY_DELAY + SSticker.round_start_time
 
-	data["current_arrival"] = safe_abnormality_delay
-	data["next_arrival"] = safe_abnormality_delay + SSabnormality_queue.next_abno_spawn_time + ((min(16, (SSabnormality_queue.spawned_abnos + 1)) - 6) * 6) SECONDS
-	data["progress_component"] = (world.time - ABNORMALITY_DELAY) / safe_abnormality_delay
+	data["previous_arrival_time"] = floor(SSabnormality_queue.previous_abno_spawn ? SSabnormality_queue.previous_abno_spawn : ROUNDTIME)
+	data["current_arrival_time"] = floor(world.time)
+	data["next_arrival_time"] = safe_abnormality_delay + 5 SECONDS // The seconds are because the subsystem fires every 10 seconds
 	// END OF ARRIVAL INFORMATION
-	*/
 
 	return data
 

--- a/tgui/packages/tgui/interfaces/SephirahPanel.js
+++ b/tgui/packages/tgui/interfaces/SephirahPanel.js
@@ -20,11 +20,9 @@ const AbnoInfo = (props, context) => {
   const {
     abno_number,
     queued_abno,
-    minimum_arrival,
-    current_arrival,
-    next_arrival,
-    maximum_arrival,
-    progress_component,
+    previous_arrival_time,
+    current_arrival_time,
+    next_arrival_time,
   } = data;
 
   return (
@@ -36,19 +34,17 @@ const AbnoInfo = (props, context) => {
         <LabeledList.Item label="Currently queued abnormality: ">
           {queued_abno}
         </LabeledList.Item>
-        {/*
-        <LabeledList.Item label="Current abnormality arrival time">
+        <LabeledList.Item label="Time until next abnormality arrival">
           <ProgressBar
-            value={progress_component}>
+            value={current_arrival_time}
+            minValue={previous_arrival_time}
+            maxValue={next_arrival_time}
+          >
             <AnimatedNumber
-              value={current_arrival / 10
-              + ' seconds, (estimated next arrival: '
-              + next_arrival / 10
-              + ' seconds)'}
+              value={(next_arrival_time - current_arrival_time) / 10 + " seconds"}
             />
           </ProgressBar>
         </LabeledList.Item>
-        */}
       </LabeledList>
     </Section>
   );
@@ -59,163 +55,161 @@ const ButtonPanel = (props, context) => {
   const { abnormality_arrival, meltdown_speed } = data;
 
   return (
-    <Section title="Avaible actions">
+    <Section title="Available actions">
       <Box mt="0.5em">
-        <LabeledList>
-          <Collapsible title="Complete quest">
-            <LabeledList.Item
-              labelWrap
-              label="Reward the facility for completing a custom quest that you set out earlier this shift."
-              buttons={
-                <Button
-                  content={'Complete quest'}
-                  color={'green'}
-                  onClick={() => act('Complete quest')}
-                />
-              }
-            />
-          </Collapsible>
-          <Collapsible title="Make announcement">
-            <LabeledList.Item
-              labelWrap
-              label="Allows you to make a global announcement."
-              buttons={
-                <Button
-                  content={'Make announcement'}
-                  color={'green'}
-                  onClick={() => act('Make announcement')}
-                />
-              }
-            />
-          </Collapsible>
-          <Collapsible title="Randomize abnormality">
-            <LabeledList.Item
-              labelWrap
-              label="Randomizes the current abnormality, only works if the abnormality has not yet been randomized at its current state. Gives the manager 1 LOB."
-              buttons={
-                <Button
-                  content={'Randomize abnormality'}
-                  color={'green'}
-                  onClick={() => act('Randomize abnormality')}
-                />
-              }
-            />
-          </Collapsible>
-          <Collapsible title="Randomize selection">
-            <LabeledList.Item
-              labelWrap
-              label="Randomizes the current abnormality selection. Gives the manager 1 LOB."
-              buttons={
-                <Button
-                  content={'RRandomize selection'}
-                  color={'green'}
-                  onClick={() => act('Randomize selection')}
-                />
-              }
-            />
-          </Collapsible>
-          <Collapsible title="Manipulate abnormality arrival time">
-            <LabeledList.Item>
-              <ProgressBar
-                minValue={-3}
-                maxValue={3}
-                value={abnormality_arrival}>
-                <AnimatedNumber value={abnormality_arrival} />
-              </ProgressBar>
-            </LabeledList.Item>
-            <LabeledList.Item
-              labelWrap
-              label="Makes all abnormalities arrive 20% quicker (multiplicativelly)"
-              buttons={
-                <Button
-                  content={abnormality_arrival < 3 ? 'Quicken abnormality arrival' : 'Speed at maximum!'}
-                  color={abnormality_arrival < 3 ? 'green' : 'red'}
-                  onClick={() => act('Quicken abnormality arrival')}
-                />
-              }
-            />
-            <LabeledList.Item
-              labelWrap
-              label="Makes all abnormalities arrive 20% slower (multiplicativelly)"
-              buttons={
-                <Button
-                  content={abnormality_arrival > -3 ? 'Slow abnormality arrival': 'Speed at minimum!'}
-                  color={abnormality_arrival > -3 ? 'green' : 'red'}
-                  onClick={() => act('Slow abnormality arrival')}
-                />
-              }
-            />
-          </Collapsible>
-          <Collapsible title="Manipulate Work per Meltdown ratio">
-            <LabeledList.Item>
-              <ProgressBar
-                minValue={-4}
-                maxValue={6}
-                value={meltdown_speed}>
-                <AnimatedNumber value={meltdown_speed} />
-              </ProgressBar>
-            </LabeledList.Item>
-            <LabeledList.Item
-              labelWrap
-              label="All meltdowns will take one more work before accuring"
-              buttons={
-                <Button
-                  content={meltdown_speed < 6 ? 'Increase Work per Meltdown ratio': 'Additional meltdown works at maximum!'}
-                  color={meltdown_speed < 6 ? 'green' : 'red'}
-                  onClick={() => act('Increase Work per Meltdown ratio')}
-                />
-              }
-            />
-            <LabeledList.Item
-              labelWrap
-              label="All meltdowns will take one less work before accuring"
-              buttons={
-                <Button
-                  content={meltdown_speed > -4 ? 'Decrease Work per Meltdown ratio': 'Additional meltdown works at minimum!'}
-                  color={meltdown_speed > -4 ? 'green' : 'red'}
-                  onClick={() => act('Decrease Work per Meltdown ratio')}
-                />
-              }
-            />
-          </Collapsible>
-          <Collapsible title="Manipulate Abnormalities melting down per meltdown">
-            <LabeledList.Item
-              labelWrap
-              label="One more abnormality will melt per event"
-              buttons={
-                <Button
-                  content={'Increase abnormality per meltdown ratio'}
-                  color={'green'}
-                  onClick={() => act('Increase abnormality per meltdown ratio')}
-                />
-              }
-            />
-            <LabeledList.Item
-              labelWrap
-              label="One less abnormality will melt per event"
-              buttons={
-                <Button
-                  content={'Decrease abnormality per meltdown'}
-                  color={'green'}
-                  onClick={() => act('Decrease abnormality per meltdown')}
-                />
-              }
-            />
-          </Collapsible>
-          <Collapsible title="Authorize execution bullets">
-            <LabeledList.Item
-              labelWrap
-              label="Put your vote in to authorize execution bullets for the manager. 2 Sephirah have to agree for this to pass."
-              buttons={
-                <Button
-                  content={'Authorize execution bullets'}
-                  color={'red'}
-                  onClick={() => act('Authorize execution bullets')}
-                />
-              }
-            />
-          </Collapsible>
-        </LabeledList>
+        <Collapsible title="Complete quest">
+          <LabeledList.Item
+            labelWrap
+            label="Reward the facility for completing a custom quest that you set out earlier this shift."
+            buttons={
+              <Button
+                content={'Complete quest'}
+                color={'green'}
+                onClick={() => act('Complete quest')}
+              />
+            }
+          />
+        </Collapsible>
+        <Collapsible title="Make announcement">
+          <LabeledList.Item
+            labelWrap
+            label="Allows you to make a global announcement."
+            buttons={
+              <Button
+                content={'Make announcement'}
+                color={'green'}
+                onClick={() => act('Make announcement')}
+              />
+            }
+          />
+        </Collapsible>
+        <Collapsible title="Randomize abnormality">
+          <LabeledList.Item
+            labelWrap
+            label="Randomizes the current abnormality, only works if the abnormality has not yet been randomized at its current state. Gives the manager 1 LOB."
+            buttons={
+              <Button
+                content={'Randomize abnormality'}
+                color={'green'}
+                onClick={() => act('Randomize abnormality')}
+              />
+            }
+          />
+        </Collapsible>
+        <Collapsible title="Randomize selection">
+          <LabeledList.Item
+            labelWrap
+            label="Randomizes the current abnormality selection. Gives the manager 1 LOB."
+            buttons={
+              <Button
+                content={'RRandomize selection'}
+                color={'green'}
+                onClick={() => act('Randomize selection')}
+              />
+            }
+          />
+        </Collapsible>
+        <Collapsible title="Manipulate abnormality arrival time">
+          <LabeledList.Item>
+            <ProgressBar
+              minValue={-3}
+              maxValue={3}
+              value={abnormality_arrival}>
+              <AnimatedNumber value={abnormality_arrival} />
+            </ProgressBar>
+          </LabeledList.Item>
+          <LabeledList.Item
+            labelWrap
+            label="Makes all abnormalities arrive 20% quicker (multiplicativelly)"
+            buttons={
+              <Button
+                content={abnormality_arrival < 3 ? 'Quicken abnormality arrival' : 'Speed at maximum!'}
+                color={abnormality_arrival < 3 ? 'green' : 'red'}
+                onClick={() => act('Quicken abnormality arrival')}
+              />
+            }
+          />
+          <LabeledList.Item
+            labelWrap
+            label="Makes all abnormalities arrive 20% slower (multiplicativelly)"
+            buttons={
+              <Button
+                content={abnormality_arrival > -3 ? 'Slow abnormality arrival': 'Speed at minimum!'}
+                color={abnormality_arrival > -3 ? 'green' : 'red'}
+                onClick={() => act('Slow abnormality arrival')}
+              />
+            }
+          />
+      </Collapsible>
+        <Collapsible title="Manipulate Work per Meltdown ratio">
+          <LabeledList.Item>
+            <ProgressBar
+              minValue={-4}
+              maxValue={6}
+              value={meltdown_speed}>
+              <AnimatedNumber value={meltdown_speed} />
+            </ProgressBar>
+          </LabeledList.Item>
+          <LabeledList.Item
+            labelWrap
+            label="All meltdowns will take one more work before accuring"
+            buttons={
+              <Button
+                content={meltdown_speed < 6 ? 'Increase Work per Meltdown ratio': 'Additional meltdown works at maximum!'}
+                color={meltdown_speed < 6 ? 'green' : 'red'}
+                onClick={() => act('Increase Work per Meltdown ratio')}
+              />
+            }
+          />
+          <LabeledList.Item
+            labelWrap
+            label="All meltdowns will take one less work before accuring"
+            buttons={
+              <Button
+                content={meltdown_speed > -4 ? 'Decrease Work per Meltdown ratio': 'Additional meltdown works at minimum!'}
+                color={meltdown_speed > -4 ? 'green' : 'red'}
+                onClick={() => act('Decrease Work per Meltdown ratio')}
+              />
+            }
+          />
+        </Collapsible>
+        <Collapsible title="Manipulate Abnormalities melting down per meltdown">
+          <LabeledList.Item
+            labelWrap
+            label="One more abnormality will melt per event"
+            buttons={
+              <Button
+                content={'Increase abnormality per meltdown ratio'}
+                color={'green'}
+                onClick={() => act('Increase abnormality per meltdown ratio')}
+              />
+            }
+          />
+          <LabeledList.Item
+            labelWrap
+            label="One less abnormality will melt per event"
+            buttons={
+              <Button
+                content={'Decrease abnormality per meltdown'}
+                color={'green'}
+                onClick={() => act('Decrease abnormality per meltdown')}
+              />
+            }
+          />
+        </Collapsible>
+        <Collapsible title="Authorize execution bullets">
+          <LabeledList.Item
+            labelWrap
+            label="Put your vote in to authorize execution bullets for the manager. 2 Sephirah have to agree for this to pass."
+            buttons={
+              <Button
+                content={'Authorize execution bullets'}
+                color={'red'}
+                onClick={() => act('Authorize execution bullets')}
+              />
+            }
+          />
+        </Collapsible>
       </Box>
     </Section>
   );


### PR DESCRIPTION

## About The Pull Request

How the menu now looks fully-extended:

![image](https://github.com/user-attachments/assets/4efb5d94-f49b-4e89-9de0-d1a41fb93147)

How the menu looks when compacted:

![image](https://github.com/user-attachments/assets/3c1f1cde-ec03-48b0-87a6-a674c414861e)

## Why It's Good For The Game

I think this is fine to add to sephirahs

## Changelog
:cl:
add: Added a progressbar telling sephirahs how long until the next abnormality arrives
/:cl:
