### PR TITLE
[RCA] 5th Pack Rat Buff

### DIFF
--- a/code/modules/jobs/job_types/rcorp/fifthpack/rat.dm
+++ b/code/modules/jobs/job_types/rcorp/fifthpack/rat.dm
@@ -83,10 +83,13 @@
 	head = /obj/item/clothing/head/rabbit_helmet/rat
 	suit = /obj/item/clothing/suit/armor/ego_gear/rabbit/rat
 	belt = /obj/item/ego_weapon/city/rabbit_blade
-	suit_store = /obj/item/gun/energy/e_gun/rabbitdash/small
+	suit_store = /obj/item/gun/energy/e_gun/rabbitdash/shotgun
 	l_pocket = /obj/item/flashlight/seclite
 	r_pocket = /obj/item/pinpointer/nuke/rcorp
 	backpack_contents = list(
+		/obj/item/grenade/r_corp,
+		/obj/item/grenade/r_corp/black,
+		/obj/item/grenade/r_corp/white,
 		/obj/item/storage/firstaid/revival = 1)
 
 


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Added 1 red, 1 black, and 1 white grenade to the Rat's backpack.

Swapped R-corp rat's pistol to the shotgun.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The shotgun was obliterated due to lag.
They are buffed as they were intentionally made
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Added 1 red, 1 black, and 1 white grenade to the Rat's Backpack
balance: Swapped R-corp rat's pistol to the shotgun.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
