### PR TITLE
Fixes round-end not auto-triggering when a player dies on combat maps because of pinocchio + R-corp round-end improvements

### DIFF
--- a/ModularTegustation/tegu_items/rcorp/objective.dm
+++ b/ModularTegustation/tegu_items/rcorp/objective.dm
@@ -162,19 +162,24 @@ GLOBAL_VAR_INIT(rcorp_payload, null)
 		light_on = FALSE
 		update_light()
 
-		//Round End Effects
-		SSticker.SetRoundEndSound('sound/abnormalities/donttouch/end.ogg')
-		SSticker.force_ending = 1
-		for(var/mob/M in GLOB.player_list)
-			to_chat(M, span_userdanger("[uppertext(user.real_name)] has collected the bough!"))
+		if(!SSticker.force_ending)
+			//Round End Effects
+			SSticker.SetRoundEndSound('sound/abnormalities/donttouch/end.ogg')
+			SSticker.force_ending = 1
+			for(var/mob/M in GLOB.player_list)
+				to_chat(M, span_userdanger("[uppertext(user.real_name)] has collected the bough!"))
 
-			switch(GLOB.rcorp_wincondition)
-				if(0)
-					to_chat(M, span_userdanger("R-CORP MAJOR VICTORY."))
-				if(1)
-					to_chat(M, span_userdanger("R-CORP MINOR VICTORY."))
-				if(2)
-					to_chat(M, span_userdanger("R-CORP SUPREME VICTORY."))
+				switch(GLOB.rcorp_wincondition)
+					if(0)
+						to_chat(M, span_userdanger("R-CORP MAJOR VICTORY."))
+					if(1)
+						to_chat(M, span_userdanger("R-CORP MINOR VICTORY."))
+					if(2)
+						to_chat(M, span_userdanger("R-CORP SUPREME VICTORY."))
+		else
+			var/turf/turf = get_turf(src)
+			new /obj/effect/decal/cleanable/confetti(turf)
+			playsound(turf, 'sound/misc/sadtrombone.ogg', 100)
 
 	else
 		user.gib() //lol, idiot.
@@ -191,11 +196,16 @@ GLOBAL_VAR_INIT(rcorp_payload, null)
 
 
 /mob/living/simple_animal/hostile/shrimp_vip/death(gibbed)
-	for(var/mob/M in GLOB.player_list)
-		to_chat(M, span_userdanger("THE VIP HAS BEEN SLAIN."))
-		to_chat(M, span_userdanger("R-CORP MAJOR VICTORY."))
-	SSticker.force_ending = 1
-	..()
+	if(!SSticker.force_ending)
+		for(var/mob/M in GLOB.player_list)
+			to_chat(M, span_userdanger("THE VIP HAS BEEN SLAIN."))
+			to_chat(M, span_userdanger("R-CORP MAJOR VICTORY."))
+		SSticker.force_ending = 1
+	else
+		var/turf/turf = get_turf(src)
+		new /obj/effect/decal/cleanable/confetti(turf)
+		playsound(turf, 'sound/misc/sadtrombone.ogg', 100)
+	return ..()
 
 //Arbiter
 /obj/effect/mob_spawn/human/arbiter/rcorp

--- a/ModularTegustation/tegu_items/rcorp/objective.dm
+++ b/ModularTegustation/tegu_items/rcorp/objective.dm
@@ -239,15 +239,15 @@ GLOBAL_VAR_INIT(rcorp_payload, null)
 	resistance_flags &= ~INDESTRUCTIBLE
 
 /obj/structure/rcorpcomms/deconstruct(disassembled = TRUE)
-	for(var/mob/M in GLOB.player_list)
-		to_chat(M, span_userdanger("RCORP'S COMMUNICATIONS HAVE BEEN DESTROYED."))
-		switch(GLOB.rcorp_wincondition)
-			if(0)
-				to_chat(M, span_userdanger("ABNORMALITY MAJOR VICTORY."))
-			if(1)
-				to_chat(M, span_userdanger("ABNORMALITY SUPREME VICTORY."))
-			if(2)
-				to_chat(M, span_userdanger("ABNORMALITY MINOR VICTORY."))
-	SSticker.force_ending = 1
-	..()
-
+	if(!SSticker.force_ending)
+		for(var/mob/M in GLOB.player_list)
+			to_chat(M, span_userdanger("RCORP'S COMMUNICATIONS HAVE BEEN DESTROYED."))
+			switch(GLOB.rcorp_wincondition)
+				if(0)
+					to_chat(M, span_userdanger("ABNORMALITY MAJOR VICTORY."))
+				if(1)
+					to_chat(M, span_userdanger("ABNORMALITY SUPREME VICTORY."))
+				if(2)
+					to_chat(M, span_userdanger("ABNORMALITY MINOR VICTORY."))
+		SSticker.force_ending = 1
+	return ..()

--- a/ModularTegustation/tegu_items/rcorp/objective.dm
+++ b/ModularTegustation/tegu_items/rcorp/objective.dm
@@ -250,4 +250,8 @@ GLOBAL_VAR_INIT(rcorp_payload, null)
 				if(2)
 					to_chat(M, span_userdanger("ABNORMALITY MINOR VICTORY."))
 		SSticker.force_ending = 1
+	else
+		var/turf/turf = get_turf(src)
+		new /obj/effect/decal/cleanable/confetti(turf)
+		playsound(turf, 'sound/misc/sadtrombone.ogg', 100)
 	return ..()

--- a/code/game/gamemodes/management/event/combat.dm
+++ b/code/game/gamemodes/management/event/combat.dm
@@ -89,7 +89,7 @@ GLOBAL_VAR_INIT(wcorp_enemy_faction, "") //decides which faction WCorp will be u
 /// Automatically ends the shift if no humanoid players are alive
 /datum/game_mode/combat/proc/CheckLiving()
 	for(var/mob/living/carbon/human/hooman in GLOB.human_list)
-		if(hooman.stat != DEAD && hooman.ckey)
+		if(hooman.stat != DEAD && hooman.ckey && !istype(hooman, /mob/living/carbon/human/species/pinocchio))
 			return
 
 	if(SSticker.force_ending == TRUE) // they lost another way before we could do it, how rude.
@@ -134,7 +134,7 @@ GLOBAL_VAR_INIT(wcorp_enemy_faction, "") //decides which faction WCorp will be u
 //Gamemode stuff
 /datum/game_mode/combat/proc/counterincrease()
 	addtimer(CALLBACK(src, PROC_REF(counterincrease)), 1 MINUTES)
-	GLOB.combat_counter+=1
+	GLOB.combat_counter++
 	if(SSmaptype.maptype == "wcorp")
 		for(var/mob/living/carbon/human/H in GLOB.human_list)
 			if(H.stat == DEAD)


### PR DESCRIPTION
## About The Pull Request

- Makes Pinocchio no longer hold the round hostage by preventing round-end from triggering when all R-corp members die
- Makes getting any R-corp objective at round-end make some confetti instead of giving a big red text

## Why It's Good For The Game

> Makes Pinocchio no longer hold the round hostage by preventing round-end from triggering when all R-corp members die
- Yeah, thats a thing
> Makes getting any R-corp objective at round-end make some confetti instead of giving a big red text
- Round's already over, sadly you cannot get an R-corp victory when you've already lost

## Changelog
:cl:
fix: Pinocchio no longer stops round restarts
/:cl:
