### PR TITLE
Adds Adventure Console to the Rep's Equipment

### DIFF
--- a/ModularTegustation/lc13_obj/_adventure_console/adventure_layout.dm
+++ b/ModularTegustation/lc13_obj/_adventure_console/adventure_layout.dm
@@ -84,6 +84,10 @@
 		new /datum/data/extraction_cargo("CAT",	/mob/living/simple_animal/pet/cat,			50) = 1,
 		new /datum/data/extraction_cargo("CAK",	/mob/living/simple_animal/pet/cat/cak,		100) = 1,
 		new /datum/data/extraction_cargo("SNAKE", /mob/living/simple_animal/hostile/retaliate/poison/snake,	100) = 1,
+
+		//Actual Shit
+		new /datum/data/extraction_cargo("SOME AHN",				/obj/item/stack/spacecash/c500,		10) = 1,
+		new /datum/data/extraction_cargo("POSITIVE ENKEPHALIN",		/obj/item/rawpe,					20) = 1,
 	)
 
 /datum/adventure_layout/New(set_debug_menu = FALSE)

--- a/_maps/map_files/generic/Manager.dmm
+++ b/_maps/map_files/generic/Manager.dmm
@@ -64,14 +64,11 @@
 /turf/open/floor/plasteel/white,
 /area/facility_hallway/manager)
 "bO" = (
-/obj/structure/table/wood,
 /obj/effect/turf_decal/siding/blue{
 	color = "#3234B9";
 	dir = 8
 	},
-/obj/item/paper_bin/bundlenatural{
-	pixel_y = 5
-	},
+/obj/machinery/text_adventure_console,
 /turf/open/floor/carpet/royalblue,
 /area/facility_hallway/manager)
 "bS" = (
@@ -2628,7 +2625,10 @@
 	color = "#3234B9";
 	dir = 4
 	},
-/obj/item/clipboard,
+/obj/item/clipboard{
+	pixel_x = -10
+	},
+/obj/item/paper_bin,
 /obj/item/pen/fourcolor,
 /turf/open/floor/carpet/royalblue,
 /area/facility_hallway/manager)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds the adventure console to the Rep's office.
Lets you buy a small chunk of ahn and PE from it for a pretty high price.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Representative in general needs to be slightly more self-sufficient for the sake of the role's enjoyment.
The Adventure console is rarely used, but a fun little side game for people who have tried it.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added Adventure Console to Representative Office
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
