### PR TITLE
Removes noise pollution from ordeals

### DIFF
--- a/code/modules/ordeals/_ordeal.dm
+++ b/code/modules/ordeals/_ordeal.dm
@@ -39,7 +39,7 @@
 /datum/ordeal/proc/Run()
 	start_time = ROUNDTIME
 	SSlobotomy_corp.current_ordeals += src
-	priority_announce(announce_text, name, sound='sound/effects/meltdownAlert.ogg')
+	priority_announce(announce_text, name, sound='sound/vox_fem/..ogg') // We want this to be silent, so play a silent sound since null uses defaults
 	/// If dawn started - clear suppression options
 	if(level == 1 && !istype(SSlobotomy_corp.core_suppression))
 		SSlobotomy_corp.ResetPotentialSuppressions()
@@ -54,7 +54,7 @@
 // Ends the event
 /datum/ordeal/proc/End()
 	var/total_reward = max(SSlobotomy_corp.box_goal, 3000) * reward_percent
-	priority_announce("The Ordeal has ended. Facility has been rewarded with [reward_percent*100]% PE.", name, sound=null)
+	priority_announce("The Ordeal has ended. Facility has been rewarded with [reward_percent*100]% PE.", name, sound='sound/vox_fem/..ogg')
 	SSlobotomy_corp.AdjustAvailableBoxes(total_reward)
 	SSlobotomy_corp.current_ordeals -= src
 	SSlobotomy_corp.ordeal_stats += 5


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Technically this further diverges us from Lobotomy Corporation, but this pull request removes a soundbyte from ordeal starting and ending that makes them overall sound a bit better. This is due to the fact that not all ordeal sounds play at the same volume, and sometimes the meltdown SFX can drown them out.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Better sound design.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
sounddel: removed an old sound thingy from ordeals
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
