### PR TITLE
Better brown dawn

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/ordeal/brown/dawn.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/brown/dawn.dm
@@ -7,11 +7,11 @@
 	icon_living = "sinrock"
 	icon_dead = "sin_dead"
 	faction = list("brown_ordeal")
-	maxHealth = 200
-	health = 200
+	maxHealth = 80
+	health = 80
 	melee_damage_type = BLACK_DAMAGE
-	melee_damage_lower = 14
-	melee_damage_upper = 24
+	melee_damage_lower = 9
+	melee_damage_upper = 15
 	attack_verb_continuous = "bashes"
 	attack_verb_simple = "bashes"
 	attack_sound = 'sound/effects/ordeals/brown/rock_attack.ogg'
@@ -20,146 +20,67 @@
 	butcher_results = list(/obj/item/food/meat/slab/human/mutant/golem = 1)
 	guaranteed_butcher_results = list(/obj/item/food/meat/slab/human/mutant/golem = 1)
 	ranged = TRUE
-	var/list/movement_path = list()
-	var/list/been_hit = list()
-	var/charging = FALSE
-	var/charging_cooldown
-	var/charging_cooldown_time = 8 SECONDS //apparantly charge is already used in /hostile.dm
-	var/charge_damage = 20
-	/// Delay between each subsequent move when charging
-	var/charge_speed = 1
-	/// How many paths do we create between several landmarks?
-	var/charge_nodes = 3
-	/// Maximum AStar pathfinding distances from one point to another
-	var/charge_max_distance = 40
+	move_to_delay = 8
 	var/dash_cooldown_time = 15 SECONDS //will dash at people if they get out of range but not too often
 	var/dash_cooldown
+	var/can_act = TRUE
+	var/jump_range = 7
+	var/jump_aoe = 1
+	var/jump_damage = 20
 
-/mob/living/simple_animal/hostile/ordeal/sin_sloth/Life()
+/mob/living/simple_animal/hostile/ordeal/sin_sloth/AttackingTarget(atom/attacked_target)
+	if(!can_act)
+		return
 	. = ..()
-	if(.)
-		if((charging_cooldown <= world.time) && prob(15))
-			ChargeStart()
 
 /mob/living/simple_animal/hostile/ordeal/sin_sloth/OpenFire()
-	if(!target || charging)
+	if(!target)
 		return
 	Dash(target)
 
 /mob/living/simple_animal/hostile/ordeal/sin_sloth/Move()
-	return FALSE
+	if(!can_act)
+		return FALSE
+	. = ..()
+	if(.)
+		var/para = TRUE
+		if(dir in list(WEST, NORTHWEST, SOUTHWEST))
+			para = FALSE
+		SpinAnimation(6, 1, para)
 
 /mob/living/simple_animal/hostile/ordeal/sin_sloth/proc/Dash(mob/living/target)
 	if(!istype(target))
 		return
 	var/dist = get_dist(target, src)
-	if(dist > 2 && dash_cooldown < world.time)
+	if(dist > 2 && dash_cooldown < world.time && dist < jump_range)
+		can_act = FALSE
 		var/list/dash_line = getline(src, target)
+		animate(src, pixel_y = (base_pixel_y + 30), time = 2)
+		playsound(src, 'sound/effects/ordeals/brown/rock_kill.ogg', 50, FALSE, 4)
 		for(var/turf/line_turf in dash_line) //checks if there's a valid path between the turf and the target
 			if(line_turf.is_blocked_turf(exclude_mobs = TRUE))
 				break
 			forceMove(line_turf)
-			SLEEP_CHECK_DEATH(0.8)
-		playsound(src, 'sound/effects/ordeals/brown/rock_runover.ogg', 50, FALSE, 4)
-		dash_cooldown = world.time + dash_cooldown_time
-
-/mob/living/simple_animal/hostile/ordeal/sin_sloth/proc/ChargeStart(target)
-	if(charging || charging_cooldown > world.time)
-		return
-	charging = TRUE
-	movement_path = list()
-	var/list/initial_turfs = GLOB.xeno_spawn.Copy() + GLOB.department_centers.Copy()
-	var/list/potential_turfs = list()
-	for(var/turf/open/T in initial_turfs)
-		if(get_dist(src, T) > 3)
-			potential_turfs += T
-	for(var/mob/living/L in livinginrange(32, src))
-		if(prob(50))
-			continue
-		if((L.status_flags & GODMODE) || faction_check_mob(L))
-			continue
-		if(L.stat == DEAD)
-			continue
-		if(ishuman(L))
-			var/mob/living/carbon/human/H = L
-			if(H.is_working)
-				continue
-		potential_turfs += get_turf(L)
-	var/turf/picking_from = get_turf(src)
-	var/turf/path_start = get_turf(src)
-	if(target)
-		var/turf/open/target_turf = get_turf(target)
-		if(istype(target_turf))
-			picking_from = target_turf
-			potential_turfs |= target_turf
-		face_atom(target)
-	for(var/i = 1 to charge_nodes)
-		if(!LAZYLEN(potential_turfs))
-			break
-		var/turf/T = get_closest_atom(/turf/open, potential_turfs, picking_from)
-		if(!T)
-			break
-		var/list/our_path = list()
-		for(var/o = 1 to 3) // Grand total of 3 retries
-			our_path = get_path_to(path_start, T, TYPE_PROC_REF(/turf, Distance_cardinal), charge_max_distance)
-			if(islist(our_path) && LAZYLEN(our_path))
-				break
-			potential_turfs -= T // Couldn't find path to it, don't try again
-			if(!LAZYLEN(potential_turfs))
-				break
-			T = get_closest_atom(/turf/open, potential_turfs, picking_from)
-		if(!islist(our_path) || !LAZYLEN(our_path))
-			continue
-		movement_path += our_path
-		picking_from = T
-		path_start = T
-		potential_turfs -= T
-	if(!LAZYLEN(movement_path))
-		return FALSE
-	playsound(src, 'sound/effects/ordeals/brown/rock_runover.ogg', 50, TRUE, 7)
-	for(var/turf/T in movement_path) // Warning before charging
-		new /obj/effect/temp_visual/mustardgas(T)
-	SLEEP_CHECK_DEATH(18)
-	been_hit = list()
-	SpinAnimation(3, 10)
-	for(var/turf/T in movement_path)
-		if(QDELETED(T))
-			break
-		if(!Adjacent(T))
-			break
-		ChargeAt(T)
-		SLEEP_CHECK_DEATH(charge_speed)
-	charging = FALSE
-	icon_state = icon_living
-	charging_cooldown = world.time + charging_cooldown_time
-
-/mob/living/simple_animal/hostile/ordeal/sin_sloth/proc/ChargeAt(turf/T)
-	face_atom(T)
-	for(var/obj/structure/window/W in T.contents)
-		W.obj_destruction("teeth")
-	for(var/obj/machinery/door/D in T.contents)
-		if(D.density)
-			addtimer(CALLBACK (D, TYPE_PROC_REF(/obj/machinery/door, open)))
-	forceMove(T)
-	if(prob(33))
-		playsound(T, 'sound/effects/ordeals/brown/rock_attack.ogg', 10, TRUE, 3)
-	for(var/turf/TF in view(1, T))
-		new /obj/effect/temp_visual/mustardgas(TF)
-		for(var/mob/living/L in TF)
-			if(!faction_check_mob(L))
-				if(L in been_hit)
+			SLEEP_CHECK_DEATH(0.4)
+		addtimer(CALLBACK(src, PROC_REF(AnimateBack)), 8)
+		SLEEP_CHECK_DEATH(10)
+		for(var/turf/T in view(1, src))
+			new /obj/effect/temp_visual/mustardgas(T)
+			for(var/mob/living/L in T)
+				if(faction_check_mob(L))
 					continue
-				L.visible_message(span_warning("[src] rams [L]!"), span_boldwarning("[src] rams into you!"))
-				L.apply_damage(charge_damage, BLACK_DAMAGE, null, L.run_armor_check(null, RED_DAMAGE), spread_damage = TRUE)
-				new /obj/effect/temp_visual/cleave(get_turf(L))
-				playsound(L, 'sound/effects/ordeals/brown/rock_kill.ogg', 50, TRUE)
+				L.deal_damage(jump_damage, BLACK_DAMAGE)
 				if(L.health < 0)
 					L.gib()
-				if(!QDELETED(L))
-					been_hit += L
-					if(ishuman(L))
-						var/mob/living/carbon/human/H = L
-						H.Knockdown(4)
+			for(var/obj/vehicle/sealed/mecha/V in T)
+				V.take_damage(jump_damage, BLACK_DAMAGE)
+		can_act = TRUE
+		dash_cooldown = world.time + dash_cooldown_time
+
+
+/mob/living/simple_animal/hostile/ordeal/sin_sloth/proc/AnimateBack()
+	animate(src, pixel_y = base_pixel_y, time = 2)
+	return TRUE
 
 /mob/living/simple_animal/hostile/ordeal/sin_gluttony
 	name = "Peccatulum Gulae"
@@ -169,8 +90,8 @@
 	icon_living = "sinflower"
 	icon_dead = "sin_dead"
 	faction = list("brown_ordeal")
-	maxHealth = 150
-	health = 150
+	maxHealth = 80
+	health = 80
 	melee_damage_type = RED_DAMAGE
 	rapid_melee = 3
 	melee_damage_lower = 4
@@ -226,12 +147,11 @@
 	icon_living = "sinflea"
 	icon_dead = "flea_dead"
 	faction = list("brown_ordeal")
-	maxHealth = 200
-	health = 200
+	maxHealth = 80
+	health = 80
 	melee_damage_type = WHITE_DAMAGE
-	rapid_melee = 2
-	melee_damage_lower = 14
-	melee_damage_upper = 14
+	melee_damage_lower = 35
+	melee_damage_upper = 45
 	attack_verb_continuous = "bashes"
 	attack_verb_simple = "bashes"
 	attack_sound = 'sound/effects/ordeals/brown/flea_attack.ogg'
@@ -241,27 +161,49 @@
 	guaranteed_butcher_results = list(/obj/item/food/meat/slab/human/mutant/slime = 1)
 	is_flying_animal = TRUE
 	ranged = TRUE
+	ranged_cooldown_time = 5 SECONDS // Fires a laser dealing 10 white damage
 	minimum_distance = 2 // Don't move all the way to melee
 	projectiletype = /obj/projectile/beam/water_jet
 	projectilesound = 'sound/effects/ordeals/brown/flea_attack.ogg'
+	var/can_act = TRUE
 
-/mob/living/simple_animal/hostile/ordeal/sin_gloom/MeleeAction()
-	if(health <= maxHealth*0.5 && stat != DEAD)
-		walk_to(src, 0)
-		animate(src, transform = matrix()*1.8, time = 15)
-		addtimer(CALLBACK(src, PROC_REF(DeathExplosion)), 15)
-	..()
+/mob/living/simple_animal/hostile/ordeal/sin_gloom/Move()
+	if(!can_act)
+		return FALSE
+	return ..()
 
-/mob/living/simple_animal/hostile/ordeal/sin_gloom/proc/DeathExplosion()
-	if(QDELETED(src))
-		return
+/mob/living/simple_animal/hostile/ordeal/sin_gloom/OpenFire()
+	if(!can_act)
+		return FALSE
+	return ..()
+
+/mob/living/simple_animal/hostile/ordeal/sin_gloom/AttackingTarget(atom/attacked_target)
+	if(!can_act)
+		return FALSE
+	. = AreaAttack()
+
+/mob/living/simple_animal/hostile/ordeal/sin_gloom/proc/AreaAttack()
+	set waitfor = FALSE
+	changeNext_move(SSnpcpool.wait / rapid_melee) //Prevents attack spam
+	animate(src, transform = matrix()*1.4, time = 16)
+	can_act = FALSE
+	SLEEP_CHECK_DEATH(16)
+	var/obj/effect/temp_visual/decoy/D = new /obj/effect/temp_visual/decoy(get_turf(src), src)
+	animate(D, alpha = 0, transform = matrix()*1.6, time = 5)
 	visible_message(span_danger("[src] suddenly explodes!"))
-	playsound(loc, 'sound/effects/ordeals/brown/tentacle_explode.ogg', 60, TRUE)
-	new /obj/effect/temp_visual/explosion(get_turf(src))
-	for(var/mob/living/L in viewers(2, src))
-		L.apply_damage(40, WHITE_DAMAGE, null, L.run_armor_check(null, WHITE_DAMAGE))
+	playsound(loc, 'sound/abnormalities/ichthys/hardslap.ogg', 60, TRUE)
+	var/damage_dealt = rand(melee_damage_lower, melee_damage_upper)
+	for(var/turf/T in view(2, src))
+		new /obj/effect/temp_visual/small_smoke/halfsecond(T)
+		for(var/mob/living/L in T)
+			if(faction_check_mob(L))
+				continue
+			L.deal_damage(damage_dealt, melee_damage_type)
+		for(var/obj/vehicle/sealed/mecha/V in T)
+			V.take_damage(damage_dealt, melee_damage_type)
 	animate(src, transform = matrix(), time = 0)
-	death()
+	SLEEP_CHECK_DEATH(8)
+	can_act = TRUE
 
 /mob/living/simple_animal/hostile/ordeal/sin_pride
 	name = "Peccatulum Superbiae"
@@ -273,8 +215,8 @@
 	icon_living = "sinwheel"
 	icon_dead = "sin_dead"
 	faction = list("brown_ordeal")
-	maxHealth = 100
-	health = 100
+	maxHealth = 80
+	health = 80
 	melee_damage_type = RED_DAMAGE
 	rapid_melee = 2
 	melee_damage_lower = 7
@@ -387,7 +329,7 @@
 
 /mob/living/simple_animal/hostile/ordeal/sin_lust //Tank that is resistant to bullets
 	name = "Peccatulum Luxuriae"
-	desc = "It looks like a creature made of lumps of flesh. It looks eagar to devour human flesh."
+	desc = "A creature made of lumps of flesh. It looks eagar to devour human flesh."
 	icon = 'ModularTegustation/Teguicons/64x32.dmi'
 	icon_state = "sincromer"
 	icon_living = "sincromer"
@@ -439,8 +381,8 @@
 	pixel_x = -8
 	base_pixel_x = -8
 	faction = list("brown_ordeal")
-	maxHealth = 150
-	health = 150
+	maxHealth = 80
+	health = 80
 	melee_damage_type = RED_DAMAGE
 	rapid_melee = 2
 	melee_damage_lower = 2
@@ -482,7 +424,7 @@
 
 /atom/movable/screen/alert/status_effect/fuming
 	name = "Fuming Wrath"
-	desc = "You feel so angry that your head might explode! You take additional BURN damage whenever you are hurt, which is reduced by WHITE armor."
+	desc = "You feel so angry that your head might explode! You take additional BURN damage whenever you are hurt, which is reduced by RED armor."
 	icon = 'ModularTegustation/Teguicons/status_sprites.dmi'
 	icon_state = "sin_wrath"
 
@@ -510,6 +452,6 @@
 	if(damagetype == BURN)
 		return
 	var/damage_amt = ((damage/100) * (stacks * 10)) //10-200% of damage taken is dealt as additional burn
-	H.apply_damage(damage_amt, BURN, blocked = H.run_armor_check(null, WHITE_DAMAGE), spread_damage = TRUE) //Damage reduced by white armor
+	H.apply_damage(damage_amt, BURN, blocked = H.run_armor_check(null, RED_DAMAGE), spread_damage = TRUE) //Damage reduced by red armor
 
 #undef STATUS_EFFECT_FUMING


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Reduces the HP of stage 1 peccatulum by roughly half across the board, reworks sloth/gloom to play better with other gamemodes and to make it a better fit for the later ordeals. Also contains some visual and audio updates for sloth and gloom peccatulum.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I actually have a plan for the harder versions of this ordeal now, and this is more in line with that plan. Also, this should be a bit more in line with the other dawns in terms of difficulty now.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: made sloth peccatulum fight a bit differently
balance: made the brown dawn ordeal a bit easier
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
