### PR TITLE
Fix Warbanner and Warcry

### DIFF
--- a/code/game/objects/items/fixerskills/level4/team.dm
+++ b/code/game/objects/items/fixerskills/level4/team.dm
@@ -35,8 +35,8 @@
 		human.physiology.pale_mod *= 0.6
 		affected+= human
 
-	addtimer(CALLBACK(src, PROC_REF(Recall),), 10 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
-	addtimer(CALLBACK(src, PROC_REF(Warcry),), 0.5 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
+	addtimer(CALLBACK(src, PROC_REF(Recall)), 10 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
+	addtimer(CALLBACK(src, PROC_REF(Warcry)), 0.5 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
 	StartCooldown()
 
 /datum/action/cooldown/warbanner/proc/Recall()
@@ -45,6 +45,7 @@
 		human.physiology.white_mod /= 0.6
 		human.physiology.black_mod /= 0.6
 		human.physiology.pale_mod /= 0.6
+		affected-=human
 
 /datum/action/cooldown/warbanner/proc/Warcry()
 	for(var/mob/living/carbon/human/human in affected)
@@ -84,11 +85,11 @@
 	for(var/mob/living/carbon/human/human in view(range, get_turf(src)))
 		if (human == owner && !affect_self)
 			continue
-		human.add_movespeed_modifier(/datum/movespeed_modifier/retreat)
+		human.add_movespeed_modifier(/datum/movespeed_modifier/warcry)
 		addtimer(CALLBACK(human, TYPE_PROC_REF(/mob, remove_movespeed_modifier), /datum/movespeed_modifier/warcry), 5 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
 		affected+=human
 
-	addtimer(CALLBACK(src, PROC_REF(Warcry),), 0.5 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
+	addtimer(CALLBACK(src, PROC_REF(Warcry)), 0.5 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
 	StartCooldown()
 
 /datum/action/cooldown/warcry/proc/Warcry()
@@ -96,6 +97,7 @@
 		if(human == owner)
 			continue
 		human.say("YES SIR!")
+		affected-=human
 
 /datum/movespeed_modifier/warcry
 	variable = TRUE


### PR DESCRIPTION
## About The Pull Request

Agent captains have been unknowingly killing everyone by using their "buff"
Said buff doesn't delete its list of affected people and subsequent uses add the same people into the list,
making it permanently take away their resistance on every use which stacks
Also minor cleanup for both codes

## Why It's Good For The Game

Removes the secret strongest Level 4 skill in gone from CoL/CF
Infinite Debuff

## Changelog
:cl:
fix: fixed the lv4 team fixer skills
:cl:
