### PR TITLE
Make the porta copier and portable prediction device smaller

### DIFF
--- a/ModularTegustation/tegu_items/gadgets/unpowered.dm
+++ b/ModularTegustation/tegu_items/gadgets/unpowered.dm
@@ -44,6 +44,8 @@
 	icon = 'ModularTegustation/Teguicons/teguitems.dmi'
 	icon_state = "gadget3"
 	var/paperstock = 1
+	w_class = WEIGHT_CLASS_SMALL
+	slot_flags = ITEM_SLOT_BELT | ITEM_SLOT_POCKETS
 
 /obj/item/portacopier/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/paper))
@@ -103,6 +105,8 @@
 		Needs to be recharged at a printer."
 	icon = 'ModularTegustation/Teguicons/teguitems.dmi'
 	icon_state = "gadget3"
+	w_class = WEIGHT_CLASS_SMALL
+	slot_flags = ITEM_SLOT_BELT | ITEM_SLOT_POCKETS
 	var/mob/living/simple_animal/hostile/abnormality/target_abno
 	var/mob/living/carbon/human/target_agent
 	var/print_charges = 1


### PR DESCRIPTION
## About The Pull Request
RO unique tools (specifically the copier and prediction device) are now small items and fit in the belt and pockets

## Why It's Good For The Game
RO already have to carry around the watches, the copier and prediction device took even more space, leaving basically no usable backpack space.
