### PR TITLE
Button changes -- Buttoning now takes 60 seconds instead of 45, vendors unmoveable, SOME doors unhackable

### DIFF
--- a/ModularTegustation/lc13_machinery.dm
+++ b/ModularTegustation/lc13_machinery.dm
@@ -1,3 +1,12 @@
+/obj/machinery/vending/can_be_unfasten_wrench(mob/user, silent)
+	. = ..()
+	if(!.)
+		return FAILED_UNFASTEN
+
+	// Mechanics are in pain right now, as this is the most real thing ever
+	to_chat(user, span_warning("Aw dangit, your wrench is for 20 size bolts, but this vendor has size 17 bolts, your wrench keeps slipping!"))
+	return FAILED_UNFASTEN
+
 //Links to abnormality consoles when the console spawns
 /obj/machinery/containment_panel
 	name = "containment panel"

--- a/_maps/map_files/Alpha/alphacorp.dmm
+++ b/_maps/map_files/Alpha/alphacorp.dmm
@@ -2227,7 +2227,8 @@
 /area/department_main/safety)
 "qv" = (
 /obj/machinery/door/airlock/highsecurity{
-	name = "Records Office Secure Area"
+	name = "Records Office Secure Area";
+	hackProof = 1
 	},
 /turf/open/floor/carpet/black,
 /area/department_main/records)
@@ -2642,7 +2643,8 @@
 /area/department_main/training)
 "tO" = (
 /obj/machinery/door/airlock/highsecurity{
-	name = "Records Office"
+	name = "Records Office";
+	hackProof = 1
 	},
 /obj/structure/fans/tiny,
 /turf/open/floor/plasteel/elevatorshaft,
@@ -5031,7 +5033,9 @@
 "Ne" = (
 /obj/structure/fans/tiny,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/hatch,
+/obj/machinery/door/airlock/hatch{
+	hackProof = 1
+	},
 /turf/open/floor/plasteel/elevatorshaft,
 /area/department_main/training)
 "Nf" = (

--- a/_maps/map_files/Beta/betacorp.dmm
+++ b/_maps/map_files/Beta/betacorp.dmm
@@ -547,7 +547,8 @@
 /area/department_main/command)
 "da" = (
 /obj/machinery/door/airlock/highsecurity{
-	name = "Records Office"
+	name = "Records Office";
+	hackProof = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/department_main/records)
@@ -4600,7 +4601,8 @@
 /area/facility_hallway/discipline)
 "vZ" = (
 /obj/machinery/door/airlock/highsecurity{
-	name = "Records Office Secure Area"
+	name = "Records Office Secure Area";
+	hackProof = 1
 	},
 /turf/open/floor/carpet/black,
 /area/department_main/records)

--- a/_maps/map_files/Epsilon/epsiloncorp.dmm
+++ b/_maps/map_files/Epsilon/epsiloncorp.dmm
@@ -4779,6 +4779,13 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/sepia,
 /area/department_main/welfare)
+"oq" = (
+/obj/machinery/door/airlock/glass{
+	icon = 'icons/obj/doors/airlocks/station/science.dmi';
+	hackProof = 1
+	},
+/turf/open/floor/facility/halls,
+/area/facility_hallway/information)
 "or" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -4798,7 +4805,8 @@
 /area/facility_hallway/human)
 "ow" = (
 /obj/machinery/door/airlock/highsecurity{
-	name = "Records Office Secure Area"
+	name = "Records Office Secure Area";
+	hackProof = 1
 	},
 /turf/open/floor/facility/halls,
 /area/facility_hallway/information)
@@ -12938,7 +12946,8 @@
 /obj/machinery/door/airlock{
 	icon = 'icons/obj/doors/airlocks/station/science.dmi';
 	max_integrity = 500;
-	name = "Information Department"
+	name = "Information Department";
+	hackProof = 1
 	},
 /turf/open/floor/facility/halls,
 /area/facility_hallway/information)
@@ -50391,12 +50400,12 @@ pH
 pH
 pH
 pH
-WF
+oq
 sl
 sl
 sl
 sl
-WF
+oq
 jd
 jd
 ow

--- a/_maps/map_files/Eta/etacorp.dmm
+++ b/_maps/map_files/Eta/etacorp.dmm
@@ -1145,7 +1145,8 @@
 /area/facility_hallway/safety)
 "fR" = (
 /obj/machinery/door/airlock/highsecurity{
-	name = "Records Office Secure Area"
+	name = "Records Office Secure Area";
+	hackProof = 1
 	},
 /turf/open/floor/facility/halls,
 /area/facility_hallway/records)
@@ -2011,7 +2012,8 @@
 /obj/machinery/door/airlock{
 	icon = 'icons/obj/doors/airlocks/station/science.dmi';
 	max_integrity = 500;
-	name = "Information Department"
+	name = "Information Department";
+	hackProof = 1
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/facility/halls,

--- a/_maps/map_files/Gamma/gammacorp.dmm
+++ b/_maps/map_files/Gamma/gammacorp.dmm
@@ -2567,7 +2567,8 @@
 /area/facility_hallway/discipline)
 "rn" = (
 /obj/machinery/door/airlock/highsecurity{
-	name = "Information Department"
+	name = "Information Department";
+	hackProof = 1
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/facility/halls,
@@ -3072,7 +3073,8 @@
 /area/department_main/records)
 "ui" = (
 /obj/machinery/door/airlock/highsecurity{
-	name = "Records Office Secure Area"
+	name = "Records Office Secure Area";
+	hackProof = 1
 	},
 /turf/open/floor/carpet/black,
 /area/department_main/records)
@@ -3843,7 +3845,8 @@
 /area/facility_hallway/south)
 "yM" = (
 /obj/machinery/door/airlock/highsecurity{
-	name = "Records Office"
+	name = "Records Office";
+	hackProof = 1
 	},
 /turf/open/floor/facility/halls,
 /area/department_main/records)

--- a/_maps/map_files/Kappa/kappacorp.dmm
+++ b/_maps/map_files/Kappa/kappacorp.dmm
@@ -2263,6 +2263,16 @@
 	name = "Outskirt"
 	},
 /area/space)
+"lX" = (
+/obj/machinery/door/airlock/highsecurity{
+	name = "Records Office Secure Area";
+	hackProof = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/facility/halls,
+/area/facility_hallway/information)
 "lZ" = (
 /turf/closed/indestructible/reinforced{
 	desc = "A huge chunk of wing-grade metal used in various L corporation facilities. Effectively impervious to conventional methods of destruction.";
@@ -5566,6 +5576,18 @@
 	slowdown = -0.3
 	},
 /area/department_main/command)
+"Ab" = (
+/obj/machinery/door/airlock{
+	icon = 'icons/obj/doors/airlocks/station/science.dmi';
+	max_integrity = 500;
+	name = "Information Department";
+	hackProof = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/facility/halls,
+/area/facility_hallway/information)
 "Ac" = (
 /turf/open/floor/plasteel/freezer,
 /area/facility_hallway/control)
@@ -45416,7 +45438,7 @@ cA
 cA
 Cx
 PB
-uq
+Ab
 PB
 cA
 cA
@@ -50295,7 +50317,7 @@ PH
 PH
 nO
 gF
-eL
+lX
 nO
 nO
 SK

--- a/_maps/map_files/Lambda/lambdacorp.dmm
+++ b/_maps/map_files/Lambda/lambdacorp.dmm
@@ -1902,7 +1902,8 @@
 /area/facility_hallway/control)
 "ja" = (
 /obj/machinery/door/airlock/glass{
-	icon = 'icons/obj/doors/airlocks/station/science.dmi'
+	icon = 'icons/obj/doors/airlocks/station/science.dmi';
+	hackProof = 1
 	},
 /turf/open/floor/facility/halls,
 /area/department_main/records)
@@ -5221,7 +5222,8 @@
 /area/department_main/information)
 "zi" = (
 /obj/machinery/door/airlock/highsecurity{
-	name = "Records Office Secure Area"
+	name = "Records Office Secure Area";
+	hackProof = 1
 	},
 /turf/open/floor/facility/halls,
 /area/department_main/records)

--- a/_maps/map_files/Psi/psicorp.dmm
+++ b/_maps/map_files/Psi/psicorp.dmm
@@ -2986,7 +2986,8 @@
 /area/facility_hallway/discipline)
 "pZ" = (
 /obj/machinery/door/airlock/highsecurity{
-	name = "Lower Level Department"
+	name = "Lower Level Department";
+	hackProof = 1
 	},
 /turf/open/floor/facility/halls,
 /area/department_main/extraction)
@@ -8988,7 +8989,8 @@
 /area/facility_hallway/discipline)
 "VH" = (
 /obj/machinery/door/airlock/highsecurity{
-	name = "Records Office"
+	name = "Records Office";
+	hackProof = 1
 	},
 /turf/open/floor/facility/dark,
 /area/department_main/extraction)
@@ -9948,7 +9950,8 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/vault{
-	name = "Dont Touch Me containment zone"
+	name = "Dont Touch Me containment zone";
+	hackProof = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/department_main/extraction)

--- a/_maps/map_files/Theta/thetacorp.dmm
+++ b/_maps/map_files/Theta/thetacorp.dmm
@@ -701,7 +701,8 @@
 /obj/machinery/door/airlock{
 	icon = 'icons/obj/doors/airlocks/station/science.dmi';
 	max_integrity = 500;
-	name = "Information Department"
+	name = "Information Department";
+	hackProof = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 1
@@ -8465,6 +8466,13 @@
 	color = "#ccc8c0"
 	},
 /area/facility_hallway/information)
+"Dh" = (
+/obj/machinery/door/airlock/highsecurity{
+	name = "Records Office Secure Area";
+	hackProof = 1
+	},
+/turf/open/floor/facility/halls,
+/area/facility_hallway/command)
 "Dj" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -11470,6 +11478,16 @@
 /obj/structure/sign/ordealmonitor,
 /turf/open/floor/plasteel/dark,
 /area/facility_hallway/control)
+"Nj" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock{
+	icon = 'icons/obj/doors/airlocks/station/atmos.dmi';
+	name = "Central Command";
+	normal_integrity = 500;
+	hackProof = 1
+	},
+/turf/open/floor/facility/halls,
+/area/facility_hallway/command)
 "Nn" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -48017,7 +48035,7 @@ JE
 JE
 JE
 mt
-sS
+Nj
 Av
 NX
 ir
@@ -49053,7 +49071,7 @@ dW
 kH
 Jn
 xf
-lt
+Dh
 Oy
 ss
 lu

--- a/_maps/map_files/Xi/xicorp.dmm
+++ b/_maps/map_files/Xi/xicorp.dmm
@@ -3283,6 +3283,16 @@
 	},
 /turf/open/floor/plating,
 /area/facility_hallway/training)
