### PR TITLE
How i lost my sanity painfully changing 159 files one by one -- Reworks observation code to be better for any amount of answers

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/_abnormality.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_abnormality.dm
@@ -123,13 +123,19 @@
 	/// Offset for secret skins in the Y axis
 	var/secret_vertical_offset = 0
 
-	/// Final Observation details
-	var/observation_in_progress = FALSE
+	/// Final Observation stuffs
+	/// The prompt we get alongside our choices for observing it
 	var/observation_prompt = "The abnormality is watching you. What will you do?"
-	var/list/observation_choices = list("Approach", "Leave")
-	var/list/correct_choices = list("Approach", "Leave")
-	var/observation_success_message = "Final Observation Success!"
-	var/observation_fail_message = "Final Observation Failed!"
+	/**
+	 * observation_choices is made in the format of:
+	 * "Choice" = list(TRUE or FALSE [depending on if the answer is correct], "Response"),
+	 */
+	var/list/observation_choices = list(
+		"Approach" = list(TRUE, "You approach the abnormality... and obtain a gift from it."),
+		"Leave" = list(TRUE, "You leave the abnormality... and before you notice a gift is in your hands."),
+	)
+	/// Is there a currently on-going observation?
+	var/observation_in_progress = FALSE
 
 /mob/living/simple_animal/hostile/abnormality/Initialize(mapload)
 	SHOULD_CALL_PARENT(TRUE)
@@ -339,13 +345,6 @@
 /mob/living/simple_animal/hostile/abnormality/proc/PostSpawn()
 	SHOULD_CALL_PARENT(TRUE)
 	HandleStructures()
-	var/condition = FALSE //Final observation debug
-	for(var/answer in observation_choices)
-		if(answer in correct_choices)
-			condition = TRUE
-	if(!condition)
-		CRASH("Abnormality has no correct choice for final observation!")
-	return
 
 // Moves structures already in its datum; Overrides can spawn structures here.
 /mob/living/simple_animal/hostile/abnormality/proc/HandleStructures()
@@ -552,25 +551,29 @@
 			return
 		to_chat(user, span_warning("You already have a gift in the [gift_type.slot] slot, dissolve it first!"))
 		return
-	var/condition = FALSE
+
 	if(observation_in_progress)
 		to_chat(user, span_notice("Someone is already observing [src]!"))
 		return
 	observation_in_progress = TRUE
-	var/answer = final_observation_alert(user, "[observation_prompt]", "Final Observation of [src]", observation_choices, timeout = 60 SECONDS)
-	if(answer in correct_choices)
-		condition = TRUE
-	ObservationResult(user, condition, answer) //We pass along the answer just in case
+	var/answer = final_observation_alert(user, "[observation_prompt]", "Final Observation of [src]", shuffle(observation_choices), timeout = 60 SECONDS)
+	if(answer == "timed out")
+		ObservationResult(user, reply = answer)
+	else
+		var/list/answer_vars = observation_choices[answer]
+		ObservationResult(user, answer_vars[1], answer_vars[2])
+
 	observation_in_progress = FALSE
 
-/mob/living/simple_animal/hostile/abnormality/proc/ObservationResult(mob/living/carbon/human/user, condition, answer)
-	if(condition) //Successful, could override for longer observations as well.
-		final_observation_alert(user,"[observation_success_message]", "OBSERVATION SUCCESS",list("Ok"), timeout=20 SECONDS) //Some of these take a long time to read
+/mob/living/simple_animal/hostile/abnormality/proc/ObservationResult(mob/living/carbon/human/user, success = FALSE, reply = "")
+	if(success) //Successful, could override for longer observations as well.
+		final_observation_alert(user, "[reply]", "OBSERVATION SUCCESS", list("Ok"), timeout = 20 SECONDS) //Some of these take a long time to read
 		if(gift_type)
 			user.Apply_Gift(new gift_type)
 			playsound(get_turf(user), 'sound/machines/synth_yes.ogg', 30 , FALSE)
 	else
-		final_observation_alert(user,"[observation_fail_message]", "OBSERVATION FAIL",list("Ok"), timeout=20 SECONDS)
+		if(reply != "timed out")
+			final_observation_alert(user, "[reply]", "OBSERVATION FAIL", list("Ok"), timeout = 20 SECONDS)
 		playsound(get_turf(user), 'sound/machines/synth_no.ogg', 30 , FALSE)
 	datum_reference.observation_ready = FALSE
 

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/army_in_black.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/army_in_black.dm
@@ -55,11 +55,11 @@ GLOBAL_LIST_EMPTY(army)
 
 	observation_prompt = "\"We're here to help sir, to keep the hearts of humans a clean pink, we're willing to dirty our own. We won't overlook a single speck of black.\" <br>\
 		The soldier in pink makes a salute. <br>You..."
-	observation_choices = list("Don't salute", "Salute him back")
-	correct_choices = list("Don't salute")
-	observation_success_message = "The soldier frowns. <br>\"As expected. <br>You're only human, a clean heart is only ever temporary for you. <br>Yours is rife with sin. <br>Ours are...\" <br>\
-		The soldier falls silent, as if in deep thought."
-	observation_fail_message = "The soldier in pink smiles. <br>\"Glad to have you on board Sir, with our help, there will be no more black hearts.\""
+	observation_choices = list(
+		"Don't salute" = list(TRUE, "The soldier frowns. <br>\"As expected. <br>You're only human, a clean heart is only ever temporary for you. <br>\
+			Yours is rife with sin. <br>Ours are...\" <br>The soldier falls silent, as if in deep thought."),
+		"Salute him back" = list(FALSE, "The soldier in pink smiles. <br>\"Glad to have you on board Sir, with our help, there will be no more black hearts.\""),
+	)
 
 	//Unique variables
 	var/death_counter = 0

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/black_sun.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/black_sun.dm
@@ -42,7 +42,7 @@
 		StageChange()
 
 /mob/living/simple_animal/hostile/abnormality/black_sun/proc/StageChange()
-	stage+=1
+	stage++
 	//Add 10 stats to everyone.
 	if(stage == 1)
 		affected_players = list()	//Clear the list, then fill it up

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/blue_star.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/blue_star.dm
@@ -48,13 +48,13 @@
 	observation_prompt = "A group of employees worship this abnormality, despite the fact nothing can be sacred in this place. <br>\
 		You recall how you pulled away one employee away from it in the past, even as she screamed and wailed that you were keeping her chained to this world. <br>You thought you were saving her. <br>\
 		You can hear a distant howl emanating from the centre of the blue-coloured heart. <br>It's the sound of stars. <br>They're welcoming you, asking you to join them as a star."
-	observation_choices = list("Be pulled in", "Hold yourself tight")
-	correct_choices = list("Be pulled in")
-	observation_success_message = "You don't hesitate as you approach the centre of the void. <br>Sensation in your hands and legs are the first things to go, creeping up your body until you couldn't feel anything physical at all. <br>\
-		Despite how scary it should have been, you feel at peace, <br>this isn't an end it's a new beginning - You're a martyr. <br>\
-		Let's meet everyone again, as stars."
-	observation_fail_message = "You wrapped your arms around yourself and shut your eyes, turning your senses inward until the temptation passes and the sounds become distant howls again. <br>\
-		You opened your eyes and looked again at the heart. <br>It remains in the air, floating towards a new beginning."
+	observation_choices = list(
+		"Be pulled in" = list(TRUE, "You don't hesitate as you approach the centre of the void. <br>Sensation in your hands and legs are the first things to go, creeping up your body until you couldn't feel anything physical at all. <br>\
+			Despite how scary it should have been, you feel at peace, <br>this isn't an end it's a new beginning - You're a martyr. <br>\
+			Let's meet everyone again, as stars."),
+		"Hold yourself tight" = list(FALSE, "You wrapped your arms around yourself and shut your eyes, turning your senses inward until the temptation passes and the sounds become distant howls again. <br>\
+			You opened your eyes and looked again at the heart. <br>It remains in the air, floating towards a new beginning."),
+	)
 
 	var/pulse_cooldown
 	var/pulse_cooldown_time = 12 SECONDS

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/censored.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/censored.dm
@@ -46,12 +46,12 @@
 	abnormality_origin = ABNORMALITY_ORIGIN_LOBOTOMY
 
 	observation_prompt = "This is the containment unit of \[CENSORED\]. <br>Many managers went mad, before they implemented the cognition filter, from the sight of it."
-	observation_choices = list("Enter the containment unit", "Don't enter")
-	correct_choices = list("Enter the containment unit")
-	observation_success_message = "You enter the containment unit of \[CENSORED\], the smell of \[REDACTED\] and the sound of \[ANULLED\] filled the air. <br>\
-		After steeling yourself, you finally saw \[CENSORED\]. <br>You manage to face the fear."
-	observation_fail_message = "A wave of nausea rises up within at the thought of entering the containment unit, and you turn on your heels to leave. <br>\
-		You're not ready to build the future."
+	observation_choices = list(
+		"Enter the containment unit" = list(TRUE, "You enter the containment unit of \[CENSORED\], the smell of \[REDACTED\] and the sound of \[ANULLED\] filled the air. <br>\
+			After steeling yourself, you finally saw \[CENSORED\]. <br>You manage to face the fear."),
+		"Don't enter" = list(FALSE, "A wave of nausea rises up within at the thought of entering the containment unit, and you turn on your heels to leave. <br>\
+			You're not ready to build the future."),
+	)
 
 	var/can_act = TRUE
 	var/ability_damage = 150

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/distortedform.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/distortedform.dm
@@ -51,21 +51,21 @@
 		But the largest creature of all surrounds me entirely. <br>Every direction is covered in a undulating mass of flesh, blood, fur, and feathers. <br>\
 		I am always butchering monsters like these. <br>I tear them limb from limb.<br>\
 		Bringing death in brutal fashion. <br>Am I not a fitting piece of the scenery before me?"
-	observation_choices = list("I am a monster", "I am not a monster")
-	correct_choices = list("I am not a monster")
-	observation_success_message = "It is hard to live in the city. <br>\
-		To pretend to be a civilized human when living in this manner. <br>\
-		It is easy to give into the temptation of giving up all pretenses of humanity. <br>\
-		But I do it because it is hard. <br>\
-		... <br>\
-		I am not a monster. <br>\
-		I will never become a monster."
-	observation_fail_message = "\"Do you wish to be so?\" <br>\
-		\"Then it can be as you wish.\" <br>\
-		... <br>\
-		Her voice is like sunshine. <br>\
-		... <br>\
-		I am a monster. <br>"
+	observation_choices = list(
+		"I am not a monster" = list(TRUE, "It is hard to live in the city. <br>\
+			To pretend to be a civilized human when living in this manner. <br>\
+			It is easy to give into the temptation of giving up all pretenses of humanity. <br>\
+			But I do it because it is hard. <br>\
+			... <br>\
+			I am not a monster. <br>\
+			I will never become a monster."),
+		"I am a monster" = list(FALSE, "\"Do you wish to be so?\" <br>\
+			\"Then it can be as you wish.\" <br>\
+			... <br>\
+			Her voice is like sunshine. <br>\
+			... <br>\
+			I am a monster. <br>"),
+	)
 
 //Work vars
 	var/transform_timer

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/last_shot.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/last_shot.dm
@@ -38,16 +38,16 @@ GLOBAL_LIST_EMPTY(meat_list)
 		\"You won't survive out there. <br>Every single day in this facility is a constant, unending battle.\" <br>\
 		\"The only way you'll survive is if you join me. <br>To serve L-Corp til your last breath.\" <br>\
 		A tendril of rotten meat is held out to you, beckoning for you to join it."
-	observation_choices = list("EMBRACE IT", "REJECT IT")
-	correct_choices = list("EMBRACE IT")
-	observation_success_message = "You grab onto the tendril. You can feel your flesh tingling. <br>\
-		\"Good choice.\" <br>\
-		\"Don't worry. <br>You won't regret this, you know? <br>This is the only path you had.\" <br>\
-		\"You're dead meat out there. <br>Might as well accept who you are.\""
-	observation_fail_message = "You slap the tendril away. <br>\
-		\"Feh. <br>So be it. <br>You won't survive out there, you know?\" <br>\
-		\"When there's nothing left of the staff but blood and gore, I'll remain. <br>Do you understand?\" <br>\
-		You can't help but to shudder in disgust as you exit the cell. <br>Was it right? You'll never know."
+	observation_choices = list(
+		"EMBRACE IT" = list(TRUE, "You grab onto the tendril. You can feel your flesh tingling. <br>\
+			\"Good choice.\" <br>\
+			\"Don't worry. <br>You won't regret this, you know? <br>This is the only path you had.\" <br>\
+			\"You're dead meat out there. <br>Might as well accept who you are.\""),
+		"REJECT IT" = list(FALSE, "You slap the tendril away. <br>\
+			\"Feh. <br>So be it. <br>You won't survive out there, you know?\" <br>\
+			\"When there's nothing left of the staff but blood and gore, I'll remain. <br>Do you understand?\" <br>\
+			You can't help but to shudder in disgust as you exit the cell. <br>Was it right? You'll never know."),
+	)
 
 	var/list/gremlins = list()	//For the meatballs
 	var/list/meat = list()		//For the floors

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/melting_love.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/melting_love.dm
@@ -52,11 +52,11 @@
 	observation_prompt = "The slime craves affection, it covers the cell's floor, walls and celing. <br>\
 		It clings to your clothes, your mask and your skin as you enter. <br>At the centre of the cell, where the deluge conglomerates most, is the facismile of a girl. <br>\
 		She waves at you shyly. <br>You..."
-	observation_choices = list("Retreat from the slime", "Reach out to her")
-	correct_choices = list("Retreat from the slime")
-	observation_success_message = "You retreat from the cell in a hurry, the slime clinging to you turns acidic. If she won't find affection from you, she'll find it another way..."
-	observation_fail_message = "You reach out your hand and she does the same, your fingers entwine with the slimy appendage and she giggles. <br>\"Let's be together forever.\" <br>\
-		You pull your hand away, but it comes out with the slime. <br>You try to retreat, but you are already caught in her trap. <br>\"Don't betray me, okay?\" <br>Those are the last words you ever hear..."
+	observation_choices = list(
+		"Retreat from the slime" = list(TRUE, "You retreat from the cell in a hurry, the slime clinging to you turns acidic. If she won't find affection from you, she'll find it another way..."),
+		"Reach out to her" = list(FALSE, "You reach out your hand and she does the same, your fingers entwine with the slimy appendage and she giggles. <br>\"Let's be together forever.\" <br>\
+			You pull your hand away, but it comes out with the slime. <br>You try to retreat, but you are already caught in her trap. <br>\"Don't betray me, okay?\" <br>Those are the last words you ever hear..."),
+	)
 
 	var/mob/living/carbon/human/gifted_human = null
 	/// Amount of BLACK damage done to all enemies around main target on melee attack. Also includes original target

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/mountain.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/mountain.dm
@@ -49,10 +49,10 @@
 	observation_prompt = "It smells like death itself in its containment unit, the mound of rotted, half-purtefied flesh stares at you with its many faces. <br>\
 		Arms and legs bent at odd angles, entrails draped like lazy christmas decorations, innumerable limbs twisted and distorted into a sphere - all blanketed black with necrotic skin. <br>\
 		Yet the faces remain intact, pale from a lack of blood, but still as recognizable as they've always been. <br>They're smiling at you."
-	observation_choices = list("I recognize those faces", "I don't recognize them")
-	correct_choices = list("I recognize those faces")
-	observation_success_message = "From the mountain of bodies; the dead give their life to be something greater. <br>Why shouldn't they be smiling? <br>You should be smiling too."
-	observation_fail_message = "They're holding all the laughter of those who cannot be seen here. <br>The mounds begins to shamble, upon borrowed hands and feet, it has your scent now and it will never be satisfied."
+	observation_choices = list(
+		"I recognize those faces" = list(TRUE, "From the mountain of bodies; the dead give their life to be something greater. <br>Why shouldn't they be smiling? <br>You should be smiling too."),
+		"I don't recognize them" = list(FALSE, "They're holding all the laughter of those who cannot be seen here. <br>The mounds begins to shamble, upon borrowed hands and feet, it has your scent now and it will never be satisfied."),
+	)
 
 	/// Is user performing work hurt at the beginning?
 	var/agent_hurt = FALSE

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/nihil.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/nihil.dm
@@ -41,7 +41,7 @@
 		"They've become me" = list(TRUE, "It doesn't matter. <br>My choices do not matter. <br>\
 			Nothing matters. <br>We will repeat this song and dance until the end of time.<br> I can only laugh at this pointless endeavor."),
 		"I came to resemble them" = list(TRUE, "It doesn't matter. <br>My choices do not matter. <br>\
-			Nothing matters. <br>We will repeat this song and dance until the end of time.<br> I can only laugh at this pointless endeavor."),,
+			Nothing matters. <br>We will repeat this song and dance until the end of time.<br> I can only laugh at this pointless endeavor."),
 	)
 
 	var/can_act = TRUE

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/nihil.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/nihil.dm
@@ -37,10 +37,12 @@
 
 	observation_prompt = "I have no plans or destination. I'm too tired to fly. <br>With no one to guide me, and no path open to me. <br>It is my fate to play the fool. <br>\
 		Before I do, I turn to face the 4 Magical Girls. <br>Are they just like me, or am I just like them?"
-	observation_choices = list("They've become me", "I came to resemble them")
-	correct_choices = list("They've become me", "I came to resemble them")
-	observation_success_message = "It doesn't matter. <br>My choices do not matter. <br>\
-		Nothing matters. <br>We will repeat this song and dance until the end of time.<br> I can only laugh at this pointless endeavor."
+	observation_choices = list(
+		"They've become me" = list(TRUE, "It doesn't matter. <br>My choices do not matter. <br>\
+			Nothing matters. <br>We will repeat this song and dance until the end of time.<br> I can only laugh at this pointless endeavor."),
+		"I came to resemble them" = list(TRUE, "It doesn't matter. <br>My choices do not matter. <br>\
+			Nothing matters. <br>We will repeat this song and dance until the end of time.<br> I can only laugh at this pointless endeavor."),,
+	)
 
 	var/can_act = TRUE
 	//Teleports

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/nobody_is.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/nobody_is.dm
@@ -47,11 +47,11 @@
 	observation_prompt = "No matter where you walk to in the cell, the mirror is always facing you. <br>You trace a path around it but all you ever see is your own reflection. <br>\
 		\"It's not fair, why do you get to be you and not me?\" <br>Your reflection mutters, parroting your voice. <br>\"Why are you, you and not I? I could be you so much better than you can, just let me try.\" <br>\
 		Your reflection is holding out its hand, waiting for a handshake."
-	observation_choices = list("Shake their hand", "Turn away and leave")
-	correct_choices = list("Turn away and leave")
-	observation_success_message = "You make to exit the cell. \"Don't just leave me! I'm somebody, I'm real! I'm..! What's my name?! Just give me your name!\" <br>\
-		You don't give your name to the imitation, the closer it starts to mirrors another, the more its mimicry becomes mockery."
-	observation_fail_message = "The you in the mirror smiles. <br>\"Just you wait, I'll show you what we can do.\""
+	observation_choices = list(
+		"Turn away and leave" = list(TRUE, "You make to exit the cell. \"Don't just leave me! I'm somebody, I'm real! I'm..! What's my name?! Just give me your name!\" <br>\
+			You don't give your name to the imitation, the closer it starts to mirrors another, the more its mimicry becomes mockery."),
+		"Shake their hand" = list(FALSE, "The you in the mirror smiles. <br>\"Just you wait, I'll show you what we can do.\""),
+	)
 
 	//Contained Variables
 	var/reflect_timer

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/nothing_there.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/nothing_there.dm
@@ -50,16 +50,16 @@
 	observation_prompt = "*Teeth grinding* <br>Incomprehensible sounds can be heard. <br>\
 		Its body was already broken long time ago. <br>\
 		The twisted mouth opens, the crushed down tongue undulates. <br>\"M-ma......man-ag......r.......\" <br>It's calling for the manager."
-	observation_choices = list("Approach it", "Ignore it")
-	correct_choices = list("Ignore it")
-	observation_success_message = "A chunk of flesh dropped from the mouth to the ground, depriving the abnormality an ability to talk. <br>\
-		It's talking inside the body of an employee. <br>But it is not the employee who speaks. <br>\
-		The sound of calling me. <br>Is nothing but an empty shell mimicking a dead person. <br>\
-		How many employees would have suffered to this sound? <br>It keeps getting closer to human. <br>\
-		It keeps trying. <br>However, as always, at the end, Nothing there."
-	observation_fail_message = "I think of people who were friends with this employee. <br>\
-		Those eyes, shoulders, and every bit of muscle belong to someone else. <br>\
-		It smiles. <br>No, it pretends to smile. <br>Who could be it?"
+	observation_choices = list(
+		"Ignore it" = list(TRUE, "A chunk of flesh dropped from the mouth to the ground, depriving the abnormality an ability to talk. <br>\
+			It's talking inside the body of an employee. <br>But it is not the employee who speaks. <br>\
+			The sound of calling me. <br>Is nothing but an empty shell mimicking a dead person. <br>\
+			How many employees would have suffered to this sound? <br>It keeps getting closer to human. <br>\
+			It keeps trying. <br>However, as always, at the end, Nothing there."),
+		"Approach it" = list(FALSE, "I think of people who were friends with this employee. <br>\
+			Those eyes, shoulders, and every bit of muscle belong to someone else. <br>\
+			It smiles. <br>No, it pretends to smile. <br>Who could be it?"),
+	)
 
 	var/mob/living/disguise = null
 	var/saved_appearance

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/seasons.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/seasons.dm
@@ -53,14 +53,14 @@
 	observation_prompt = "I'm standing outside a forest I both have never seen before, yet know well. <br>There is no City, no civilization on the horizon, I am utterly alone. <br>\
 		Dauntlessly, I press into the forest, seeing no other path forward, and encounter a cute-looking, pink forest spirit. <br>\
 		The spirits of the forest are playful, but it's best not to offend them by forgetting to make an offering"
-	observation_choices = list("Make an offering", "Continue on")
-	correct_choices = list("Make an offering")
-	observation_success_message = "I ask the spirit to lead me to an altar to make my offering and it leads me off a beaten path... <br>\
-		It felt as though I had walked for miles and days, my clothes torn and skin pricked by brambles and thorns but finally we arrived. <br>\
-		Before me is a skull-headed pagan God hanging ominously over its altar, fear grips my heart as the pink spirit leads me to lay down on the altar..."
-	observation_fail_message = "I pass by the spirit and hear it giggle ominously... <br>\
-		... <br>\
-		In the end, I am never able to find a way out of the forest."
+	observation_choices = list(
+		"Make an offering" = list(TRUE, "I ask the spirit to lead me to an altar to make my offering and it leads me off a beaten path... <br>\
+			It felt as though I had walked for miles and days, my clothes torn and skin pricked by brambles and thorns but finally we arrived. <br>\
+			Before me is a skull-headed pagan God hanging ominously over its altar, fear grips my heart as the pink spirit leads me to lay down on the altar..."),
+		"Continue on" = list(FALSE, "I pass by the spirit and hear it giggle ominously... <br>\
+			... <br>\
+			In the end, I am never able to find a way out of the forest."),
+	)
 
 	//Var Lists
 	var/list/season_stats = list(

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/silent_orchestra.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/silent_orchestra.dm
@@ -38,10 +38,10 @@
 	observation_prompt = "I was the conductor of Lobotomy Corporation, I put my everything into it. <br>\
 		Now, I conduct the song of apocalypse to make everything right. <br>As if he is about to start the performance, he stretches his arm. <br>\
 		The conductor, who thought he is the freest soul, was not free at all. <br>The performance ended. <br>I......."
-	observation_choices = list("Gave an applause.", "Did not give applause.")
-	correct_choices = list("Did not give applause.")
-	observation_success_message = "I am not worthy to give an applause yet. <br>The music replays. <br>Angelos, my movement."
-	observation_fail_message = "The performance never ends. <br>And Da Capo."
+	observation_choices = list(
+		"Did not give applause" = list(TRUE, "I am not worthy to give an applause yet. <br>The music replays. <br>Angelos, my movement."),
+		"Gave an applause" = list(FALSE, "The performance never ends. <br>And Da Capo."),
+	)
 
 	/// Range of the damage
 	var/symphony_range = 20

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/space_lady.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/space_lady.dm
@@ -37,32 +37,21 @@
 
 	observation_prompt = "What touched this place cannot be quantified or understood by human science. <br>It was just a color out of space. <br>\
 		It exists on the border of our waking minds, where darkness and light are one, and time and space do not intersect. <br>She has a message, from another place, another time."
-	observation_choices = list("Hear the past", "Hear the present", "Hear the future")
-	correct_choices = list("Hear the past", "Hear the present", "Hear the future")
-	observation_success_message = "What I learned and saw during those two hideous days and nights, it is better not to tell."
-	//Extra correct answers
-	var/observation_success_message_2 = "A thousand years compressed into a day, a countably infinite number of people work, die and live in its corridors; <br>\
-		the line between them and the monsters they keep gets blurrier and blurrier. <br>\
-		A seed is about to sprout..."
-	var/observation_success_message_3 = "The Library is what the Bookhunters call it, a mystical place of life and death. <br>\
-		Should you conquer its trials, they say, you can find the book that will grant the answers to whatever it is you seek. <br>\
-		Black feathers and regret..."
+	observation_choices = list(
+		"Hear the past" = list(TRUE, "What I learned and saw during those two hideous days and nights, it is better not to tell."),
+		"Hear the present" = list(TRUE, "A thousand years compressed into a day, a countably infinite number of people work, die and live in its corridors; <br>\
+			the line between them and the monsters they keep gets blurrier and blurrier. <br>\
+			A seed is about to sprout..."),
+		"Hear the future" = list(TRUE, "The Library is what the Bookhunters call it, a mystical place of life and death. <br>\
+			Should you conquer its trials, they say, you can find the book that will grant the answers to whatever it is you seek. <br>\
+			Black feathers and regret..."),
+	)
 
 	var/explosion_timer = 2 SECONDS
 	var/explosion_state = 3
 	var/explosion_damage = 100
 	var/can_act = TRUE
 	var/negative_range = 10
-
-/mob/living/simple_animal/hostile/abnormality/space_lady/ObservationResult(mob/living/carbon/human/user, condition, answer) //special answers
-	switch(answer)
-		if("Hear the present")
-			observation_success_message = observation_success_message_2
-		if("Hear the future")
-			observation_success_message = observation_success_message_3
-		else
-			observation_success_message = initial(observation_success_message)
-	return ..()
 
 //She can't move or attack.
 /mob/living/simple_animal/hostile/abnormality/space_lady/Move()

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/staining_rose.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/staining_rose.dm
@@ -35,10 +35,10 @@
 
 	observation_prompt = "This isn't worth being called a sacrifice, is it? <br>I've always wanted to be a hero, but... <br>Even when I'm ordered forth to die a worthless death... <br>\
 		I find myself laughable for deciding to do it still. <br>I joined this company to save people. <br>If I can save the lives of those I love, I have no regrets."
-	observation_choices = list("100 paper roses")
-	correct_choices = list("100 paper roses")
-	observation_success_message = "I was the only one who could do it... <br>\
-		... <br>that's all."
+	observation_choices = list(
+		"100 paper roses" = list(TRUE, "I was the only one who could do it... <br>\
+			... <br>that's all."),
+	)
 
 	var/chosen
 	var/list/sacrificed = list()

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/titania.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/titania.dm
@@ -37,10 +37,11 @@
 	abnormality_origin = ABNORMALITY_ORIGIN_WONDERLAB
 
 	observation_prompt = "Is that you Oberon? <br>My nemesis, my beloved devil. <br>Is it you, who applied the concotion of baneful herb to my eyes?"
-	observation_choices = list("I am the Oberon you seek", "I am not him", "Stay silent")
-	correct_choices = list("I am the Oberon you seek")
-	observation_success_message = "The abhorrent name of the one who stole my child. <br>By your death, I shall finally have my revenge."
-	observation_fail_message = "Ah... <br>A mere human, human, human. <br>Cease your fear, I shall rid you of your pains. <br>Be reborn as a flower."
+	observation_choices = list(
+		"I am the Oberon you seek" = list(TRUE, "The abhorrent name of the one who stole my child. <br>By your death, I shall finally have my revenge."),
+		"I am not him" = list(FALSE, "Ah... <br>A mere human, human, human. <br>Cease your fear, I shall rid you of your pains. <br>Be reborn as a flower."),
+		"Stay silent" = list(FALSE, "Ah... <br>A mere human, human, human. <br>Cease your fear, I shall rid you of your pains. <br>Be reborn as a flower."),
+	)
 
 	var/fairy_spawn_number = 2
 	var/fairy_spawn_time = 5 SECONDS

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/white_night.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/white_night.dm
@@ -54,10 +54,11 @@ GLOBAL_LIST_EMPTY(apostles)
 
 	observation_prompt = "Thou knocked the door, now it hath opened. <br>\
 		Thou who carries burden, came to seek the answer."
-	observation_choices = list("Who are you?", "Where did you come from?", "Why have you come?")
-	correct_choices = list("Where did you come from?")
-	observation_success_message = "I am from the end." //TODO: multiple messages, the answer should be irrelevant, code should check for wing gift.
-	observation_fail_message = "Thy question is empty, I cannot answer"
+	observation_choices = list( // TODO IN A FEW YEARS: multiple messages, the answer should be irrelevant, code should check for wing gift.
+		"Where did you come from?" = list(TRUE, "I am from the end." ),
+		"Who are you?" = list(FALSE, "Thy question is empty, I cannot answer"),
+		"Why have you come?" = list(FALSE, "Thy question is empty, I cannot answer"),
+	)
 
 	var/holy_revival_cooldown
 	var/holy_revival_cooldown_base = 75 SECONDS

--- a/code/modules/mob/living/simple_animal/abnormality/final_observations.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/final_observations.dm
@@ -61,9 +61,9 @@
 		playsound(src, 'sound/machines/terminal_prompt_confirm.ogg', 50, FALSE)
 	var/dat = {"<div style=text-align:center;" valign="top">[message]<BR><BR></div>"}
 	var/menu_width = 200
-	for(var/i in 1 to buttons.len)
+	for(var/i in 1 to length(buttons))
 		menu_width += 150
-		switch(buttons.len)
+		switch(length(buttons))
 			if(1)
 				dat += {"<a style="font-size:large;float:center" href="?src=[REF(src)];button=[i]">[buttons[i]]</a>"}
 			if(2)

--- a/code/modules/mob/living/simple_animal/abnormality/he/KHz.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/KHz.dm
@@ -36,17 +36,17 @@
 		\"Sierra... Oscar... Sierra...\" <br>\
 		What could this callsign mean? <br>\
 		Are you in danger, or is someone else? <br>What will you do?"
-	observation_choices = list("Tune your radio to 680 KHz", "Ignore it")
-	correct_choices = list("Tune your radio to 680 KHz")
-	observation_success_message = "Suddenly, you hear something from your radio, clear as day. <br>\
-		\"We hear you loud and clear.\" <br>\
-		\"You've done a great service.\" <br>\
-		The operator on the other end continues babbling, completely obscured by the returning static. <br>\
-		However, it seems you somehow managed solve their problem somehow."
-	observation_fail_message = "You turn off your radio and leave the room. <br>\
-		All abnormalities are dangerous, right? <br>\
-		This cry for help could just be a trick to make you let your guard down. <br>\
-		If there is anyone really out there, they are going to have to fend for themselves."
+	observation_choices = list(
+		"Tune your radio to 680 KHz" = list(TRUE, "Suddenly, you hear something from your radio, clear as day. <br>\
+			\"We hear you loud and clear.\" <br>\
+			\"You've done a great service.\" <br>\
+			The operator on the other end continues babbling, completely obscured by the returning static. <br>\
+			However, it seems you somehow managed solve their problem somehow."),
+		"Ignore it" = list(FALSE, "You turn off your radio and leave the room. <br>\
+			All abnormalities are dangerous, right? <br>\
+			This cry for help could just be a trick to make you let your guard down. <br>\
+			If there is anyone really out there, they are going to have to fend for themselves."),
+	)
 
 	var/input
 	var/bitposition = 4	//You write in bits. You need to successfully write a string of 5 to sucessfully work

--- a/code/modules/mob/living/simple_animal/abnormality/he/KQE.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/KQE.dm
@@ -58,17 +58,17 @@
 		Is that leakage antifreeze, or blood? <br>\
 		While you were wondering, the terminal on its chest flashed to life. <br>\
 		Looks like you can write something."
-	observation_choices = list("Hello", "Goodbye")
-	correct_choices = list("Hello")
-	observation_success_message = "The robot lifts both arms with some struggle. <br>\
-		The terminal prints out its words: <br>\
-		<Welcome, Dear Guest. Have you enjoyed the town tour? \
-		We’d like you to have a souvenir. :-)> <br>\
-		A smile is displayed on the terminal, <br>\
-		but in the robot’s gestures, you feel a plea for help."
-	observation_fail_message = "The terminal’s light goes red, and warnings start to blare. <br>\
-		The robot shakes intensely as if in pain. <br>\
-		<Farewell. <br>Farewell, <br>FarewellFarewellFarewellFarewellFarewellFarewellFarewellFarewellFarewell>"
+	observation_choices = list(
+		"Hello" = list(TRUE, "The robot lifts both arms with some struggle. <br>\
+			The terminal prints out its words: <br>\
+			<Welcome, Dear Guest. Have you enjoyed the town tour? \
+			We’d like you to have a souvenir. :-)> <br>\
+			A smile is displayed on the terminal, <br>\
+			but in the robot’s gestures, you feel a plea for help."),
+		"Goodbye" = list(FALSE, "The terminal’s light goes red, and warnings start to blare. <br>\
+			The robot shakes intensely as if in pain. <br>\
+			<Farewell. <br>Farewell, <br>FarewellFarewellFarewellFarewellFarewellFarewellFarewellFarewellFarewell>"),
+	)
 
 	var/can_act = TRUE
 	var/grab_cooldown

--- a/code/modules/mob/living/simple_animal/abnormality/he/ardor_blossom_moth.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/ardor_blossom_moth.dm
@@ -47,18 +47,18 @@
 		The lights flutter and dance in the air, creating a haze. <br>\
 		Something is burning to death within. <br>\
 		Would you be scorched as well if the flames touched you?"
-	observation_choices = list("Turn around", "Reach out")
-	correct_choices = list("Reach out")
-	observation_success_message = "Enchanted by the haze, you extend a finger, <br>\
-		waiting for one of the lights to land. <br>\
-		A glimmering ball gently perches on your digit. <br>\
-		Then, a fire engulfs it. <br>\
-		Another glow attaches to your body, then four, then eight. <br>\
-		They multiply until you have been entirely shrouded in light."
-	observation_fail_message = "Resisting the temptation to reach out, <br>\
-		you decide it’s better to stay away from such dubious warmth. <br>\
-		You feel a cold wave crawl up your spine in an instant, but it may be the right choice. <br>\
-		Even children know not to play with fire."
+	observation_choices = list(
+		"Reach out" = list(TRUE, "Enchanted by the haze, you extend a finger, <br>\
+			waiting for one of the lights to land. <br>\
+			A glimmering ball gently perches on your digit. <br>\
+			Then, a fire engulfs it. <br>\
+			Another glow attaches to your body, then four, then eight. <br>\
+			They multiply until you have been entirely shrouded in light."),
+		"Turn around" = list(FALSE, "Resisting the temptation to reach out, <br>\
+			you decide it’s better to stay away from such dubious warmth. <br>\
+			You feel a cold wave crawl up your spine in an instant, but it may be the right choice. <br>\
+			Even children know not to play with fire."),
+	)
 
 	var/stoked
 

--- a/code/modules/mob/living/simple_animal/abnormality/he/basilisoup.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/basilisoup.dm
@@ -44,10 +44,10 @@
 	abnormality_origin = ABNORMALITY_ORIGIN_LIMBUS
 
 	observation_prompt = "In front of me is a brass soup cauldron with a wooden ladle, I look inside the pot and see only water and a singular stone, boiling over an open fire."
-	observation_choices = list("Taste the soup", "Knock it over")
-	correct_choices = list("Taste the soup")
-	observation_success_message = "I take the ladle and sip the contents, the taste is indescribably good. It truly is magic."
-	observation_fail_message = "The contents put out the flames as the pot tumbles the floor, water and a singular stone coat the floor. Soup from a stone? Ridiculous."
+	observation_choices = list(
+		"Taste the soup" = list(TRUE, "I take the ladle and sip the contents, the taste is indescribably good. It truly is magic."),
+		"Knock it over" = list(FALSE, "The contents put out the flames as the pot tumbles the floor, water and a singular stone coat the floor. Soup from a stone? Ridiculous."),
+	)
 
 	var/spit_cooldown
 	var/spit_cooldown_time = 12 SECONDS

--- a/code/modules/mob/living/simple_animal/abnormality/he/better_memories.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/better_memories.dm
@@ -38,11 +38,11 @@
 
 	observation_prompt = "In the pile around the abnormality, you find a old card. <br>You almost forgot about them. <br>\
 		A pink light grows and you feel a tug on your memory."
-	observation_choices = list("Let go", "Hold on")
-	correct_choices = list("Let go")
-	observation_success_message = "You let go of the memory forever. <br>You look forward to the day you can make a memory like that again."
-	observation_fail_message = "You pull the letter back from the pink light inside the abnormality's gate. <br>\
-		The memory becomes more and more vivid as if its happening now... <br>when you finally break free you cannot recall what you fought so hard for."
+	observation_choices = list(
+		"Let go" = list(TRUE, "You let go of the memory forever. <br>You look forward to the day you can make a memory like that again."),
+		"Hold on" = list(FALSE, "You pull the letter back from the pink light inside the abnormality's gate. <br>\
+			The memory becomes more and more vivid as if its happening now... <br>when you finally break free you cannot recall what you fought so hard for."),
+	)
 
 	var/minions = 0
 

--- a/code/modules/mob/living/simple_animal/abnormality/he/blue_shepherd.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/blue_shepherd.dm
@@ -55,11 +55,11 @@
 	observation_prompt = "Got nothing better to do than to watch me? Anyway, while I'm lazing around... <br>\
 		The wolf is coming down the hill. <br>I'm the only one who can stop it, if you let me out I'll save you from the Wolf. <br>\
 		So, how about it?"
-	observation_choices = list("Release him", "You're a liar")
-	correct_choices = list("You're a liar")
-	observation_success_message = "Hmph. Sad ain't it? It only waits for me, I'm free to abandon it all I wish. <br>\
-		Lifeless things like that mutt and I don't deserve love but it'll wait for me all the same. <br>Does anyone wait for you?"
-	observation_fail_message = "Good choice, don't worry about the rest - I won't hurt them, pinky swear."
+	observation_choices = list(
+		"You're a liar" = list(TRUE, "Hmph. Sad ain't it? It only waits for me, I'm free to abandon it all I wish. <br>\
+			Lifeless things like that mutt and I don't deserve love but it'll wait for me all the same. <br>Does anyone wait for you?"),
+		"Release him" = list(FALSE, "Good choice, don't worry about the rest - I won't hurt them, pinky swear."),
+	)
 
 	var/death_counter //He won't go off a timer, he'll go off deaths. Takes 8 for him.
 	var/slash_current = 4

--- a/code/modules/mob/living/simple_animal/abnormality/he/der_freischutz.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/der_freischutz.dm
@@ -38,11 +38,11 @@
 	observation_prompt = "Before you stands a man with an ornate rifle. <br>\
 		\"My bullets never miss, whatever I take aim at will have its head pierced true by the inevitability of my bullets. <br>\
 		If you have a target, you only need to make the payment.\""
-	observation_choices = list("Pay for his services", "Don't pay")
-	correct_choices = list("Pay for his services")
-	observation_success_message = "True to his word, the marksman racks a bullet into his rifle, takes aim and fires at your target, piercing their head, but it travels on. <br>\
-		Piercing the heads of others, forever."
-	observation_fail_message = "The man scowls. <br>\"Don't waste my time with such shaky conviction.\""
+	observation_choices = list(
+		"Pay for his services" = list(TRUE, "True to his word, the marksman racks a bullet into his rifle, takes aim and fires at your target, piercing their head, but it travels on. <br>\
+			Piercing the heads of others, forever."),
+		"Don't pay" = list(FALSE, "The man scowls. <br>\"Don't waste my time with such shaky conviction.\""),
+	)
 
 	var/can_act = TRUE
 	var/bullet_cooldown

--- a/code/modules/mob/living/simple_animal/abnormality/he/doomsday_calendar.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/doomsday_calendar.dm
@@ -47,11 +47,11 @@
 	observation_prompt = "I'm standing before an altar on top of an impossibly long flight of stairs, the sky is crimson red and the heat from the air licks at my skin painfully. <br>The world is ending. <br>\
 		On the altar is a tied and bound man with a clay mask on his head, he squirms and is clearly crying but I cannot hear his words. <br>\
 		In my hand is a dagger. <br>I know what I have to do."
-	observation_choices = list("Plunge the dagger into his chest", "Cut his bindings")
-	correct_choices = list("Plunge the dagger into his chest")
-	observation_success_message = "I'm laying on an altar, a heavy clay mask is on my head, my arms and legs are tied with thick rope and the air is hot enough to scald my skin. <br>\
-		I see the priest through the pinholes of the mask and plead for him to spare me, before I feel cold metal plunge into my chest."
-	observation_fail_message = "I cut the man free and he thanks me profusely before he speeds down the stairs. <br>He won't make it. <br>I close my eyes and accept the end."
+	observation_choices = list(
+		"Plunge the dagger into his chest" = list(TRUE, "I'm laying on an altar, a heavy clay mask is on my head, my arms and legs are tied with thick rope and the air is hot enough to scald my skin. <br>\
+			I see the priest through the pinholes of the mask and plead for him to spare me, before I feel cold metal plunge into my chest."),
+		"Cut his bindings" = list(FALSE, "I cut the man free and he thanks me profusely before he speeds down the stairs. <br>He won't make it. <br>I close my eyes and accept the end."),
+	)
 
 	var/player_count
 	var/other_works_maximum

--- a/code/modules/mob/living/simple_animal/abnormality/he/drifting_fox.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/drifting_fox.dm
@@ -55,20 +55,20 @@
 		The umbrellas jiggled. <br.\
 		Looking closer, there’s a large fox underneath. <br.\
 		The umbrellas’ rusted iron blades have firmly rooted themselves in its back."
-	observation_choices = list("Pet the fox", "Pull out the umbrellas")
-	correct_choices = list("Pet the fox")
-	observation_success_message = "Its growl recedes. <br.\
-		You stroke it once more, <br.\
-		and it closes its eyes, pleased. <br.\
-		You stroke it once more, <br.\
-		and it settles on the ground, comforted. <br.\
-		You stroke it once more, <br.\
-		and it shrinks to become a statue."
-	observation_fail_message = "Those umbrellas seem to be causing it pain. <br.\
-		When you pull them out with force, bits of its flesh come off with them. <br.\
-		The fox yelped sharply and gave us a glare. <br.\
-		Then, it smacked you with the umbrella in its mouth. <br.\
-		It seemed to reprimand your attitude of pursuing resolution without forethought."
+	observation_choices = list(
+		"Pet the fox" = list(TRUE, "Its growl recedes. <br.\
+			You stroke it once more, <br.\
+			and it closes its eyes, pleased. <br.\
+			You stroke it once more, <br.\
+			and it settles on the ground, comforted. <br.\
+			You stroke it once more, <br.\
+			and it shrinks to become a statue."),
+		"Pull out the umbrellas" = list(FALSE, "Those umbrellas seem to be causing it pain. <br.\
+			When you pull them out with force, bits of its flesh come off with them. <br.\
+			The fox yelped sharply and gave us a glare. <br.\
+			Then, it smacked you with the umbrella in its mouth. <br.\
+			It seemed to reprimand your attitude of pursuing resolution without forethought."),
+	)
 
 	var/list/pet = list()
 	pet_bonus = "yips"

--- a/code/modules/mob/living/simple_animal/abnormality/he/eris.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/eris.dm
@@ -47,13 +47,13 @@
 		A human head is on prominent display on my plate.<br> It belongs to someone who was assigned to work on \"Eris\", not too long ago.<br>\
 		\"Not hungry? Perhaps you'd like to visit my boudoir?\"<br>\
 		Vile, disgusting. <br>I want to get out of here."
-	observation_choices = list("Accept her proposal", "Run")
-	correct_choices = list("Run")
-	observation_success_message = "I get up from the table, make an excuse, and bolt for the door as fast as I can. <br>\
-		Surprisingly, it's not locked. <br>I hear the imitation of a young woman's voice on my way out. <br>\
-	\"Come back soon, sweetie!\"<br> \"You're always invited to dinner, and i'll be sure to serve you one day!\""
-	observation_fail_message = "How bad can it be? <br>I follow Eris as she leads me into a room. <br>\
-		Hours later, Eris dines with another stranger. <br>My head is resting on that very same plate."
+	observation_choices = list(
+		"Run" = list(TRUE, "I get up from the table, make an excuse, and bolt for the door as fast as I can. <br>\
+			Surprisingly, it's not locked. <br>I hear the imitation of a young woman's voice on my way out. <br>\
+			\"Come back soon, sweetie!\"<br> \"You're always invited to dinner, and i'll be sure to serve you one day!\""),
+		"Accept her proposal" = list(FALSE, "How bad can it be? <br>I follow Eris as she leads me into a room. <br>\
+			Hours later, Eris dines with another stranger. <br>My head is resting on that very same plate."),
+	)
 
 	var/girlboss_level = 0
 	var/can_heal = TRUE

--- a/code/modules/mob/living/simple_animal/abnormality/he/fan.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/fan.dm
@@ -29,13 +29,12 @@
 
 	observation_prompt = "It's an ordinary office fan, made of metal. <br>It's turned off for now and you're feeling warm. <br>\
 		Turn it on?"
-	observation_choices = list("Leave it off", "Set it to 1", "Set it to 2", "Set it to 3") //Waiting for multiple answers
-	correct_choices = list("Set it to 3")
-	observation_success_message = "You set it to its highest setting. <br>The breeze feels pleasant, a nap would be nice..."
-	observation_fail_message = "It's just an old urban legend, but, they say fans like this one can kill people if you slept with them on..."
-	//extra wrong answers
-	var/observation_fail_message_2 = "It's not enough, you're still too hot!"
-	var/observation_fail_message_3 = "You can barely feel a breeze, you just need a little more..."
+	observation_choices = list(
+		"Set it to 3" = list(TRUE, "You set it to its highest setting. <br>The breeze feels pleasant, a nap would be nice..."),
+		"Leave it off" = list(FALSE, "It's just an old urban legend, but, they say fans like this one can kill people if you slept with them on..."),
+		"Set it to 1" = list(FALSE, "It's not enough, you're still too hot!"),
+		"Set it to 2" = list(FALSE, "You can barely feel a breeze, you just need a little more..."),
+	)
 
 	var/list/safe = list()
 	var/list/warning = list()
@@ -44,16 +43,6 @@
 	var/safework = FALSE //Safe if the abnormality was melting
 	var/successcount
 	var/turned_off = FALSE
-
-/mob/living/simple_animal/hostile/abnormality/fan/ObservationResult(mob/living/carbon/human/user, condition, answer) //special answers
-	switch(answer)
-		if("Set it to 1")
-			observation_fail_message = observation_fail_message_2
-		if("Set it to 2")
-			observation_fail_message = observation_fail_message_3
-		else
-			observation_fail_message = initial(observation_success_message)
-	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/fan/examine(mob/user)
 	. = ..()

--- a/code/modules/mob/living/simple_animal/abnormality/he/funeral.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/funeral.dm
@@ -47,19 +47,18 @@
 
 	observation_prompt = "A tall butterfly-faced man stands before, clad in an undertakers's garment. <br>\
 		Between the two of you is a coffin and he gestures you towards it with all 3 of his hands."
-	observation_choices = list("Enter the coffin", "Don't enter the coffin")
-	correct_choices = list("Enter the coffin", "Don't enter the coffin")
-	observation_success_message = "You lie down in the coffin as the butterfly-faced man stands by, his head angled and all 3 hands crossed together over his waist in a solemn gesture. <br>\
-		It's a perfect fit for you. <br>\
-		You feel the weight of innumerable lifetimes and the weariness that came with them. <br>\
-		The butterflies lift you and the coffin as pallbearers, they lament for you in place of the people who cannot."
-	//Special answer for choice 2
-	var/observation_success_message_2 = "You don't enter because it's not your coffin. <br>\
-		The undertaker reaches out his middle hand to his waiting, insectile audience and one of the butterflies lands upon his fingers. <br>\
-		He offers you the butterfly and you place it into the coffin, gently. <br>\
-		The butterflies are the souls of the dead, waiting to be put to rest, but are still mourning for the living. <br>\
-		You and the butterfly-faced man stand in silent vigil. You both now share a vow; to grieve for the living and dead. <br>\
-		A kaledioscope of butterflies follows you as you leave the containment unit."
+	observation_choices = list(
+		"Enter the coffin" = list(TRUE, "You lie down in the coffin as the butterfly-faced man stands by, his head angled and all 3 hands crossed together over his waist in a solemn gesture. <br>\
+			It's a perfect fit for you. <br>\
+			You feel the weight of innumerable lifetimes and the weariness that came with them. <br>\
+			The butterflies lift you and the coffin as pallbearers, they lament for you in place of the people who cannot."),
+		"Don't enter the coffin" = list(TRUE, "You don't enter because it's not your coffin. <br>\
+			The undertaker reaches out his middle hand to his waiting, insectile audience and one of the butterflies lands upon his fingers. <br>\
+			He offers you the butterfly and you place it into the coffin, gently. <br>\
+			The butterflies are the souls of the dead, waiting to be put to rest, but are still mourning for the living. <br>\
+			You and the butterfly-faced man stand in silent vigil. You both now share a vow; to grieve for the living and dead. <br>\
+			A kaledioscope of butterflies follows you as you leave the containment unit."),
+	)
 
 	var/gun_cooldown
 	var/gun_cooldown_time = 4 SECONDS
@@ -84,13 +83,6 @@
 	toggle_attack_num = 1
 	toggle_message = span_colossus("You will now fire butterflies from your hands.")
 	button_icon_toggle_deactivated = "funeral_toggle0"
-
-/mob/living/simple_animal/hostile/abnormality/funeral/ObservationResult(mob/living/carbon/human/user, condition, answer) //special answer for cake result
-	if(answer == "Don't enter the coffin")
-		observation_success_message = observation_success_message_2
-	else
-		observation_success_message = initial(observation_success_message)
-	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/funeral/AttackingTarget(atom/attacked_target)
 	return OpenFire()

--- a/code/modules/mob/living/simple_animal/abnormality/he/galaxy_child.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/galaxy_child.dm
@@ -31,12 +31,12 @@
 	observation_prompt = "You entered the containment chamber. <br>\
 		A child is standing there. <br>\"I know who you are.\" <br>\
 		\"Of course. <br>We were born from each other.\" <br>You decided to......."
-	observation_choices = list("Stay", "Exit the chamber")
-	correct_choices = list("Exit the chamber")
-	observation_success_message = "You turned your back to the child and walked out. <br>\
-		The pebble in your hands sparkles sways, and tickles. <br>It becomes the universe. <br>\
-		\"Goodbye. <br>I hope you never come back.\" <br>As the child bid the cold farewell, he was smiling."
-	observation_fail_message = "\"Will you stay here with me?\" <br>\"If you won't, I don't need you.\""
+	observation_choices = list(
+		"Exit the chamber" = list(TRUE, "You turned your back to the child and walked out. <br>\
+			The pebble in your hands sparkles sways, and tickles. <br>It becomes the universe. <br>\
+			\"Goodbye. <br>I hope you never come back.\" <br>As the child bid the cold farewell, he was smiling."),
+		"Stay" = list(FALSE, "\"Will you stay here with me?\" <br>\"If you won't, I don't need you.\""),
+	)
 
 	var/heal_cooldown_time = 2 SECONDS
 	var/heal_cooldown

--- a/code/modules/mob/living/simple_animal/abnormality/he/golden_false_apple.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/golden_false_apple.dm
@@ -77,12 +77,12 @@
 
 	observation_prompt = "A giant, glistening golden apple stands before you. <br>\
 		Radiant, shining, and pure. <br>There is a tempting crack in it, what could possibly be inside?"
-	observation_choices = list("Slice it open", "Destroy it")
-	correct_choices = list("Destroy it")
-	observation_success_message = "You put the golden apple to the torch. <br>You hear a sickening pops and sizzling as the swarm of maggots inside begins to burn and scatter. <br>\
-		The mass of maggots falls apart in a hail of silent screams."
-	observation_fail_message = "You slice open the apple, and a tidal wave of disgusting maggots bursts out. <br>\
-		You are swept in the tide. <br>Your flesh is riddled with wounds as they slowly devour you."
+	observation_choices = list(
+		"Destroy it" = list(TRUE, "You put the golden apple to the torch. <br>You hear a sickening pops and sizzling as the swarm of maggots inside begins to burn and scatter. <br>\
+			The mass of maggots falls apart in a hail of silent screams."),
+		"Slice it open" = list(FALSE, "You slice open the apple, and a tidal wave of disgusting maggots bursts out. <br>\
+			You are swept in the tide. <br>Your flesh is riddled with wounds as they slowly devour you."),
+	)
 
 	var/is_maggot = FALSE
 	var/can_act = TRUE

--- a/code/modules/mob/living/simple_animal/abnormality/he/happy_teddy_bear.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/happy_teddy_bear.dm
@@ -35,11 +35,11 @@
 
 	observation_prompt = "Here lies a piece of rubbish, a teddy bear. <br>Its wool sticks out here and there. <br>\
 		The amount of dust piled up on it tells how long this teddy has been abandoned. <br>One of the buttons, which are eyes, is hanging loose."
-	observation_choices = list("Leave it alone", "Take the button off")
-	correct_choices = list("Take the button off")
-	observation_success_message = "You took the button off. <br>It was disturbing for some reason. <br>The button is old and rotten and makes you uncomfortable. <br>\
-		You replace the button with one off your suit with great care. <br>While the teddy looks awkward because of the mismatching buttons, it adds to its charm."
-	observation_fail_message = "You don't know what to do with it so you just left it alone. <br>The teddy sits there without any movement."
+	observation_choices = list(
+		"Take the button off" = list(TRUE, "You took the button off. <br>It was disturbing for some reason. <br>The button is old and rotten and makes you uncomfortable. <br>\
+			You replace the button with one off your suit with great care. <br>While the teddy looks awkward because of the mismatching buttons, it adds to its charm."),
+		"Leave it alone" = list(FALSE, "You don't know what to do with it so you just left it alone. <br>The teddy sits there without any movement."),
+	)
 
 	/// if the same person works on Happy Teddy Bear twice in a row, the person will die unless certain requirements are met.
 	var/last_worker = null

--- a/code/modules/mob/living/simple_animal/abnormality/he/headless_ichthys.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/headless_ichthys.dm
@@ -45,12 +45,12 @@
 
 	observation_prompt = "Deep, deep, at the bottom of the sea, a creature lies, dreaming. <br>\
 		It seems to be holding on to a sack of fluid. <br>What will you do?"
-	observation_choices = list("Try and swim away", "Puncture the sack")
-	correct_choices = list("Try and swim away")
-	observation_success_message = "You swim upwards, hoping it doesn't notice you. <br>\
-		Surprisingly, after a few seconds you break the water's surface and make your escape. <br>You find a trinket in your pocket."
-	observation_fail_message = "You cannot get close enough, the water slows your movements. <br>\
-		The creature notices you, and prepares an attack. <br>It is impossible to evade, and you are torn to shreds."
+	observation_choices = list(
+		"Try and swim away" = list(TRUE, "You swim upwards, hoping it doesn't notice you. <br>\
+			Surprisingly, after a few seconds you break the water's surface and make your escape. <br>You find a trinket in your pocket."),
+		"Puncture the sack" = list(FALSE, "You cannot get close enough, the water slows your movements. <br>\
+			The creature notices you, and prepares an attack. <br>It is impossible to evade, and you are torn to shreds."),
+	)
 
 	var/can_act = TRUE
 	var/jump_cooldown = 0

--- a/code/modules/mob/living/simple_animal/abnormality/he/helper.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/helper.dm
@@ -53,11 +53,11 @@
 	)
 
 	observation_prompt = "Is fun to clean. I was..."
-	observation_choices = list("You are special")
-	correct_choices = list("You are special")
-	observation_success_message = "There were many friends who looked like me. <br>I was special. <br>\
-		My creator always said to me. <br>\"You have to be sent to her. You are special. <br>You can give them a very special present.\" <br>\
-		Numbers of tools, which were devoid of for my friends, were put into me. <br>When I was sent to a new home, I gave them a present."
+	observation_choices = list(
+		"You are special" = list(TRUE, "There were many friends who looked like me. <br>I was special. <br>\
+			My creator always said to me. <br>\"You have to be sent to her. You are special. <br>You can give them a very special present.\" <br>\
+			Numbers of tools, which were devoid of for my friends, were put into me. <br>When I was sent to a new home, I gave them a present."),
+	)
 
 	var/charging = FALSE
 	var/dash_num = 50

--- a/code/modules/mob/living/simple_animal/abnormality/he/highway_devotee.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/highway_devotee.dm
@@ -39,17 +39,17 @@
 		\"This is a one-way road. No U-turns.\" <br>\
 		\"If you take this road, it'll take ages to come back here.\" <br>\
 		As the person claims, the road seems to be stretched almost endlessly into the distance."
-	observation_choices = list("Go back the way you came instead of taking the main road", "Take the byway instead of taking the main road")
-	correct_choices = list("Go back the way you came instead of taking the main road")
-	observation_success_message = "\"The road might seem vacant right now, but take it for a bit and you'll see. <br>That the road is jam-packed with cars, and you'd be slowed to a crawl.\" <br>\
-		\"Turning around is not an option, either. There would be a car right behind you by the time you decide to go back.\" <br>\
-		\"You made the right choice.\" <br>\
-		It lightly smiled. <br>\
-		The sign was still held high for whoever might enter this highway in the future."
-	observation_fail_message = "\"Not a good choice.\" <br>\
-		\"Everyone is following the same rules to traverse this road. In any case, this highway is for everyone.\" <br>\
-		\"I assure you, the god of traffic won't forgive cheap shortcuts like that.\" <br>\
-		As you take the byway, you endured the piercing glare on your back for a good while."
+	observation_choices = list(
+		"Go back the way you came instead of taking the main road" = list(TRUE, "\"The road might seem vacant right now, but take it for a bit and you'll see. <br>That the road is jam-packed with cars, and you'd be slowed to a crawl.\" <br>\
+			\"Turning around is not an option, either. There would be a car right behind you by the time you decide to go back.\" <br>\
+			\"You made the right choice.\" <br>\
+			It lightly smiled. <br>\
+			The sign was still held high for whoever might enter this highway in the future."),
+		"Take the byway instead of taking the main road" = list(FALSE, "\"Not a good choice.\" <br>\
+			\"Everyone is following the same rules to traverse this road. In any case, this highway is for everyone.\" <br>\
+			\"I assure you, the god of traffic won't forgive cheap shortcuts like that.\" <br>\
+			As you take the byway, you endured the piercing glare on your back for a good while."),
+	)
 
 	var/talk = FALSE
 	var/list/structures = list()

--- a/code/modules/mob/living/simple_animal/abnormality/he/jangsan.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/jangsan.dm
@@ -46,13 +46,13 @@
 
 	observation_prompt = "I'm in a field of flowers, the flowers are my friends. <br>There are many kinds of friends but I wish to pluck them all. <br>\
 		Some friends have thorns and hurt when I try to pick them. <br>Before me is a particularly juicy, thornless flower."
-	observation_choices = list("Pluck the flower", "Smell it")
-	correct_choices = list("Smell it")
-	observation_success_message = "The flower shuffles away from me as I draw near, the scent is enticing but I do not pluck it. <br>\
-		There's always time to stop and enjoy the flowers."
-	observation_fail_message = "The flower lets out a scream as I pluck it with my teeth, its ichor stains my teeth and fur red - \
-		the other thornless flowers scream in unison and flee in all directions whilst the thorniest ones scratch my fur and skin. <br>\
-		Flowers are my friends and I shall pluck them all."
+	observation_choices = list(
+		"Smell it" = list(TRUE, "The flower shuffles away from me as I draw near, the scent is enticing but I do not pluck it. <br>\
+			There's always time to stop and enjoy the flowers."),
+		"Pluck the flower" = list(FALSE, "The flower lets out a scream as I pluck it with my teeth, its ichor stains my teeth and fur red - \
+			the other thornless flowers scream in unison and flee in all directions whilst the thorniest ones scratch my fur and skin. <br>\
+			Flowers are my friends and I shall pluck them all."),
+	)
 
 	var/bullet_threshold = 40
 //breach related

--- a/code/modules/mob/living/simple_animal/abnormality/he/laetitia.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/laetitia.dm
@@ -34,12 +34,12 @@
 	observation_prompt = "This place is so gloomy, everyone always seems so sad and they don't smile. <br>\
 		It's lonely to be sad, so, this little lady has been secretly giving them all presents filled with friends! <br>\
 		Did they like the surprise?"
-	observation_choices = list("Tell the truth", "Lie and say they did")
-	correct_choices = list("Tell the truth")
-	observation_success_message = "Oh, that's sad... <br>Even if they're my friends, that doesn't mean they're your friends as well. <br>\
-		I won't give you a present, but, could you stay and play with me some more today?"
-	observation_fail_message = "I'm glad! <br>I wish I could have seen their faces, I bet they were so surprised! <br>\
-		You look lonely too, I hope my present will make you laugh as well!"
+	observation_choices = list(
+		"Tell the truth" = list(TRUE, "Oh, that's sad... <br>Even if they're my friends, that doesn't mean they're your friends as well. <br>\
+			I won't give you a present, but, could you stay and play with me some more today?"),
+		"Lie and say they did" = list(FALSE, "I'm glad! <br>I wish I could have seen their faces, I bet they were so surprised! <br>\
+			You look lonely too, I hope my present will make you laugh as well!"),
+	)
 
 	attack_action_types = list(/datum/action/cooldown/laetitia_gift, /datum/action/cooldown/laetitia_summon)
 

--- a/code/modules/mob/living/simple_animal/abnormality/he/missed_reaper.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/missed_reaper.dm
@@ -37,11 +37,10 @@
 
 	observation_prompt = "She was so pale at the end, she looked more like a porcelain doll than the little girl I knew, \
 		laughing and smiling that bright colourful smile I loved so much. <br>I sat next to her bed, powerless to do anything."
-	observation_choices = list("Hold her hand")
-	correct_choices = list("Hold her hand")
-	observation_success_message = "Her skin was clammy and cool to the touch and not a trace of a pulse to be found, she passed the night before. <br>\
-		It didn't mean anything. <br>In the corner of the room, I saw the reaper bow his head in apology."
-
+	observation_choices = list(
+		"Hold her hand" = list(TRUE, "Her skin was clammy and cool to the touch and not a trace of a pulse to be found, she passed the night before. <br>\
+			It didn't mean anything. <br>In the corner of the room, I saw the reaper bow his head in apology."),
+	)
 
 	var/meltdown_cooldown //no spamming the meltdown effect
 	var/meltdown_cooldown_time = 15 SECONDS

--- a/code/modules/mob/living/simple_animal/abnormality/he/nameless_fetus.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/nameless_fetus.dm
@@ -31,13 +31,13 @@
 	observation_prompt = "The baby never cries. <br>It kept that way forever. <br>\
 		As a lack of words doesn't necessarily mean a lack of emotions, a lack of crying doesn't mean lack of desire. <br>\
 		Since time unknown, the baby has had a mouth. <br>The baby who does not understand cries, expresses hunger, and causes pain for the others. <br>You..."
-	observation_choices = list("Call its name.", "Didn't call its name.")
-	correct_choices = list("Call its name.")
-	observation_success_message = "No one else knows the name of the fetus. <br>\
-		But you know. <br>You called its name. <br>\
-		The unstoppable desire shut its mouth for a while. <br>Even only for a short time, the desire silenced."
-	observation_fail_message = "The fetus is still crying. <br>\
-		You plugged your ears silently. <br>No sound is heard."
+	observation_choices = list(
+		"Call its name" = list(TRUE, "No one else knows the name of the fetus. <br>\
+			But you know. <br>You called its name. <br>\
+			The unstoppable desire shut its mouth for a while. <br>Even only for a short time, the desire silenced."),
+		"Didn't call its name" = list(FALSE, "The fetus is still crying. <br>\
+			You plugged your ears silently. <br>No sound is heard."),
+	)
 
 	var/mob/living/carbon/human/calling = null
 	var/criesleft

--- a/code/modules/mob/living/simple_animal/abnormality/he/norinori.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/norinori.dm
@@ -46,22 +46,22 @@
 		You have been tasked to work on this creature. <br>\
 		What type of work will you attempt? <br>\
 		Choose carefully."
-	observation_choices = list("Try to make friends with it", "Inject Cogito")
-	correct_choices = list("Inject Cogito")
-	observation_success_message = "You prepare to start instinct work .<br>\
-		... <br>\
-		Checking Vitals <br>\
-		... <br>\
-		Adjusting Fluid Intake <br>\
-		... <br>\
-		Allocating 37% Cogito <br>\
-		... <br>\
-		The work is complete, <br>you report the good result to the work log."
-	observation_fail_message = "Surely such a cute thing must be friendly, right? <br>\
-		It seems you have not learned your lesson <br>\
-		The split fox senses your intent. <br>\
-		It opens up, revealing a core connected to several sharp cutting tools <br>\
-		You are too close to get away."
+	observation_choices = list(
+		"Inject Cogito" = list(TRUE, "You prepare to start instinct work .<br>\
+			... <br>\
+			Checking Vitals <br>\
+			... <br>\
+			Adjusting Fluid Intake <br>\
+			... <br>\
+			Allocating 37% Cogito <br>\
+			... <br>\
+			The work is complete, <br>you report the good result to the work log."),
+		"Try to make friends with it" = list(FALSE, "Surely such a cute thing must be friendly, right? <br>\
+			It seems you have not learned your lesson <br>\
+			The split fox senses your intent. <br>\
+			It opens up, revealing a core connected to several sharp cutting tools <br>\
+			You are too close to get away."),
+	)
 
 //breach related
 	var/can_act = TRUE

--- a/code/modules/mob/living/simple_animal/abnormality/he/pinocchio.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/pinocchio.dm
@@ -34,10 +34,10 @@
 
 	observation_prompt = "I've been watching people for as long as I've known them, it's not hard to imitate others. <br>\
 		Can I be a human if I mimic humans?"
-	observation_choices = list("You're human", "You will never be a human")
-	correct_choices = list("You will never be a human")
-	observation_success_message = "Can I... not become a human..? <br>You could've let me fool you, you're too cruel."
-	observation_fail_message = "Did I look just like a human? <br>I hope I fooled you, it's other people's fault for falling for my lies."
+	observation_choices = list(
+		"You will never be a human" = list(TRUE, "Can I... not become a human..? <br>You could've let me fool you, you're too cruel."),
+		"You're human" = list(FALSE, "Did I look just like a human? <br>I hope I fooled you, it's other people's fault for falling for my lies."),
+	)
 
 	var/lying = FALSE
 	var/caught_lie = FALSE

--- a/code/modules/mob/living/simple_animal/abnormality/he/pisc_mermaid.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/pisc_mermaid.dm
@@ -51,14 +51,14 @@
 		if you said I did not need to see then I'd scoop out my eyes as well.\" <br>She splashes her aquamarine tail, foam, water and something else was flicked towards you. <br>\
 		\"I made you a gift, just wear it and say that you love me too.\" <br>\
 		The water carries the comb to your feet, you pick it up as she watches you expectantly."
-	observation_choices = list("Accept the comb", "Cast it into the sea")
-	correct_choices = list("Cast it into the sea")
-	observation_success_message = "\"I don't understand, don't you love me? <br>Can't you hear, see or understand my love? <br>\
-		If I give you my eyes, my ears and my brain, could you percieve and learn to love me too? <br>Just please trade me your heart to fill this void in my chest...\" <br>\
-		You left the mermaid to her babble, love could never be something so transactional."
-	observation_fail_message = "You place the comb in your hair and the mermaid smiles, her pupils like tiny hearts, and you find yourself walking into the depths as she embraces you. <br>\
-		\"I'm so happy you gave me your heart...\" <br>She whispers as she draws you into a kiss, pulling you further and further into the waves, the water passing your chest and then your head but still she wouldn't release her embrace. <br>\
-		Salt water fills your lungs as you lose consciousness."
+	observation_choices = list(
+		"Cast it into the sea" = list(TRUE, "\"I don't understand, don't you love me? <br>Can't you hear, see or understand my love? <br>\
+			If I give you my eyes, my ears and my brain, could you percieve and learn to love me too? <br>Just please trade me your heart to fill this void in my chest...\" <br>\
+			You left the mermaid to her babble, love could never be something so transactional."),
+		"Accept the comb" = list(FALSE, "You place the comb in your hair and the mermaid smiles, her pupils like tiny hearts, and you find yourself walking into the depths as she embraces you. <br>\
+			\"I'm so happy you gave me your heart...\" <br>She whispers as she draws you into a kiss, pulling you further and further into the waves, the water passing your chest and then your head but still she wouldn't release her embrace. <br>\
+			Salt water fills your lungs as you lose consciousness."),
+	)
 
 	response_help_continuous = "pets" //You sick fuck
 	response_help_simple = "pet"

--- a/code/modules/mob/living/simple_animal/abnormality/he/porccubus.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/porccubus.dm
@@ -46,13 +46,13 @@
 
 	observation_prompt = "The red flower waits expectantly for you as you enter the containment unit, \
 		studying your movements it leans down towards you and bares its thorns to you."
-	observation_choices = list("Touch the thorns", "Just observe")
-	correct_choices = list("Just observe")
-	observation_success_message = "The flower pulls back when it realises you make no effort to try and touch it. <br>\
-		You study it and it studies you back, it only ever wanted to make people happy the only way it knew how. <br>\
-		You turn to leave, resolving to chase after happiness with your own power."
-	observation_fail_message = "The thorns prick your hands and you feel an indescribable rush of pleasure. <br>\
-		Poppy flowers like this one have ruined many lives and now it's ruined yours, but for now - you're happy."
+	observation_choices = list(
+		"Just observe" = list(TRUE, "The flower pulls back when it realises you make no effort to try and touch it. <br>\
+			You study it and it studies you back, it only ever wanted to make people happy the only way it knew how. <br>\
+			You turn to leave, resolving to chase after happiness with your own power."),
+		"Touch the thorns" = list(FALSE, "The thorns prick your hands and you feel an indescribable rush of pleasure. <br>\
+			Poppy flowers like this one have ruined many lives and now it's ruined yours, but for now - you're happy."),
+	)
 
 	//the agent that started work on porccubus
 	var/agent_ckey

--- a/code/modules/mob/living/simple_animal/abnormality/he/puss_in_boots.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/puss_in_boots.dm
@@ -43,10 +43,10 @@
 	observation_prompt = "The miller, my old master, when he passed he left his mill, his donkey and myself to his three sons. <br>\
 		I was left to the youngest and the elders denied him any right to the mill. <br>I felt for the poor lad and so, I turned the young master into a Prince, <br>\
 		and one day a King. <br>I can do the same for you - Are you ready to claim your inheritance?"
-	observation_choices = list("Yes", "No")
-	correct_choices = list("Yes")
-	observation_success_message = "Excellent, by my paw you shall make a fine master, envy of all your peers!"
-	observation_fail_message = "Bah! When will someone worthy arrive?"
+	observation_choices = list(
+		"Yes" = list(TRUE, "Excellent, by my paw you shall make a fine master, envy of all your peers!"),
+		"No" = list(FALSE, "Bah! When will someone worthy arrive?"),
+	)
 
 	//Work/misc Vars
 	var/list/stats = list(

--- a/code/modules/mob/living/simple_animal/abnormality/he/red_buddy.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/red_buddy.dm
@@ -51,14 +51,14 @@
 
 	observation_prompt = "You enter the containment unit and see a cartoonish-looking dog collapsed in the centre, shivering from pain and inflicted with terribly deep, red wounds. <br>\
 		\"My master wants a wolf...\" <br>It says breathlessly. <br>\"I'm waiting for my master, waiting, waiting... <br>I'm waiting for them...\""
-	observation_choices = list("Hug and console it", "Beat it within an inch of it's life")
-	correct_choices = list("Hug and console it")
-	observation_success_message = "You hold the wounded animal in your arms as it continues to shake. <br>\
-		\"I shook my split tail hard until flesh fell off it, I lied flat on the floor and begged... <br>My heart for my Master...\" <br>\
-		Finally it stops shivering and wounds stopped appearing on its body. <br>\"Left only red scars...\""
-	observation_fail_message = "You pull out your baton and hit the animal over and over again, kicking, spitting and cursing at it but it never reacts to any of your abuse beyond hastening its transformation. <br>\
-		The skinless dog now stands above you, neither wolf nor dog. <br>\"You can't stop a wolf with a touch gentler than my master's. <br>I'm a wolf, vile and vicious, belonging to my master.\" <br>\
-		The faux-wolf eats you in one bite."
+	observation_choices = list(
+		"Hug and console it" = list(TRUE, "You hold the wounded animal in your arms as it continues to shake. <br>\
+			\"I shook my split tail hard until flesh fell off it, I lied flat on the floor and begged... <br>My heart for my Master...\" <br>\
+			Finally it stops shivering and wounds stopped appearing on its body. <br>\"Left only red scars...\""),
+		"Beat it within an inch of it's life" = list(FALSE, "You pull out your baton and hit the animal over and over again, kicking, spitting and cursing at it but it never reacts to any of your abuse beyond hastening its transformation. <br>\
+			The skinless dog now stands above you, neither wolf nor dog. <br>\"You can't stop a wolf with a touch gentler than my master's. <br>I'm a wolf, vile and vicious, belonging to my master.\" <br>\
+			The faux-wolf eats you in one bite."),
+	)
 
 	///The blue smocked shepherd linked to red buddy
 	var/datum/abnormality/master

--- a/code/modules/mob/living/simple_animal/abnormality/he/red_queen.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/red_queen.dm
@@ -27,10 +27,12 @@
 
 	observation_prompt = "This abnormality has a notorious reputation for being particularly dry to work with. <br>It's hard to tell what it's thinking or what work it prefers. <br>\
 		What type of work will you attempt?"
-	observation_choices = list(ABNORMALITY_WORK_INSTINCT, ABNORMALITY_WORK_INSIGHT, ABNORMALITY_WORK_ATTACHMENT, ABNORMALITY_WORK_REPRESSION)
-	correct_choices = list(ABNORMALITY_WORK_INSTINCT) // Matches Red Queen's real preferred work. This default is set to stop warnings
-	observation_success_message = "You are granted an audience with the red queen. <br>Today, you were able to to satisfy her unpredictable whims"
-	observation_fail_message = "You narrowly dodge the card-guillotine coming for your neck, that was close, let's try something else."
+	observation_choices = list( // Matches Red Queen's real preferred work.
+		ABNORMALITY_WORK_INSTINCT = list(FALSE, "You narrowly dodge the card-guillotine coming for your neck, that was close, let's try something else."),
+		ABNORMALITY_WORK_INSIGHT = list(FALSE, "You narrowly dodge the card-guillotine coming for your neck, that was close, let's try something else."),
+		ABNORMALITY_WORK_ATTACHMENT = list(FALSE, "You narrowly dodge the card-guillotine coming for your neck, that was close, let's try something else."),
+		ABNORMALITY_WORK_REPRESSION = list(FALSE, "You narrowly dodge the card-guillotine coming for your neck, that was close, let's try something else."),
+	)
 	var/liked
 
 /mob/living/simple_animal/hostile/abnormality/red_queen/Initialize(mapload)
@@ -41,8 +43,7 @@
 
 /mob/living/simple_animal/hostile/abnormality/red_queen/PostSpawn()
 	. = ..()
-	correct_choices = list()
-	correct_choices += liked
+	observation_choices[liked] = list(TRUE, "You are granted an audience with the red queen. <br>Today, you were able to to satisfy her unpredictable whims")
 
 /mob/living/simple_animal/hostile/abnormality/red_queen/PostWorkEffect(mob/living/carbon/human/user, work_type, pe)
 	if(work_type != liked)

--- a/code/modules/mob/living/simple_animal/abnormality/he/red_shoes.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/red_shoes.dm
@@ -39,14 +39,14 @@
 
 	observation_prompt = "There is a pair of red shoes. <br>\
 		It could be sitting in front of me, or in my feet. I am......"
-	observation_choices = list("Wearing them.", "Not wearing them.")
-	correct_choices = list("Wearing them.") //TODO: Second line of dialogue, must be coded
-	observation_success_message = "I am wearing the shoes. <br>\
-		They are perfect fit, it feels good. <br>I have a weird feeling as if I am in another world. <br>\
-		There is a sharp axe in front of me. Maybe it was there all along, or maybe I just haven't realized it until now. <br>\
-		A weapon will change a lot of things."
-	observation_fail_message = "I was not wearing the shoes. <br>\
-		The shoes' crimson color is getting deeper."
+	observation_choices = list( //TODO: Second line of dialogue, must be coded
+		"Wearing them." = list(TRUE, "I am wearing the shoes. <br>\
+			They are perfect fit, it feels good. <br>I have a weird feeling as if I am in another world. <br>\
+			There is a sharp axe in front of me. Maybe it was there all along, or maybe I just haven't realized it until now. <br>\
+			A weapon will change a lot of things."),
+		"Not wearing them." = list(FALSE, "I was not wearing the shoes. <br>\
+			The shoes' crimson color is getting deeper."),
+	)
 
 	var/mutable_appearance/breach_icon
 	var/mob/living/possessee

--- a/code/modules/mob/living/simple_animal/abnormality/he/road_home.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/road_home.dm
@@ -44,10 +44,10 @@
 	)
 
 	observation_prompt = "Last of all, road that is lost. <br>I will send you home. <br>The wizard grants you..."
-	observation_choices = list("The home cannot be reached", "The road home")
-	correct_choices = list("The home cannot be reached")
-	observation_success_message = "What are you fighting for so fiercely when you have nowhere to go back to?"
-	observation_fail_message = "Wear this pair of shoes and be on your way. To the hometown you miss so much."
+	observation_choices = list(
+		"The home cannot be reached" = list(TRUE, "What are you fighting for so fiercely when you have nowhere to go back to?"),
+		"The road home" = list(FALSE, "Wear this pair of shoes and be on your way. To the hometown you miss so much."),
+	)
 
 	///Stuff related to the house and its path
 	var/obj/road_house/house

--- a/code/modules/mob/living/simple_animal/abnormality/he/rudolta.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/rudolta.dm
@@ -44,12 +44,12 @@
 		That night, when everyone was sleeping. <br>I waited for the man, sitting next to sleeping Alex. <br>\
 		Sometimes, for someone, an absurd fairy tale is a silver lining of hope. <br>When I met Santa, I imagined dismembering him. <br>... <br>\
 		In front of me is Santa. <br>My ideal. <br>People don't call it Santa. <br>Something is twitching inside of that sack. I......"
-	observation_choices = list("Opened the sack.", "Did not open the sack.")
-	correct_choices = list("Did not open the sack.")
-	observation_success_message = "Inside of the sack is a desire. <br>\
-		A hope that I've been waiting for since when I was very young. <br>I never opened the sack. <br>Did you wish come true?"
-	observation_fail_message = "There was something that I have been longing for my entire life. <br>\
-		Like Pandora's Box, it will never go back into the sack."
+	observation_choices = list(
+		"Did not open the sack" = list(TRUE, "Inside of the sack is a desire. <br>\
+			A hope that I've been waiting for since when I was very young. <br>I never opened the sack. <br>Did your wish come true?"),
+		"Opened the sack" = list(FALSE, "There was something that I have been longing for my entire life. <br>\
+			Like Pandora's Box, it will never go back into the sack."),
+	)
 
 	var/pulse_cooldown
 	var/pulse_cooldown_time = 1.8 SECONDS

--- a/code/modules/mob/living/simple_animal/abnormality/he/scarecrow.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/scarecrow.dm
@@ -49,10 +49,10 @@
 	)
 
 	observation_prompt = "Poor stuffing of straw. <br>I'll give you the wisdom to ponder over anything. <br>The wizard grants you..."
-	observation_choices = list("A silk sack of sawdust", "Wisdom")
-	correct_choices = list("A silk sack of sawdust")
-	observation_success_message = "Do you think jabbering away with your oh-so smart mouth is all that matters?"
-	observation_fail_message = "Come closer. <br>I’ll help you forget all of your woes and worries."
+	observation_choices = list(
+		"A silk sack of sawdust" = list(TRUE, "Do you think jabbering away with your oh-so smart mouth is all that matters?"),
+		"Wisdom" = list(FALSE, "Come closer. <br>I’ll help you forget all of your woes and worries."),
+	)
 
 	/// Can't move/attack when it's TRUE
 	var/finishing = FALSE

--- a/code/modules/mob/living/simple_animal/abnormality/he/scaredy_cat.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/scaredy_cat.dm
@@ -51,10 +51,10 @@
 	)
 
 	observation_prompt = "Cowardly kitten. <br>I’ll give you the courage to stand up to anything and everything. <br>The wizard grants you..."
-	observation_choices = list("A vial of \"liquid courage\"", "Courage")
-	correct_choices = list("A vial of \"liquid courage\"")
-	observation_success_message = "What are you even going to do when you lack the bravery to face anything head-on?"
-	observation_fail_message = "Drink this potion, it’ll give you courage. <br>You’ll be braver than anyone."
+	observation_choices = list(
+		"A vial of \"liquid courage\"" = list(TRUE, "What are you even going to do when you lack the bravery to face anything head-on?"),
+		"Courage" = list(FALSE, "Drink this potion, it’ll give you courage. <br>You’ll be braver than anyone."),
+	)
 
 	/// The list of abnormality scaredy cat will automatically join when they breach, add any "Oz" abno to this list if possible
 	var/list/prefered_abno_list = list(

--- a/code/modules/mob/living/simple_animal/abnormality/he/schadenfreude.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/schadenfreude.dm
@@ -39,14 +39,14 @@
 	abnormality_origin = ABNORMALITY_ORIGIN_LOBOTOMY
 
 	observation_prompt = "You put on the blindfold and entered the containment unit. <br>You can feel the metal box's gaze through the thick fabric."
-	observation_choices = list("Take off the blindfold", "Feel for the wall")
-	correct_choices = list("Feel for the wall")
-	observation_success_message = "You turn to the wall and feel for it until you find your way back to the door. <br>\
-		The box can't ever be more than a box, it can only exist as something real in the gaze of others. <br>Perhaps you're more alike than you think."
-	observation_fail_message = "You remove the blindfold and wait a moment for your eyes to adjust to the light, your gaze meets the eye in the keyhole's. <br>\
-		The box comes to life with saws and blades, but all it is for - is to catch your attention."
+	observation_choices = list(
+		"Feel for the wall" = list(TRUE, "You turn to the wall and feel for it until you find your way back to the door. <br>\
+			The box can't ever be more than a box, it can only exist as something real in the gaze of others. <br>Perhaps you're more alike than you think."),
+		"Take off the blindfold" = list(FALSE, "You remove the blindfold and wait a moment for your eyes to adjust to the light, your gaze meets the eye in the keyhole's. <br>\
+			The box comes to life with saws and blades, but all it is for - is to catch your attention."),
+	)
 
-	var/seen	//Are you being looked at right now?
+	var/seen //Are you being looked at right now?
 	var/solo_punish	//Is an agent alone on the Z level, but not overall?
 	var/total_players
 

--- a/code/modules/mob/living/simple_animal/abnormality/he/shock_centipede.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/shock_centipede.dm
@@ -47,22 +47,22 @@
 		The segments of the creature spark each time they move, suggesting faulty connections. <br>\
 		There are two buttons at the tank. <br>\
 		One is shaped like a thunderbolt, while the other looks like a waterdrop."
-	observation_choices = list("Thunderbolt", "Water drop")
-	correct_choices = list("Thunderbolt")
-	observation_success_message = "You press the lightning-shaped button. <br>\
-		\"Apply stimulation and pain to the centipede to increase the discharge intensity.\" <br>\
-		So writes a message above the buttons. <br>\
-		That seems to be what this one does. <br>\
-		When you pressed it, a mechanical sound played for a short while. <br>\
-		The centipede has stopped moving."
-	observation_fail_message = "You press the water drop-shaped button. <br>\
-		\"Apply stimulation and pain to the centipede to increase the discharge intensity.\" <br>\
-		So writes a message above the buttons. <br>\
-		When you pressed the drop-shaped button, the tank was filled with water. <br>\
-		The centipede twists its body as if in some sort of dance. <br>\
-		You watched the centipede’s tail scratch the tank’s surface. <br>\
-		The glass cracked and fell apart immediately afterward. <br>\
-		The electrified water fell right on your head."
+	observation_choices = list(
+		"Thunderbolt" = list(TRUE, "You press the lightning-shaped button. <br>\
+			\"Apply stimulation and pain to the centipede to increase the discharge intensity.\" <br>\
+			So writes a message above the buttons. <br>\
+			That seems to be what this one does. <br>\
+			When you pressed it, a mechanical sound played for a short while. <br>\
+			The centipede has stopped moving."),
+		"Water drop" = list(FALSE, "You press the water drop-shaped button. <br>\
+			\"Apply stimulation and pain to the centipede to increase the discharge intensity.\" <br>\
+			So writes a message above the buttons. <br>\
+			When you pressed the drop-shaped button, the tank was filled with water. <br>\
+			The centipede twists its body as if in some sort of dance. <br>\
+			You watched the centipede’s tail scratch the tank’s surface. <br>\
+			The glass cracked and fell apart immediately afterward. <br>\
+			The electrified water fell right on your head."),
+	)
 
 // Work vars
 	var/bonus_pe = 6

--- a/code/modules/mob/living/simple_animal/abnormality/he/silent_girl.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/silent_girl.dm
@@ -35,11 +35,11 @@
 	abnormality_origin = ABNORMALITY_ORIGIN_ARTBOOK
 
 	observation_prompt = "..."
-	observation_choices = list("Accept your guilt", "Plead your ignorance")
-	correct_choices = list("Accept your guilt")
-	observation_success_message = "The nails pierce your heart as the girl in the white dress hammers them home. <br>\
-		She opens hers eyes and you meet her gaze. <br>You're forgiven."
-	observation_fail_message = "The nails pierce your heart as the girl in the white dress hammers them home."
+	observation_choices = list(
+		"Accept your guilt" = list(TRUE, "The nails pierce your heart as the girl in the white dress hammers them home. <br>\
+			She opens hers eyes and you meet her gaze. <br>You're forgiven."),
+		"Plead your ignorance" = list(FALSE, "The nails pierce your heart as the girl in the white dress hammers them home."),
+	)
 
 /mob/living/simple_animal/hostile/abnormality/silent_girl/proc/GuiltEffect(mob/living/carbon/human/user, enable_qliphoth = TRUE, stack_count = 1)
 	if (user.stat == DEAD)

--- a/code/modules/mob/living/simple_animal/abnormality/he/singing_machine.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/singing_machine.dm
@@ -39,10 +39,10 @@ Finally, an abnormality that DOESN'T have to do any fancy movement shit. It's a 
 
 	observation_prompt = "You know that people die every time this machine sings. <br>\
 		Or perhaps this machine sings when people die. <br>Though it has spilled blood of countless people, the song put you in a rapturous mood."
-	observation_choices = list("Listen to the music", "Turn off the machine")
-	correct_choices = list("Turn off the machine")
-	observation_success_message = "You turned the machine off. Silence fills the air."
-	observation_fail_message = "Aah. The music gives you sense of warm coziness and relaxation."
+	observation_choices = list(
+		"Turn off the machine" = list(TRUE, "You turned the machine off. Silence fills the air."),
+		"Listen to the music" = list(FALSE, "Aah. The music gives you sense of warm coziness and relaxation."),
+	)
 
 	var/cleanliness = "clean"
 	var/statChecked = 0

--- a/code/modules/mob/living/simple_animal/abnormality/he/siren.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/siren.dm
@@ -32,14 +32,13 @@
 		When she passed he would play this song all the time until the vinyl began to warp. <br>One day, I visited him after a long time and the song wasn't playing. <br>\
 		\"It's not the same song,\" he'd whisper chin resting over his clenched hands, gripped together until they were as white as his knuckles. <br>\
 		\"Why isn't the same song?\""
-	observation_choices = list("Put the song on again", "Throw it away")
-	correct_choices = list("Put the song on again")
-	observation_success_message = "The record began to play, the slow warped song filled the air. <br>\
-		\"It's just not the same without her here...\""
-	observation_fail_message = "You throw the old record into the trash, the well-used viny shattering. <br>\
-		\"NO! HOW CAN I REMEMBER HER NOW?\" Your grandfather wails, coming at you with fury in his eyes before stopping. <br>\
-		\"...Who were you again?\""
-
+	observation_choices = list(
+		"Put the song on again" = list(TRUE, "The record began to play, the slow warped song filled the air. <br>\
+			\"It's just not the same without her here...\""),
+		"Throw it away" = list(FALSE, "You throw the old record into the trash, the well-used viny shattering. <br>\
+			\"NO! HOW CAN I REMEMBER HER NOW?\" Your grandfather wails, coming at you with fury in his eyes before stopping. <br>\
+			\"...Who were you again?\""),
+	)
 
 //meltdown effects
 	var/meltdown_cooldown_time = 144 SECONDS

--- a/code/modules/mob/living/simple_animal/abnormality/he/snow_queen.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/snow_queen.dm
@@ -50,10 +50,10 @@
 		Freezing and cold. <br>\
 		You thought about it often, seeing she who couldn't see her dreams come true, trapped inside ice. <br>\
 		The brave agent headed to the Snow Palace and..."
-	observation_choices = list("Saved Kai", "Met the Snow Queen")
-	correct_choices = list("Met the Snow Queen")
-	observation_success_message = "The Snow Queen was cold and beautiful. <br>You heard ice melting."
-	observation_fail_message = "Gerda saved Kai and returned home. <br>They lived happily ever after."
+	observation_choices = list(
+		"Met the Snow Queen" = list(TRUE, "The Snow Queen was cold and beautiful. <br>You heard ice melting."),
+		"Saved Kai" = list(FALSE, "Gerda saved Kai and returned home. <br>They lived happily ever after."),
+	)
 
 	ego_list = list(
 		/datum/ego_datum/weapon/frostsplinter,

--- a/code/modules/mob/living/simple_animal/abnormality/he/steam_transport_machine.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/steam_transport_machine.dm
@@ -55,16 +55,16 @@
 		As it does its work, the number on the electronic display seems to update. <br>\
 		Machines exist for a purpose. <br>\
 		You feel like you should give it an order."
-	observation_choices = list("Order it to carry luggage", "Order it to do nothing")
-	correct_choices = list("Order it to carry luggage")
-	observation_success_message = "It lifts a nearby object to carry it from left to right. <br>\
-		The count on its body went up by 1. <br>\
-		Just as you started to wonder if that was it, the machine replaced one of its vacuum tubes with a new one. <br>\
-		It presented the old one to you, and naturally, you accepted."
-	observation_fail_message = "A purposeless machine is bound to lose the meaning of its existence, even if it is functional. <br>\
-		A machine whose purpose is to do nothing will do whatever it takes to achieve its directive. <br>\
-		With a loud boiling noise, the machine’s body begins to heat, expelling hot steam. <br>\
-		Seeing it glow a dangerous-looking hue, you quickly escaped the room."
+	observation_choices = list(
+		"Order it to carry luggage" = list(TRUE, "It lifts a nearby object to carry it from left to right. <br>\
+			The count on its body went up by 1. <br>\
+			Just as you started to wonder if that was it, the machine replaced one of its vacuum tubes with a new one. <br>\
+			It presented the old one to you, and naturally, you accepted."),
+		"Order it to do nothing" = list(FALSE, "A purposeless machine is bound to lose the meaning of its existence, even if it is functional. <br>\
+			A machine whose purpose is to do nothing will do whatever it takes to achieve its directive. <br>\
+			With a loud boiling noise, the machine’s body begins to heat, expelling hot steam. <br>\
+			Seeing it glow a dangerous-looking hue, you quickly escaped the room."),
+	)
 
 	var/gear = 0
 	var/steam_damage = 5

--- a/code/modules/mob/living/simple_animal/abnormality/he/watchman.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/watchman.dm
@@ -42,12 +42,12 @@
 
 	observation_prompt = "\"Natureless creatures roam the night, you should find shelter.\" <br>\
 		The watchman beckons you over. <br>You..."
-	observation_choices = list("Approach", "Run away")
-	correct_choices = list("Approach")
-	observation_success_message = "Good. <br>It's not safe to roam the woods at night.<br>\
-		Come now, I will guide you home."
-	observation_fail_message = "You don't get far before you start hearing howling and shrieking. <br>\
-		Numerous talons, claws, and fangs bite into you all at once. <br>Now you will know why you fear the night."
+	observation_choices = list(
+		"Approach" = list(TRUE, "Good. <br>It's not safe to roam the woods at night.<br>\
+			Come now, I will guide you home."),
+		"Run away" = list(FALSE, "You don't get far before you start hearing howling and shrieking. <br>\
+			Numerous talons, claws, and fangs bite into you all at once. <br>Now you will know why you fear the night."),
+	)
 
 	// Speech Lines
 	speak_chance = 4

--- a/code/modules/mob/living/simple_animal/abnormality/he/wayward_passenger.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/wayward_passenger.dm
@@ -59,20 +59,20 @@
 		but they’ll simply pretend that the passenger never existed. <br>\
 		Lost and abandoned, tossed out like trash, <br>\
 		having no place left in the City."
-	observation_choices = list("Sit still", "Guide them out")
-	correct_choices = list("Guide them out")
-	observation_success_message = "You take a few steps, and the passenger follows. <br>\
-		As you draw closer to what appears to be an exit, the passenger bows down as though to show you gratitude. <br>\
-		You heard something fall; it left behind a gift. <br>\
-		Looks like it wasn't lost after all. It may have been an employee that happened to be patrolling the area. <br>\
-		Maybe you didn't guide it—maybe it was merely following you to make sure that you found the right exit."
-	observation_fail_message = "It idly stared in your direction. <br>\
-		Then, it began shambling for you, realizing something. <br>\
-		As it drew closer, you were able to identify <br>\
-		that the being was an employee of a certain transport company, not a passenger. <br>\
-		The ID card on its chest gave it away. <br>\
-		This stranded employee was approaching you, <br>\
-		preparing to go through the motions."
+	observation_choices = list(
+		"Guide them out" = list(TRUE, "You take a few steps, and the passenger follows. <br>\
+			As you draw closer to what appears to be an exit, the passenger bows down as though to show you gratitude. <br>\
+			You heard something fall; it left behind a gift. <br>\
+			Looks like it wasn't lost after all. It may have been an employee that happened to be patrolling the area. <br>\
+			Maybe you didn't guide it—maybe it was merely following you to make sure that you found the right exit."),
+		"Sit still" = list(FALSE, "It idly stared in your direction. <br>\
+			Then, it began shambling for you, realizing something. <br>\
+			As it drew closer, you were able to identify <br>\
+			that the being was an employee of a certain transport company, not a passenger. <br>\
+			The ID card on its chest gave it away. <br>\
+			This stranded employee was approaching you, <br>\
+			preparing to go through the motions."),
+	)
 
 	//teleport vars
 	var/teleport_cooldown

--- a/code/modules/mob/living/simple_animal/abnormality/he/white_lake.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/white_lake.dm
@@ -34,13 +34,13 @@
 	observation_prompt = "The feathered lady dances in the centre of the containment unit to a tempo that exists only in her world, it's elegant and precise. <br>\
 		\"This domain, my lunar palace, it's mine birdcage gilded with fine gold. <br>Whatever I wish, it is brought for me and all that is expected of me is to dance. <br>\
 		Even if I possessed the fortitude to bend these bars and free myself, I would not - what good comes from change? <br>Fortitude won't avail anyone, wouldn't you agree?\""
-	observation_choices = list("Agree", "Disagree")
-	correct_choices = list("Agree")
-	observation_success_message = "\"Hmm, you'll make for a cute decoration in mine sanctum, bear my circlet and come to your Princess' aid, won't you? <br>\
-		Protect her from witches seeking to bully this poor Lake.\" <br>\
-		She dances towards you, placing the circlet upon your head. \"Sully your hands so mine stay clean and beautiful.\" She turns away, returning to her dance."
-	observation_fail_message = "\"I don't find heroes cute at all. <br>Leave me to my dancing butcher, before you tarnish my pure-white feathers with your blood-soaked hands.\" <br>\
-		The ballerina turns away from you and continues her dance, ignoring you."
+	observation_choices = list(
+		"Agree" = list(TRUE, "\"Hmm, you'll make for a cute decoration in mine sanctum, bear my circlet and come to your Princess' aid, won't you? <br>\
+			Protect her from witches seeking to bully this poor Lake.\" <br>\
+			She dances towards you, placing the circlet upon your head. \"Sully your hands so mine stay clean and beautiful.\" She turns away, returning to her dance."),
+		"Disagree" = list(FALSE, "\"I don't find heroes cute at all. <br>Leave me to my dancing butcher, before you tarnish my pure-white feathers with your blood-soaked hands.\" <br>\
+			The ballerina turns away from you and continues her dance, ignoring you."),
+	)
 
 /mob/living/simple_animal/hostile/abnormality/whitelake/WorkChance(mob/living/carbon/human/user, chance)
 	if(get_attribute_level(user, FORTITUDE_ATTRIBUTE) >= 60)

--- a/code/modules/mob/living/simple_animal/abnormality/he/woodsman.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/woodsman.dm
@@ -50,10 +50,10 @@
 	)
 
 	observation_prompt = "Tin-cold woodsman. <br>I’ll give you the heart to forgive and love anyone. <br>The wizard grants you..."
-	observation_choices = list("A heart of lead", "A warm heart")
-	correct_choices = list("A heart of lead")
-	observation_success_message = "Who do you possibly expect to understand with that ice-cold heart of yours?"
-	observation_fail_message = "You’re a machine, aren’t you? A heart is unnecessary for a machine."
+	observation_choices = list(
+		"A heart of lead" = list(TRUE, "Who do you possibly expect to understand with that ice-cold heart of yours?"),
+		"A warm heart" = list(FALSE, "You’re a machine, aren’t you? A heart is unnecessary for a machine."),
+	)
 
 	// Flurry Vars
 	var/flurry_cooldown = 0

--- a/code/modules/mob/living/simple_animal/abnormality/he/you_strong.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/you_strong.dm
@@ -37,9 +37,9 @@
 		'I would never amount to anything in life or in death', I thought until one day I recieved a curious offer, a pamphlet in my mail. <br>\
 		\"Have you become strong? Strong for your City? Become Strong! Strong for your City!\" The suspicious pamphlet had an address and I followed it, <br>\
 		I detested my weakness and I cared not if I lived or died, I'd take any chance to not be weak. <br>At the address was a most curious machine and an instruction to enter."
-	observation_choices = list("Enter the machine")
-	correct_choices = list("Enter the machine")
-	observation_success_message = "I did as instructed and entered; now I have become strong, strong for my City. <br>I love the City I live in."
+	observation_choices = list(
+		"Enter the machine" = list(TRUE, "I did as instructed and entered; now I have become strong, strong for my City. <br>I love the City I live in."),
+	)
 
 	var/penalize = FALSE
 	var/work_count = 0

--- a/code/modules/mob/living/simple_animal/abnormality/teth/MHz.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/MHz.dm
@@ -40,11 +40,11 @@
 		As you wait, your radio hisses with static and ghostly voices, buried in electromagnetic snow. <br>\
 		\"h...e...l...p\" <br>\
 		A ghost from the past calls out, the voice is familiar but you can't place who it belongs to."
-	observation_choices = list("Tune your radio to 1.76 MHz", "Forget")
-	correct_choices = list("Tune your radio to 1.76 MHz")
-	observation_success_message = "You tune your radio and hear her plea plain as day, her voice is like sunshine. <br>\
-		Unbridled anger and sorrow at the unfairness of it all fills you as you leave the cell."
-	observation_fail_message = "But you can't forget. Not until you've atoned."
+	observation_choices = list(
+		"Tune your radio to 1.76 MHz" = list(TRUE, "You tune your radio and hear her plea plain as day, her voice is like sunshine. <br>\
+			Unbridled anger and sorrow at the unfairness of it all fills you as you leave the cell."),
+		"Forget" = list(FALSE, "But you can't forget. Not until you've atoned."),
+	)
 
 	var/reset_time = 4 MINUTES //Qliphoth resets after this time. To prevent bugs
 

--- a/code/modules/mob/living/simple_animal/abnormality/teth/beanstalk.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/beanstalk.dm
@@ -30,10 +30,10 @@
 	observation_prompt = "You remember an employee was obsessed with this abnormality. <br>\"\
 		If you reach the top, you'll find what you've been looking for!\", He'd tell every employee. <br>\
 		One day he did climb the beanstalk, and never came back down. <br>Perhaps he's doing okay up there."
-	observation_choices = list("Climb the beanstalk", "Chop it down")
-	correct_choices = list("Chop it down") //TODO: Make this event a bit special
-	observation_success_message = "If something's too big to understand, it's too big to be allowed to exist. The axe bites into the stem..."
-	observation_fail_message = "You begin to climb the beanstalk, but no matter how much you climb there's always more stalk. You peer at the clouds, squinting your eyes, but still can't see anyone..."
+	observation_choices = list( //TODO: Make this event a bit special
+		"Chop it down" = list(TRUE, "If something's too big to understand, it's too big to be allowed to exist. The axe bites into the stem..."),
+		"Climb the beanstalk" = list(FALSE, "You begin to climb the beanstalk, but no matter how much you climb there's always more stalk. You peer at the clouds, squinting your eyes, but still can't see anyone..."),
+	)
 
 	var/climbing = FALSE
 

--- a/code/modules/mob/living/simple_animal/abnormality/teth/beauty_beast.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/beauty_beast.dm
@@ -36,12 +36,12 @@
 		These puddles are evidence of monster's futile struggle to end its life. \
 		\"Kill me. Stab me with that knife you have.\" The monster cannot talk. However, the soul trapped in it can talk and I can hear it. \
 		\"Why are you not helping me when you can hear me?\" The monster asks reproachfully."
-	observation_choices = list("Because I don't have a knife.", "Because this problem can't be solved with death.")
-	correct_choices = list("Because this problem can't be solved with death.")
-	observation_success_message = "'That's not important. Every single second is an agony for me. \
-		Death is a prize compared to this endless pain.' \"But you are right. It is your job to solve it. Not mine.\" \
-		\"Child, would you make a promise? Would you free me from this cycle when you are ready?\""
-	observation_fail_message = "You are lying. You know you can pull out that knife out from your pocket whenever you want."
+	observation_choices = list(
+		"Because this problem can't be solved with death" = list(TRUE, "'That's not important. Every single second is an agony for me. \
+			Death is a prize compared to this endless pain.' \"But you are right. It is your job to solve it. Not mine.\" \
+			\"Child, would you make a promise? Would you free me from this cycle when you are ready?\""),
+		"Because I don't have a knife" = list(FALSE, "You are lying. You know you can pull out that knife out from your pocket whenever you want."),
+	)
 
 	var/injured = FALSE
 

--- a/code/modules/mob/living/simple_animal/abnormality/teth/blood_bath.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/blood_bath.dm
@@ -32,10 +32,10 @@
 		One of problems, one of them was numbing. <br>People believed they could live happy life. <br>\
 		People believed they could buy sadness and sell happiness with money. <br>When the first suicide happened, we should have known that these beliefs had been shattered. <br>\
 		Many hands float in the bath. <br>Hands that wanted to grab something but could not. <br>You......"
-	observation_choices = list("Grabbed a hand", "Did not grab a hand")
-	correct_choices = list("Grabbed a hand")
-	observation_success_message = "I feel coldness and stiffness. <br>I know these hands. <br>These are the hands of people I once loved."
-	observation_fail_message = "You looked away. <br>This is not the first time you ignore them. <br>It will be the same afterwards."
+	observation_choices = list(
+		"Grabbed a hand" = list(TRUE, "I feel coldness and stiffness. <br>I know these hands. <br>These are the hands of people I once loved."),
+		"Did not grab a hand" = list(FALSE, "You looked away. <br>This is not the first time you ignore them. <br>It will be the same afterwards."),
+	)
 
 	var/hands = 0
 

--- a/code/modules/mob/living/simple_animal/abnormality/teth/book.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/book.dm
@@ -27,10 +27,10 @@
 	observation_prompt = "It's just a stupid rumour. <br>\"If you fill it in whatever way, then the book will grant one wish!\" <br>\
 		All the newbies crow, waiting for their chance to fill the pages with their wishes. <br>\
 		You open the book and read through every wish, splotched with ink and tears, every employee had, living and dead, wrote..."
-	observation_choices = list("Tear out the wishes", "Write your own wish")
-	correct_choices = list("Write your own wish")
-	observation_success_message = "You take out the pen from your pocket and write down your wish. It'll never come true but that's why it will always remain a wish."
-	observation_fail_message = "You tear out their wishes one by one. The book's page count remains the same. Did your wish come true?"
+	observation_choices = list(
+		"Write your own wish" = list(TRUE, "You take out the pen from your pocket and write down your wish. It'll never come true but that's why it will always remain a wish."),
+		"Tear out the wishes" = list(FALSE, "You tear out their wishes one by one. The book's page count remains the same. Did your wish come true?"),
+	)
 
 	var/wordcount = 0
 	var/list/oddities = list() //List gets populated with friendly animals

--- a/code/modules/mob/living/simple_animal/abnormality/teth/cherry_blossoms.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/cherry_blossoms.dm
@@ -33,12 +33,12 @@
 	observation_prompt = "The tree is adorned with beautiful leaves growing here and there. <br>\
 		The kind of sight you could never even hope to see in this dark and dreary place. <br>\
 		You can take a moment to take in the beauty before you begin to work."
-	observation_choices = list("Take in the beauty")
-	correct_choices = list("Take in the beauty")
-	observation_success_message = "You feel refreshed after just taking a moment to watch such a beautiful thing. <br>\
-		This doesn't mean that you don't know that this is a dangerous abnormality. <br>\
-		There is beauty even in great and terrible things. <br>\
-		Even the bodies underneath this tree would agree with you."
+	observation_choices = list(
+		"Take in the beauty" = list(TRUE, "You feel refreshed after just taking a moment to watch such a beautiful thing. <br>\
+			This doesn't mean that you don't know that this is a dangerous abnormality. <br>\
+			There is beauty even in great and terrible things. <br>\
+			Even the bodies underneath this tree would agree with you."),
+	)
 
 	var/number_of_marks = 5
 

--- a/code/modules/mob/living/simple_animal/abnormality/teth/cinderella.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/cinderella.dm
@@ -38,14 +38,13 @@
 		(You sit and wait.) <br>\
 		Do you not need me anymore? Did I not take you to the happiest night of your life? <br>\
 		(You sit and...)"
-	observation_choices = list("Remember that night", "Wait")
-	correct_choices = list("Remember that night")
-	observation_success_message = "Yes, it was the happiest night of both our lives... <br>\
-		(The colour returns to your flesh and your wheels begin to mend.) <br>\
-		Let's go back to that wonderous, magical night..."
-	observation_fail_message = "She still may have need of me, I'll wait until I'm called. <br>\
-		(Your flesh turns grey, no one will need such a horrid looking carriage.)"
-
+	observation_choices = list(
+		"Remember that night" = list(TRUE, "Yes, it was the happiest night of both our lives... <br>\
+			(The colour returns to your flesh and your wheels begin to mend.) <br>\
+			Let's go back to that wonderous, magical night..."),
+		"Wait" = list(FALSE, "She still may have need of me, I'll wait until I'm called. <br>\
+			(Your flesh turns grey, no one will need such a horrid looking carriage.)"),
+	)
 
 	var/freshness = 0
 	//Breach stuff

--- a/code/modules/mob/living/simple_animal/abnormality/teth/cleaner.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/cleaner.dm
@@ -54,16 +54,16 @@
 		The model next to mine boasted that it has multiple parts that others don't. <br>\
 		Is that what makes one special? <br>\
 		Am I special the way I am?"
-	observation_choices = list("You are special", "You are not special")
-	correct_choices = list("You are not special")
-	observation_success_message = "\"Am I not special, not special, not special?\" <br>\
-		After giving a lagged reply, it suddenly began tearing off all the cleaning gadgets from its body and crashing into walls. <br>\
-		It rubbed its body on other objects while sparks flew off as if it was trying to attach things to it. <br>\
-		It only stopped after a while. <br>\
-		\"Maybe I wanted to be special.\""
-	observation_fail_message = "\"No. I am not special.\" <br>\
-		Disregarding the answer, it gives a stern reply. <br>\
-		\"I will keep living an ordinary life, the same as now, just as assigned to me.\""
+	observation_choices = list(
+		"You are not special" = list(TRUE, "\"Am I not special, not special, not special?\" <br>\
+			After giving a lagged reply, it suddenly began tearing off all the cleaning gadgets from its body and crashing into walls. <br>\
+			It rubbed its body on other objects while sparks flew off as if it was trying to attach things to it. <br>\
+			It only stopped after a while. <br>\
+			\"Maybe I wanted to be special.\""),
+		"You are special" = list(FALSE, "\"No. I am not special.\" <br>\
+			Disregarding the answer, it gives a stern reply. <br>\
+			\"I will keep living an ordinary life, the same as now, just as assigned to me.\""),
+	)
 
 	var/bumpdamage = 10
 

--- a/code/modules/mob/living/simple_animal/abnormality/teth/crumbling_armor.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/crumbling_armor.dm
@@ -31,10 +31,10 @@
 	secret_icon_state = "megalovania"
 
 	observation_prompt = "The armor that took away many people's lives is sitting in front of you. <br>You can put it on, if you wish."
-	observation_choices = list("Put it on", "Dont't put it on")
-	correct_choices = list("Put it on")
-	observation_success_message = "It seems like you were not pacifist. <br>You feel the armor's warm welcome."
-	observation_fail_message = "The armor waits for another reckless one."
+	observation_choices = list(
+		"Put it on" = list(TRUE, "It seems like you were not pacifist. <br>You feel the armor's warm welcome."),
+		"Dont't put it on" = list(FALSE, "The armor waits for another reckless one."),
+	)
 
 	var/buff_icon = 'ModularTegustation/Teguicons/tegu_effects.dmi'
 	var/user_armored
@@ -49,15 +49,14 @@
 	..()
 	gift_type = null
 
-/mob/living/simple_animal/hostile/abnormality/crumbling_armor/ObservationResult(mob/living/carbon/human/user, condition)
+/mob/living/simple_animal/hostile/abnormality/crumbling_armor/ObservationResult(mob/living/carbon/human/user, success, reply)
 	. = ..()
-	if(condition)
+	if(success)
 		var/datum/ego_gifts/recklessCourage/R = new
 		user.Apply_Gift(R)
 		if(!armor_dispensed) // You only get one of these. Ever.
 			new /obj/item/clothing/suit/armor/ego_gear/he/crumbling_armor(get_turf(user))
 			armor_dispensed = TRUE
-	datum_reference.observation_ready = FALSE
 
 /mob/living/simple_animal/hostile/abnormality/crumbling_armor/SuccessEffect(mob/living/carbon/human/user, work_type, pe)
 	. = ..()

--- a/code/modules/mob/living/simple_animal/abnormality/teth/dealerdamned.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/dealerdamned.dm
@@ -32,10 +32,10 @@
 
 	observation_prompt = "You awaken to a building flooded with stimulation; guests mingle and drink as slot machines whirr and blare their tunes, drowning out the mourning of those who have lost it all. <br>\
 	Amidst all this, you find yourself sat in front of a poker table, already in the middle of a game. The Dealer turns to you, eagerly awaiting your next move."
-	observation_choices = list("Call", "Fold")
-	correct_choices = list("Call")
-	observation_success_message = "You call, confident your hand is enough to win. However, you lose, beat by none other than a Royal Flush. Despite this loss, you continue to play, confident your luck will eventually turn around..."
-	observation_fail_message = "You fold, wishing to cling to what little remains of your wealth. Despite lacking any facial features, you can feel the Dealer's disappointment..."
+	observation_choices = list(
+		"Call" = list(TRUE, "You call, confident your hand is enough to win. However, you lose, beat by none other than a Royal Flush. Despite this loss, you continue to play, confident your luck will eventually turn around..."),
+		"Fold" = list(FALSE, "You fold, wishing to cling to what little remains of your wealth. Despite lacking any facial features, you can feel the Dealer's disappointment..."),
+	)
 
 //Coinflip V1; Expect Jank
 /mob/living/simple_animal/hostile/abnormality/dealerdamned/funpet(mob/petter)

--- a/code/modules/mob/living/simple_animal/abnormality/teth/dingle_dangle.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/dingle_dangle.dm
@@ -29,11 +29,14 @@
 	abnormality_origin = ABNORMALITY_ORIGIN_WONDERLAB
 
 	observation_prompt = "You pass by the containment cell and, in the corner of your eye, spy your comrades dangling from ribbons, furiously scratching at their necks in choked agony."
-	observation_choices = list("Save them", "Do not save them")
-	correct_choices = list("Save them", "Do not save them")
-	observation_success_message = "Regardless of your resolution, you find yourself before the tree anyway as one of its ribbons wrap around your neck. <br>\
-		\"Let's dangle together, let your sorrows, your pain dangle, let's all dangle down...\" <br>It whispers into your mind. <br>\
-		Your comrades were never here, the life passes from your body painlessly. <br> None of this is real."
+	observation_choices = list(
+		"Save them" = list(TRUE, "Regardless of your resolution, you find yourself before the tree anyway as one of its ribbons wrap around your neck. <br>\
+			\"Let's dangle together, let your sorrows, your pain dangle, let's all dangle down...\" <br>It whispers into your mind. <br>\
+			Your comrades were never here, the life passes from your body painlessly. <br> None of this is real."),
+		"Do not save them" = list(TRUE, "Regardless of your resolution, you find yourself before the tree anyway as one of its ribbons wrap around your neck. <br>\
+			\"Let's dangle together, let your sorrows, your pain dangle, let's all dangle down...\" <br>It whispers into your mind. <br>\
+			Your comrades were never here, the life passes from your body painlessly. <br> None of this is real."),
+	)
 
 //Introduction to our hallucinations. This is a global hallucination, but it's all it really does.
 /mob/living/simple_animal/hostile/abnormality/dingledangle/ZeroQliphoth(mob/living/carbon/human/user)

--- a/code/modules/mob/living/simple_animal/abnormality/teth/drowned_sisters.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/drowned_sisters.dm
@@ -30,10 +30,12 @@
 
 	observation_prompt = "You sit cross-legged before the pair, flowers conceal their faces and expression. <br>\
 		\"Ahh, woe is us. We have become sinners. Please hear us, hear of our sins that we do not know we've committed, and absolve us of our grief...\""
-	observation_choices = list("Listen to their story", "Don't listen")
-	correct_choices = list("Listen to their story", "Don't listen")
-	observation_success_message = "You exit the cell, their story leaving your mind and voices on the wind but their sorrow remains. <br>\
-		You'll be back again and still won't understand their grief."
+	observation_choices = list(
+		"Listen to their story" = list(TRUE, "You exit the cell, their story leaving your mind and voices on the wind but their sorrow remains. <br>\
+			You'll be back again and still won't understand their grief."),
+		"Don't listen" = list(TRUE, "You exit the cell, their story leaving your mind and voices on the wind but their sorrow remains. <br>\
+			You'll be back again and still won't understand their grief."),
+	)
 
 	var/breaching = FALSE
 

--- a/code/modules/mob/living/simple_animal/abnormality/teth/faelantern.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/faelantern.dm
@@ -45,16 +45,15 @@
 		A small fairy with a green glow sits atop it. <br>\
 		Saying no words, the fairy waves at you, inviting you to come over and take a break. <br>\
 		It looked like it was smiling, and it might have been dancing."
-	observation_choices = list("Take a momentary break", "Move on without resting", "Take a break where you're standing")
-	correct_choices = list("Move on without resting")
-	observation_success_message = "This is no time to be careless and stop here. <br>\
-		Tree branches came at you to halt you from leaving, but you narrowly dodged them. <br>\
-		You knew the real meaning of the fairy's gesture: <br>\
-		\"There's no such thing as a free gift\"."
-	observation_fail_message = "The fairy's smile stretches into an eerie grin. You shouldn't have trusted its appearance and now you'll have to pay the price."
-	//Extra wrong answer
-	var/observation_fail_message_2 = "You ignore the beckoning fairy and take a short break where you stand. <br>\
-		As you gather yourself to continue on the journey, you realize that several branches had grown in the premises, trapping you in."
+	observation_choices = list(
+		"Move on without resting" = list(TRUE, "This is no time to be careless and stop here. <br>\
+			Tree branches came at you to halt you from leaving, but you narrowly dodged them. <br>\
+			You knew the real meaning of the fairy's gesture: <br>\
+			\"There's no such thing as a free gift\"."),
+		"Take a momentary break" = list(FALSE, "The fairy's smile stretches into an eerie grin. You shouldn't have trusted its appearance and now you'll have to pay the price."),
+		"Take a break where you're standing" = list(FALSE, "You ignore the beckoning fairy and take a short break where you stand. <br>\
+			As you gather yourself to continue on the journey, you realize that several branches had grown in the premises, trapping you in."),
+	)
 
 	var/can_act = FALSE
 	var/break_threshold = 450
@@ -67,13 +66,6 @@
 	var/stab_cooldown
 	var/stab_cooldown_time = 30
 	var/lured_list = list()
-
-/mob/living/simple_animal/hostile/abnormality/faelantern/ObservationResult(mob/living/carbon/human/user, condition, answer) //special answer
-	if(answer == "Take a break where you're standing")
-		observation_fail_message = observation_fail_message_2
-	else
-		observation_fail_message = initial(observation_fail_message)
-	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/faelantern/AttackingTarget(atom/attacked_target)
 	return OpenFire()

--- a/code/modules/mob/living/simple_animal/abnormality/teth/fairy_gentleman.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/fairy_gentleman.dm
@@ -48,11 +48,11 @@
 	)
 
 	observation_prompt = "\"Care for a drink?\""
-	observation_choices = list("Yes", "No")
-	correct_choices = list("Yes")
-	observation_success_message = "\"Yer a good drinkin buddy as any!\""
-	observation_fail_message = "\"Pssh! you're no fun!\" <br>\
-		The fairy walks away, stumbling along the way."
+	observation_choices = list(
+		"Yes" = list(TRUE, "\"Yer a good drinkin buddy as any!\""),
+		"No" = list(FALSE, "\"Pssh! you're no fun!\" <br>\
+			The fairy walks away, stumbling along the way."),
+	)
 
 	var/can_act = TRUE
 	var/jump_cooldown = 0

--- a/code/modules/mob/living/simple_animal/abnormality/teth/fairy_long_legs.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/fairy_long_legs.dm
@@ -52,16 +52,16 @@
 
 	observation_prompt = "Come on, why don'cha stay under the umbrella with me? <br>\
 		Just for old times sake?"
-	observation_choices = list("Yes", "No")
-	correct_choices = list("No")
-	observation_success_message = "You'd think that you'd have learned your lesson by now. <br>\
-		You leave the cell, having narrowly dodged the imminent attack. <br>\
-		This guy will always be a crook."
-	observation_fail_message = "Ouch! <br>\
-		The moment you get in striking range of fairy long legs, you are attacked. <br>\
-		\"Heh. You really think you could be one of us, pal?\" <br>\
-		\"You aint part of the family, chump.\" <br>\
-		You walk away, and bandage the bleeding wound."
+	observation_choices = list(
+		"No" = list(TRUE, "You'd think that you'd have learned your lesson by now. <br>\
+			You leave the cell, having narrowly dodged the imminent attack. <br>\
+			This guy will always be a crook."),
+		"Yes" = list(FALSE, "Ouch! <br>\
+			The moment you get in striking range of fairy long legs, you are attacked. <br>\
+			\"Heh. You really think you could be one of us, pal?\" <br>\
+			\"You aint part of the family, chump.\" <br>\
+			You walk away, and bandage the bleeding wound."),
+	)
 
 	var/finishing = FALSE //cant move/attack when it's TRUE
 	var/work_count = 0

--- a/code/modules/mob/living/simple_animal/abnormality/teth/falada.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/falada.dm
@@ -33,13 +33,13 @@
 
 	observation_prompt = "A severed horse-like creature's head hangs high on the wall, sobbing. <br>\
 		You can't help but feel some pity for the thing."
-	observation_choices = list("Why the long face?", "What happened to you?")
-	correct_choices = list("What happened to you?")
-	observation_success_message = "The horse head begins speaking. <br>\
-		\"Oh, woe is me. If only it could be - the powers that be, would see fit to have me die in her stead.\" <br>\
-		It speaks in rhymes, but it clearly lost someone important to it. <br>\
-		Even if there is nothing you can do, at least you are there to listen."
-	observation_fail_message = "The horse head continues sobbing, despite your cheesy joke. <br>Maybe that wasn't the best approach."
+	observation_choices = list(
+		"What happened to you?" = list(TRUE, "The horse head begins speaking. <br>\
+			\"Oh, woe is me. If only it could be - the powers that be, would see fit to have me die in her stead.\" <br>\
+			It speaks in rhymes, but it clearly lost someone important to it. <br>\
+			Even if there is nothing you can do, at least you are there to listen."),
+		"Why the long face?" = list(FALSE, "The horse head continues sobbing, despite your cheesy joke. <br>Maybe that wasn't the best approach."),
+	)
 
 	var/liked
 	var/happy = TRUE

--- a/code/modules/mob/living/simple_animal/abnormality/teth/forsaken_employee.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/forsaken_employee.dm
@@ -32,14 +32,14 @@
 		The card is almost too battered and contaminated to recognize. <br>\
 		Wearing a box filled with Enkephalin on their head, the employee rams it into what looks like the door to a containment unit. <br>\
 		A rubber O-ring is worn around their neck. Could it be there to prevent Enkephalin from spilling?"
-	observation_choices = list("Cut the ring.", "Don't cut the ring.")
-	correct_choices = list("Cut the ring.")
-	observation_success_message = " The blade kept bouncing off the slippery O-ring... <br>\
-		\"Brgrrgh...\ <br>\
-		And the submerged thing pushed you away and ran off. Did it prefer to stay like that? <br>\
-		All it left was a small employee card."
-	observation_fail_message = "Tang- Tang- Tang- The ramming at the door and the sloshing continue. <br>\
-		I keep watching and listening. A more attentive hearing reveals that the sounds have a rhythm. Perhaps there is delight to be found in it."
+	observation_choices = list(
+		"Cut the ring" = list(TRUE, "The blade kept bouncing off the slippery O-ring... <br>\
+			\"Brgrrgh...\ <br>\
+			And the submerged thing pushed you away and ran off. Did it prefer to stay like that? <br>\
+			All it left was a small employee card."),
+		"Don't cut the ring" = list(FALSE, "Tang- Tang- Tang- The ramming at the door and the sloshing continue. <br>\
+			I keep watching and listening. A more attentive hearing reveals that the sounds have a rhythm. Perhaps there is delight to be found in it."),
+	)
 
 /mob/living/simple_animal/hostile/abnormality/forsaken_employee/FailureEffect(mob/living/carbon/human/user, work_type, pe, work_time, canceled)
 	. = ..()

--- a/code/modules/mob/living/simple_animal/abnormality/teth/forsaken_murderer.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/forsaken_murderer.dm
@@ -97,13 +97,16 @@
 	abnormality_origin = ABNORMALITY_ORIGIN_LOBOTOMY
 
 	/**
-	* Final observation code. These variables should be self-explanatory.
-	*/
+	 * Final observation code.
+	 * observation_prompt controls the text that the user sees when they start the observation
+	 * observation_choices is made in the format of:
+	 * "Choice" = list(TRUE or FALSE [depending on if the answer is correct], "Response"),
+	 */
 	observation_prompt = "Around his neck is a rope. It is up to you to cut his rope."
-	observation_choices = list("Cut the rope.", "Don't cut the rope.")
-	correct_choices = list("Don't cut the rope.")
-	observation_success_message = "His neck snaps, granting him silence and eternal rest."
-	observation_fail_message = "\"You think I'm pathetic, huh? But is you people who are really pathetic. Because you get killed. By people like me.\""
+	observation_choices = list(
+		"Don't cut the rope" = list(TRUE, "His neck snaps, granting him silence and eternal rest."),
+		"Cut the rope" = list(FALSE, "\"You think I'm pathetic, huh? But is you people who are really pathetic. Because you get killed. By people like me.\""),
+	)
 
 	//Unique variable im defining for this abnormality. This is the timer for their during work emotes.
 	var/work_emote_cooldown = 0

--- a/code/modules/mob/living/simple_animal/abnormality/teth/fragment.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/fragment.dm
@@ -39,11 +39,11 @@
 	abnormality_origin = ABNORMALITY_ORIGIN_LOBOTOMY
 
 	observation_prompt = "It started singing. You..."
-	observation_choices = list("Listen to it", "Plug your ears")
-	correct_choices = list("Listen to it")
-	observation_success_message = "You silently listen to it. \
-		The universe lingers in your ears. You see the song. Glamorously, it approaches you."
-	observation_fail_message = "You are not prepared yet. The song stopped when you plugged the ears."
+	observation_choices = list(
+		"Listen to it" = list(TRUE, "You silently listen to it. \
+			The universe lingers in your ears. You see the song. Glamorously, it approaches you."),
+		"Plug your ears" = list(FALSE, "You are not prepared yet. The song stopped when you plugged the ears."),
+	)
 
 	var/song_cooldown
 	var/song_cooldown_time = 10 SECONDS

--- a/code/modules/mob/living/simple_animal/abnormality/teth/lady_facing_the_wall.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/lady_facing_the_wall.dm
@@ -34,11 +34,10 @@
 		Her muttering is unintelligible, and it gives you goosebumps. You don't like being in the same space with her. \
 		You want to get out. The woman seems to be sobbing. You feel as though her crying is insisting you to turn towards her. \
 		And you also feel, that you should not."
-	observation_choices = list("Do not turn back.", "Turn back.")
-	correct_choices = list("Turn back.")
-	observation_success_message = "You face the fear, and turn to face the woman."
-	observation_fail_message = "Something terrible could happen if you turn back. You exit the room, without looking back."
-
+	observation_choices = list(
+		"Turn back" = list(TRUE, "You face the fear, and turn to face the woman."),
+		"Do not turn back" = list(FALSE, "Something terrible could happen if you turn back. You exit the room, without looking back."),
+	)
 
 /mob/living/simple_animal/hostile/abnormality/wall_gazer/NeutralEffect(mob/living/carbon/human/user, work_type, pe)
 	. = ..()

--- a/code/modules/mob/living/simple_animal/abnormality/teth/meat_lantern.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/meat_lantern.dm
@@ -39,10 +39,10 @@
 
 	observation_prompt = "It's always the same, dull colours in the facility. Grey walls, grey floors, grey ceilings, even the people were grey. <br>\
 		Every day was grey until, one day, you saw the a small, beautifully green flower growing and glowing from the ground."
-	observation_choices = list("Approach the flower", "Call for security")
-	correct_choices = list("Approach the flower")
-	observation_success_message = "It's the most beautiful thing you've ever seen, you brush your hand against it and the petals tickle your hand. You feel a tremor beneath and..."
-	observation_fail_message = "Something so beautiful had no right to exist in the City. You called for security and left in a hurry back to your grey workplace."
+	observation_choices = list(
+		"Approach the flower" = list(TRUE, "It's the most beautiful thing you've ever seen, you brush your hand against it and the petals tickle your hand. You feel a tremor beneath and..."),
+		"Call for security" = list(FALSE, "Something so beautiful had no right to exist in the City. You called for security and left in a hurry back to your grey workplace."),
+	)
 
 	var/can_act = TRUE
 	var/detect_range = 1

--- a/code/modules/mob/living/simple_animal/abnormality/teth/my_sweet_home.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/my_sweet_home.dm
@@ -49,13 +49,13 @@
 		A perfect, safe place away from this scary room. <br>\
 		Everything for you. <br>\
 		Won't you come inside?"
-	observation_choices = list("Go inside", "Don't go inside")
-	correct_choices = list("Don't go inside")
-	observation_success_message = "Some things are too good to be true. <br>\
-		You take the key from under the doormat, and leave."
-	observation_fail_message = "A key appears in your hand. <br>\
-		You move to open the door. <br>\
-		But at the last minute, you are pulled away by another agent to safety."
+	observation_choices = list(
+		"Don't go inside" = list(TRUE, "Some things are too good to be true. <br>\
+			You take the key from under the doormat, and leave."),
+		"Go inside" = list(FALSE, "A key appears in your hand. <br>\
+			You move to open the door. <br>\
+			But at the last minute, you are pulled away by another agent to safety."),
+	)
 
 	var/ranged_damage = 15
 	var/damage_dealt = 0

--- a/code/modules/mob/living/simple_animal/abnormality/teth/old_lady.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/old_lady.dm
@@ -30,12 +30,12 @@
 		Because I don't like to listen to stories. Bugs were buzzing around here and there. \
 		Something slimy popped as I set my foot on it. I found her. Every hole on her face was swarming bugs. \
 		I don't want to stay here. I want to get out. It's damp, nasty, and awful. I can't stand it anymore."
-	observation_choices = list("Get out", "Stay")
-	correct_choices = list("Stay")
-	observation_success_message = "I stayed, bearing the unpleasantness. \
-		She was so talkative before. In the end, loneliness was the only listener. \
-		She called me, with her finger. I am now ready to listen to her story."
-	observation_fail_message = "I turned around to get out of this place. Once again, I bit lips in self-hatred while escaping."
+	observation_choices = list(
+		"Stay" = list(TRUE, "I stayed, bearing the unpleasantness. \
+			She was so talkative before. In the end, loneliness was the only listener. \
+			She called me, with her finger. I am now ready to listen to her story."),
+		"Get out" = list(FALSE, "I turned around to get out of this place. Once again, I bit lips in self-hatred while escaping."),
+	)
 
 	var/meltdown_cooldown_time = 120 SECONDS
 	var/meltdown_cooldown

--- a/code/modules/mob/living/simple_animal/abnormality/teth/pale_horse.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/pale_horse.dm
@@ -41,12 +41,12 @@
 	observation_prompt = "Joseph came to you once, his face flush with excitement after the horse wept before him. He's \"Nothing There\"'s shell now. <br>\
 		Did the horse merely prognosticate his death or did it doom him? You're outside the containment unit now and your legs tremble, you've been ordered to work it today. <br>\
 		You..."
-	observation_choices = list("Enter the containment unit", "Pretend you didn't get the order")
-	correct_choices = list("Enter the containment unit")
-	observation_success_message = "You enter the containment unit and kneel before the horse. <br>\
-		It kneels next to you and a single tear drips from its eye onto your shoulder. You hold onto its head as you both weep. <br>\
-		Death is terrifying but at least you know something weeps for you."
-	observation_fail_message = "You pretend you didn't get the order and make to leave, your PDA flashes again, you've been assigned to \"Nothing There\" and this time, you're being escorted."
+	observation_choices = list(
+		"Enter the containment unit" = list(TRUE, "You enter the containment unit and kneel before the horse. <br>\
+			It kneels next to you and a single tear drips from its eye onto your shoulder. You hold onto its head as you both weep. <br>\
+			Death is terrifying but at least you know something weeps for you."),
+		"Pretend you didn't get the order" = list(FALSE, "You pretend you didn't get the order and make to leave, your PDA flashes again, you've been assigned to \"Nothing There\" and this time, you're being escorted."),
+	)
 
 	//teleport
 	var/can_act = TRUE

--- a/code/modules/mob/living/simple_animal/abnormality/teth/penitent_girl.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/penitent_girl.dm
@@ -31,13 +31,13 @@
 	observation_prompt = "A girl in front of you dances, stumbling to and fro. <br>\
 		Her feet are chopped off at the ankles, and yet they still move. <br>\
 		You..."
-	observation_choices = list("Put on the shoes.", "Don't put on the shoes.")
-	correct_choices = list("Put on the shoes.")
-	observation_success_message = "You remove the severed feet, and put on the shoes. <br>\
-		It feels good. <br>You want to dance. <br>Please, chop off my feet."
-	observation_fail_message = "How could you do something so gross? <br>\
-		You leave the shoes where they are. <br>\
-		The girl continues shifting about without a care in the world."
+	observation_choices = list(
+		"Put on the shoes" = list(TRUE, "You remove the severed feet, and put on the shoes. <br>\
+			It feels good. <br>You want to dance. <br>Please, chop off my feet."),
+		"Don't put on the shoes" = list(FALSE, "How could you do something so gross? <br>\
+			You leave the shoes where they are. <br>\
+			The girl continues shifting about without a care in the world."),
+	)
 
 //Work Mechanics
 /mob/living/simple_animal/hostile/abnormality/penitentgirl/AttemptWork(mob/living/carbon/human/user, work_type)

--- a/code/modules/mob/living/simple_animal/abnormality/teth/ppodae.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/ppodae.dm
@@ -37,10 +37,10 @@
 	abnormality_origin = ABNORMALITY_ORIGIN_LOBOTOMY
 
 	observation_prompt = "Before me stands a creature, eagerly awaiting its next meal. The creature is..."
-	observation_choices = list("A puppy", "A monster")
-	correct_choices = list("A monster")
-	observation_success_message = "I don't know how I didn't see it before, I rushed out to warn the others. I was fired the next day."
-	observation_fail_message = "It's the cutest puppy I've ever seen."
+	observation_choices = list(
+		"A monster" = list(TRUE, "I don't know how I didn't see it before, I rushed out to warn the others. I was fired the next day."),
+		"A puppy" = list(FALSE, "It's the cutest puppy I've ever seen."),
+	)
 
 	var/smash_damage_low = 16
 	var/smash_damage_high = 28

--- a/code/modules/mob/living/simple_animal/abnormality/teth/punishing_bird.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/punishing_bird.dm
@@ -60,9 +60,10 @@
 	)
 
 	observation_prompt = "A bird stares at you. What is the name of this bird?"
-	observation_choices = list("Little bird", "Punishing bird")
-	correct_choices = list("Little bird", "Punishing bird")
-	observation_success_message = "The small bird accepts whatever name you decide to give it. Its nature can never change now."
+	observation_choices = list(
+		"Little bird" = list(TRUE, "The small bird accepts whatever name you decide to give it. Its nature can never change now."),
+		"Punishing bird" = list(TRUE, "The small bird accepts whatever name you decide to give it. Its nature can never change now."),
+	)
 
 	do_not_possess = TRUE
 

--- a/code/modules/mob/living/simple_animal/abnormality/teth/redblooded.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/redblooded.dm
@@ -52,14 +52,14 @@
 		\"Blowing freakshits away with my shotgun. <br>Talking with my brothers in arms.\" <br>\
 		\"That's all I ever needed. <br>All I ever wanted. <br>Even now, I fight for the glory of my country.\" <br>\
 		\"Do you have anything, anyone, to serve and protect?\""
-	observation_choices = list("I don't.", "I do.")
-	correct_choices = list("I do.")
-	observation_success_message = "\"Heh.\" <br>\
-		\"We might not be on the same side but I can respect that.\" <br>\
-		\"Go on then, freak. <br>Show me that you can protect what matters to you.\""
-	observation_fail_message = "\"Feh. <br>Then what's the point of living, huh?\" <br>\
-		\"Without a flag to protect, without a goal to achieve...\" <br>\
-		\"Are you any better than an animal? <br>Get out of my sight.\""
+	observation_choices = list(
+		"I do" = list(TRUE, "\"Heh.\" <br>\
+			\"We might not be on the same side but I can respect that.\" <br>\
+			\"Go on then, freak. <br>Show me that you can protect what matters to you.\""),
+		"I don't" = list(FALSE, "\"Feh. <br>Then what's the point of living, huh?\" <br>\
+			\"Without a flag to protect, without a goal to achieve...\" <br>\
+			\"Are you any better than an animal? <br>Get out of my sight.\""),
+	)
 
 	var/bloodlust = 0 //more you do repression, more damage it deals. decreases on other works.
 	var/list/fighting_quotes = list(

--- a/code/modules/mob/living/simple_animal/abnormality/teth/scorched_girl.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/scorched_girl.dm
@@ -40,13 +40,13 @@
 		The match that never caught a fire before now burns to ash. Maybe is a price for taking my body, to burn so bright and fiery. \
 		Let's run when I can burn. I have been suffering and will suffer. But why you are still happy? \
 		I know the menace I have become. If nothing will change, I at least want to see you suffering."
-	observation_choices = list("Go to her", "Do not go to her")
-	correct_choices = list("Do not go to her")
-	observation_success_message = "I stopped. I can see her in the distance. \
-		\"Maybe you are thinking I am some kind of lighthouse.\" \
-		\"At least, I hope you realize my ash is all that remains after this flame consumes the all of me.\""
-	observation_fail_message = "Come to me. \
-		You who will soon become ashes just like me."
+	observation_choices = list(
+		"Do not go to her" = list(TRUE, "I stopped. I can see her in the distance. \
+			\"Maybe you are thinking I am some kind of lighthouse.\" \
+			\"At least, I hope you realize my ash is all that remains after this flame consumes the all of me.\""),
+		"Go to her" = list(FALSE, "Come to me. \
+			You who will soon become ashes just like me."),
+	)
 
 	/// Restrict movement when this is set to TRUE
 	var/exploding = FALSE

--- a/code/modules/mob/living/simple_animal/abnormality/teth/shy_look.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/shy_look.dm
@@ -30,10 +30,10 @@
 	abnormality_origin = ABNORMALITY_ORIGIN_LOBOTOMY
 
 	observation_prompt = "It's a good day! Are you still shy today?"
-	observation_choices = list("Yes", "No")
-	correct_choices = list("Yes")
-	observation_success_message = "\"That's no good, it's very important to have a smile on one's face! We need to be happy for our City!\""
-	observation_fail_message = "\"That's great to hear! Let's see the biggest smile you can put on to make those in the Outskirts jealous!\""
+	observation_choices = list(
+		"Yes" = list(TRUE, "\"That's no good, it's very important to have a smile on one's face! We need to be happy for our City!\""),
+		"No" = list(FALSE, "\"That's great to hear! Let's see the biggest smile you can put on to make those in the Outskirts jealous!\""),
+	)
 
 	var/chance_modifier = 1
 	var/previous_mood

--- a/code/modules/mob/living/simple_animal/abnormality/teth/simple_smile.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/simple_smile.dm
@@ -44,14 +44,14 @@
 	abnormality_origin = ABNORMALITY_ORIGIN_WONDERLAB
 
 	observation_prompt = "The abnormality appears to you from out of thin air, and swipes away your weapon."
-	observation_choices = list("Chase after it")
-	correct_choices = list("Chase after it")
-	observation_success_message = "You chase gone with a simple smile across the facility <br>\
-		You trip and scrape your leg on the facility's floor. <br>\
-		\"Well that wasn't very nice! You should apologize for so rudely disarming me, and having me run around like that!\" <br>\
-		The words come out of your mouth before you even realize what is happening. <br>\
-		And as if to answer, Gone with a Simple Smile hands your weapon back. <br>\
-		Then, it disappears with a smile."
+	observation_choices = list(
+		"Chase after it" = list(TRUE, "You chase gone with a simple smile across the facility <br>\
+			You trip and scrape your leg on the facility's floor. <br>\
+			\"Well that wasn't very nice! You should apologize for so rudely disarming me, and having me run around like that!\" <br>\
+			The words come out of your mouth before you even realize what is happening. <br>\
+			And as if to answer, Gone with a Simple Smile hands your weapon back. <br>\
+			Then, it disappears with a smile."),
+	)
 
 	var/list/stats = list(
 		FORTITUDE_ATTRIBUTE,

--- a/code/modules/mob/living/simple_animal/abnormality/teth/skin_prophet.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/skin_prophet.dm
@@ -32,16 +32,16 @@
 		hands are busy nonetheless. <br>\
 		Yearning for destruction and doom, it writes and writes and writes. <br>\
 		You feel the passages it’s writing may be prophecies for someplace and sometime."
-	observation_choices = list("Snuff out the candles", "Peek at the book")
-	correct_choices = list("Snuff out the candles")
-	observation_success_message = "You hushed the candles, one by one. <br>\
-		The space grew darker, but its hands won’t stop. <br>\
-		The only light left was on the quill it held. <br>\
-		Even that was snuffed by our breaths. <br>\
-		Then, the whole place went dark. <br>\
-		All that’s left is the pen in its hand."
-	observation_fail_message = "!@)(!@&)&*%(%@!@#*(#)*(%&!@#$ <br>\
-		@$*@)$ ? <br> @#$!!@#* ! <br> @*()!%&$(^!!!!@&(@)"
+	observation_choices = list(
+		"Snuff out the candles" = list(TRUE, "You hushed the candles, one by one. <br>\
+			The space grew darker, but its hands won’t stop. <br>\
+			The only light left was on the quill it held. <br>\
+			Even that was snuffed by our breaths. <br>\
+			Then, the whole place went dark. <br>\
+			All that’s left is the pen in its hand."),
+		"Peek at the book" = list(FALSE, "!@)(!@&)&*%(%@!@#*(#)*(%&!@#$ <br>\
+			@$*@)$ ? <br> @#$!!@#* ! <br> @*()!%&$(^!!!!@&(@)"),
+	)
 
 	var/list/speak_list = list(
 		"!@)(!@&)&*%(%@!@#*(#)*(%&!@#$",

--- a/code/modules/mob/living/simple_animal/abnormality/teth/so_that_no_cry.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/so_that_no_cry.dm
@@ -44,15 +44,15 @@
 		In this cramped cell, the wooden doll stands. <br>\
 		Are the talismans here to fulfill a wish? <br>\
 		Does this wooden doll wish for anything?"
-	observation_choices = list("Remove the doll's talismans", "Do nothing")
-	correct_choices = list("Remove the doll's talismans")
-	observation_success_message = "After you removed them, the doll knelt. <br>\
-		Is it begging you not to take it,<br>\
-		or is it a gesture of gratitude?<br>\
-		You won’t know for now."
-	observation_fail_message = "Nothing happened. <br>\
-		The doll would simply stand there, producing small noises. <br>\
-		It now ignores you, as if disappointed."
+	observation_choices = list(
+		"Remove the doll's talismans" = list(TRUE, "After you removed them, the doll knelt. <br>\
+			Is it begging you not to take it,<br>\
+			or is it a gesture of gratitude?<br>\
+			You won’t know for now."),
+		"Do nothing" = list(FALSE, "Nothing happened. <br>\
+			The doll would simply stand there, producing small noises. <br>\
+			It now ignores you, as if disappointed."),
+	)
 
 	var/can_act = TRUE
 	/// When this reaches 400 - begins reflecting damage

--- a/code/modules/mob/living/simple_animal/abnormality/teth/someonesportrait.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/someonesportrait.dm
@@ -29,11 +29,11 @@
 //TODO: Resprite + redo of this
 	observation_prompt = "The portrait has been in our family's possession for a long time. <br>\
 		They say it was of a very important relative of ours, but we do not recognize anyone present. <br>I've always hated the picture, why couldn't anyone else see it was just biding its time, waiting to strike?"
-	observation_choices = list("Destroy the picture")
-	correct_choices = list("Destroy the picture")
-	observation_success_message = "One night, when everyone else was asleep, I snuck out of my room and found myself before that horrible thing. <br>\
-		Retrieving a lighter from my pocket I flicked it on and held it to the painting... <br>\
-		It turned out I was right, it was waiting to attack and I got into its striking range when no one else was around..."
+	observation_choices = list(
+		"Destroy the picture" = list(TRUE, "One night, when everyone else was asleep, I snuck out of my room and found myself before that horrible thing. <br>\
+			Retrieving a lighter from my pocket I flicked it on and held it to the painting... <br>\
+			It turned out I was right, it was waiting to attack and I got into its striking range when no one else was around..."),
+	)
 
 //Initialize
 /mob/living/simple_animal/hostile/abnormality/someones_portrait/PostSpawn()

--- a/code/modules/mob/living/simple_animal/abnormality/teth/spider_bud.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/spider_bud.dm
@@ -30,13 +30,13 @@
 	observation_prompt = "I am a spider. <br>I eat anything my web catches. <br>I am starving. <br>\
 		I haven't eaten anything for days. <br>There is a big prey hanging on my web. <br>\
 		My starvation could kill me if I don't eat something."
-	observation_choices = list("Eat the prey.", "Do not eat the prey.")
-	correct_choices = list("Do not eat the prey.")
-	observation_success_message = "I could not eat the prey in front of me. <br>\
-		This starvation is slowly tiring me. <br>The prey struggles to get out, to survive. <br>\
-		The struggle did nothing but shaking my web a little bit. <br>And I watch the prey."
-	observation_fail_message = "I devoured the prey. <br>\
-		My body reacted faster than my thoughts. <br>... <br>I am a spider. <br>I eat anything my web catches."
+	observation_choices = list(
+		"Do not eat the prey" = list(TRUE, "I could not eat the prey in front of me. <br>\
+			This starvation is slowly tiring me. <br>The prey struggles to get out, to survive. <br>\
+			The struggle did nothing but shaking my web a little bit. <br>And I watch the prey."),
+		"Eat the prey" = list(FALSE, "I devoured the prey. <br>\
+			My body reacted faster than my thoughts. <br>... <br>I am a spider. <br>I eat anything my web catches."),
+	)
 
 	/// Filled with ckeys of people who broke our cocoons, they need to pay if they dare mess with us
 	var/list/metagame_list = list()

--- a/code/modules/mob/living/simple_animal/abnormality/teth/training_rabbit.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/training_rabbit.dm
@@ -37,14 +37,14 @@
 	observation_prompt = "This is the training dummy that Lobotomy Corporation uses for training new agents. <br>\
 		But is that really all there is to it? <br>\
 		Looking closely, you find..."
-	observation_choices = list("A dead body?", "Nothing")
-	correct_choices = list("A dead body?")
-	observation_success_message = "The facial structure, the torso, arms and legs, not to mention the stench... <br>\
-		There's no doubt that this is just a dead body in a body bag, flipped upside-down. <br>\
-		In spite of all this, it provides a gift to you. It continues moving around as if it were alive. <br>\
-		So this is what they call an abnormality. <br>\
-		Are all abnormalities at Lobotomy Corporation this strange?"
-	observation_fail_message = "Your imagination must be going haywire due to the stress. <br>There's no way such an out-of-place thing could be there!"
+	observation_choices = list(
+		"A dead body?" = list(TRUE, "The facial structure, the torso, arms and legs, not to mention the stench... <br>\
+			There's no doubt that this is just a dead body in a body bag, flipped upside-down. <br>\
+			In spite of all this, it provides a gift to you. It continues moving around as if it were alive. <br>\
+			So this is what they call an abnormality. <br>\
+			Are all abnormalities at Lobotomy Corporation this strange?"),
+		"Nothing" = list(FALSE, "Your imagination must be going haywire due to the stress. <br>There's no way such an out-of-place thing could be there!"),
+	)
 
 /mob/living/simple_animal/hostile/abnormality/training_rabbit/BreachEffect(mob/living/carbon/human/user, breach_type)
 	. = ..()

--- a/code/modules/mob/living/simple_animal/abnormality/teth/void_dream.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/void_dream.dm
@@ -40,10 +40,10 @@
 		I go out and bring such sweet dreams to those who've only learned to stop dreaming, <br>\
 		I'm not to blame if their dreams are so entrancing they become hollow people in their waking lives, am I not? <br>\
 		Don't you want such sweet dreams too?\""
-	observation_choices = list("You're a demon", "Please, eat my dreams")
-	correct_choices = list("You're a demon")
-	observation_success_message = "\"Don't say such scary, complicated things. <br>I just gave them the enrapturing dreams they wanted. <br>They're destined to come back to me.\""
-	observation_fail_message = "It's alright, dreams are harmless but unnecessary things. <br>So, just close your eyes and show me your most delectable dream..."
+	observation_choices = list(
+		"You're a demon" = list(TRUE, "\"Don't say such scary, complicated things. <br>I just gave them the enrapturing dreams they wanted. <br>They're destined to come back to me.\""),
+		"Please, eat my dreams" = list(FALSE, "It's alright, dreams are harmless but unnecessary things. <br>So, just close your eyes and show me your most delectable dream..."),
+	)
 
 	var/punched = FALSE
 	var/pulse_damage = 50

--- a/code/modules/mob/living/simple_animal/abnormality/waw/alriune.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/alriune.dm
@@ -35,12 +35,11 @@
 	observation_prompt = "You told me, shedding petals instead of tears. <br>\
 		\"We were all nothing but soil once, so do not speak of an end here.\" <br>\
 		You told me, blossoming flowers from body as if they are your last words. <br>\"Soon...\""
-	observation_choices = list("Spring will come.", "Winter will come.")
-	correct_choices = list("Spring will come.", "Winter will come.")
-	observation_success_message = "Spring is coming. <br>Slowly, rapturously, my end began."
-	//Special answer for choice 2
-	var/observation_success_message_2 = "Winter is coming. <br>\
-		Gradually, my exipation was drawing to an end hectically."
+	observation_choices = list(
+		"Spring will come" = list(TRUE, "Spring is coming. <br>Slowly, rapturously, my end began."),
+		"Winter will come" = list(TRUE, "Winter is coming. <br>\
+			Gradually, my exipation was drawing to an end hectically."),
+	)
 
 	/// Currently displayed petals. When value is at 3 - reset to 0 and perform attack
 	var/petals_current = 0
@@ -57,13 +56,6 @@
 	)
 	gift_type =  /datum/ego_gifts/aroma
 	abnormality_origin = ABNORMALITY_ORIGIN_LOBOTOMY
-
-/mob/living/simple_animal/hostile/abnormality/alriune/ObservationResult(mob/living/carbon/human/user, condition, answer) //special answer for winter
-	if(answer == "Winter will come.")
-		observation_success_message = observation_success_message_2
-	else
-		observation_success_message = initial(observation_success_message)
-	return ..()
 
 /* Combat */
 

--- a/code/modules/mob/living/simple_animal/abnormality/waw/apex_predator.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/apex_predator.dm
@@ -50,14 +50,14 @@
 		You're not sure if it's even able to understand you. <br>Despite being shaped like a human, there's no face to relate to. <br>No eyes to look at. <br>\
 		Just the rough outline of a human. <br>\
 		Is there even anything you can say to it?"
-	observation_choices = list("Beat it up.", "Why?")
-	correct_choices = list("Why?")
-	observation_success_message = "The abnormality suddenly stops moving. <br>It doesn't quite know how to respond either. <br>\
-		It stares down at the floor as if to contemplate the question. <br>\
-		All it can offer is a shrug. <br>Perhaps there isn't an answer."
-	observation_fail_message = "There's nothing to say. <br>A crash test dummy's only purpose is to enable violence. <br>\
-		Violence for the sake of violence. <br>\
-		You smile as you pull out your baton."
+	observation_choices = list(
+		"Why?" = list(TRUE, "The abnormality suddenly stops moving. <br>It doesn't quite know how to respond either. <br>\
+			It stares down at the floor as if to contemplate the question. <br>\
+			All it can offer is a shrug. <br>Perhaps there isn't an answer."),
+		"Beat it up" = list(FALSE, "There's nothing to say. <br>A crash test dummy's only purpose is to enable violence. <br>\
+			Violence for the sake of violence. <br>\
+			You smile as you pull out your baton."),
+	)
 
 	var/revealed = TRUE
 	var/can_act = TRUE

--- a/code/modules/mob/living/simple_animal/abnormality/waw/babayaga.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/babayaga.dm
@@ -40,11 +40,11 @@
 		Seeing little recourse, you follow them to a palace made of ice, surrounded by a fence made out of various bones. <br>\
 		The palace stands on the precipice of life and death. <br>You know this palace and who it belongs to. <br>\
 		A terrifying witch lives here."
-	observation_choices = list("Knock on the door", "Keep wandering the blizzard")
-	correct_choices = list("Knock on the door")
-	observation_success_message = "You can't keep shivering in the cold forever. <br>You knock on the door..."
-	observation_fail_message = "You keep wandering the blizzard, the cold continuing to sap your strength. <br>\
-		Eventually you collapse in the snow, your whole body frozen. <br>Ahh... <br>There's no more pain..."
+	observation_choices = list(
+		"Knock on the door" = list(TRUE, "You can't keep shivering in the cold forever. <br>You knock on the door..."),
+		"Keep wandering the blizzard" = list(FALSE, "You keep wandering the blizzard, the cold continuing to sap your strength. <br>\
+			Eventually you collapse in the snow, your whole body frozen. <br>Ahh... <br>There's no more pain..."),
+	)
 
 	var/jump_cooldown = 0
 	var/jump_cooldown_time = 35 SECONDS

--- a/code/modules/mob/living/simple_animal/abnormality/waw/big_bird.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/big_bird.dm
@@ -63,11 +63,11 @@
 		For monsters could come, hurting creatures at any time. <br>By the time eyes covered the whole body of the big bird, no one was around for it to protect. <br>\
 		To shine the light in this dark forest, the big bird burned every single feather it had to make an everlasting lamp. <br>\
 		The big bird now could hardly be called a bird now, it has no feathers at all."
-	observation_choices = list("Don't pet it", "Pet it")
-	correct_choices = list("Pet it")
-	observation_success_message = "It was not soft actually, it gave you chills. <br>You felt eyes looking at you with curiosity. <br>\
-		Eyes started closing as you pet the bird. <br>The big bird, for the first time in a very long time, peacefully fell asleep."
-	observation_fail_message = "The bird could get angry and bite you. <br>You ran out of the room in fear."
+	observation_choices = list(
+		"Pet it" = list(TRUE, "It was not soft actually, it gave you chills. <br>You felt eyes looking at you with curiosity. <br>\
+			Eyes started closing as you pet the bird. <br>The big bird, for the first time in a very long time, peacefully fell asleep."),
+		"Don't pet it" = list(FALSE, "The bird could get angry and bite you. <br>You ran out of the room in fear."),
+	)
 
 	var/bite_cooldown
 	var/bite_cooldown_time = 8 SECONDS

--- a/code/modules/mob/living/simple_animal/abnormality/waw/big_wolf.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/big_wolf.dm
@@ -60,12 +60,12 @@
 	observation_prompt = "(You see a wolf with patchy fur) <br>\
 		I like it here. <br>At least it's better than where I used to live. <br>There are no pigs or chickens, but I don't have to be Big Bad Wolf, at least. <br>\
 		You didn't immediately kick me out, so I will tell you my name. <br>My name is..."
-	observation_choices = list("Forget the name", "Remember the name")
-	correct_choices = list("Remember the name")
-	observation_success_message = "It's no use to remember it. <br>Nobody cares about my name. <br>\
-		(Even though the wolf said such a thing, it seems happy.)"
-	observation_fail_message = "You better watch out. <br>I can eat you with one bite if I want to. <br>\
-		(The wolf seems unhappy)"
+	observation_choices = list(
+		"Remember the name" = list(TRUE, "It's no use to remember it. <br>Nobody cares about my name. <br>\
+			(Even though the wolf said such a thing, it seems happy.)"),
+		"Forget the name" = list(FALSE, "You better watch out. <br>I can eat you with one bite if I want to. <br>\
+			(The wolf seems unhappy)"),
+	)
 
 	var/can_act = TRUE
 	//For when the wolf becomes incorporal and flees.

--- a/code/modules/mob/living/simple_animal/abnormality/waw/black_swan.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/black_swan.dm
@@ -60,12 +60,12 @@
 		One day, her skin covered in blisters and her mouth oozing with spittle and pus, she passed by a lake, seemingly untouched by the pollution of the City. <br>\
 		Though her eyesight was almost ruined by fog and affliction, she could see it clearly. <br>\
 		Upon that lake were six white swans and a singular black swan. Elijah..."
-	observation_choices = list("Observed the white swans", "Observed the black swan")
-	correct_choices = list("Observed the black swan")
-	observation_success_message = "The black swan watches forlornly as her family takes flight, she's willing to give up everything for her family. <br>\
-		Elijah embraces the near-finished nettle clothing wholeheartedly, soon..."
-	observation_fail_message = "The white swans were Elijah's favourite. <br>\
-		They spread their wings and took flight to the sky, high above the fog, leaving the black swan behind. Elijah clutched her brooch tighter, she only had to work a little harder..."
+	observation_choices = list(
+		"Observed the black swan" = list(TRUE, "The black swan watches forlornly as her family takes flight, she's willing to give up everything for her family. <br>\
+			Elijah embraces the near-finished nettle clothing wholeheartedly, soon..."),
+		"Observed the white swans" = list(FALSE, "The white swans were Elijah's favourite. <br>\
+			They spread their wings and took flight to the sky, high above the fog, leaving the black swan behind. Elijah clutched her brooch tighter, she only had to work a little harder..."),
+	)
 
 	//family breach conditions
 	var/insane_humans = 0

--- a/code/modules/mob/living/simple_animal/abnormality/waw/clouded_monk.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/clouded_monk.dm
@@ -44,9 +44,9 @@
 	abnormality_origin = ABNORMALITY_ORIGIN_LOBOTOMY
 
 	observation_prompt = "Are you a monk?"
-	observation_choices = list("I am no longer a monk")
-	correct_choices = list("I am no longer a monk")
-	observation_success_message = "A demon shall never reach Heaven."
+	observation_choices = list(
+		"I am no longer a monk" = list(TRUE, "A demon shall never reach Heaven."),
+	)
 
 	var/datum/looping_sound/cloudedmonk_ambience/soundloop
 	var/charging = FALSE

--- a/code/modules/mob/living/simple_animal/abnormality/waw/clown_smiling.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/clown_smiling.dm
@@ -66,11 +66,11 @@
 		When I first met this thing, I started to understand how those people feel. <br>\
 		Right now, during my attachment work, it started its usual clown performance. <br>\
 		Things are looking good so far. <br>Out of its pocket, the clown pulls out..."
-	observation_choices = list("It's just a tool" ,"Run")
-	correct_choices = list("Run")
-	observation_success_message = "I bolted out of containment unit as fast as I could. <br>\
-		I could hear giggling as I left. <br>But that was more than just a cruel prank."
-	observation_fail_message = "I thought it was a tool. <br>Just for that moment."
+	observation_choices = list(
+		"Run" = list(TRUE, "I bolted out of containment unit as fast as I could. <br>\
+		I could hear giggling as I left. <br>But that was more than just a cruel prank."),
+		"It's just a tool" = list(FALSE, "I thought it was a tool. <br>Just for that moment."),
+	)
 
 	del_on_death = FALSE //for explosions
 	var/finishing = FALSE

--- a/code/modules/mob/living/simple_animal/abnormality/waw/contract.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/contract.dm
@@ -33,17 +33,17 @@
 		The paper is a jumbled mess of words, you can't make out anything on it. <br>\
 		A pen appears in your hand. <br>\
 		The seems to be running out of patience. <br>Will you sign?"
-	observation_choices = list("Sign the contract", "Do not sign")
-	correct_choices = list("Do not sign")
-	observation_success_message = "You take a closer look at the contract <br>\
-		There is a tiny clause in fine print <br>\
-		\"Your soul becomes the property of a contract signed.\" <br>\
-		At your refusal, the man sighs and hands you a new contract. <br>\
-		This contract seems legitimate, so you sign."
-	observation_fail_message = "You sign the contract in haste. <br>\
-		In a few moments, you feel as if a piece of you is missing. <br>\
-		You walk out in a daze, unable to remember what the contract was about. <br>\
-		Perhaps you should have read the fine print."
+	observation_choices = list(
+		"Do not sign" = list(TRUE, "You take a closer look at the contract <br>\
+			There is a tiny clause in fine print <br>\
+			\"Your soul becomes the property of a contract signed.\" <br>\
+			At your refusal, the man sighs and hands you a new contract. <br>\
+			This contract seems legitimate, so you sign."),
+		"Sign the contract" = list(FALSE, "You sign the contract in haste. <br>\
+			In a few moments, you feel as if a piece of you is missing. <br>\
+			You walk out in a daze, unable to remember what the contract was about. <br>\
+			Perhaps you should have read the fine print."),
+	)
 
 	var/list/total_havers = list()
 	var/list/fort_havers = list()

--- a/code/modules/mob/living/simple_animal/abnormality/waw/despair_knight.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/despair_knight.dm
@@ -50,11 +50,11 @@
 
 	observation_prompt = "I once dedicated myself to the justice of this world, to protect my king, the kingdom and the weak. <br>\
 		However in the end nothing was truly upheld on my watch. <br>Even so... I still want to protect someone, anyone..."
-	observation_choices = list("Accept her blessing", "Refuse it")
-	correct_choices = list("Refuse it")
-	observation_success_message = "Am I not needed anymore? <br>\
-		No... <br>You're saying I should move on. <br>I don't know how, or if I can, but, perhaps things could turn out for the better. <br>We need only try."
-	observation_fail_message = "Thank you, though I am but a pitiful knight, I still yearn to protect, if I can't protect others, I may as well disappear..."
+	observation_choices = list(
+		"Refuse it" = list(TRUE, "Am I not needed anymore? <br>\
+			No... <br>You're saying I should move on. <br>I don't know how, or if I can, but, perhaps things could turn out for the better. <br>We need only try."),
+		"Accept her blessing" = list(FALSE, "Thank you, though I am but a pitiful knight, I still yearn to protect, if I can't protect others, I may as well disappear..."),
+	)
 
 	var/mob/living/carbon/human/blessed_human = null
 	var/teleport_cooldown

--- a/code/modules/mob/living/simple_animal/abnormality/waw/dimension_refraction.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/dimension_refraction.dm
@@ -40,12 +40,12 @@
 
 	observation_prompt = "It's invisible to almost all means of measurement, the only way I know it's there is due to the effect it has on the cup of water before me. <br>\
 		I calmly observe the chamber's surroundings and make adjustments when I notice the surface of the cup's liquid begin to bubble."
-	observation_choices = list("Stay and observe", "Exit the containment unit")
-	correct_choices = list("Stay and observe")
-	observation_success_message = "I continue to record my observations as the water rises up into the air, followed by the cup. <br>\
-		The water folds into a sphere around the cup in a most immaculate manner before being violently dispersed, the cup shattering into infinitesmal fragments. <br>\
-		I leave the chamber, satisfied with my observations."
-	observation_fail_message = "The manual says to leave the chamber immediately if the cup's condition becomes violent. <br>As I leave, the water falls still."
+	observation_choices = list(
+		"Stay and observe" = list(TRUE, "I continue to record my observations as the water rises up into the air, followed by the cup. <br>\
+			The water folds into a sphere around the cup in a most immaculate manner before being violently dispersed, the cup shattering into infinitesmal fragments. <br>\
+			I leave the chamber, satisfied with my observations."),
+		"Exit the containment unit" = list(FALSE, "The manual says to leave the chamber immediately if the cup's condition becomes violent. <br>As I leave, the water falls still."),
+	)
 
 	var/cooldown_time = 3
 	var/aoe_damage = 12

--- a/code/modules/mob/living/simple_animal/abnormality/waw/dreaming_current.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/dreaming_current.dm
@@ -45,11 +45,11 @@
 	observation_prompt = "My mom and dad took me to this place when I was very small, it smells strange and the people in it only wear white. <br>\
 		Mom says she and dad will come back for me very soon. <br>\
 		Today one of the men in the white clothing offers me the purple candy, it's grape-flavoured he says. <br>Grape is my favourite."
-	observation_choices = list("Eat the candy", "Don't eat the candy")
-	correct_choices = list("Eat the candy")
-	observation_success_message = "It's grape flavour, the grape is my favourite. <br>\
-		When I eat the grape candy I imagine myself swimming in an ocean of colour. <br>Today, I think I'm going to go to the Sea..."
-	observation_fail_message = "I don't eat the candy given to me. <br>When will mom and dad come? <br>Why aren't they here? <br>It doesn't stop hurting, <br>I'm scared..."
+	observation_choices = list(
+		"Eat the candy" = list(TRUE, "It's grape flavour, the grape is my favourite. <br>\
+			When I eat the grape candy I imagine myself swimming in an ocean of colour. <br>Today, I think I'm going to go to the Sea..."),
+		"Don't eat the candy" = list(FALSE, "I don't eat the candy given to me. <br>When will mom and dad come? <br>Why aren't they here? <br>It doesn't stop hurting, <br>I'm scared..."),
+	)
 
 	var/list/movement_path = list()
 	var/list/been_hit = list()

--- a/code/modules/mob/living/simple_animal/abnormality/waw/ebony_queen.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/ebony_queen.dm
@@ -53,12 +53,12 @@
 		Her plan was a success - her behated Snow White has fallen into a death-like state. <br>\
 		Is that all I was for? <br>To bring pain to others whilst never experiencing it myself? <br>\
 		I'm beginning to rot and feel pests and other lowly creatures make a meal out of me..."
-	observation_choices = list("Rot into nothing", "Don't accept the end")
-	correct_choices = list("Don't accept the end")
-	observation_success_message = "The impression of poison brings pause to the pests and even they no longer wish to remain with me. <br>\
-		Petrified roots grow from within me and I gain some sense of being ambulatory. <br>I know now how long I had laid but I refuse to remain still. <br>\
-		I shall find vengeance. <br>Bring me snow white..."
-	observation_fail_message = "An apple culminates when it shrivels up and attracts lesser creatures. <br>I'm just an apple, I can't change a thing."
+	observation_choices = list(
+		"Don't accept the end" = list(TRUE, "The impression of poison brings pause to the pests and even they no longer wish to remain with me. <br>\
+			Petrified roots grow from within me and I gain some sense of being ambulatory. <br>I know now how long I had laid but I refuse to remain still. <br>\
+			I shall find vengeance. <br>Bring me snow white..."),
+		"Rot into nothing" = list(FALSE, "An apple culminates when it shrivels up and attracts lesser creatures. <br>I'm just an apple, I can't change a thing."),
+	)
 
 	var/barrier_cooldown
 	var/barrier_cooldown_time = 4 SECONDS

--- a/code/modules/mob/living/simple_animal/abnormality/waw/express_train.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/express_train.dm
@@ -33,10 +33,10 @@
 	observation_prompt = "The booking clerk who remains dauntingly quiet sells tickets for a train with no final destination. <br>\
 		There are no clocks to alert the arrival times, instead, there are some blinking lights. <br>\
 		\"Sir! Your ticket?\" The clerk behind the counter smothered in shadow, save for two pinpricks of amber light for eyes, holds out an unmarked ticket with its gangly appendage."
-	observation_choices = list("Take the ticket")
-	correct_choices = list("Take the ticket")
-	observation_success_message = "I took the ticket from his hand, it felt like a lead weight, and asked him when the train would arrive. <br>\
-		\"Sooner than you'd like, later than you prepare for. <br>It comes for everyone Sir.\" <br>I hear the sound of a distant horn."
+	observation_choices = list(
+		"Take the ticket" = list(TRUE, "I took the ticket from his hand, it felt like a lead weight, and asked him when the train would arrive. <br>\
+			\"Sooner than you'd like, later than you prepare for. <br>It comes for everyone Sir.\" <br>I hear the sound of a distant horn."),
+	)
 
 	var/meltdown_tick = 60 SECONDS
 	var/meltdown_timer

--- a/code/modules/mob/living/simple_animal/abnormality/waw/fire_bird.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/fire_bird.dm
@@ -42,18 +42,17 @@
 	observation_prompt = "You can only hunt it wearing a thick blindfold, but even through the fabric you can track it by the light that manages to seep through and by the heat it radiates. <br>\
 		In your hands you carry a bow nocked with an arrow, it's your last one. <br>\
 		You've been pursuing your prey for days, you..."
-	observation_choices = list("Fire an arrow", "Take off your blindfold", "Do nothing")
-	correct_choices = list("Do nothing", "Take off your blindfold")
-	observation_success_message = "You watch and wait as the light and heat pass until only cold and darkness reign in the forest. <br>\
-		Feeling safe, you remove your blindfold and find on the ground one of its radiant feathers. <br>\
-		Bravo brave hunter, have you found what you were seeking?"
-	observation_fail_message = "You fire an arrow at what you percieve to be the source of the light and miss entirely. <br>You return empty-handed like so many hunters before you."
-	//Special answer for choice 2
-	var/observation_success_message_2 = "Your curiosity gets the better of you. <br>\
-		The sight of a mythological bird that no one has seen before is a prize no hunter has claimed. <br>\
-		Steeling yourself, you remove the blindfold and immediately your vision is seared by the intensity of the light but you will yourself through the pain to catch a glimpse of what has long evaded every hunter's sight. <br>\
-		The bird offers a tear for your efforts. <br>\
-		Though your eyes may never recover, you have done what no hunter has dared to accomplish - captured it in your sight."
+	observation_choices = list(
+		"Do nothing" = list(TRUE, "You watch and wait as the light and heat pass until only cold and darkness reign in the forest. <br>\
+			Feeling safe, you remove your blindfold and find on the ground one of its radiant feathers. <br>\
+			Bravo brave hunter, have you found what you were seeking?"),
+		"Take off your blindfold" = list(TRUE, "Your curiosity gets the better of you. <br>\
+			The sight of a mythological bird that no one has seen before is a prize no hunter has claimed. <br>\
+			Steeling yourself, you remove the blindfold and immediately your vision is seared by the intensity of the light but you will yourself through the pain to catch a glimpse of what has long evaded every hunter's sight. <br>\
+			The bird offers a tear for your efforts. <br>\
+			Though your eyes may never recover, you have done what no hunter has dared to accomplish - captured it in your sight."),
+		"Fire an arrow" = list(FALSE, "You fire an arrow at what you percieve to be the source of the light and miss entirely. <br>You return empty-handed like so many hunters before you."),
+	)
 
 	var/pulse_cooldown
 	var/pulse_cooldown_time = 1 SECONDS
@@ -64,13 +63,6 @@
 	var/dash_max = 50
 	var/dash_damage = 220
 	var/list/been_hit = list()
-
-/mob/living/simple_animal/hostile/abnormality/fire_bird/ObservationResult(mob/living/carbon/human/user, condition, answer) //borrowed from Bottle of Tears
-	if(answer == "Take off your blindfold")
-		observation_success_message = observation_success_message_2
-	else
-		observation_success_message = initial(observation_success_message)
-	return ..()
 
 //Initialize
 /mob/living/simple_animal/hostile/abnormality/fire_bird/HandleStructures()

--- a/code/modules/mob/living/simple_animal/abnormality/waw/flesh_idol.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/flesh_idol.dm
@@ -30,10 +30,10 @@
 	observation_prompt = "I've been praying for 7 days and 7 nights, my skin is taut from malnutrition, my eyes bloodshot from lack of sleep and my clothes soiled with my own filth. <br>\
 		Though my throat is so dry I cannot even maintain the chants I move my lips anyway. <br>\
 		Is anyone even listening? <br>Does my prayer reach Him? <br>All I ask for is a sign."
-	observation_choices = list("Stop praying", "Keep praying")
-	correct_choices = list("Stop praying")
-	observation_success_message = "No one is there, God does not reside here."
-	observation_fail_message = "If God truly loves us, he'll show us a sign."
+	observation_choices = list(
+		"Stop praying" = list(TRUE, "No one is there, God does not reside here."),
+		"Keep praying" = list(FALSE, "If God truly loves us, he'll show us a sign."),
+	)
 
 	var/work_count = 0
 	var/breach_count = 4	//when do you breach?

--- a/code/modules/mob/living/simple_animal/abnormality/waw/generalb.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/generalb.dm
@@ -45,13 +45,18 @@
 		Unquestioningly loyal, I follow my orders to the letter. <br>\
 		I even feel excited whenever I get a new order. <br>\
 		Why am I doing this all again?"
-	observation_choices = list("I fight to survive", "I fight out of loyalty")
-	correct_choices = list("I fight to survive","I fight out of loyalty")
-	observation_success_message = "Bees have a natural instinct to fight for their queen. <br>\
-		It is not something as complicated as human emotion. <br>\
-		Rather, it is a hormone produced by the queen. <br>\
-		I will die the moment I leave the queendom.<br>\
-		There is no other option but to remain unquestionably loyal."
+	observation_choices = list(
+		"I fight to survive" = list(TRUE, "Bees have a natural instinct to fight for their queen. <br>\
+			It is not something as complicated as human emotion. <br>\
+			Rather, it is a hormone produced by the queen. <br>\
+			I will die the moment I leave the queendom.<br>\
+			There is no other option but to remain unquestionably loyal."),
+		"I fight out of loyalty" = list(TRUE, "Bees have a natural instinct to fight for their queen. <br>\
+			It is not something as complicated as human emotion. <br>\
+			Rather, it is a hormone produced by the queen. <br>\
+			I will die the moment I leave the queendom.<br>\
+			There is no other option but to remain unquestionably loyal."),
+	)
 
 	var/fire_cooldown_time = 3 SECONDS	//She has 4 cannons, fires 4 times faster than the artillery bees
 	var/fire_cooldown

--- a/code/modules/mob/living/simple_animal/abnormality/waw/greed_king.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/greed_king.dm
@@ -38,15 +38,15 @@
 		Happiness of the world means happiness for me. <br>I'm trying to stay happy. <br>\
 		I don't care even if it got me to the point where I look like this. <br>Have you met my sisters? <br>We were always one. <br>\
 		We fought together, and shared a common goal. <br>By the way, are you happy now?"
-	observation_choices = list("Yes, I'm happy", "No, I'm not happy")
-	correct_choices = list("Yes, I'm happy")
-	observation_success_message = "(The egg shook violently) <br>\
-		Don't lie. <br>Why have we been ruined like this if that's true? <br>\
-		And why have you ended up like that? <br>My greed will not be sated with such flimsy conviction. <br>\
-		But if your answer is a resolve for the future, and not just a statement of fact... <br>Things might change, slowly."
-	observation_fail_message = "I knew you were not happy. <br>\
-		You are like me. <br>You trapped yourself inside of an egg, just like me. <br>\
-		The amber-colored sky is beautiful. <br>Oh, I'm getting hungry again."
+	observation_choices = list(
+		"Yes, I'm happy" = list(TRUE, "(The egg shook violently) <br>\
+			Don't lie. <br>Why have we been ruined like this if that's true? <br>\
+			And why have you ended up like that? <br>My greed will not be sated with such flimsy conviction. <br>\
+			But if your answer is a resolve for the future, and not just a statement of fact... <br>Things might change, slowly."),
+		"No, I'm not happy" = list(FALSE, "I knew you were not happy. <br>\
+			You are like me. <br>You trapped yourself inside of an egg, just like me. <br>\
+			The amber-colored sky is beautiful. <br>Oh, I'm getting hungry again."),
+	)
 
 	//Some Variables cannibalized from helper
 	var/charge_check_time = 1 SECONDS

--- a/code/modules/mob/living/simple_animal/abnormality/waw/hatred_queen.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/hatred_queen.dm
@@ -62,13 +62,13 @@
 
 	observation_prompt = "Everyone likes me, every day someone new visits me and asks about my stories, the villains I've fought, the friends I've made, the adventures I've had. <br>\
 		They never grow tired of my stories but, hey is it always peaceful around here? <br>The world still needs me, doesn't it?"
-	observation_choices = list("The world still needs you", "The world doesn't need you")
-	correct_choices = list("The world doesn't need you")
-	observation_success_message = "... <br>Somehow I think I already knew that. <br>\
-		I don't know if I can accept a world that doesn't love me as I love it. <br>Can I keep on loving the world, even if I'm no longer a real Magical Girl..?"
-	observation_fail_message = "I knew it! Whilst I'm here, no villains will go unpunished! <br>Just call on me anytime!.. <br>\
-		... <br>\
-		Why is still so peaceful..?"
+	observation_choices = list(
+		"The world doesn't need you" = list(TRUE, "... <br>Somehow I think I already knew that. <br>\
+			I don't know if I can accept a world that doesn't love me as I love it. <br>Can I keep on loving the world, even if I'm no longer a real Magical Girl..?"),
+		"The world still needs you" = list(FALSE, "I knew it! Whilst I'm here, no villains will go unpunished! <br>Just call on me anytime!.. <br>\
+			... <br>\
+			Why is still so peaceful..?"),
+	)
 
 	var/obj/effect/qoh_wand/wand
 	var/chance_modifier = 1

--- a/code/modules/mob/living/simple_animal/abnormality/waw/judgement_bird.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/judgement_bird.dm
@@ -52,11 +52,11 @@
 
 	observation_prompt = "\"Long Bird\" who lived in the forest didn't want to let creatures to be eaten by monsters. <br>\
 		His initial goal was pure, at least. <br>The forest began to be saturated by darkness. <br>His long vigil is saturated with memories and regrets."
-	observation_choices = list("Leave him be", "Console the bird")
-	correct_choices = list("Console the bird")
-	observation_success_message = "Long Bird put down his scales, that had been with him for a long time. <br>\
-		The long-lasting judgement finally ends. <br>Long Bird slowly realizes the secrets behind the monster, and he waits. <br>For the forest that he will never take back."
-	observation_fail_message = "Long Bird sees through you, even though he is blind. <br>He is weighing your sins."
+	observation_choices = list(
+		"Console the bird" = list(TRUE, "Long Bird put down his scales, that had been with him for a long time. <br>\
+			The long-lasting judgement finally ends. <br>Long Bird slowly realizes the secrets behind the monster, and he waits. <br>For the forest that he will never take back."),
+		"Leave him be" = list(FALSE, "Long Bird sees through you, even though he is blind. <br>He is weighing your sins."),
+	)
 
 	var/judgement_cooldown = 10 SECONDS
 	var/judgement_cooldown_base = 10 SECONDS

--- a/code/modules/mob/living/simple_animal/abnormality/waw/little_prince.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/little_prince.dm
@@ -28,12 +28,12 @@
 		I have come across 15 billion light years to meet you. <br>\
 		However, a butterfly can only fly as high in the sky as the sun warms. <br>\
 		It does not know that it will crumble before it can reach the stars. <br>It fell from the sky and crushed into the ground."
-	observation_choices = list("Do nothing", "Become its friend")
-	correct_choices = list("Become its friend")
-	observation_success_message = "My voice can reach you unlike others. <br>\
-		Come to me, step by step. <br>You will reach the stars if those steps continue."
-	observation_fail_message = "Many who tried to reach me got lost. <br>\
-		Perhaps, we are standing on parallel lines. <br>Perhaps, we were looking at something that can never be reached."
+	observation_choices = list(
+		"Become its friend" = list(TRUE, "My voice can reach you unlike others. <br>\
+			Come to me, step by step. <br>You will reach the stars if those steps continue."),
+		"Do nothing" = list(FALSE, "Many who tried to reach me got lost. <br>\
+			Perhaps, we are standing on parallel lines. <br>Perhaps, we were looking at something that can never be reached."),
+	)
 
 	var/insight_count = 0
 	var/non_insight_count = 0

--- a/code/modules/mob/living/simple_animal/abnormality/waw/luna.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/luna.dm
@@ -33,15 +33,15 @@
 	observation_prompt = "You enter the containment unit as respectfully as you can, the woman by the piano does not acknowledge your presence, merely clutching her cane tighter. <br>\
 		\"Begin.\" She commands, her lips a tight thin line. <br>It's the first time she's ever spoken. <br>\
 		The piano waits for you expectantly."
-	observation_choices = list("Begin a performance", "Refuse")
-	correct_choices = list("Begin a performance")
-	observation_success_message = "You begin to play, there is no sheet music to guide you, you play the performance that you were always meant to play. <br>\
-		It's haunting and beautiful, <br>terrifying yet entrancing. <br>\
-		With every key press, your body feels heavier and heavier and with every step upon the shrunken heads for pedals, your mind grows slower and more sluggish. <br>\
-		By the end of the performance, you're slumped over the keyboard with hardly the strength or wherewithal to move. <br>\
-		Above the piano, through your fading vision, you can swear you see the moon. <br>\
-		And you despair."
-	observation_fail_message = "She gives no indication of being disappointed. <br>Perhaps if you played, you might understand the truth behind yourself as she did."
+	observation_choices = list(
+		"Begin a performance" = list(TRUE, "You begin to play, there is no sheet music to guide you, you play the performance that you were always meant to play. <br>\
+			It's haunting and beautiful, <br>terrifying yet entrancing. <br>\
+			With every key press, your body feels heavier and heavier and with every step upon the shrunken heads for pedals, your mind grows slower and more sluggish. <br>\
+			By the end of the performance, you're slumped over the keyboard with hardly the strength or wherewithal to move. <br>\
+			Above the piano, through your fading vision, you can swear you see the moon. <br>\
+			And you despair."),
+		"Refuse" = list(FALSE, "She gives no indication of being disappointed. <br>Perhaps if you played, you might understand the truth behind yourself as she did."),
+	)
 
 	var/performance = FALSE
 	var/performance_length = 60 SECONDS

--- a/code/modules/mob/living/simple_animal/abnormality/waw/my_form_empties.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/my_form_empties.dm
@@ -41,15 +41,15 @@
 	abnormality_origin = ABNORMALITY_ORIGIN_LIMBUS
 
 	observation_prompt = "A bell occasionally tolls in the room. <br>\
-It's a heavy, subduing sound. You're unable to recognize its words. <br>\
-But, you feel that whatever it is, is not a joyous thing."
-	observation_choices = list("Listen closer.", "Repeat the mantras.")
-	correct_choices = list("Listen closer.")
-	observation_success_message = "You close your eyes and focus on the sound. What is is saying? <br>\
-	This thing is uttering thoughts. Empty oneself by verbalizing one's thoughts. <br>\
-	Expel everything within so that nothing remains."
-	observation_fail_message = "The statue won't move, no matter what happens around it. <br>\
-	Though the tone of its mantra remains consistent, you knew its chants are imbued with a curse."
+		It's a heavy, subduing sound. You're unable to recognize its words. <br>\
+		But, you feel that whatever it is, is not a joyous thing."
+	observation_choices = list(
+		"Listen closer" = list(TRUE, "You close your eyes and focus on the sound. What is is saying? <br>\
+			This thing is uttering thoughts. Empty oneself by verbalizing one's thoughts. <br>\
+			Expel everything within so that nothing remains."),
+		"Repeat the mantras" = list(FALSE, "The statue won't move, no matter what happens around it. <br>\
+			Though the tone of its mantra remains consistent, you knew its chants are imbued with a curse.")
+	)
 
 	var/anatman_state = FALSE
 	var/praying = FALSE

--- a/code/modules/mob/living/simple_animal/abnormality/waw/naked_nest.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/naked_nest.dm
@@ -46,12 +46,12 @@
 
 	observation_prompt = "In the beginning, a serpent tempted Eve with a bite of the forbidden fruit an act which cast Man out of the Garden of Eden. <br>\
 		Now all that remains of that fruit is a rotten, decayed mass squirming with more evil serpents."
-	observation_choices = list("Cover your mouth", "Take a bite")
-	correct_choices = list("Take a bite")
-	observation_success_message = "Mankind's sin began long ago but it was never the serpent that was evil, it only followed its nature as did Man. <br>\
-		The serpents within the fruit paused and entered into your mouth with the bite, and evil took root - \
-		it's hard to blame them for mistaking you for being the same as the fruit that has long been their home."
-	observation_fail_message = "They could infect you at any time through any orifice, you best leave in a hurry."
+	observation_choices = list(
+		"Take a bite" = list(TRUE, "Mankind's sin began long ago but it was never the serpent that was evil, it only followed its nature as did Man. <br>\
+			The serpents within the fruit paused and entered into your mouth with the bite, and evil took root - \
+			it's hard to blame them for mistaking you for being the same as the fruit that has long been their home."),
+		"Cover your mouth" = list(FALSE, "They could infect you at any time through any orifice, you best leave in a hurry."),
+	)
 
 	var/serpentsnested = 4
 	var/origin_cooldown = 0

--- a/code/modules/mob/living/simple_animal/abnormality/waw/nosferatu.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/nosferatu.dm
@@ -48,11 +48,11 @@
 		He seemed lost, wandering the backstreets in such finery made him a tempting target, I never realised it was everyone else who was in danger. <br>\
 		He wears the mask of humanity well, but a single drop of blood is all it took for him to reveal his ferocity. <br>\
 		\"It's too early for a nap... <br>Won't you join me and share the pleasure?\" <br>He asks, his lips still red with my blood."
-	observation_choices = list("Join the Danse Macabre")
-	correct_choices = list("Join the Danse Macabre")
-	observation_success_message = "Refusing wasn't an option and he smiles, raising his glass. <br>\
-		\"A toast then! To a night when one is allowed to pursue all kinds of desire, a never-ending blood-red night!\" <br>\
-		Blood.... <br>The blood brings me eternal happiness, forfeiting false hope, let's forget all pretenses of humanity..."
+	observation_choices = list(
+		"Join the Danse Macabre" = list(TRUE, "Refusing wasn't an option and he smiles, raising his glass. <br>\
+			\"A toast then! To a night when one is allowed to pursue all kinds of desire, a never-ending blood-red night!\" <br>\
+			Blood.... <br>The blood brings me eternal happiness, forfeiting false hope, let's forget all pretenses of humanity..."),
+	)
 
 	//work stuff
 	var/feeding

--- a/code/modules/mob/living/simple_animal/abnormality/waw/orange_tree.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/orange_tree.dm
@@ -38,10 +38,10 @@
 
 	observation_prompt = "Whenever I enter this containment cell, I find myself whisked away to Never Never Land by Peter Pan to join his merry band of Lost Boys. <br>\
 		I had forgotten all about him when I grew up, I want to stay longer..."
-	observation_choices = list("Stay", "Leave")
-	correct_choices = list("Leave")
-	observation_success_message = "Second to the right, and straight on till morning, I found my way back to where I'm supposed to - there's still work to be done."
-	observation_fail_message = "If no one comes to get me, I'll remain here - never noticing the passing of time..."
+	observation_choices = list(
+		"Leave" = list(TRUE, "Second to the right, and straight on till morning, I found my way back to where I'm supposed to - there's still work to be done."),
+		"Stay" = list(FALSE, "If no one comes to get me, I'll remain here - never noticing the passing of time..."),
+	)
 
 	var/datum/looping_sound/orangetree_ambience/soundloop
 

--- a/code/modules/mob/living/simple_animal/abnormality/waw/parasite_tree.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/parasite_tree.dm
@@ -41,31 +41,23 @@
 		At the heart of the minituare forest you see a lush green tree with heavy, ripened fruit and a peaceful-looking face upon its trunk. <br>\
 		\"Hello, have you come here to recieve my blessing, too?\" <br>\
 		The voice on the wind (there is no wind) spoke, carrying a sweet, flowery scent asked. \"I just want to help you all, could you bring your friends to me as well?\" "
-	observation_choices = list("Accept the blessing and do as it asks", "Accept the blessing and refuse", "Refuse the blessing")
-	correct_choices = list("Accept the blessing and refuse")
-	observation_success_message = "\"You're a bad child, I don't need someone like you.\" <br>\
-		Blessings should be given earnestly, not treated as an obligation. <br>You leave the chamber, pleased with yourself."
-	observation_fail_message = "\"If you say you've never had need of anyone's blessing, then that's a lie.\" The tree said, frowning deeply. <br>\
-		\"... if you don't need my blessing then you're a bad person. <br>\
-		There's nothing for you here, leave.\" <br>\
-		You leave the verdant containment unit behind, the tree waits for someone else to fall into its snare."
-	//Extra wrong answers
-	var/observation_fail_message_2 = "You venture out and find some of your most trusting colleagues. <br>\
-		\"Come with me, I have something wonderous to show you all\", you tell them as you bring them to stand before the tree, that same calm visage etched into its trunk. <br>\
-		\"You're a good child, aren't you? Thank you for bringing these children to me.\" <br>\
-		It says as you all stare rapturously at the bulbs about to flower. \"Let me gift you with something...\" <br>\
-		I feel something sprout from my body..."
+	observation_choices = list(
+		"Accept the blessing and refuse" = list(TRUE, "\"You're a bad child, I don't need someone like you.\" <br>\
+			Blessings should be given earnestly, not treated as an obligation. <br>You leave the chamber, pleased with yourself."),
+		"Refuse the blessing" = list(FALSE, "\"If you say you've never had need of anyone's blessing, then that's a lie.\" The tree said, frowning deeply. <br>\
+			\"... if you don't need my blessing then you're a bad person. <br>\
+			There's nothing for you here, leave.\" <br>\
+			You leave the verdant containment unit behind, the tree waits for someone else to fall into its snare."),
+		"Accept the blessing and do as it asks" = list(FALSE, "You venture out and find some of your most trusting colleagues. <br>\
+			\"Come with me, I have something wonderous to show you all\", you tell them as you bring them to stand before the tree, that same calm visage etched into its trunk. <br>\
+			\"You're a good child, aren't you? Thank you for bringing these children to me.\" <br>\
+			It says as you all stare rapturously at the bulbs about to flower. \"Let me gift you with something...\" <br>\
+			I feel something sprout from my body..."),
+	)
 
 	var/origin_cooldown = 0 //null when compared to numbers is a eldritch concept so world.time cannot be more or less.
 	var/static/list/blessed = list() //keeps track of status effected individuals
 	var/static/list/minions = list() //keeps track of minions if suppressed forcefully
-
-/mob/living/simple_animal/hostile/abnormality/parasite_tree/ObservationResult(mob/living/carbon/human/user, condition, answer) //special answer
-	if(answer == "Accept the blessing and do as it asks")
-		observation_fail_message = observation_fail_message_2
-	else
-		observation_fail_message = initial(observation_fail_message)
-	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/parasite_tree/Initialize()
 	. = ..()

--- a/code/modules/mob/living/simple_animal/abnormality/waw/pygmalion.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/pygmalion.dm
@@ -46,9 +46,10 @@
 	observation_prompt = "The King Pygmalion prayed earnestly to the Goddess Aphrodite, wishing for the marble statue he had made and fallen in love to come to life. <br>\
 		She answered his prayer, bringing Galatea to life and united them in matrinomy. <br>\
 		What is the real name of the abnormality before you?"
-	observation_choices = list("Galatea", "Pygmalion")
-	correct_choices = list("Galatea", "Pygmalion")
-	observation_success_message = "Perhaps they sculpted each other."
+	observation_choices = list(
+		"Galatea" = list(TRUE, "Perhaps they sculpted each other."),
+		"Pygmalion" = list(TRUE, "Perhaps they sculpted each other."),
+	)
 
 	var/missing_prudence = 0
 	var/mob/living/carbon/human/sculptor = null

--- a/code/modules/mob/living/simple_animal/abnormality/waw/queen_bee.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/queen_bee.dm
@@ -35,29 +35,21 @@
 	)
 
 	observation_prompt = "There was one summer so hot and unpleasant. <br>Bees were busily flying around the beehive. <br>\
-		They live for the only one queen. <br>\'Are they happy? Living only to work\' I asked myself. <br>Then someone answered."
-	observation_choices = list("They work to survive", "They work out of loyalty")
-	correct_choices = list("They work to survive", "They work out of loyalty")
-	observation_success_message = "They have no other option but to obey. <br>\
-		For they know that the moment they leave the queendom, only death awaits them. <br>\
-		It is years later that I found out that their unshakable loyalty is because of special pheromone which only queen can produce. <br>\
-		Everything started when I began to study that pheromone."
-	//Special answer for choice 2. Yes, the same text is used multiple times intentionally. This is from legacy LC.
-	var/observation_success_message_2 = "Loyalty that bees possess is a natural instinct. <br>\
-		If we find a way to control that instinct, <br>\
-		Things will change. <br>\
-		It is years later that I found out that their unshakable loyalty is because of special pheromone which only queen can produce. <br>\
-		Everything started when I began to study that pheromone."
+		They live for the only one queen. <br>'Are they happy? Living only to work' I asked myself. <br>Then someone answered."
+	observation_choices = list(
+		"They work to survive" = list(TRUE, "They have no other option but to obey. <br>\
+			For they know that the moment they leave the queendom, only death awaits them. <br>\
+			It is years later that I found out that their unshakable loyalty is because of special pheromone which only queen can produce. <br>\
+			Everything started when I began to study that pheromone."),
+		"They work out of loyalty" = list(TRUE, "Loyalty that bees possess is a natural instinct. <br>\
+			If we find a way to control that instinct, <br>\
+			Things will change. <br>\
+			It is years later that I found out that their unshakable loyalty is because of special pheromone which only queen can produce. <br>\
+			Everything started when I began to study that pheromone."),
+	)
 
 	var/datum/looping_sound/queenbee/soundloop
 	var/breached_others = FALSE
-
-/mob/living/simple_animal/hostile/abnormality/queen_bee/ObservationResult(mob/living/carbon/human/user, condition, answer) //special answer
-	if(answer == "They work out of loyalty")
-		observation_success_message = observation_success_message_2
-	else
-		observation_success_message = initial(observation_success_message)
-	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/queen_bee/Initialize()
 	. = ..()

--- a/code/modules/mob/living/simple_animal/abnormality/waw/red_riding_mercenary.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/red_riding_mercenary.dm
@@ -56,12 +56,12 @@ It has now been over four months. Now we get her for real. -Coxswain
 	observation_prompt = "(The chamber is empty, except the Little Red Riding Hooded Mercenary, and her axe and gun. She seems exhausted) <br>\
 		Am I really alive? <br>What if I'm a ghost that doesn't even know it's dead? <br>\
 		The only thing I love in my life is the death of the wolf."
-	observation_choices = list("Exit the room", "Mourn for her memories")
-	correct_choices = list("Mourn for her memories")
-	observation_success_message = "I will swing my axe again tomorrow, still driven by hatred like I have been forever. <br>\
-		But tonight, I think I can sleep peacefully."
-	observation_fail_message = "Knock on my door whenever you need my service. <br>\
-		This is my struggle."
+	observation_choices = list(
+		"Mourn for her memories" = list(TRUE, "I will swing my axe again tomorrow, still driven by hatred like I have been forever. <br>\
+			But tonight, I think I can sleep peacefully."),
+		"Exit the room" = list(FALSE, "Knock on my door whenever you need my service. <br>\
+			This is my struggle."),
+	)
 
 	/*
 	Red's targeting logic

--- a/code/modules/mob/living/simple_animal/abnormality/waw/rose_sign.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/rose_sign.dm
@@ -39,18 +39,18 @@
 	observation_prompt = "What does this signboard say? <br>\
 		It hangs itself on a tree, trying to make its content known. <br>\
 		Its desperation is almost pitiable."
-	observation_choices = list("Pick a rose", "Unravel the brambles")
-	correct_choices = list("Pick a rose")
-	observation_success_message = "You pick a rose out of it. <br>\
-		With closer examination, you notice <br>\
-		that it has an intestinal texture. <br>\
-		What is a flower-shaped organ for?"
-	observation_fail_message = "As you try to untangle the vines, <br>\
-		sallow bits of flesh fall off. <br>\
-		The thorny brambles you thought were a source of constricting pain <br>\
-		ironically had been keeping the body together. <br>\
-		The body writhes as its flesh falls apart. <br>\
-		Blossoms of flowers sprawled on the ground substitute its screams."
+	observation_choices = list(
+		"Pick a rose" = list(TRUE, "You pick a rose out of it. <br>\
+			With closer examination, you notice <br>\
+			that it has an intestinal texture. <br>\
+			What is a flower-shaped organ for?"),
+		"Unravel the brambles" = list(FALSE, "As you try to untangle the vines, <br>\
+			sallow bits of flesh fall off. <br>\
+			The thorny brambles you thought were a source of constricting pain <br>\
+			ironically had been keeping the body together. <br>\
+			The body writhes as its flesh falls apart. <br>\
+			Blossoms of flowers sprawled on the ground substitute its screams."),
+	)
 
 	var/list/work_roses = list()
 	var/list/work_damages = list()

--- a/code/modules/mob/living/simple_animal/abnormality/waw/screenwriter.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/screenwriter.dm
@@ -40,9 +40,11 @@ Defeating the murderer also surpresses the abnormality.
 	abnormality_origin = ABNORMALITY_ORIGIN_ARTBOOK //Technically it was in the beta but I dont want it showing it up in LC-only modes
 
 	observation_prompt = "The play started long ago. Here is the man who killed many. And you are holding a gun."
-	observation_choices = list("Shoot the man", "Wait and see", "Shoot someone else")
-	correct_choices = list("Shoot the man", "Wait and see", "Shoot someone else")
-	observation_success_message = "Whether you shoot or not, the play ends with tragedy." //TODO: multiple texts
+	observation_choices = list( //TODO: multiple texts
+		"Shoot the man" = list(TRUE, "Whether you shoot or not, the play ends with tragedy."),
+		"Wait and see" = list(TRUE, "Whether you shoot or not, the play ends with tragedy."),
+		"Shoot someone else" = list(TRUE, "Whether you shoot or not, the play ends with tragedy."),
+	)
 
 	pet_bonus = "shuffles" //saves a few lines of code by allowing funpet() to be called by attack_hand()
 	var/mob/living/simple_animal/hostile/actor/A

--- a/code/modules/mob/living/simple_animal/abnormality/waw/shrimp.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/shrimp.dm
@@ -38,10 +38,12 @@
 		The shrimp offers you a champagne glass full of... Something. <br>\
 		It looks and smells like wellcheers grape soda. It's soda. <br>\
 		You can even see the can's label torn off and stuck on the side. <br>Will you drink it?"
-	observation_choices = list("Drink the soda","Refuse")
-	correct_choices = list("Drink the soda","Refuse")
-	observation_success_message = "Before you can make a choice, two gigantic and heavily armed shrimp guards bust in through the door. <br>\
-		They hold you down and force you to drink the soda, and you fall asleep... <br>... <br>Somewhere in the distance, you hear seagulls."
+	observation_choices = list(
+		"Drink the soda" = list(TRUE, "Before you can make a choice, two gigantic and heavily armed shrimp guards bust in through the door. <br>\
+			They hold you down and force you to drink the soda, and you fall asleep... <br>... <br>Somewhere in the distance, you hear seagulls."),
+		"Refuse" = list(TRUE, "Before you can make a choice, two gigantic and heavily armed shrimp guards bust in through the door. <br>\
+			They hold you down and force you to drink the soda, and you fall asleep... <br>... <br>Somewhere in the distance, you hear seagulls."),
+	)
 
 	var/liked
 	var/happy = TRUE

--- a/code/modules/mob/living/simple_animal/abnormality/waw/silence.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/silence.dm
@@ -25,11 +25,11 @@
 
 	observation_prompt = "Time's wasting. <br>Time's running out... <br>They are nothing but meaningless tantrums. <br>\
 		The watch will not only take your lost time back, but also give you even more time."
-	observation_choices = list("Do not use the watch", "Use the watch")
-	correct_choices = list("Use the watch")
-	observation_success_message = "The price will follow to your decision. <br>It is designed this way."
-	observation_fail_message = "Actually, you have no right to refuse this gift. <br>\
-		Whether you want it or not, we all know that you have to take it."
+	observation_choices = list(
+		"Use the watch" = list(TRUE, "The price will follow to your decision. <br>It is designed this way."),
+		"Do not use the watch" = list(FALSE, "Actually, you have no right to refuse this gift. <br>\
+			Whether you want it or not, we all know that you have to take it."),
+	)
 
 	var/meltdown_cooldown_time = 13 MINUTES
 	var/meltdown_cooldown

--- a/code/modules/mob/living/simple_animal/abnormality/waw/siltcurrent.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/siltcurrent.dm
@@ -67,16 +67,16 @@
 		We were all abandoned, yes. <br>But we all had dreams, too. <br>Remember? <br>\
 		Well, let's make our dreams come true. <br>Let's sink together into the depths.\" <br>\
 		The dim fluorescent lights impaling the entity's back flicker."
-	observation_choices = list("Say that you will sink together", "Fix the entity's flickering fluorescent lights")
-	correct_choices = list("Fix the entity's flickering fluorescent lights")
-	observation_success_message = "\"I remember. <br>I've always wanted to run across a rolling field of grass under the warm sun. <br>\
-		To swim across the vast ocean that I've seen only through pictures. <br>\
-		That was my dream. <br>\
-		My only dream. <br>\
-		Now, if you ever recall a dream in which you wished to twinkle, even as a faint flicker...\""
-	observation_fail_message = "You still fear the dark, don't you? <br>\
-		I know that you will miss the surface, forever out of your reach once this fluorescent lamp dies. <br>\
-		So do return once you're ready.\""
+	observation_choices = list(
+		"Fix the entity's flickering fluorescent lights" = list(TRUE, "\"I remember. <br>I've always wanted to run across a rolling field of grass under the warm sun. <br>\
+			To swim across the vast ocean that I've seen only through pictures. <br>\
+			That was my dream. <br>\
+			My only dream. <br>\
+			Now, if you ever recall a dream in which you wished to twinkle, even as a faint flicker...\""),
+		"Say that you will sink together" = list(FALSE, "You still fear the dark, don't you? <br>\
+			I know that you will miss the surface, forever out of your reach once this fluorescent lamp dies. <br>\
+			So do return once you're ready.\""),
+	)
 
 	var/stunned = FALSE
 	//Stuff relating to the dive attack

--- a/code/modules/mob/living/simple_animal/abnormality/waw/snow_whites_apple.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/snow_whites_apple.dm
@@ -59,15 +59,14 @@
 		Why does no one visit me? <br>Why does no one share my pain? <br>\
 		Why does no one like me? <br>I hope I had legs, no, it doesn't have to be legs. <br>\
 		All I want is to be able to move. <br>Oh, redemption......"
-	observation_choices = list("I shall go find it.", "It does not exist.")
-	correct_choices = list("It does not exist.")
-	observation_success_message = "This is unfair. <br>I want to be happy. <br>It's too painful to wait. <br>\
-		It is my bane that no one is around me. <br>I want this misery to crush me to nonexistence. <br>\
-		Some kind of legs sprouted out of me but I have no place to go. <br>However, I do not rot. <br>I cannot stop existing. <br>\
-		I have to go, although I have no place to go. <br>I have to go. <br>I go."
-
-	observation_fail_message = "From some moment, I realized I can walk. <br>\
-		I see light. <br>I hear people. <br>I will be free from this torment. <br>For I will meet my redemption"
+	observation_choices = list(
+		"It does not exist" = list(TRUE, "This is unfair. <br>I want to be happy. <br>It's too painful to wait. <br>\
+			It is my bane that no one is around me. <br>I want this misery to crush me to nonexistence. <br>\
+			Some kind of legs sprouted out of me but I have no place to go. <br>However, I do not rot. <br>I cannot stop existing. <br>\
+			I have to go, although I have no place to go. <br>I have to go. <br>I go."),
+		"I shall go find it" = list(FALSE, "From some moment, I realized I can walk. <br>\
+			I see light. <br>I hear people. <br>I will be free from this torment. <br>For I will meet my redemption"),
+	)
 
 	initial_language_holder = /datum/language_holder/plant //essentially flavor
 	var/togglemovement = FALSE

--- a/code/modules/mob/living/simple_animal/abnormality/waw/sphinx.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/sphinx.dm
@@ -53,23 +53,23 @@
 		Beside me, the great sphinx lies. <br>It beckons me to answer the plaque. <br>\
 		Written in characters I have never seen before, well are the sculptor's passions read. <br>\
 		\"What goes on four feet in the morning, two feet in midday, and three feet in the evening?\""
-	observation_choices = list("Man", "Monster")
-	correct_choices = list("Man")
-	observation_success_message = "The sphinx says something. <br>It seems happy, or proud. <br>\
-		Then, it turns to stone, and sinks into the sand. <br>\
-		Nothing beside remains. Round the decay <br>\
-		Of that colossal Wreck, boundless and bare <br>\
-		The lone and level sands stretch far away."
-	observation_fail_message = "The sphinx seems displeased. \
-		It says some incomprehensible but hurtful words to me.<br>\
-		Then, it turns to stone. <br>I try and look away, but I find that I cannot move either.<br>\
-		My skin cracks like stone, my breathing stops. <br>I fall into an abyss. <br>\
-		... <br>\
-		I am entombed in stone, with no end in sight. <br>\
-		I cannot scream, for I have no tongue to scream with. <br>\
-		I cannot see, for I have no eyes to see with. <br>\
-		I cannot hear anything, for I have no ears to hear with. <br>\
-		Soon after, my heart is taken away too. <br>And then there is nothing left."
+	observation_choices = list(
+		"Man" = list(TRUE, "The sphinx says something. <br>It seems happy, or proud. <br>\
+			Then, it turns to stone, and sinks into the sand. <br>\
+			Nothing beside remains. Round the decay <br>\
+			Of that colossal Wreck, boundless and bare <br>\
+			The lone and level sands stretch far away."),
+		"Monster" = list(FALSE, "The sphinx seems displeased. \
+			It says some incomprehensible but hurtful words to me.<br>\
+			Then, it turns to stone. <br>I try and look away, but I find that I cannot move either.<br>\
+			My skin cracks like stone, my breathing stops. <br>I fall into an abyss. <br>\
+			... <br>\
+			I am entombed in stone, with no end in sight. <br>\
+			I cannot scream, for I have no tongue to scream with. <br>\
+			I cannot see, for I have no eyes to see with. <br>\
+			I cannot hear anything, for I have no ears to hear with. <br>\
+			Soon after, my heart is taken away too. <br>And then there is nothing left."),
+	)
 
 	//work-related
 	var/happy = FALSE

--- a/code/modules/mob/living/simple_animal/abnormality/waw/thunder_bird.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/thunder_bird.dm
@@ -56,12 +56,12 @@
 	observation_prompt = "The totem sits atop a pile of gore and viscera. <br>\
 		Human scalps dangle motionlessly, strung to its wings. <br>\
 		Though the totem lies still, you feel compelled to answer it."
-	observation_choices = list("Speak", "Remain silent")
-	correct_choices = list("Remain silent")
-	observation_success_message = "The disgusting totem answered with silence. <br>\
-		The Thunderbird had been defeated long ago, its existence being its only privilege."
-	observation_fail_message = "Before you can utter a word, thunder booms within the cell. <br>\
-		The Thunderbird can be spoken to, but never reasoned with."
+	observation_choices = list(
+		"Remain silent" = list(TRUE, "The disgusting totem answered with silence. <br>\
+			The Thunderbird had been defeated long ago, its existence being its only privilege."),
+		"Speak" = list(FALSE, "Before you can utter a word, thunder booms within the cell. <br>\
+			The Thunderbird can be spoken to, but never reasoned with."),
+	)
 
 /*---Combat---*/
 	//Melee stats

--- a/code/modules/mob/living/simple_animal/abnormality/waw/warden.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/warden.dm
@@ -44,13 +44,13 @@
 		As far as I know it's just me left. <br>\
 		The site burial went off and escape is impossible, yet, the other abnormalities remain in their cells - if they leave she forces them back inside. <br>\
 		Maybe if I enter one of the unused cells, she might leave me alone?"
-	observation_choices = list("Enter a cell", "Surrender to her")
-	correct_choices = list("Enter a cell")
-	observation_success_message = "I step inside and lock the door behind me, <br>I'm stuck inside. <br>\
-		She passes by the containment unit and peers through the glass and seems satisfied."
-	observation_fail_message = "Steeling myself, I confront her during one of her rounds. <br>I tell her I'm tired and just want it to end. <br>\
-		She gets closer and lifts her skirt(?) and I'm thrust underneath, my colleagues are here- they're alive and well! <br>\
-		But, they seem despondent. <br>One looks at me says simply; \"In here, you're with us. Forever.\""
+	observation_choices = list(
+		"Enter a cell" = list(TRUE, "I step inside and lock the door behind me, <br>I'm stuck inside. <br>\
+			She passes by the containment unit and peers through the glass and seems satisfied."),
+		"Surrender to her" = list(FALSE, "Steeling myself, I confront her during one of her rounds. <br>I tell her I'm tired and just want it to end. <br>\
+			She gets closer and lifts her skirt(?) and I'm thrust underneath, my colleagues are here- they're alive and well! <br>\
+			But, they seem despondent. <br>One looks at me says simply; \"In here, you're with us. Forever.\""),
+	)
 
 	var/finishing = FALSE
 

--- a/code/modules/mob/living/simple_animal/abnormality/waw/wrath_servant.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/wrath_servant.dm
@@ -60,13 +60,13 @@
 
 	observation_prompt = "I made a mistake, I put my trust in someone I shouldn't have and my world paid the price for my indiscretion. <br>\
 		Was I wrong to call them friend? <br>Were they really my friend, all along?"
-	observation_choices = list("You were wrong", "It wasn't wrong")
-	correct_choices = list("It wasn't wrong")
-	observation_success_message = "If that's the case, then why did balance, why did justice, fail me? <br>\
-		Why did my world burn if I truly did not make a mistake? <br>It still hurts, but, if you're right then maybe I can put my trust in you..."
-	observation_fail_message = "It was the most precious relationship to me... <br>\
-		That's why I lost; I fell to my beloved companion... <br>\
-		I should have killed them when I had the chance! <br>Sinners!! <br>Embodiments of evil..!"
+	observation_choices = list(
+		"It wasn't wrong" = list(TRUE, "If that's the case, then why did balance, why did justice, fail me? <br>\
+			Why did my world burn if I truly did not make a mistake? <br>It still hurts, but, if you're right then maybe I can put my trust in you..."),
+		"You were wrong" = list(FALSE, "It was the most precious relationship to me... <br>\
+			That's why I lost; I fell to my beloved companion... <br>\
+			I should have killed them when I had the chance! <br>Sinners!! <br>Embodiments of evil..!"),
+	)
 
 	var/friendly = TRUE
 	var/list/friend_ship = list()

--- a/code/modules/mob/living/simple_animal/abnormality/waw/yang.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/yang.dm
@@ -61,14 +61,14 @@
 
 	observation_prompt = "The Angel's Pendant was one half of a greater whole, but now they've been cleaved in half, forever wanting to reunite. <br>\
 		The pendant laid upon the podium before you, even being in the same room as it seemed to fortify your body and soul."
-	observation_choices = list("Put it on", "Don't put it on")
-	correct_choices = list("Put it on")
-	observation_success_message = "The moment you put it on, you feel a radiance emanate out and mend pain you didn't even know was there. <br>\
-		It doesn't intend to heal you, it's just the way it is. <br>\
-		If there is darkness and evil in this world, shouldn't there be light and good too? <br>\
-		The world is far more than darkness and cold."
-	observation_fail_message = "It is all that is bright given form, made to gather all the positivity in the world. <br>\
-		If you can't accept the goodness in yourself, you're not ready to accept the goodness of the world."
+	observation_choices = list(
+		"Put it on" = list(TRUE, "The moment you put it on, you feel a radiance emanate out and mend pain you didn't even know was there. <br>\
+			It doesn't intend to heal you, it's just the way it is. <br>\
+			If there is darkness and evil in this world, shouldn't there be light and good too? <br>\
+			The world is far more than darkness and cold."),
+		"Don't put it on" = list(FALSE, "It is all that is bright given form, made to gather all the positivity in the world. <br>\
+			If you can't accept the goodness in yourself, you're not ready to accept the goodness of the world."),
+	)
 
 	var/explosion_damage = 150
 	var/explosion_timer = 7 SECONDS

--- a/code/modules/mob/living/simple_animal/abnormality/waw/yin.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/yin.dm
@@ -46,14 +46,14 @@
 
 	observation_prompt = "The Devil's Pendant was one half of a greater whole, but now they've been cleaved in half, forever wanting to reunite. <br>\
 		The pendant laid upon the podium before you, even being in the same room as it seemed to suck the life out of you and erodes your very essence."
-	observation_choices = list("Put it on", "Don't put it on")
-	correct_choices = list("Put it on")
-	observation_success_message = "The moment you put it on, your body is stricken with deepest agony, feeling like thorns racing through your body, puncturing flesh and mind alike but you endure. <br>\
-		It didn't mean to harm you, it's just the way it is. <br>\
-		If there is light and goodness in this world, shouldn't there be darkness and evil too? <br>\
-		The world is far more than brightness and warmth."
-	observation_fail_message = "It is darkness made manifest, made to encapsulate all the negativity in the world. <br>\
-		If you can't accept the darkness of the world, you're not ready to accept the darkness in you."
+	observation_choices = list(
+		"Put it on" = list(TRUE, "The moment you put it on, your body is stricken with deepest agony, feeling like thorns racing through your body, puncturing flesh and mind alike but you endure. <br>\
+			It didn't mean to harm you, it's just the way it is. <br>\
+			If there is light and goodness in this world, shouldn't there be darkness and evil too? <br>\
+			The world is far more than brightness and warmth."),
+		"Don't put it on" = list(FALSE, "It is darkness made manifest, made to encapsulate all the negativity in the world. <br>\
+			If you can't accept the darkness of the world, you're not ready to accept the darkness in you."),
+	)
 
 	faction = list("neutral", "hostile") // Not fought by anything, typically. But...
 	var/faction_override = list("hostile") // The effects hit non-hostiles.

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/bald.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/bald.dm
@@ -42,10 +42,10 @@
 	harvest_phrase_third = "%PERSON squeezes %ABNO. Some juice drips into %VESSEL."
 
 	observation_prompt = "This abnormality is filled with dreams of bald people. Are you balding, or already bald?"
-	observation_choices = list("Yes", "No")
-	correct_choices = list("Yes")
-	observation_success_message = "Lobotomy Corporation welcomes you."
-	observation_fail_message = "Come back after watching the fast and the furious 7 five more times."
+	observation_choices = list(
+		"Yes" = list(TRUE, "Lobotomy Corporation welcomes you."),
+		"No" = list(FALSE, "Come back after watching the fast and the furious 7 five more times."),
+	)
 
 	var/bald_users = list()
 	chem_type = /datum/reagent/abnormality/bald

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/blubbering_toad.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/blubbering_toad.dm
@@ -58,20 +58,20 @@
 		This resin is like gloom. <br>\
 		A sap of gloom, not quite like tears or sadness. <br>\
 		The toad holds this resin."
-	observation_choices = list("Mimic the cry", "Sit and wait")
-	correct_choices = list("Sit and wait")
-	observation_success_message = "An indeterminate amount of time passes. <br>\
-		As you waited for the toad to finish its cries, <br>\
-		it gazed into you, closing and opening its eyelids slowly. <br>\
-		With a quick, slick sound,a long blue tongue popped out towards you. <br>\
-		An eyeball belonging to the toad was on its tongue. <br>\
-		When you picked it up, it blinked its other eye at us before going on its way. <br>\
-		Was that its thanks for lending an ear?"
-	observation_fail_message = "\"Croohic, croohoo.\" <br>\
-		The toad’s cry is dull and heavy. <br>\
-		It doesn’t seem to have understood what it heard. <br>\
-		After crying like that a few more times, it hopped away from its spot. <br>\
-		All that’s left is the sticky blue resin."
+	observation_choices = list(
+		"Sit and wait" = list(TRUE, "An indeterminate amount of time passes. <br>\
+			As you waited for the toad to finish its cries, <br>\
+			it gazed into you, closing and opening its eyelids slowly. <br>\
+			With a quick, slick sound, a long blue tongue popped out towards you. <br>\
+			An eyeball belonging to the toad was on its tongue. <br>\
+			When you picked it up, it blinked its other eye at us before going on its way. <br>\
+			Was that its thanks for lending an ear?"),
+		"Mimic the cry" = list(FALSE, "\"Croohic, croohoo.\" <br>\
+			The toad’s cry is dull and heavy. <br>\
+			It doesn’t seem to have understood what it heard. <br>\
+			After crying like that a few more times, it hopped away from its spot. <br>\
+			All that’s left is the sticky blue resin."),
+	)
 
 	//work
 	var/pulse_healing = 15

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/bottle.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/bottle.dm
@@ -55,26 +55,17 @@
 
 	observation_prompt = "It was all very well to say \"Drink me\" but wisdom told you not to do that in a hurry. <br>\
 		The bottle had no markings to denote whether it was poisonous but you could not be sure, it was almost certain to disagree with you, sooner or later..."
-	observation_choices = list("Drink the bottle", "Eat the cake", "Leave")
-	correct_choices = list("Leave", "Eat the cake")
-	observation_success_message = "Suspicious things are suspicious, common sense hasn't failed you yet."
-	observation_fail_message = "However this bottle was not marked as poisonous and you ventured a taste, \
-		and found it horrid, the brine clung to your tongue. <br>Who'd mark such a horrible thing for drinking?"
-	//Special answer for choice 2
-	var/observation_success_message_2 = "Abandon reason, that's how you survive in Wonderland. <br>\
-		You devour the cake by the handful, frosting and crumbs smear your hands, your face and the floor. <br>\
-		It's sweet and tart, with only the slightest hint of salt. <br>\
-		As you breach the final layer of cake, the top of the bottle cracks and a deluge of brine spills forth, filling the room faster than you could draw a breath. <br>\
-		In spite of that, you're at peace and smiling. <br>\
-		Through your fading eyesight, you spy yourself through the other side of the containment door's window - frowning."
-
-// Final Observation
-/mob/living/simple_animal/hostile/abnormality/bottle/ObservationResult(mob/living/carbon/human/user, condition, answer) //special answer for cake result
-	if(answer == "Eat the cake")
-		observation_success_message = observation_success_message_2
-	else
-		observation_success_message = initial(observation_success_message)
-	return ..()
+	observation_choices = list(
+		"Leave" = list(TRUE, "Suspicious things are suspicious, common sense hasn't failed you yet."),
+		"Eat the cake" = list(TRUE, "Abandon reason, that's how you survive in Wonderland. <br>\
+			You devour the cake by the handful, frosting and crumbs smear your hands, your face and the floor. <br>\
+			It's sweet and tart, with only the slightest hint of salt. <br>\
+			As you breach the final layer of cake, the top of the bottle cracks and a deluge of brine spills forth, filling the room faster than you could draw a breath. <br>\
+			In spite of that, you're at peace and smiling. <br>\
+			Through your fading eyesight, you spy yourself through the other side of the containment door's window - frowning."),
+		"Drink the bottle" = list(FALSE, "However this bottle was not marked as poisonous and you ventured a taste, \
+			and found it horrid, the brine clung to your tongue. <br>Who'd mark such a horrible thing for drinking?"),
+	)
 
 // Work Mechanics
 /mob/living/simple_animal/hostile/abnormality/bottle/AttemptWork(mob/living/carbon/human/user, work_type)

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/fairy_festival.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/fairy_festival.dm
@@ -46,10 +46,10 @@
 	observation_prompt = "A gaggle of fairies flitter to and fro about the containment cell, they giggle as you approach.<br>\
 		\"You're a peaceful child, aren't you? You're lucky to accept our care.\" <br>\
 		They say in a sing-song all around you. \"Only good people ever speak to us, you're a good person too, right?\""
-	observation_choices = list("Accept their care")
-	correct_choices = list("Accept their care")
-	observation_success_message = "The fairies sprinkle their powder around you and it collects upon your hands. <br>You feel special. <br>\
-		You retreat from the cell and the fairies' hungry gazes. <br>You've always known the true meaning of The Fairies' Care."
+	observation_choices = list(
+		"Accept their care" = list(TRUE, "The fairies sprinkle their powder around you and it collects upon your hands. <br>You feel special. <br>\
+			You retreat from the cell and the fairies' hungry gazes. <br>You've always known the true meaning of The Fairies' Care."),
+	)
 
 /mob/living/simple_animal/hostile/abnormality/fairy_festival/proc/FairyHeal()
 	for(var/mob/living/carbon/human/P in protected_people)

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/fallen_amurdad.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/fallen_amurdad.dm
@@ -27,10 +27,10 @@
 
 	observation_prompt = "The sweet stench of rot and decay hit you before you noticed the source was the bleeding person covered in plants. <br>\
 		His lips gape open and close like a fish's and what little strength he has in his limbs, he uses to beckons you closer..."
-	observation_choices = list("Get closer and listen", "Leave")
-	correct_choices = list("Get closer and listen")
-	observation_success_message = "You bend down and lend your ear to his mouth... <br>You hear the words you've been waiting your whole life to hear."
-	observation_fail_message = "The man clearly needs help, you rush to find a medic."
+	observation_choices = list(
+		"Get closer and listen" = list(TRUE, "You bend down and lend your ear to his mouth... <br>You hear the words you've been waiting your whole life to hear."),
+		"Leave" = list(FALSE, "The man clearly needs help, you rush to find a medic."),
+	)
 
 	var/seed_list = list(
 		/obj/item/seeds/grass/fairy,

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/hammer_light.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/hammer_light.dm
@@ -30,14 +30,13 @@
 	gift_type = /datum/ego_gifts/evening
 	abnormality_origin = ABNORMALITY_ORIGIN_ARTBOOK // Technically it was in the beta but I dont want it showing it up in LC-only modes
 
-	observation_prompt = "I was the unluckiest man in the world. <br>\
-		Everything around me did nothing but ruining my life.But I had no power to change this fate. <br>\
-		Someday, someone made an offer to me.\"If you accept it, your whole world will change.\" <br>\
+	observation_prompt = "I was the unluckiest man in the world.<br>\
+		Everything around me did nothing but ruining my life. But I had no power to change this fate.<br>\
+		Someday, someone made an offer to me. \"If you accept it, your whole world will change.\"<br>\
 		Such a tempting offer. I would become something that I could only hope to be."
-	observation_choices = list("Accept the offer")
-	correct_choices = list("Accept the offer")
-	observation_success_message = "I accepted the offer and paid the price. <br>\
-		The $0 Hammer of Light shined."
+	observation_choices = list(
+		"Accept the offer" = list(TRUE, "I accepted the offer and paid the price. <br>The $0 Hammer of Light shined.")
+	)
 
 	pet_bonus = "hums" // saves a few lines of code by allowing funpet() to be called by attack_hand()
 	var/sealed = TRUE

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/oceanwaves.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/oceanwaves.dm
@@ -43,11 +43,11 @@
 		Where does it get its power…? <br>Besides that, what’s with this sound of crashing waves? <br>\
 		Regardless, this vacant lot looks to be a good place to take a break. <br>\
 		Standing in front of the vending machine, you see rows of buttons."
-	observation_choices = list("Press one")
-	correct_choices = list("Press one")
-	observation_success_message = "With just a single press, the machine ejected one can after another. <br>\
-		All the cans are purple. You can’t fathom the meaning of the ships and grapes doodled on them, but they somehow feel familiar, and well… cheery. <br>\
-		They should be okay to drink."
+	observation_choices = list(
+		"Press one" = list(TRUE, "With just a single press, the machine ejected one can after another. <br>\
+			All the cans are purple. You can’t fathom the meaning of the ships and grapes doodled on them, but they somehow feel familiar, and well… cheery. <br>\
+			They should be okay to drink."),
+	)
 
 	var/list/goodsoders = list(
 		/obj/item/reagent_containers/food/drinks/soda_cans/oceanwave/unlabeled,

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/one_sin.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/one_sin.dm
@@ -24,7 +24,7 @@
 		/datum/ego_datum/armor/penitence
 	)
 	max_boxes = 10
-	gift_type =  /datum/ego_gifts/penitence
+	gift_type = /datum/ego_gifts/penitence
 	gift_message = "From this day forth, you shall never forget his words."
 	abnormality_origin = ABNORMALITY_ORIGIN_LOBOTOMY
 
@@ -38,12 +38,12 @@
 
 	observation_prompt = "It has great power. It is savior that will judge you, and executioner that will put you in your demise. <br>\
 		In its eyes, you find... <br>(Technically, it has no eyes, so in its pitch-black holes you find...)"
-	observation_choices = list("You find yourself.", "Nothing.")
-	correct_choices = list("Nothing.")
-	observation_success_message = "Darkness. <br>\
-		Nothing is there. Have you found the answers you were looking for?"
-	observation_fail_message = "You are found. <br>\
-		You have great power. <br>You willingly lift the axe for the greater good."
+	observation_choices = list(
+		"Nothing" = list(TRUE, "Darkness. <br>\
+			Nothing is there. Have you found the answers you were looking for?"),
+		"You find yourself" = list(FALSE, "You are found. <br>\
+			You have great power. <br>You willingly lift the axe for the greater good."),
+	)
 
 	var/halo_status = "onesin_halo_normal" //used for changing the halo overlays
 
@@ -57,7 +57,7 @@
 	. += "onesin" //by the nine this is too cursed
 
 /mob/living/simple_animal/hostile/abnormality/onesin/WorkChance(mob/living/carbon/human/user, chance)
-	if(istype(user.ego_gift_list[HAT], /datum/ego_gifts/penitence))
+	if(istype(user.ego_gift_list[HAT], gift_type))
 		return chance + 10
 	return chance
 

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/oracle.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/oracle.dm
@@ -22,7 +22,7 @@
 	work_damage_type = WHITE_DAMAGE
 
 	ego_list = list(
-		/datum/ego_datum/weapon/dead_dream,	
+		/datum/ego_datum/weapon/dead_dream,
 		/datum/ego_datum/armor/dead_dream
 	)
 //	gift_type =  /datum/ego_gifts/oracle
@@ -32,15 +32,15 @@
 		<br>She was told that it would feel like no time at all. \
 		<br>Silently sleeping she dreams of the future, a future she was promised. \
 		<br>Before your eyes untold time passes until one day."
-	observation_choices = list("She woke up.", "The pod broke.")
-	correct_choices = list("The pod broke.")
-	observation_success_message = "You look into the window as you see her stir in her slumber before falling still. \
-		<br>Holding your breath in silence, \
-		<br>You remember Maria, \
-		<br>Forever dreaming of a future she will never see."
-	observation_fail_message = "The pod opens with a hiss as you watch her step out. \
-		<br>The joy on her face is immesurable, for she left behind so much to be here. \
-		<br>Then she melts away, for this was your dream."
+	observation_choices = list(
+		"The pod broke" = list(TRUE, "You look into the window as you see her stir in her slumber before falling still. \
+			<br>Holding your breath in silence, \
+			<br>You remember Maria, \
+			<br>Forever dreaming of a future she will never see."),
+		"She woke up" = list(FALSE, "The pod opens with a hiss as you watch her step out. \
+			<br>The joy on her face is immesurable, for she left behind so much to be here. \
+			<br>Then she melts away, for this was your dream."),
+	)
 
 	var/list/sleeplines = list(
 		"Hello...",

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/pile_of_mail.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/pile_of_mail.dm
@@ -32,12 +32,12 @@
 	observation_prompt = "Letters addressed to various addresses and recipients litter the containment cell. <br>\
 		Occasionally, some of the letters flutter in the air, as if a breeze has come through the cell. <br>\
 		A new batch of letters comes flooding out of the mailbox, one lands right in front of you, with your name on it."
-	observation_choices = list("Open the letter", "Ignore it")
-	correct_choices = list("Open the letter")
-	observation_success_message = "You open the letter, but the inside is blank. <br>\
-		Looking at the envelope, you notice that it is labelled \"RETURN TO SENDER\" <br>\
-		You put the envelope back in the mailbox, and find a gift inside."
-	observation_fail_message = "You know better than to fall for the tricks of an abnormality. <br>You walk out of the cell, never knowing what was in that letter."
+	observation_choices = list(
+		"Open the letter" = list(TRUE, "You open the letter, but the inside is blank. <br>\
+			Looking at the envelope, you notice that it is labelled \"RETURN TO SENDER\" <br>\
+			You put the envelope back in the mailbox, and find a gift inside."),
+		"Ignore it" = list(FALSE, "You know better than to fall for the tricks of an abnormality. <br>You walk out of the cell, never knowing what was in that letter."),
+	)
 
 	var/cooldown
 	var/cooldown_time = 10 SECONDS

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/quiet_day.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/quiet_day.dm
@@ -40,19 +40,19 @@
 	harvest_phrase_third = "%ABNO glances at %PERSON. Suddenly, %VESSEL seems to be more full."
 
 	observation_prompt = "The shadow of an old man seems to be contemplating about something. <br>\
-		\"Don\'t you ever wish you could go back to those better times? To be able to enjoy life to the fullest? <br>\
+		\"Don't you ever wish you could go back to those better times? To be able to enjoy life to the fullest? <br>\
 		To relive the best moments of your life again? <br>\
 		To remember her face? To remember that young man's name? <br>\
-		Perhaps it's foolish of me to ask for this. I want to hear your opinion, young\'in. <br>\
+		Perhaps it's foolish of me to ask for this. I want to hear your opinion, young'in. <br>\
 		Would it be worth chasing after those old, familiar memories?\""
-	observation_choices = list("It's not wrong.", "Perhaps it's better to move on.")
-	correct_choices = list("Perhaps it's better to move on.")
-	observation_success_message = "\"I suppose you're right after all.\" <br>\
-		\"If I can't even remember their names and faces, what worth even are those memories?\" <br>\
-		\"Go on. Leave before you forget too.\""
-	observation_fail_message = "\"Indeed. There's no harm, right?\" <br>\
-		\"...Yet why can't I remember her face?\" <br>\
-		As you're about to leave, you hear the old man croak out something. \"Who are you again?\""
+	observation_choices = list(
+		"Perhaps it's better to move on." = list(TRUE, "\"I suppose you're right after all.\" <br>\
+			\"If I can't even remember their names and faces, what worth even are those memories?\" <br>\
+			\"Go on. Leave before you forget too.\""),
+		"It's not wrong." = list(FALSE, "\"Indeed. There's no harm, right?\" <br>\
+			\"...Yet why can't I remember her face?\" <br>\
+			As you're about to leave, you hear the old man croak out something. \"Who are you again?\""),
+	)
 
 	var/performed_work
 	var/datum/looping_sound/quietday_ambience/soundloop

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/sleeping_beauty.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/sleeping_beauty.dm
@@ -39,11 +39,10 @@
 	harvest_phrase_third = "%PERSON jostles %ABNO, then captures the resulting clouds with %VESSEL."
 
 	observation_prompt = "The couch looks inviting, softer and plusher than anything you've ever known. <br>You've been working for so long, it couldn't hurt to take a break?"
-	observation_choices = list("Lie down", "Get back to work")
-	correct_choices = list("Get back to work")
-	observation_success_message = "You shake your head. You'll have time to rest when you're dead."
-	observation_fail_message = "You lay your head down into your soft and comfy pillow. You can always try again tomorrow."
-
+	observation_choices = list(
+		"Get back to work" = list(TRUE, "You shake your head. You'll have time to rest when you're dead."),
+		"Lie down" = list(FALSE, "You lay your head down into your soft and comfy pillow. You can always try again tomorrow."),
+	)
 
 	var/grab_cooldown
 	var/grab_cooldown_time = 20 SECONDS

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/sunset_traveller.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/sunset_traveller.dm
@@ -37,16 +37,16 @@
 	observation_prompt = "\"Look at those butterflies! Aren’t they just beautiful? <br>And gander at that sunset, too! Really makes you want to go for a stroll.\" <br>\
 		\"Why don’t you stop for a moment and take a breather here?\" <br>\
 		Something yellow gestures warmly at you."
-	observation_choices = list("Take a break", "Ignore it and leave")
-	correct_choices = list("Take a break")
-	observation_success_message = "\"Wasn’t it tiring coming all the way here? Really, check out those butterflies. <br>\
-		Just watching them will warm your heart.\" <br>\
-		You looked at the butterflies as the voice suggested. They indeed fill the heart with a certain warmth. <br>\
-		\"Looks like some of them want to tag along!\" <br>\
-		A kaleidoscope of butterflies started following you, even after you left that scenic spot."
-	observation_fail_message = "\"You must be very busy then!\" <br> It made the same gesture as when it first greeted you. <br>\
-		Perhaps it was waving goodbye all along. <br>\
-		\"Another time, I suppose!\""
+	observation_choices = list(
+		"Take a break" = list(TRUE, "\"Wasn’t it tiring coming all the way here? Really, check out those butterflies. <br>\
+			Just watching them will warm your heart.\" <br>\
+			You looked at the butterflies as the voice suggested. They indeed fill the heart with a certain warmth. <br>\
+			\"Looks like some of them want to tag along!\" <br>\
+			A kaleidoscope of butterflies started following you, even after you left that scenic spot."),
+		"Ignore it and leave" = list(FALSE, "\"You must be very busy then!\" <br> It made the same gesture as when it first greeted you. <br>\
+			Perhaps it was waving goodbye all along. <br>\
+			\"Another time, I suppose!\""),
+	)
 
 	light_color = COLOR_ORANGE
 	light_range = 5

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/we_can_change_anything.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/we_can_change_anything.dm
@@ -49,10 +49,10 @@
 		Is your house suffering from an outage because you don’t have the money to pay for the power bill? <br>\
 		We can change that!<br>\
 		It’s quite simple. Just open up the machine, step inside, and press the button to make it shut."
-	observation_choices = list("Enter the machine")
-	correct_choices = list("Enter the machine")
-	observation_success_message = "You step inside the machine, it's just as comfortable as advertised. <br>\
-		Now everything will be just fine."
+	observation_choices = list(
+		"Enter the machine" = list(TRUE, "You step inside the machine, it's just as comfortable as advertised. <br>\
+			Now everything will be just fine."),
+	)
 
 	var/grinding = FALSE
 	var/grind_duration = 5 SECONDS

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/wellcheers.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/wellcheers.dm
@@ -58,11 +58,12 @@
 
 	observation_prompt = "A vending machine stands before you. <br>\
 		Two delicious looking shrimp are standing at both sides of the machine. <br>Will you buy soda?"
-	observation_choices = list("Yes", "No")
-	correct_choices = list("Yes", "No")
-	observation_success_message = "Before you can make a choice, one of the shrimp buys you soda. <br>\
-		You drink the soda, and fall asleep... <br>... <br>Somewhere in the distance, you hear seagulls."
-
+	observation_choices = list(
+		"Yes" = list(TRUE, "Before you can make a choice, one of the shrimp buys you soda. <br>\
+			You drink the soda, and fall asleep... <br>... <br>Somewhere in the distance, you hear seagulls."),
+		"No" = list(TRUE, "Before you can make a choice, one of the shrimp buys you soda. <br>\
+			You drink the soda, and fall asleep... <br>... <br>Somewhere in the distance, you hear seagulls.")
+	)
 
 /mob/living/simple_animal/hostile/abnormality/wellcheers/HandleStructures()
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

_Please end my suffering_
- Makes it so you can assign any amount of wrong or right answers to observations
- Makes every observation answer capable of having custom text, without extra proc overrides
- Makes buttons be randomly shuffled every time someone does an observation
- Fixed misspellings on the correct_answer list making abnormalities unable to be observed by removing it
- Fixed FAN observation
- Closes https://github.com/vlggms/lobotomy-corp13/pull/2636 , this fixes the same issue with the new framework

## Why It's Good For The Game

> Makes it so you can assign any amount of wrong or right answers to observations
- Ayup, we now have a framework for that, FAN enjoyers rejoice

> Makes every observation answer capable of having custom text, without extra proc overrides
- Yeah, thats now a thing

> Makes buttons be randomly shuffled every time someone does an observation
- This is a lil controversial of a change imo, but its for the better. Now all the correct answers are at the top of the list so we can organize a lil bit more neatly. Shouldnt have much of an effect on gameplay tho

> Fixed misspellings on the correct_answer list making abnormalities unable to be observed by removing it
- Now the format is `"Choice" = list(TRUE or FALSE [depending on if the answer is correct], "Response")` making it MUCH harder to make observations unachieveable since we now have to mis-spell "true" for "false" or vice-versa instead of a single letter

> Fixed FAN observation
- before we used the `in` keyword to search for the correct answer, i think that caused jank with abnos that have a lot of buttons (only FAN). This made it so we directly just yoink the value if its the correct answer or not instead of relying on `in`


## Changelog
:cl:
tweak: Observations now have randomly shuffled buttons
fix: FAN's observation now works
/:cl:
