### PR TITLE
Some Projectile Dummy Fixes

### DIFF
--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -211,6 +211,8 @@
 			for(var/mob/living/L in T)
 				if(istype(L, /mob/living/simple_animal/projectile_blocker_dummy))
 					var/mob/living/simple_animal/projectile_blocker_dummy/pbd = L
+					if(pbd.parent == src)
+						continue
 					L = pbd.parent
 				if(L.invisibility > see_invisible)
 					continue

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/melting_love.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/melting_love.dm
@@ -493,6 +493,10 @@
 		return FALSE
 	if(is_type_in_list(AM, slime_types, FALSE))
 		return
+	if(istype(AM, /mob/living/simple_animal/projectile_blocker_dummy))
+		var/mob/living/simple_animal/projectile_blocker_dummy/pbd = AM
+		if(is_type_in_list(pbd.parent, slime_types, FALSE))
+			return
 	var/mob/living/L = AM
 	if((("hostile" in L.faction) && (SSmaptype.maptype in SSmaptype.combatmaps)))
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes player controlled multi tile mobs unable to target themselves when clicking tiles with their own projectile blockers.
Fixes melting love slime applying status effect to melting love's projectile blocker dummy.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Less unintended self damage. Melting love wont take damage from her own status effect in facility mode.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixed player controlled multi tile mobs hitting themselves when clicking tiles with their own projectile blockers.
fix: Fixed Melting Love getting slime status effect through her own projectile blocker.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