+"yi" = (
+/obj/machinery/door/airlock/highsecurity{
+	name = "Training Department";
+	hackProof = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/facility/halls,
+/area/department_main/training)
 "yk" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/light/cold/no_nightlight{
@@ -5842,7 +5852,8 @@
 /area/department_main/command)
 "RF" = (
 /obj/machinery/door/airlock/highsecurity{
-	name = "Records Office Secure Area"
+	name = "Records Office Secure Area";
+	hackProof = 1
 	},
 /turf/open/floor/facility/halls,
 /area/department_main/training)
@@ -44341,7 +44352,7 @@ kO
 kO
 kO
 kO
-Rh
+yi
 kO
 kO
 kO

--- a/_maps/map_files/Zeta/zetacorp.dmm
+++ b/_maps/map_files/Zeta/zetacorp.dmm
@@ -494,7 +494,8 @@
 /area/department_main/information)
 "bH" = (
 /obj/machinery/door/airlock/glass{
-	icon = 'icons/obj/doors/airlocks/station/science.dmi'
+	icon = 'icons/obj/doors/airlocks/station/science.dmi';
+	hackProof = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -3922,7 +3923,8 @@
 /area/facility_hallway/east)
 "lg" = (
 /obj/machinery/door/airlock/highsecurity{
-	name = "Records Office Secure Area"
+	name = "Records Office Secure Area";
+	hackProof = 1
 	},
 /turf/open/floor/facility/halls,
 /area/facility_hallway/information)
@@ -10951,7 +10953,8 @@
 /obj/machinery/door/airlock{
 	icon = 'icons/obj/doors/airlocks/station/science.dmi';
 	max_integrity = 500;
-	name = "Information Department"
+	name = "Information Department";
+	hackProof = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4

--- a/code/modules/mob/living/simple_animal/abnormality/_tools/zayin/touch.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_tools/zayin/touch.dm
@@ -26,55 +26,57 @@
 		to_chat(user, span_userdanger("THE BUTTON REJECTS YOU."))
 		return
 
-	cooldown = world.time + 45 SECONDS // Spam prevention
+	cooldown = world.time + 60 SECONDS // Spam prevention
 	for(var/mob/M in GLOB.player_list)
 		to_chat(M, span_userdanger("[uppertext(user.real_name)] WILL PUSH DON'T TOUCH ME[round_end ? "" : " TO BREACH ABNORMALITIES"]."))
 
 	if(round_end)
-		SSpersistence.rounds_since_button_pressed = ROUNDCOUNT_BUTTON_PRESSED
-		for(var/obj/structure/sign/button_counter/sign as anything in GLOB.map_button_counters)
-			sign.update_count(ROUNDCOUNT_BUTTON_PRESSED)
+		bastards += user.ckey
 		RoundEndEffect(user)
 	else
+		breaching_bastards += user.ckey
 		BreachEffect(user)
 
 /obj/structure/toolabnormality/touch/proc/RoundEndEffect(mob/living/carbon/human/user)
-	bastards += user.ckey
-	if(do_after(user, 45 SECONDS))
-		SSticker.SetRoundEndSound('sound/abnormalities/donttouch/end.ogg')
-		SSticker.force_ending = 1
-		var/ending = pick(1,2)
-		switch(ending)
-			if(1)
-				for(var/mob/M in GLOB.player_list)
-					if(isnewplayer(M))
-						continue
-					flash_color(M, flash_color = COLOR_RED, flash_time = 150)
-					M.playsound_local(M, pick('sound/abnormalities/donttouch/kill.ogg', 'sound/abnormalities/donttouch/kill2.ogg'), 50, FALSE)
-					if(ishuman(M))
-						var/mob/living/carbon/human/H = M
-						H.gib()
-			if(2)
-				for(var/mob/M in GLOB.player_list)
-					if(isnewplayer(M))
-						continue
-					flash_color(M, flash_color = COLOR_RED, flash_time = 150)
-					M.playsound_local(M, 'sound/abnormalities/donttouch/panic.ogg', 50, FALSE)
-					if(ishuman(M))
-						var/mob/living/carbon/human/H = M
-						H.apply_damage(5000, WHITE_DAMAGE, null, null, spread_damage = TRUE)//You cannot escape.
-	else
-		user.gib() //lol, idiot.
+	if(!do_after(user, 60 SECONDS))
+		user.gib() // lol, idiot.
+		return
 
-/obj/structure/toolabnormality/touch/proc/BreachEffect(mob/living/carbon/human/user)
-	breaching_bastards += user.ckey
-	if(do_after(user, 45 SECONDS))
-		for(var/obj/structure/toolabnormality/clock/backclock in world.contents) //prevents an exploit
-			backclock.clock_cooldown = backclock.clock_cooldown_time + world.time
+	SSticker.SetRoundEndSound('sound/abnormalities/donttouch/end.ogg')
+	SSticker.force_ending = 1
+	SSpersistence.rounds_since_button_pressed = ROUNDCOUNT_BUTTON_PRESSED
+	for(var/obj/structure/sign/button_counter/sign as anything in GLOB.map_button_counters)
+		sign.update_count(ROUNDCOUNT_BUTTON_PRESSED)
+
+	if(prob(50)) // Randomly choose to eighter gib or insane everyone
 		for(var/mob/M in GLOB.player_list)
 			if(isnewplayer(M))
 				continue
-			flash_color(M, flash_color = COLOR_RED, flash_time = 30)
-			M.playsound_local(M, 'sound/abnormalities/donttouch/breach.ogg', 50, FALSE)
-		for(var/datum/abnormality/A in SSlobotomy_corp.all_abnormality_datums)
-			A.qliphoth_change(-A.qliphoth_meter) // Down to 0
+			flash_color(M, flash_color = COLOR_RED, flash_time = 150)
+			M.playsound_local(M, pick('sound/abnormalities/donttouch/kill.ogg', 'sound/abnormalities/donttouch/kill2.ogg'), 50, FALSE)
+			if(ishuman(M))
+				var/mob/living/carbon/human/H = M
+				H.gib()
+	else
+		for(var/mob/M in GLOB.player_list)
+			if(isnewplayer(M))
+				continue
+			flash_color(M, flash_color = COLOR_RED, flash_time = 150)
+			M.playsound_local(M, 'sound/abnormalities/donttouch/panic.ogg', 50, FALSE)
+			if(ishuman(M))
+				var/mob/living/carbon/human/H = M
+				H.apply_damage(5000, WHITE_DAMAGE, null, null, spread_damage = TRUE) // You cannot escape.
+
+/obj/structure/toolabnormality/touch/proc/BreachEffect(mob/living/carbon/human/user)
+	if(!do_after(user, 60 SECONDS))
+		return
+
+	for(var/obj/structure/toolabnormality/clock/backclock in world.contents) //prevents an exploit
+		backclock.clock_cooldown = backclock.clock_cooldown_time + world.time
+	for(var/mob/M in GLOB.player_list)
+		if(isnewplayer(M))
+			continue
+		flash_color(M, flash_color = COLOR_RED, flash_time = 30)
+		M.playsound_local(M, 'sound/abnormalities/donttouch/breach.ogg', 50, FALSE)
+	for(var/datum/abnormality/A in SSlobotomy_corp.all_abnormality_datums)
+		A.qliphoth_change(-A.qliphoth_meter) // Down to 0


### PR DESCRIPTION

## About The Pull Request

- Buttoning now takes 60 seconds instead of 45
- The button counter:tm: now only resets after you button, instead of when you start attempting to harm button
- Vendors now cannot be un-wrenched from the floor
- Dont touch me and records doors were given the unhackable flag

## Why It's Good For The Game

> Buttoning now takes 60 seconds instead of 45
- I like a rounder number, should be that way imo
> The button counter:tm: now only resets after you button, instead of when you start attempting to harm button
- Always was meant to be that way, but i couldn't be bothered to earlier. This PR was a nice opportunity to fix it
> Vendors now cannot be un-wrenched from the floor
- Yeah no, lets not do that
> Dont touch me and records doors were given the unhackable flag
- You can destroy the doors, but it takes a while. Now you cannot hack the button doors directly nor the records doors leading to them, some doors in the departments where the button rests also got this flag (for example, 2 disposal doors) so its easier to get to the button aswell

## Changelog
:cl:
balance: The button is now takes 60 seconds instead of 45 to activate, the button was given several more safety measures
/:cl:
