### PR TITLE
Damage effects and big mob improvement.

### DIFF
--- a/ModularTegustation/tegu_mobs/apocalypse_bird.dm
+++ b/ModularTegustation/tegu_mobs/apocalypse_bird.dm
@@ -24,6 +24,7 @@
 	occupied_tiles_left = 3
 	occupied_tiles_right = 3
 	occupied_tiles_up = 2
+	damage_effect_scale = 1.25
 	blood_volume = BLOOD_VOLUME_NORMAL
 	del_on_death = TRUE
 	death_message = "finally stops moving, falling to the ground."

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -136,6 +136,9 @@
 
 	return dist
 
+/proc/get_dist_manhattan(atom/Loc1, atom/Loc2)
+	return abs(Loc1.x - Loc2.x) + abs(Loc1.y - Loc2.y)
+
 /proc/circlerangeturfs(center=usr,radius=3)
 
 	var/turf/centerturf = get_turf(center)

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -145,9 +145,12 @@
 	if(CanReach(A,W))
 		if(W)
 			var/atom/target_thing = A
-			if((isturf(A) || iseffect(A)) && W.force > 10)
+			if(a_intent != INTENT_HARM && (isturf(A) || iseffect(A)) && W.force > 10)
 				var/turf/T = get_turf(A)
 				for(var/mob/living/L in T)
+					if(istype(L, /mob/living/simple_animal/projectile_blocker_dummy))
+						var/mob/living/simple_animal/projectile_blocker_dummy/pbd = L
+						L = pbd.parent
 					if(L.invisibility > see_invisible)
 						continue
 					if(L.stat != DEAD)

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -84,6 +84,9 @@
 
 	for(var/turf/T in hit_turfs)
 		for(var/mob/M in T)
+			if(istype(M, /mob/living/simple_animal/projectile_blocker_dummy))
+				var/mob/living/simple_animal/projectile_blocker_dummy/pbd = M
+				M = pbd.parent
 			potential_targets |= M
 
 	potential_targets -= user

--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -209,6 +209,9 @@
 		if(isturf(A) || iseffect(A))
 			var/turf/T = get_turf(A)
 			for(var/mob/living/L in T)
+				if(istype(L, /mob/living/simple_animal/projectile_blocker_dummy))
+					var/mob/living/simple_animal/projectile_blocker_dummy/pbd = L
+					L = pbd.parent
 				if(L.invisibility > see_invisible)
 					continue
 				if(L.stat != DEAD)

--- a/code/modules/mob/living/carbon/human/damage_procs.dm
+++ b/code/modules/mob/living/carbon/human/damage_procs.dm
@@ -6,18 +6,17 @@
 
 //// Damage Effects
 /mob/living/carbon/human/adjustRedLoss(amount, updating_health = TRUE, forced = FALSE)
+	if(stat != DEAD)
+		DamageEffect(amount, RED_DAMAGE)
 	. = ..()
-	//Failsafe
-	if(. && !forced)
-		if(. > 0)
-			new /obj/effect/temp_visual/damage_effect/red(get_turf(src))
+
 
 /mob/living/carbon/human/adjustWhiteLoss(amount, updating_health = TRUE, forced = FALSE, white_healable = FALSE)
 	var/damage_amt = amount
 	if(sanity_lost && white_healable) // Heal sanity instead.
 		damage_amt *= -1
-	if(damage_amt > 0 && !forced)
-		new /obj/effect/temp_visual/damage_effect/white(get_turf(src))
+	if(stat != DEAD)
+		DamageEffect(damage_amt, WHITE_DAMAGE)
 	adjustSanityLoss(damage_amt, forced)
 	if(updating_health)
 		updatehealth()
@@ -27,29 +26,26 @@
 	var/damage_amt = amount
 	if(sanity_lost && white_healable) // Heal sanity instead.
 		damage_amt *= -1
-	if(amount > 0 && !forced)
-		new /obj/effect/temp_visual/damage_effect/black(get_turf(src))
+	if(stat != DEAD)
+		DamageEffect(amount, BLACK_DAMAGE)
 	adjustBruteLoss(amount, forced = forced)
 	adjustSanityLoss(damage_amt, forced = forced)
 	return damage_amt
 
 /mob/living/carbon/human/adjustPaleLoss(amount, updating_health = TRUE, forced = FALSE)
+	if(stat != DEAD)
+		DamageEffect(amount, PALE_DAMAGE)
 	. = ..()
-	if(. && !forced)
-		if(. > 0)
-			new /obj/effect/temp_visual/damage_effect/pale(get_turf(src))
 
 /mob/living/carbon/human/adjustToxLoss(amount, updating_health = TRUE, forced = FALSE)
+	if(stat != DEAD)
+		DamageEffect(amount, TOX)
 	. = ..()
-	if(. && !forced)
-		if(. > 0)
-			new /obj/effect/temp_visual/damage_effect/tox(get_turf(src))
 
 /mob/living/carbon/human/adjustFireLoss(amount, updating_health = TRUE, forced = FALSE, required_status)
+	if(stat != DEAD)
+		DamageEffect(amount, BURN)
 	. = ..()
-	if(. && !forced)
-		if(. > 0)
-			new /obj/effect/temp_visual/damage_effect/burn(get_turf(src))
 
 //
 

--- a/code/modules/mob/living/simple_animal/abnormality/waw/greed_king.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/greed_king.dm
@@ -133,6 +133,7 @@
 	offsets_pixel_y = list("south" = -8, "north" = -8, "west" = -8, "east" = -8)
 	transform = matrix(1.5, MATRIX_SCALE)
 	SetOccupiedTiles(1, 1, 1, 1)
+	damage_effect_scale = 1.2
 	startTeleport()	//Let's Spaghettioodle out of here
 
 /mob/living/simple_animal/hostile/abnormality/greed_king/proc/startTeleport()

--- a/code/modules/mob/living/simple_animal/abnormality/waw/warden.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/warden.dm
@@ -152,4 +152,5 @@
 
 /mob/living/simple_animal/hostile/abnormality/warden/bullet_act(obj/projectile/P)
 	visible_message(span_userdanger("[src] is unfazed by \the [P]!"))
+	new /obj/effect/temp_visual/healing/no_dam(get_turf(src))
 	P.Destroy()

--- a/code/modules/mob/living/simple_animal/animal_defense.dm
+++ b/code/modules/mob/living/simple_animal/animal_defense.dm
@@ -141,6 +141,7 @@
 
 	if(temp_damage >= 0 && temp_damage <= force_threshold)
 		visible_message(span_warning("[src] looks unharmed!"))
+		DamageEffect(0, damagetype)
 		return FALSE
 
 	if(actuallydamage)

--- a/code/modules/mob/living/simple_animal/hostile/ordeal/amber.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/amber.dm
@@ -192,6 +192,7 @@
 	should_projectile_blockers_change_orientation = TRUE
 	occupied_tiles_up = 1
 	offsets_pixel_x = list("south" = -16, "north" = -16, "west" = 0, "east" = -32)
+	offsets_pixel_y = list("south" = 9, "north" = -20, "west" = 0, "east" = 0)
 
 	/// This cooldown responds for both the burrowing and spawning in the dawns
 	var/burrow_cooldown
@@ -226,9 +227,24 @@
 
 /mob/living/simple_animal/hostile/ordeal/amber_dusk/Initialize()
 	. = ..()
+	setDir(WEST)
 	soundloop = new(list(src), TRUE)
 	if(LAZYLEN(butcher_results))
 		addtimer(CALLBACK(src, PROC_REF(BurrowOut), get_turf(src)))
+
+/mob/living/simple_animal/hostile/ordeal/amber_dusk/OnDirChange(atom/thing, dir, newdir)
+	. = ..()
+	if(stat == DEAD)
+		return
+	var/static/matrix/add_vertical_transform = matrix(0.8, 1.4, MATRIX_SCALE)
+	var/static/south_north = SOUTH | NORTH
+	var/static/east_west = EAST | WEST
+	var/combined = dir | newdir
+	if((combined & south_north) && (combined & east_west))
+		if(newdir & south_north)
+			transform = add_vertical_transform
+		else
+			transform = matrix()
 
 /mob/living/simple_animal/hostile/ordeal/amber_dusk/Destroy()
 	QDEL_NULL(soundloop)
@@ -249,6 +265,8 @@
 	if(LAZYLEN(butcher_results))
 		alpha = 255
 	offsets_pixel_x = list("south" = -16, "north" = -16, "west" = -16, "east" = -16)
+	offsets_pixel_y = list("south" = 0, "north" = 0, "west" = 0, "east" = 0)
+	transform = matrix()
 	soundloop.stop()
 	for(var/mob/living/simple_animal/hostile/ordeal/amber_bug/bug in spawned_mobs)
 		bug.can_burrow_solo = TRUE
@@ -257,6 +275,8 @@
 /mob/living/simple_animal/hostile/ordeal/amber_dusk/revive(full_heal, admin_revive)
 	. = ..()
 	offsets_pixel_x = list("south" = -16, "north" = -16, "west" = 0, "east" = -32)
+	offsets_pixel_y = list("south" = 9, "north" = -20, "west" = 0, "east" = 0)
+	density = TRUE
 
 /mob/living/simple_animal/hostile/ordeal/amber_dusk/proc/AttemptBirth()
 	var/max_spawn = clamp(length(GLOB.clients) * 2, 4, 8)
@@ -368,6 +388,7 @@
 	occupied_tiles_up = 2
 	offsets_pixel_x = list("south" = -96, "north" = -96, "west" = -96, "east" = -96)
 	offsets_pixel_y = list("south" = -16, "north" = -16, "west" = -16, "east" = -16)
+	damage_effect_scale = 1.25
 
 	blood_volume = BLOOD_VOLUME_NORMAL
 	death_sound = 'sound/effects/ordeals/amber/midnight_dead.ogg'

--- a/code/modules/mob/living/simple_animal/hostile/ordeal/green.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/green.dm
@@ -275,6 +275,7 @@
 	guaranteed_butcher_results = list(/obj/item/food/meat/slab/robot = 16)
 	death_sound = 'sound/effects/ordeals/green/midnight_dead.ogg'
 	offsets_pixel_x = list("south" = -96, "north" = -96, "west" = -96, "east" = -96)
+	damage_effect_scale = 1.25
 
 	var/laser_cooldown
 	var/laser_cooldown_time = 20 SECONDS

--- a/code/modules/mob/living/simple_animal/projectile_blocker.dm
+++ b/code/modules/mob/living/simple_animal/projectile_blocker.dm
@@ -47,7 +47,7 @@
 		return TRUE
 	if(!isturf(parent.loc))
 		return TRUE
-	if(parent.CanPassThroughBlocker(mover, target))
+	if(parent.CanPassThroughBlocker(mover, target, get_turf(src)))
 		return TRUE
 	return parent.CanPass(mover, target)
 
@@ -126,10 +126,12 @@
 		moveToNullspace()
 
 ///For letting some mobs walk through the blockers
-/mob/living/simple_animal/proc/CanPassThroughBlocker(atom/movable/mover, turf/target)
+/mob/living/simple_animal/proc/CanPassThroughBlocker(atom/movable/mover, turf/start, turf/destination)
 	return FALSE
 
-/mob/living/simple_animal/hostile/CanPassThroughBlocker(atom/movable/mover, turf/target)
+/mob/living/simple_animal/hostile/CanPassThroughBlocker(atom/movable/mover, turf/start, turf/destination)
 	if(isliving(mover) && faction_check_mob(mover))
+		return TRUE
+	if(isliving(mover) && get_dist_manhattan(get_turf(src), destination) > get_dist_manhattan(get_turf(src), start))
 		return TRUE
 	return FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds damage_effect_scale variable to hostiles that scales the visual damage effects.
Big multi tile mobs get their damage effects randomly spread out over the whole multi tile body instead of just the core.
Multi tile mobs now let you move out of the multi tile mob if it appeared on top of you.
Added the no damage visual effect when projectiles hit Warden.
Made Damage Effects work the same way for humans and hostiles with DamageEffect now as a /mob/living proc. This means hostiles will now show damage effects for any damage source.
Made clicking turfs to hit mobs not work on harm intent to let weapon swinging do its own thing.
Made both clicking turfs and weapon swings properly detect multi tile mob hitboxes.
Visually scaled Amber dusk worm when facing south and north a bit to fit 2 turfs.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Looks better.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: damage effects on big mobs scale.
tweak: big mobs dont block movement if trying to get out of their hitbox.
fix: fixed damage effects from projectiles not working.
refactor: DamageEffect is now a /mob/living proc.
tweak: Clicking turfs and weapon swings can hit multi tile mobs properly.
tweak: Click turf to hit mob is disabled on harm intent to not conflict with weapon swings.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
