### PR TITLE
Adds Holopads to 6 Different maps 

### DIFF
--- a/_maps/map_files/Alpha/alphacorp.dmm
+++ b/_maps/map_files/Alpha/alphacorp.dmm
@@ -1578,6 +1578,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/landmark/department_center,
 /obj/machinery/navbeacon/wayfinding/informationdepartment,
+/obj/machinery/holopad,
 /turf/open/floor/facility/dark,
 /area/department_main/information)
 "lo" = (
@@ -1853,6 +1854,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/navbeacon/wayfinding/controldepartment,
 /mob/living/simple_animal/bot/cleanbot,
+/obj/machinery/holopad,
 /turf/open/floor/carpet/red,
 /area/department_main/control)
 "nH" = (
@@ -2103,6 +2105,18 @@
 "pu" = (
 /obj/structure/chair/comfy/beige,
 /turf/open/floor/carpet/orange,
+/area/department_main/training)
+"pA" = (
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/siding/brown,
+/obj/effect/turf_decal/siding/brown{
+	dir = 1
+	},
+/obj/machinery/holopad,
+/turf/open/floor/plasteel,
 /area/department_main/training)
 "pF" = (
 /obj/effect/turf_decal/tile/brown,
@@ -5068,6 +5082,7 @@
 /obj/effect/landmark/department_center,
 /obj/machinery/navbeacon/wayfinding/centralcommanddepartment,
 /mob/living/simple_animal/bot/cleanbot,
+/obj/machinery/holopad,
 /turf/open/floor/wood,
 /area/department_main/command)
 "Nw" = (
@@ -6126,6 +6141,7 @@
 "Vt" = (
 /obj/effect/landmark/department_center,
 /obj/machinery/navbeacon/wayfinding/safetydepartment,
+/obj/machinery/holopad,
 /turf/open/floor/carpet/green,
 /area/department_main/safety)
 "Vu" = (
@@ -47314,7 +47330,7 @@ uL
 pu
 KH
 ed
-uL
+pA
 qO
 Ky
 zW

--- a/_maps/map_files/Beta/betacorp.dmm
+++ b/_maps/map_files/Beta/betacorp.dmm
@@ -913,6 +913,7 @@
 "ez" = (
 /obj/effect/landmark/department_center,
 /obj/machinery/navbeacon/wayfinding/welfaredepartment,
+/obj/machinery/holopad,
 /turf/open/floor/carpet/royalblue,
 /area/department_main/welfare)
 "eA" = (
@@ -2388,6 +2389,7 @@
 "md" = (
 /obj/effect/landmark/department_center,
 /obj/machinery/navbeacon/wayfinding/controldepartment,
+/obj/machinery/holopad,
 /turf/open/floor/facility/dark,
 /area/department_main/control)
 "mg" = (
@@ -3461,6 +3463,11 @@
 	},
 /turf/open/floor/carpet/orange,
 /area/department_main/training)
+"rf" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/holopad,
+/turf/open/floor/carpet/red,
+/area/department_main/discipline)
 "rg" = (
 /obj/machinery/disposal/bin,
 /obj/structure/sign/departments/custodian{
@@ -5059,6 +5066,7 @@
 /area/facility_hallway/north)
 "yx" = (
 /mob/living/simple_animal/bot/cleanbot/medbay,
+/obj/machinery/holopad,
 /turf/open/floor/carpet/green,
 /area/department_main/safety)
 "yy" = (
@@ -6786,6 +6794,7 @@
 	},
 /obj/effect/landmark/department_center,
 /obj/machinery/navbeacon/wayfinding/trainingdepartment,
+/obj/machinery/holopad,
 /turf/open/floor/plasteel,
 /area/department_main/training)
 "HC" = (
@@ -8431,6 +8440,7 @@
 "PZ" = (
 /obj/effect/landmark/department_center,
 /obj/machinery/navbeacon/wayfinding/informationdepartment,
+/obj/machinery/holopad,
 /turf/open/floor/facility/dark,
 /area/department_main/information)
 "Qa" = (
@@ -9695,6 +9705,7 @@
 	pixel_y = 5
 	},
 /obj/machinery/navbeacon/wayfinding/centralcommanddepartment,
+/obj/machinery/holopad,
 /turf/open/floor/wood,
 /area/department_main/command)
 "WI" = (
@@ -37582,7 +37593,7 @@ rN
 Ns
 oT
 oT
-Ns
+rf
 Qi
 on
 VS

--- a/_maps/map_files/Delta/deltacorp.dmm
+++ b/_maps/map_files/Delta/deltacorp.dmm
@@ -4314,6 +4314,7 @@
 	dir = 4
 	},
 /mob/living/simple_animal/bot/cleanbot,
+/obj/machinery/holopad,
 /turf/open/floor/bronze,
 /area/department_main/training)
 "jE" = (
@@ -5381,6 +5382,7 @@
 	},
 /obj/structure/disposalpipe/junction,
 /mob/living/simple_animal/bot/cleanbot,
+/obj/machinery/holopad,
 /turf/open/floor/plasteel/sepia{
 	color = "#ccc8c0"
 	},
@@ -6067,6 +6069,7 @@
 	dir = 9
 	},
 /mob/living/simple_animal/bot/cleanbot,
+/obj/machinery/holopad,
 /turf/open/floor/plasteel/sepia,
 /area/department_main/control)
 "nS" = (
@@ -9708,6 +9711,7 @@
 	color = "#090807";
 	dir = 4
 	},
+/obj/machinery/holopad,
 /turf/open/floor/plasteel/sepia{
 	color = "#ccc8c0"
 	},
@@ -10225,6 +10229,7 @@
 	color = "#bf48b1";
 	dir = 4
 	},
+/obj/machinery/holopad,
 /turf/open/floor/plasteel/sepia,
 /area/department_main/command)
 "xJ" = (
@@ -13064,6 +13069,7 @@
 	dir = 4
 	},
 /mob/living/simple_animal/bot/cleanbot,
+/obj/machinery/holopad,
 /turf/open/floor/plasteel/sepia,
 /area/department_main/welfare)
 "DT" = (
@@ -15065,6 +15071,7 @@
 	dir = 4
 	},
 /mob/living/simple_animal/bot/cleanbot,
+/obj/machinery/holopad,
 /turf/open/floor/plasteel/sepia,
 /area/department_main/discipline)
 "II" = (

--- a/_maps/map_files/Epsilon/epsiloncorp.dmm
+++ b/_maps/map_files/Epsilon/epsiloncorp.dmm
@@ -1886,6 +1886,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/holopad,
 /turf/open/floor/bronze,
 /area/department_main/command)
 "fL" = (
@@ -8858,6 +8859,7 @@
 	},
 /obj/machinery/navbeacon/wayfinding/welfaredepartment,
 /mob/living/simple_animal/bot/cleanbot,
+/obj/machinery/holopad,
 /turf/open/floor/plasteel/sepia{
 	color = "#ccc8c0"
 	},
@@ -10261,6 +10263,7 @@
 	},
 /obj/machinery/navbeacon/wayfinding/controldepartment,
 /mob/living/simple_animal/bot/cleanbot,
+/obj/machinery/holopad,
 /turf/open/floor/plasteel/sepia{
 	color = "#ccc8c0"
 	},
@@ -10766,6 +10769,7 @@
 	icon_state = "LC2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/holopad,
 /turf/open/floor/plasteel/sepia{
 	color = "#ccc8c0"
 	},
@@ -11888,6 +11892,7 @@
 	icon_state = "LC2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/holopad,
 /turf/open/floor/plasteel/sepia{
 	color = "#ccc8c0"
 	},

--- a/_maps/map_files/Eta/etacorp.dmm
+++ b/_maps/map_files/Eta/etacorp.dmm
@@ -336,6 +336,7 @@
 	desc = "Even in death, a clerk does their job."
 	},
 /obj/machinery/navbeacon/wayfinding/trainingdepartment,
+/obj/machinery/holopad,
 /turf/open/floor/mineral/titanium/purple{
 	color = "#ffa500";
 	name = "floor"
@@ -695,6 +696,7 @@
 	set_luminosity = 24
 	},
 /obj/machinery/navbeacon/wayfinding/controldepartment,
+/obj/machinery/holopad,
 /turf/open/floor/mineral/titanium/yellow{
 	name = "floor"
 	},
@@ -2701,6 +2703,7 @@
 	},
 /obj/machinery/light/floor,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/holopad,
 /turf/open/floor/facility/dark,
 /area/department_main/command)
 "mK" = (
@@ -6647,6 +6650,7 @@
 	},
 /obj/machinery/navbeacon/wayfinding/informationdepartment,
 /obj/structure/disposalpipe/junction/yjunction,
+/obj/machinery/holopad,
 /turf/open/floor/mineral/titanium/purple{
 	name = "floor"
 	},
@@ -10010,6 +10014,7 @@
 	desc = "Even in death, a clerk does their job."
 	},
 /obj/machinery/navbeacon/wayfinding/safetydepartment,
+/obj/machinery/holopad,
 /turf/open/floor/mineral/titanium/purple{
 	color = "#7FFF00";
 	name = "floor"

--- a/_maps/map_files/Zeta/zetacorp.dmm
+++ b/_maps/map_files/Zeta/zetacorp.dmm
@@ -3125,6 +3125,7 @@
 /area/department_main/training)
 "iO" = (
 /obj/machinery/navbeacon/wayfinding/controldepartment,
+/obj/machinery/holopad,
 /turf/open/floor/plasteel/dark,
 /area/department_main/control)
 "iP" = (
@@ -4991,8 +4992,8 @@
 	pixel_x = 9
 	},
 /obj/structure/table/wood{
-	density = 0;
-	alpha = 0
+	alpha = 0;
+	density = 0
 	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
@@ -5249,8 +5250,8 @@
 	dir = 4
 	},
 /obj/structure/table/wood{
-	density = 0;
-	alpha = 0
+	alpha = 0;
+	density = 0
 	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
@@ -11853,6 +11854,7 @@
 /obj/effect/turf_decal/siding/thinplating/dark/corner{
 	dir = 8
 	},
+/obj/machinery/holopad,
 /turf/open/floor/plasteel/dark,
 /area/department_main/information)
 "HH" = (
@@ -11987,6 +11989,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/facility/dark,
 /area/department_main/information)
+"Id" = (
+/obj/effect/turf_decal/siding/brown{
+	dir = 1
+	},
+/obj/machinery/holopad,
+/turf/open/floor/plasteel/dark,
+/area/department_main/training)
 "Ig" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 1
@@ -13828,10 +13837,10 @@
 /area/facility_hallway/south)
 "Ny" = (
 /obj/structure/statue/bronze/marx{
-	pixel_y = 14;
-	pixel_x = 1;
 	desc = "The wealthy, eccentric, and former owner of land this facility is built upon.";
-	name = "\improper Late Wing Shareholder bust"
+	name = "\improper Late Wing Shareholder bust";
+	pixel_x = 1;
+	pixel_y = 14
 	},
 /obj/structure/table/wood/fancy/orange,
 /obj/effect/turf_decal/siding/wood{
@@ -14392,6 +14401,7 @@
 /obj/machinery/camera/autoname,
 /obj/effect/landmark/department_center,
 /obj/machinery/navbeacon/wayfinding/safetydepartment,
+/obj/machinery/holopad,
 /turf/open/floor/mineral/titanium/purple{
 	color = "#7FFF00";
 	name = "floor"
@@ -14658,6 +14668,7 @@
 	view_range = 13
 	},
 /obj/machinery/navbeacon/wayfinding/centralcommanddepartment,
+/obj/machinery/holopad,
 /turf/open/floor/mineral/titanium/yellow{
 	name = "floor"
 	},
@@ -42907,7 +42918,7 @@ wD
 CQ
 pI
 pS
-xT
+Id
 VH
 pM
 Ak

--- a/_maps/map_files/generic/Manager.dmm
+++ b/_maps/map_files/generic/Manager.dmm
@@ -557,6 +557,10 @@
 /obj/effect/spawner/randomcolavend,
 /turf/open/floor/plasteel/dark,
 /area/facility_hallway/manager)
+"ib" = (
+/obj/machinery/holopad/secure,
+/turf/open/floor/carpet/royalblack,
+/area/facility_hallway/manager)
 "ih" = (
 /obj/structure/rack,
 /obj/item/toy/plush/kod,
@@ -909,6 +913,13 @@
 	},
 /turf/open/floor/carpet/royalblue,
 /area/facility_hallway/manager)
