### PR TITLE
Fixes the moon expanding infinitelly, eventually consuming the entire sky and all the stars

### DIFF
--- a/ModularTegustation/fishing/code/fish_market.dm
+++ b/ModularTegustation/fishing/code/fish_market.dm
@@ -83,7 +83,7 @@
 
 /obj/machinery/fish_market/attackby(obj/item/I, mob/user, params)
 	if(SSfishing.IsAligned(/datum/planet/uranus))
-		to_chat(usr, span_notice("Uranus is aligned with earth. All fish points are increaed by 1.5x"))
+		to_chat(user, span_notice("Uranus is aligned with earth. All fish point output increased by 1.5x"))
 	if(istype(I, /obj/item/stack/fish_points))
 		var/obj/item/stack/fish_points/more_points = I
 		AdjustPoints(more_points.amount)

--- a/ModularTegustation/fishing/code/fishing_items/fishing_rod.dm
+++ b/ModularTegustation/fishing/code/fishing_items/fishing_rod.dm
@@ -189,7 +189,7 @@
 			to_chat(user, span_nicegreen("[FISHGOD_MERCURY] smiles upon you!."))
 
 		if(user.god_aligned == FISHGOD_MERCURY)
-			size_modifier*=2
+			size_modifier *= 2
 
 		fishie.randomize_weight_and_size(size_modifier)
 
@@ -198,7 +198,8 @@
 			new /obj/item/stack/spacecash/c50(get_turf(user))
 
 		if(CheckPlanetAligned(FISHGOD_SATURN))
-			to_chat(user, span_nicegreen("Saturn is in alignment. You feel like better for fishing."))
+			var/list/possible_messages = list("Your mind feels clearer after fishing.", "You feel relaxed in [FISHGOD_SATURN]'s light.")
+			to_chat(user, span_nicegreen("Saturn is in alignment. [pick(possible_messages)]"))
 			user.adjustSanityLoss(-5)
 
 		to_chat(user, span_nicegreen("You caught [fishie.name]."))

--- a/code/controllers/subsystem/fishing.dm
+++ b/code/controllers/subsystem/fishing.dm
@@ -31,6 +31,9 @@ SUBSYSTEM_DEF(fishing)
 /datum/controller/subsystem/fishing/proc/Moveplanets()
 	addtimer(CALLBACK(src, PROC_REF(Moveplanets)), 7 MINUTES)
 	moonphase++
+	if(moonphase == 5)
+		moonphase = 1
+
 	if(stopnext && moonphase != 4)
 		for(var/mob/M in GLOB.player_list)
 			to_chat(M, span_userdanger("The planets begin to move again."))


### PR DESCRIPTION

## About The Pull Request

So yeah, when i was de-hardcoding all the planets i considered making a moon into one of the de-hardcoded planets but eventually it stayed as a SSfishing variable due to no need for de-hardcoding and it having unique mechanics to itself
And nobody caught that it never actually stopped increasing its phase in code after my PR... Truly amazing.

- Fixes the moon endlessly expanding, eventually consuming the entire sky and all the stars
- Fixed the spelling, and changed it on the fishmarket saturn alignement buff from "All fish points are increaed by 1.5x" to "All fish point output increased by 1.5x"
- Fixed the slightly weird message of "Saturn is in alignment. You feel like better for fishing.", changing it into a list of 2 possible messages "Your mind feels clearer after fishing." and "You feel relaxed in [FISHGOD_SATURN]'s light."

## Why It's Good For The Game

> Fixes the moon endlessly expanding, eventually consuming the entire sky and all the stars
- The economy will never recover from this, holy fucking fish
> Fixed the spelling, and changed it on the fishmarket saturn alignement buff from "All fish points are increaed by 1.5x" to "All fish point output increased by 1.5x"
- Spellcheck my beloved
> Fixed the slightly weird message of "Saturn is in alignment. You feel like better for fishing.", changing it into a list of 2 possible messages "Your mind feels clearer after fishing." and "You feel relaxed in [FISHGOD_SATURN]'s light."
- Weirdcheck my beloved

## Changelog
:cl:
fix: Fixed the moon never resetting its phases, leading it to eventually consume everything as it endlessly expanded and make lunar rods overpowered
spellcheck: fixed a few typos
/:cl:
