### PR TITLE
In the name of Love and Hate healing is now a flat number

### DIFF
--- a/ModularTegustation/ego_weapons/ranged/ego_bullets/waw.dm
+++ b/ModularTegustation/ego_weapons/ranged/ego_bullets/waw.dm
@@ -28,12 +28,12 @@
 				return BULLET_ACT_BLOCK
 			switch(damage_type)
 				if(WHITE_DAMAGE)
-					H.adjustSanityLoss(-damage*0.2)
+					H.adjustSanityLoss(-10)
 				if(BLACK_DAMAGE)
-					H.adjustBruteLoss(-damage*0.1)
-					H.adjustSanityLoss(-damage*0.1)
+					H.adjustBruteLoss(-5)
+					H.adjustSanityLoss(-5)
 				else // Red or pale
-					H.adjustBruteLoss(-damage*0.2)
+					H.adjustBruteLoss(-10)
 			H.visible_message("<span class='warning'>[src] vanishes on contact with [H]!</span>")
 			qdel(src)
 			return BULLET_ACT_BLOCK


### PR DESCRIPTION
## About The Pull Request

QoH weapon now heal for flat amounts (10 HP, 10SP or 5HP/SP) instead of taking 20% or 10% of the projectile damage

## Why It's Good For The Game

If you got your hands on ways to increase the damage of the bullet (ranged class, wink wink), you could buff the healing output of the weapon. Healing stuff is balanced around their numbers for specific reasons, so increasing them would be funky. This also safekeep the healing in case something else further down the line can buff the damage of the projectile.