+"mT" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/machinery/holopad/secure,
+/turf/open/floor/wood,
+/area/facility_hallway/manager)
 "mU" = (
 /obj/structure/curtain/cloth,
 /turf/open/floor/plasteel/white,
@@ -1030,6 +1041,10 @@
 /obj/structure/railing,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/dark,
+/area/facility_hallway/manager)
+"pj" = (
+/obj/machinery/holopad/secure,
+/turf/open/floor/carpet/green,
 /area/facility_hallway/manager)
 "pm" = (
 /obj/machinery/door/window/brigdoor/southleft,
@@ -2597,6 +2612,7 @@
 /area/facility_hallway/manager)
 "OQ" = (
 /obj/structure/table/wood,
+/obj/item/paicard,
 /turf/open/floor/carpet/royalblue,
 /area/facility_hallway/manager)
 "OZ" = (
@@ -2626,10 +2642,14 @@
 	dir = 4
 	},
 /obj/item/clipboard{
-	pixel_x = -10
+	pixel_x = -7
 	},
-/obj/item/paper_bin,
-/obj/item/pen/fourcolor,
+/obj/item/paper_bin{
+	pixel_x = 7
+	},
+/obj/item/pen/fourcolor{
+	pixel_x = 7
+	},
 /turf/open/floor/carpet/royalblue,
 /area/facility_hallway/manager)
 "Pv" = (
@@ -2802,6 +2822,10 @@
 	dir = 1
 	},
 /turf/open/floor/carpet/green,
+/area/facility_hallway/manager)
+"Sl" = (
+/obj/machinery/holopad/secure,
+/turf/open/floor/carpet/orange,
 /area/facility_hallway/manager)
 "Sx" = (
 /obj/effect/turf_decal/siding/white{
@@ -2993,6 +3017,7 @@
 /obj/effect/turf_decal/siding/blue{
 	dir = 9
 	},
+/obj/machinery/holopad/secure,
 /turf/open/floor/carpet/cyan,
 /area/department_main/manager)
 "WS" = (
@@ -6839,7 +6864,7 @@ jj
 YM
 iO
 iO
-iO
+mT
 gC
 YQ
 Ov
@@ -7347,8 +7372,8 @@ Zi
 YQ
 YQ
 YQ
-YQ
-YQ
+HZ
+HZ
 YQ
 YQ
 YQ
@@ -9681,7 +9706,7 @@ XL
 YQ
 pv
 EQ
-EQ
+pj
 Bs
 nz
 IM
@@ -9897,7 +9922,7 @@ pE
 nz
 IM
 Lr
-Ks
+ib
 Ks
 fW
 YQ
@@ -10400,7 +10425,7 @@ bS
 Wz
 rw
 Df
-zb
+Sl
 Vl
 zb
 Iw


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Allows Holopads to be used in LC13! 

- Adds Holopads to A,B,C,D,E,F and G maps.
- Adds Secure Holopads to the Manager, Seph and Rep offices
- Gives the Rep a PAI
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Sephs and Reps want to be able to go down to the floor below to chat with people and vibe around more than their console.
So I'm giving them this so that they can somewhat do that

The PAI allows reps to have some eyes on the ground floor.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added Holopads to the first 6 maps
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
