### PR TITLE
Fire damage Overhaul

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -62,6 +62,9 @@
 	/// A lazily initiated "food" version of the clothing for moths
 	var/obj/item/food/clothing/moth_snack
 
+	/// Exclusive to LC13 - Toggles whether or not fire armor shows up in tags. Hides the armor value from the player if automatically generated.
+	var/fire_display = TRUE
+
 /obj/item/clothing/Initialize()
 	if((clothing_flags & VOICEBOX_TOGGLABLE))
 		actions_types += /datum/action/item_action/toggle_voice_box
@@ -72,6 +75,13 @@
 		LoadComponent(/datum/component/bloodysoles)
 	if(!icon_state)
 		item_flags |= ABSTRACT
+	var/burnvalue = armor.getRating(FIRE)
+	if(!burnvalue)
+		var/redvalue = armor.getRating(RED_DAMAGE)
+		if(redvalue > 0)
+			redvalue = (redvalue * 0.5)
+		armor = armor.modifyRating(FIRE = redvalue)
+		fire_display = FALSE
 
 /obj/item/clothing/MouseDrop(atom/over_object)
 	. = ..()
@@ -327,7 +337,7 @@
 
 	if(LAZYLEN(durability_list))
 		durability_list.Cut()
-	if(armor.fire)
+	if(armor.fire && fire_display)
 		durability_list += list("FIRE" = armor.fire)
 	if(armor.acid)
 		durability_list += list("ACID" = armor.acid)
@@ -361,6 +371,7 @@
 		readout += "\nYou can add numbers together by putting the symbols in descending order from left to right. You’d add all of the symbols’ individual values together to get the total value. For example, VI is 5 + 1 or 6."
 		readout += "\nYou can also subtract numbers from each other by placing a symbol with a smaller value to the left of one with a larger value. The value of the smaller symbol is subtracted from that of the larger symbol to get the total value, so IV is 5 - 1, or 4."
 		readout += "\nExamples: \nIX = 10-1 = 9. \nVI = 5+1 = 6. \nVIII = 5+1+1+1 = 8."
+		readout += "\nAdditionally, all armors that have an armor value for red damage will have half (if positive) of that value in an armor value for fire damage if not explicitly indicated."
 		to_chat(usr, "[readout.Join()]")
 
 /**

--- a/code/modules/clothing/suits/ego_gear/aleph.dm
+++ b/code/modules/clothing/suits/ego_gear/aleph.dm
@@ -4,6 +4,8 @@
 Think before you code!
 Any attempt to code risk class armor will result in a 10 day Github ban.*/
 
+/*Developer's note - All LC13 armor has 50% of its red_damage armor as fire armor by default. */
+
 /obj/item/clothing/suit/armor/ego_gear/aleph
 	icon = 'icons/obj/clothing/ego_gear/abnormality/aleph.dmi'
 	worn_icon = 'icons/mob/clothing/ego_gear/abnormality/aleph.dmi'
@@ -266,7 +268,7 @@ Any attempt to code risk class armor will result in a 10 day Github ban.*/
 			to_chat(user, span_nicegreen("[src] has gained extra resistance to PALE damage!"))
 
 		if("diamonds")
-			armor = armor.modifyRating(red = 10, pale = 5)
+			armor = armor.modifyRating(red = 10, pale = 5, fire = 5)
 			to_chat(user, span_nicegreen("[src] has gained extra resistance to RED damage!"))
 
 		if("clubs")
@@ -277,7 +279,7 @@ Any attempt to code risk class armor will result in a 10 day Github ban.*/
 	name = "Seasons Greetings"
 	desc = "This is a placeholder."
 	icon_state = "spring"
-	armor = list(RED_DAMAGE = 60, WHITE_DAMAGE = 60, BLACK_DAMAGE = 60, PALE_DAMAGE = 60) // 240
+	armor = list(RED_DAMAGE = 60, WHITE_DAMAGE = 60, BLACK_DAMAGE = 60, PALE_DAMAGE = 60, FIRE = 60) // 240
 	attribute_requirements = list(
 							FORTITUDE_ATTRIBUTE = 80,
 							PRUDENCE_ATTRIBUTE = 100,
@@ -332,36 +334,36 @@ Any attempt to code risk class armor will result in a 10 day Github ban.*/
 	var/warning_message
 	switch(stored_season) //Hopefully someday someone finds a more efficient way to change armor values
 		if("spring")
-			src.armor = new(red = 60, white = 80, black = 40, pale = 60)	//240
+			src.armor = new(red = 60, white = 80, black = 40, pale = 60, fire = 30)	//240
 			if(stored_season != current_season) //Our drip is out of season
-				src.armor = new(red = 50, white = 80, black = 40, pale = 50)	//220
+				src.armor = new(red = 50, white = 80, black = 40, pale = 50, fire = 30)	//220
 				weakened = TRUE
 				if(current_season == "fall")
-					src.armor = new(red = 50, white = 70, black = 30, pale = 50)	//200
+					src.armor = new(red = 50, white = 70, black = 30, pale = 50, fire = 30)	//200
 					warning_message = "Fall has come, the leaves on your armor wither and die."
 		if("summer")
-			src.armor = new(red = 80, white = 40, black = 60, pale = 60)
+			src.armor = new(red = 80, white = 40, black = 60, pale = 60, fire = 70)
 			if(stored_season != current_season) //Our drip is out of season
-				src.armor = new(red = 80, white = 40, black = 50, pale = 50)
+				src.armor = new(red = 80, white = 40, black = 50, pale = 50, fire = 70)
 				weakened = TRUE
 				if(current_season == "winter")
-					src.armor = new(red = 70, white = 30, black = 50, pale = 50)
+					src.armor = new(red = 70, white = 30, black = 50, pale = 50, fire = 70)
 					warning_message = "Winter is here. Your armor reacts, becoming stiff and brittle."
 		if("fall")
-			src.armor = new(red = 40, white = 60, black = 80, pale = 60)
+			src.armor = new(red = 40, white = 60, black = 80, pale = 60, fire = 70)
 			if(stored_season != current_season) //Our drip is out of season
-				src.armor = new(red = 40, white = 50, black = 80, pale = 50)
+				src.armor = new(red = 40, white = 50, black = 80, pale = 50, fire = 70)
 				weakened = TRUE
 				if(current_season == "spring")
-					src.armor = new(red = 30, white = 50, black = 70, pale = 50)
+					src.armor = new(red = 30, white = 50, black = 70, pale = 50, fire = 70)
 					warning_message = "The arrival of spring weakens your armor further."
 		if("winter")
-			src.armor = new(red = 40, white = 60, black = 60, pale = 80)
+			src.armor = new(red = 40, white = 60, black = 60, pale = 80, fire = 10)
 			if(stored_season != current_season) //Our drip is out of season
-				src.armor = new(red = 40, white = 50, black = 50, pale = 80)
+				src.armor = new(red = 40, white = 50, black = 50, pale = 80, fire = 10)
 				weakened = TRUE
 				if(current_season == "summer")
-					src.armor = new(red = 30, white = 50, black = 50, pale = 70)
+					src.armor = new(red = 30, white = 50, black = 50, pale = 70, fire = 0)
 					warning_message = "The summer heat is melting your armor."
 
 	if(current_holder && (weakened == TRUE))
@@ -399,7 +401,7 @@ Any attempt to code risk class armor will result in a 10 day Github ban.*/
 	name = "distortion"
 	desc = "To my eyes, I’m the only one who doesn’t appear distorted. In a world full of distorted people, could the one person who remains unchanged be the \"distorted\" one?"
 	icon_state = "distortion"
-	armor = list(RED_DAMAGE = 80, WHITE_DAMAGE = 70, BLACK_DAMAGE = 80, PALE_DAMAGE = 50) // 280
+	armor = list(RED_DAMAGE = 80, WHITE_DAMAGE = 70, BLACK_DAMAGE = 80, PALE_DAMAGE = 50, FIRE = 70) // 280
 	attribute_requirements = list(
 							FORTITUDE_ATTRIBUTE = 100,
 							PRUDENCE_ATTRIBUTE = 100,

--- a/code/modules/clothing/suits/ego_gear/he.dm
+++ b/code/modules/clothing/suits/ego_gear/he.dm
@@ -4,6 +4,8 @@
 Think before you code!
 Any attempt to code risk class armor will result in a 10 day Github ban.*/
 
+/*Developer's note - All LC13 armor has 50% of its red_damage armor as fire armor by default. */
+
 /obj/item/clothing/suit/armor/ego_gear/he
 	icon = 'icons/obj/clothing/ego_gear/abnormality/he.dmi'
 	worn_icon = 'icons/mob/clothing/ego_gear/abnormality/he.dmi'
@@ -91,7 +93,7 @@ Any attempt to code risk class armor will result in a 10 day Github ban.*/
 	name = "christmas"
 	desc = "When the rusty sleigh bells are ajingle, Christmas begins."
 	icon_state = "christmas"
-	armor = list(RED_DAMAGE = -10, WHITE_DAMAGE = 40, BLACK_DAMAGE = 20, PALE_DAMAGE = 20) // 70
+	armor = list(RED_DAMAGE = -10, WHITE_DAMAGE = 40, BLACK_DAMAGE = 20, PALE_DAMAGE = 20, FIRE = -20) // 70
 	attribute_requirements = list(
 							FORTITUDE_ATTRIBUTE = 40
 							)
@@ -139,7 +141,7 @@ Any attempt to code risk class armor will result in a 10 day Github ban.*/
 	name = "frost splinter"
 	desc = "Surprisingly cold to the touch."
 	icon_state = "frost_splinter"
-	armor = list(RED_DAMAGE = -10, WHITE_DAMAGE = 30, BLACK_DAMAGE = 0, PALE_DAMAGE = 50)
+	armor = list(RED_DAMAGE = -10, WHITE_DAMAGE = 30, BLACK_DAMAGE = 0, PALE_DAMAGE = 50, FIRE = -20)
 	attribute_requirements = list(
 							PRUDENCE_ATTRIBUTE = 40
 							)
@@ -302,7 +304,7 @@ Any attempt to code risk class armor will result in a 10 day Github ban.*/
 	desc = "Even still, I witnessed man and sky and earth tear into thousands of pieces."
 	icon_state = "impending_day"
 	flags_inv = NONE
-	armor = list(RED_DAMAGE = 20, WHITE_DAMAGE = -20, BLACK_DAMAGE = 50, PALE_DAMAGE = 20) // 70
+	armor = list(RED_DAMAGE = 20, WHITE_DAMAGE = -20, BLACK_DAMAGE = 50, PALE_DAMAGE = 20, FIRE = 40) // 70
 	attribute_requirements = list(
 							TEMPERANCE_ATTRIBUTE = 40
 							)
@@ -405,7 +407,7 @@ Any attempt to code risk class armor will result in a 10 day Github ban.*/
 	name = "lifetime stew"
 	desc = "A soup fit for a king - and all from a few stones. It seemed like magic!"
 	icon_state = "lifestew"
-	armor = list(RED_DAMAGE = 20, WHITE_DAMAGE = -20, BLACK_DAMAGE = 60, PALE_DAMAGE = -20) // 40
+	armor = list(RED_DAMAGE = 20, WHITE_DAMAGE = -20, BLACK_DAMAGE = 60, PALE_DAMAGE = -20, FIRE = 40) // 40
 	attribute_requirements = list(
 							TEMPERANCE_ATTRIBUTE = 40
 							)
@@ -468,7 +470,7 @@ Any attempt to code risk class armor will result in a 10 day Github ban.*/
 	name = "ardor blossom star"
 	desc = "A dress with a bright orange jacket. Warm to the touch."
 	icon_state = "ardor_blossom"
-	armor = list(RED_DAMAGE = 50, WHITE_DAMAGE = 0, BLACK_DAMAGE = 10, PALE_DAMAGE = 10) // 70
+	armor = list(RED_DAMAGE = 50, WHITE_DAMAGE = 0, BLACK_DAMAGE = 10, PALE_DAMAGE = 10, FIRE = 40) // 70
 	attribute_requirements = list(
 							PRUDENCE_ATTRIBUTE = 40
 							)

--- a/code/modules/clothing/suits/ego_gear/non_abnormality/dawn.dm
+++ b/code/modules/clothing/suits/ego_gear/non_abnormality/dawn.dm
@@ -2,7 +2,7 @@
 	name = "dawn office leader jacket"
 	desc = "An armored jacket worn by the leader of dawn office."
 	icon_state = "dawnleader"
-	armor = list(RED_DAMAGE = 20, WHITE_DAMAGE = 50, BLACK_DAMAGE = 20, PALE_DAMAGE = 20)
+	armor = list(RED_DAMAGE = 20, WHITE_DAMAGE = 50, BLACK_DAMAGE = 20, PALE_DAMAGE = 20, FIRE = 50)
 	attribute_requirements = list(
 							FORTITUDE_ATTRIBUTE = 80,
 							PRUDENCE_ATTRIBUTE = 80,
@@ -14,7 +14,7 @@
 	name = "dawn office jacket"
 	desc = "An armored jacket worn by dawn office fixers. This one is extremely well worn, and has been tailored many times."
 	icon_state = "dawn"
-	armor = list(RED_DAMAGE = 10, WHITE_DAMAGE = 40, BLACK_DAMAGE = 10, PALE_DAMAGE = 0)
+	armor = list(RED_DAMAGE = 10, WHITE_DAMAGE = 40, BLACK_DAMAGE = 10, PALE_DAMAGE = 0, FIRE = 40)
 	attribute_requirements = list(
 							FORTITUDE_ATTRIBUTE = 60,
 							PRUDENCE_ATTRIBUTE = 60,

--- a/code/modules/clothing/suits/ego_gear/non_abnormality/liu.dm
+++ b/code/modules/clothing/suits/ego_gear/non_abnormality/liu.dm
@@ -2,7 +2,7 @@
 	name = "Liu Association combat suit"
 	desc = "Armor worn by liu association section 1 and section 2."
 	icon_state = "liufire"
-	armor = list(RED_DAMAGE = 20, WHITE_DAMAGE = 40, BLACK_DAMAGE = 20, PALE_DAMAGE = 0)
+	armor = list(RED_DAMAGE = 20, WHITE_DAMAGE = 40, BLACK_DAMAGE = 20, PALE_DAMAGE = 0, FIRE = 20)
 	attribute_requirements = list(
 							FORTITUDE_ATTRIBUTE = 60,
 							PRUDENCE_ATTRIBUTE = 60,
@@ -19,7 +19,7 @@
 	name = "Liu Association combat coat"
 	desc = "Armor worn by liu association section 1 veterans."
 	icon_state = "liufire_vet"
-	armor = list(RED_DAMAGE = 30, WHITE_DAMAGE = 50, BLACK_DAMAGE = 30, PALE_DAMAGE = 20)
+	armor = list(RED_DAMAGE = 30, WHITE_DAMAGE = 50, BLACK_DAMAGE = 30, PALE_DAMAGE = 20, FIRE = 30)
 	attribute_requirements = list(
 							FORTITUDE_ATTRIBUTE = 60,
 							PRUDENCE_ATTRIBUTE = 80,
@@ -47,7 +47,7 @@
 	name = "Liu Association heavy combat coat"
 	desc = "Armor worn by the director of Liu Association Section 1 director."
 	icon_state = "liufire_director"
-	armor = list(RED_DAMAGE = 40, WHITE_DAMAGE = 70, BLACK_DAMAGE = 40, PALE_DAMAGE = 20)
+	armor = list(RED_DAMAGE = 40, WHITE_DAMAGE = 70, BLACK_DAMAGE = 40, PALE_DAMAGE = 20, FIRE = 40)
 	attribute_requirements = list(
 							FORTITUDE_ATTRIBUTE = 60,
 							PRUDENCE_ATTRIBUTE = 100,

--- a/code/modules/clothing/suits/ego_gear/teth.dm
+++ b/code/modules/clothing/suits/ego_gear/teth.dm
@@ -4,6 +4,8 @@
 Think before you code!
 Any attempt to code risk class armor will result in a 10 day Github ban.*/
 
+/*Developer's note - All LC13 armor has 50% of its red_damage armor as fire armor by default. */
+
 /obj/item/clothing/suit/armor/ego_gear/teth
 	icon = 'icons/obj/clothing/ego_gear/abnormality/teth.dmi'
 	worn_icon = 'icons/mob/clothing/ego_gear/abnormality/teth.dmi'
@@ -25,7 +27,7 @@ Any attempt to code risk class armor will result in a 10 day Github ban.*/
 	desc = "The archetype was already charred from the moment of extraction. \
 	Although the exterior is scorched, it has no adverse effects on the E.G.O’s performance."
 	icon_state = "match"
-	armor = list(RED_DAMAGE = 40, WHITE_DAMAGE = -20, BLACK_DAMAGE = -20, PALE_DAMAGE = 0) // 20
+	armor = list(RED_DAMAGE = 40, WHITE_DAMAGE = -20, BLACK_DAMAGE = -20, PALE_DAMAGE = 0, FIRE = 30) // 20
 
 /obj/item/clothing/suit/armor/ego_gear/teth/fragment
 	name = "fragments from somewhere"
@@ -206,7 +208,7 @@ Any attempt to code risk class armor will result in a 10 day Github ban.*/
 	name = "capote"
 	desc = "It suffered for such a long time... Unable to do anything about the raging thirst, the flesh endlessly burning and searing."
 	icon_state = "capote"
-	armor = list(RED_DAMAGE = 40, WHITE_DAMAGE = -30, BLACK_DAMAGE = -10, PALE_DAMAGE = 0) // 0
+	armor = list(RED_DAMAGE = 40, WHITE_DAMAGE = -30, BLACK_DAMAGE = -10, PALE_DAMAGE = 0, FIRE = 30) // 0
 
 /obj/item/clothing/suit/armor/ego_gear/teth/fourleaf_clover
 	name = "four-leaf clover"
@@ -280,4 +282,4 @@ Any attempt to code risk class armor will result in a 10 day Github ban.*/
 	desc = "Dirty rag armor, better than nothing."
 	icon_state = "desert"
 	flags_inv = NONE
-	armor = list(RED_DAMAGE = 40, WHITE_DAMAGE = 0, BLACK_DAMAGE = -20, PALE_DAMAGE = -20) // 20
+	armor = list(RED_DAMAGE = 40, WHITE_DAMAGE = 0, BLACK_DAMAGE = -20, PALE_DAMAGE = -20, FIRE = 30) // 20

--- a/code/modules/clothing/suits/ego_gear/waw.dm
+++ b/code/modules/clothing/suits/ego_gear/waw.dm
@@ -4,6 +4,8 @@
 Think before you code!
 Any attempt to code risk class armor will result in a 10 day Github ban.*/
 
+/*Developer's note - All LC13 armor has 50% of its red_damage armor as fire armor by default. */
+
 /obj/item/clothing/suit/armor/ego_gear/waw
 	icon = 'icons/obj/clothing/ego_gear/abnormality/waw.dmi'
 	worn_icon = 'icons/mob/clothing/ego_gear/abnormality/waw.dmi'
@@ -257,7 +259,7 @@ Any attempt to code risk class armor will result in a 10 day Github ban.*/
 	desc = "Bright as the abnormality it was extracted from, but somehow does not give off any heat. \
 			Maybe keep it away from the cold..."
 	icon_state = "featherofhonor"
-	armor = list(RED_DAMAGE = 50, WHITE_DAMAGE = 50, BLACK_DAMAGE = 30, PALE_DAMAGE = 10) //140
+	armor = list(RED_DAMAGE = 50, WHITE_DAMAGE = 50, BLACK_DAMAGE = 30, PALE_DAMAGE = 10, FIRE = 60) //140
 	attribute_requirements = list(
 							FORTITUDE_ATTRIBUTE = 80,
 							)
@@ -394,7 +396,7 @@ Any attempt to code risk class armor will result in a 10 day Github ban.*/
 	name = "rimeshank"
 	desc = "Well, I can't just shiver in the cold forever, can I?"
 	icon_state = "rimeshank"
-	armor = list(RED_DAMAGE = 70, WHITE_DAMAGE = 40, BLACK_DAMAGE = 0, PALE_DAMAGE = 30) //140
+	armor = list(RED_DAMAGE = 70, WHITE_DAMAGE = 40, BLACK_DAMAGE = 0, PALE_DAMAGE = 30, FIRE = 20) //140
 	attribute_requirements = list(
 					FORTITUDE_ATTRIBUTE = 80
 					)

--- a/code/modules/clothing/suits/ego_gear/zayin.dm
+++ b/code/modules/clothing/suits/ego_gear/zayin.dm
@@ -4,6 +4,8 @@
 Think before you code!
 Any attempt to code risk class armor will result in a 10 day Github ban.*/
 
+/*Developer's note - All LC13 armor has 50% of its red_damage armor as fire armor by default. */
+
 /obj/item/clothing/suit/armor/ego_gear/zayin
 	icon = 'icons/obj/clothing/ego_gear/abnormality/zayin.dmi'
 	worn_icon = 'icons/mob/clothing/ego_gear/abnormality/zayin.dmi'

--- a/code/modules/mob/living/simple_animal/abnormality/_auxiliary_modes/community/ego_armor.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_auxiliary_modes/community/ego_armor.dm
@@ -18,7 +18,7 @@
 	icon = 'code/modules/mob/living/simple_animal/abnormality/_auxiliary_modes/community/!icons/ego_armor.dmi'
 	worn_icon = 'code/modules/mob/living/simple_animal/abnormality/_auxiliary_modes/community/!icons/ego_worn.dmi'
 	flags_inv = NONE
-	armor = list(RED_DAMAGE = 50, WHITE_DAMAGE = -30, BLACK_DAMAGE = -10, PALE_DAMAGE = 20) // 70
+	armor = list(RED_DAMAGE = 50, WHITE_DAMAGE = -30, BLACK_DAMAGE = -10, PALE_DAMAGE = 20, FIRE = 50) // 70
 	attribute_requirements = list(
 							FORTITUDE_ATTRIBUTE = 40
 							)
@@ -73,12 +73,12 @@
 // Aleph
 /obj/item/clothing/suit/armor/ego_gear/aleph/waxen
 	name = "Waxen Pinion"
-	desc = "However, that alone won’t purge all evil from the world."
+	desc = "However, that alone won't purge all evil from the world."
 	icon_state = "combust"
 	icon = 'code/modules/mob/living/simple_animal/abnormality/_auxiliary_modes/community/!icons/ego_armor.dmi'
 	worn_icon = 'code/modules/mob/living/simple_animal/abnormality/_auxiliary_modes/community/!icons/ego_worn.dmi'
 	flags_inv = null
-	armor = list(RED_DAMAGE = 80, WHITE_DAMAGE = 40, BLACK_DAMAGE = 60, PALE_DAMAGE = 60)
+	armor = list(RED_DAMAGE = 80, WHITE_DAMAGE = 40, BLACK_DAMAGE = 60, PALE_DAMAGE = 60, FIRE = 70)
 	attribute_requirements = list(
 							FORTITUDE_ATTRIBUTE = 100,
 							PRUDENCE_ATTRIBUTE = 80,

--- a/code/modules/mob/living/simple_animal/abnormality/_auxiliary_modes/community/ego_weapons.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_auxiliary_modes/community/ego_weapons.dm
@@ -58,7 +58,7 @@
 /obj/item/ego_weapon/sunspit
 	name = "sunspit"
 	desc = "Goodness gracious, great mauls of fire!"
-	special = "Use in hand to prepare a powerful area attack. This attack becomes more powerful when charged."
+	special = "Use in hand to prepare a powerful area attack. This attack requires charge to use, but deals armor-piercing burn damage."
 	icon_state = "sunspit"
 	icon = 'code/modules/mob/living/simple_animal/abnormality/_auxiliary_modes/community/!icons/ego_weapons.dmi'
 	lefthand_file = 'icons/mob/inhands/64x64_lefthand.dmi'
@@ -113,7 +113,7 @@
 	if(!can_spin)
 		to_chat(user,span_warning("You attacked too recently."))
 		return
-	if(do_after(user, 12, src))
+	if(do_after(user, 8, src))
 		charge_amount -= charge_cost
 		addtimer(CALLBACK(src, PROC_REF(spin_reset)), 12)
 		playsound(src, 'sound/abnormalities/seasons/summer_attack.ogg', 75, FALSE, 4)
@@ -153,7 +153,7 @@
 		playsound(T, 'sound/weapons/fixer/generic/fire3.ogg', 30, TRUE, 3)
 		new /obj/effect/temp_visual/smash_effect(T)
 		new /obj/effect/temp_visual/fire/fast(T)
-		been_hit = user.HurtInTurf(T, been_hit, aoe_damage, RED_DAMAGE, check_faction = TRUE)
+		been_hit = user.HurtInTurf(T, been_hit, aoe_damage, BURN, check_faction = TRUE)
 
 /obj/item/ego_weapon/sunspit/get_clamped_volume()
 	return 40

--- a/code/modules/mob/living/simple_animal/abnormality/he/ardor_blossom_moth.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/ardor_blossom_moth.dm
@@ -17,7 +17,7 @@
 	stat_attack = HARD_CRIT
 	melee_damage_lower = 11
 	melee_damage_upper = 12
-	damage_coeff = list(BRUTE = 1, RED_DAMAGE = 0.5, WHITE_DAMAGE = 1, BLACK_DAMAGE = 0.7, PALE_DAMAGE = 2)
+	damage_coeff = list(BRUTE = 1, RED_DAMAGE = 0.5, WHITE_DAMAGE = 1, BLACK_DAMAGE = 0.7, PALE_DAMAGE = 2, FIRE = 0.2)
 	speak_emote = list("flutters")
 	vision_range = 14
 	aggro_vision_range = 20

--- a/code/modules/mob/living/simple_animal/abnormality/he/basilisoup.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/basilisoup.dm
@@ -15,7 +15,7 @@
 	melee_reach = 2 // Long neck = long range
 	ranged = TRUE
 	threat_level = HE_LEVEL
-	damage_coeff = list(BRUTE = 1, RED_DAMAGE = 0.8, WHITE_DAMAGE = 1.2, BLACK_DAMAGE = 0.8, PALE_DAMAGE = 1.5)
+	damage_coeff = list(BRUTE = 1, RED_DAMAGE = 0.8, WHITE_DAMAGE = 1.2, BLACK_DAMAGE = 0.8, PALE_DAMAGE = 1.5, FIRE = 0.6)
 	melee_damage_lower = 22
 	melee_damage_upper = 30
 	melee_damage_type = BLACK_DAMAGE

--- a/code/modules/mob/living/simple_animal/abnormality/he/der_freischutz.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/der_freischutz.dm
@@ -12,7 +12,7 @@
 	minimum_distance = 10
 	retreat_distance = 2
 	move_to_delay = 6
-	damage_coeff = list(RED_DAMAGE = 1, WHITE_DAMAGE = 2, BLACK_DAMAGE = 0.7, PALE_DAMAGE = 0.5)
+	damage_coeff = list(RED_DAMAGE = 1, WHITE_DAMAGE = 2, BLACK_DAMAGE = 0.7, PALE_DAMAGE = 0.5, FIRE = 0.5)
 	stat_attack = HARD_CRIT
 	vision_range = 28 // Fit for a marksman.
 	aggro_vision_range = 40

--- a/code/modules/mob/living/simple_animal/abnormality/he/pinocchio.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/pinocchio.dm
@@ -20,7 +20,7 @@
 		"Lying is Bad!" = 0,
 	)
 
-	damage_coeff = list(RED_DAMAGE = 1.2, WHITE_DAMAGE = 0.5, BLACK_DAMAGE = 0.7, PALE_DAMAGE = 0.9)
+	damage_coeff = list(RED_DAMAGE = 1.2, WHITE_DAMAGE = 0.5, BLACK_DAMAGE = 0.7, PALE_DAMAGE = 0.9, FIRE = 1.5)
 	work_damage_amount = 8
 	work_damage_type = WHITE_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/envy
@@ -320,6 +320,7 @@
 	BODY_ZONE_CHEST = /obj/item/bodypart/chest/puppet)
 	speedmod = 1.3
 	changesource_flags = MIRROR_BADMIN | WABBAJACK
+	burnmod = 2
 
 /datum/species/puppet/check_roundstart_eligible()
 	return FALSE //heck no

--- a/code/modules/mob/living/simple_animal/abnormality/he/rudolta.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/rudolta.dm
@@ -12,7 +12,7 @@
 	health = 1200
 	pixel_x = -16
 	base_pixel_x = -16
-	damage_coeff = list(RED_DAMAGE = 1.5, WHITE_DAMAGE = 0.5, BLACK_DAMAGE = 1, PALE_DAMAGE = 2)
+	damage_coeff = list(RED_DAMAGE = 1.5, WHITE_DAMAGE = 0.5, BLACK_DAMAGE = 1, PALE_DAMAGE = 2, FIRE = 1.5)
 	stat_attack = HARD_CRIT
 	can_breach = TRUE
 	threat_level = HE_LEVEL

--- a/code/modules/mob/living/simple_animal/abnormality/he/snow_queen.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/snow_queen.dm
@@ -22,7 +22,7 @@
 	health = 1500
 	blood_volume = 0
 	move_to_delay = 5
-	damage_coeff = list(BRUTE = 1, RED_DAMAGE = 1.1, WHITE_DAMAGE = 0.8, BLACK_DAMAGE = 0.8, PALE_DAMAGE = 0.8) //ASK SOMEONE GOOD AT BALANCING ABOUT THIS -IP
+	damage_coeff = list(BRUTE = 1, RED_DAMAGE = 1.1, WHITE_DAMAGE = 0.8, BLACK_DAMAGE = 0.8, PALE_DAMAGE = 0.8, FIRE = 2) //ASK SOMEONE GOOD AT BALANCING ABOUT THIS -IP
 	base_pixel_x = -16
 	pixel_x = -16
 	can_breach = TRUE

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -255,6 +255,17 @@
 				projectile_blockers += new /mob/living/simple_animal/projectile_blocker_dummy(locate(i, j, z), src)
 		RegisterSignal(src, COMSIG_ATOM_DIR_CHANGE, PROC_REF(OnDirChange))
 
+	if(damage_coeff.getCoeff(FIRE) == 1) // LC13 burn armor calculator. Looks at red armor, and ignores up to 50% of armor. deals full damage to mobs weak to red
+		var/red_mod = damage_coeff.getCoeff(RED_DAMAGE)
+		switch(red_mod)
+			if(-INFINITY to 0)
+				red_mod = red_mod
+			if(0.001 to 0.5)
+				red_mod = red_mod * 1.5
+			if(0.5 to 1)
+				red_mod = (((1 - red_mod) / 2) + red_mod) // 50% armor ignore
+		ChangeResistances(list(FIRE = red_mod))
+
 /mob/living/simple_animal/proc/SetOccupiedTiles(down = 0, up = 0, left = 0, right = 0)
 	occupied_tiles_down = down
 	occupied_tiles_up = up


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
So fire damage is kind of all over the place. This PR fixes that. Mostly, at least. It took me way too long to figure out how carbons actually take damage.

Code Changes
- For simple mobs, Fire damage is reduced by red armor at the rate of 50% of the red armor's value. If the mob has fire resistance, that's just used instead.
- Every armor in the game now has fire resistance, which is either based on this formula or higher/lower if thematically appropriate. This probably won't affect balance much as of right now.

Fixes
- Fixes LC13_Burn not functioning on naked players

Balance Changes
- The LC13_Burn status effects has been reformatted to be more generic, and now actually deals resistible burn damage instead of flat damage.

Misc
- Adds fire damage to a rare weapon since its functionally balanced now.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Making things more consistent is good, it's not great having burn work differently depending on its source. Like getting set on fire and taking red damage...

I'll tackle burn damage and resistances in a separate PR to keep things atomic.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: added burn/fire resistance to some E.G.O. Armors
balance: rebalanced burn damage in general
code: created a damage formula for burn/fire damage
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
