### PR TITLE
Cleanbots no longer disarm employees of their EGO

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/cleanbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/cleanbot.dm
@@ -198,9 +198,7 @@
 		if(istype(W, /obj/item/ego_weapon))
 			var/obj/item/ego_weapon/EW = W
 			if(!EW.CanUseEgo(src))
-				to_chat(user, span_notice("You try attaching \the [W] to \the [src]... but it falls off!"))
-				user.dropItemToGround(EW)
-				EW.forceMove(get_turf(src))
+				to_chat(user, span_notice("You try attaching \the [W] to \the [src]... but it refuses to stay on!"))
 				return FALSE
 		to_chat(user, span_notice("You start attaching \the [W] to \the [src]..."))
 		if(do_after(user, 25, target = src))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Attempting to attach EGO too strong for a cleanbot to use simply fails and no longer causes it to forcedrop.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Stop me if you've heard this before. You're fighting an abno/ordeal with a HE or better weapon when a cleanbot crosses your path and you click it by accident whilst on help intent - suddenly you're trying to poke the monster to death as the cleanbot just robbed you of your weapon, which is now laying on the floor.
Now, no longer will you have to duck and weave WhiteNight's apostles because a passing cleanbot robbed you of your Mimicry.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: EGO that is too strong for cleanbots to use simply fails to attach, rather than forcefully drops it on the floor.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
