### PR TITLE
Fixes bone hooks giving endless fishing points

### DIFF
--- a/ModularTegustation/fishing/code/fish_market.dm
+++ b/ModularTegustation/fishing/code/fish_market.dm
@@ -103,14 +103,15 @@
 		var/obj/item/storage/bag/fish/bag = I
 		var/fish_value = 0
 		for(var/item in bag.contents)
+			if(istype(item, /obj/item/stack/fish_points))
+				continue
+
 			if(istype(item, /obj/item/fishing_component/hook/bone))
 				fish_value += 5
 
 			if(istype(item, /obj/item/food/fish))
 				fish_value += ValueFish(item)
 
-			else
-				continue
 			qdel(item)
 
 		AdjustPoints(fish_value)


### PR DESCRIPTION

## About The Pull Request

Yeah the `else` in that statement made them not delete, now they do

## Why It's Good For The Game

Nothing is infinite in this universe

## Changelog
:cl:
fix: bone hooks are now properly sold to fish markets inside of fish bags
/:cl:
