### PR TITLE
Barefoot no longer heals

### DIFF
--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -891,13 +891,15 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_name = "Barefoot"
 	glass_desc = "Barefoot and pregnant."
 
+/* LOBOTOMYCORPORATION REMOVAL
 /datum/reagent/consumable/ethanol/barefoot/on_mob_life(mob/living/carbon/M)
 	if(ishuman(M)) //Barefoot causes the imbiber to quickly regenerate brute trauma if they're not wearing shoes.
 		var/mob/living/carbon/human/H = M
 		if(!H.shoes)
-			H.adjustBruteLoss(0, 0)
+			H.adjustBruteLoss(-3, 0)
 			. = 1
 	return ..() || .
+*/
 
 /datum/reagent/consumable/ethanol/snowwhite
 	name = "Snow White"

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -895,7 +895,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	if(ishuman(M)) //Barefoot causes the imbiber to quickly regenerate brute trauma if they're not wearing shoes.
 		var/mob/living/carbon/human/H = M
 		if(!H.shoes)
-			H.adjustBruteLoss(-3, 0)
+			H.adjustBruteLoss(0, 0)
 			. = 1
 	return ..() || .
 
@@ -1957,7 +1957,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	generate_data_info(data)
 
 /datum/reagent/consumable/ethanol/fruit_wine/proc/generate_data_info(list/data)
-	var/const/minimum_percent = 0.15 
+	var/const/minimum_percent = 0.15
 	var/const/notable_percent = minimum_percent * 2
 	var/list/primary_tastes = list()
 	var/list/secondary_tastes = list()


### PR DESCRIPTION
## About The Pull Request

Removed the healing component of Barefoot

## Why It's Good For The Game

Barefoot healing always felt super gamey. Healing available outside of main rooms is limited for a reason, and ESPECIALLY for safety core, this straight up trivialize half of it.

## Changelog
:cl:
balance: Barefoot no longer heals.
/:cl:

