### PR TITLE
Fishing fix

### DIFF
--- a/ModularTegustation/fishing/code/fishcooking/fishmachines/fish_cookers.dm
+++ b/ModularTegustation/fishing/code/fishcooking/fishmachines/fish_cookers.dm
@@ -22,7 +22,8 @@
 	cook_time = 12 SECONDS
 	cookables = list(
 		/obj/item/food/freshfish/pink	 					= /obj/item/food/panfry_fish,
-		/obj/item/food/freshfish/salmon	 					= /obj/item/food/panfry_fish,
+		/obj/item/food/fish/salt_water/salmon	 					= /obj/item/food/panfry_fish,
+		/obj/item/food/fish/fresh_water/salmon	 					= /obj/item/food/panfry_fish,
 		/obj/item/food/fish/salt_water/marine_shrimp 		= /obj/item/food/panfry_fish/shrimp,
 		/obj/item/food/freshfish/white 						= /obj/item/food/panfry_fish/white,
 		)
@@ -36,6 +37,7 @@
 	cook_time = 30 SECONDS
 	cookables = list(
 		/obj/item/food/fish/salt_water/lobster	 			= /obj/item/food/lobster_baked,
-		/obj/item/food/freshfish/salmon	 					= /obj/item/food/baked_salmon,
+		/obj/item/food/fish/salt_water/salmon	 					= /obj/item/food/baked_salmon,
+		/obj/item/food/fish/fresh_water/salmon	 					= /obj/item/food/baked_salmon,
 		/obj/item/food/meat/rawcrab							= /obj/item/food/meat/crab
 		)

--- a/ModularTegustation/fishing/code/fishcooking/fishmachines/sushi.dm
+++ b/ModularTegustation/fishing/code/fishcooking/fishmachines/sushi.dm
@@ -7,7 +7,8 @@
 	anchored = TRUE
 	var/list/cookables = list(
 		/obj/item/food/freshfish/white 						= /obj/item/food/sashimi/white,
-		/obj/item/food/freshfish/salmon 					= /obj/item/food/sashimi,
+		/obj/item/food/fish/salt_water/salmon 					= /obj/item/food/sashimi,
+		/obj/item/food/fish/fresh_water/salmon 					= /obj/item/food/sashimi,
 		/obj/item/food/fish/salt_water/marine_shrimp 		= /obj/item/food/sashimi/shrimp,
 		)
 	var/failed = FALSE

--- a/ModularTegustation/fishing/code/turfs.dm
+++ b/ModularTegustation/fishing/code/turfs.dm
@@ -255,7 +255,8 @@
 		/obj/item/food/breadslice/moldy = 2,
 	)
 	loot_level2 = list(
-		/obj/item/food/fish/fresh_water/catfish = 50,
+		/obj/item/food/fish/fresh_water/catfish = 35,
+		/obj/item/food/fish/fresh_water/salmon = 15,
 		/obj/item/food/fish/fresh_water/bass = 10,
 		/obj/item/food/fish/fresh_water/eel = 10,
 		/obj/item/stack/sheet/sinew/wolf = 10,
@@ -288,7 +289,8 @@
 	)
 	loot_level2 = list(
 		/obj/item/food/fish/salt_water/seabunny = 5,
-		/obj/item/food/fish/trout = 35,
+		/obj/item/food/fish/trout = 20,
+		/obj/item/food/fish/salt_water/salmon = 15,
 		/obj/item/food/fish/salt_water/cardinal = 25,
 		/obj/item/food/fish/salt_water/sheephead = 10,
 		/obj/item/food/fish/salt_water/blue_tang = 10,
@@ -299,7 +301,8 @@
 	loot_level3 = list(
 		/obj/item/food/fish/salt_water/fishmael = 8,
 		/obj/item/food/fish/salt_water/searabbit = 5,
-		/obj/item/food/fish/salt_water/lanternfish = 60,
+		/obj/item/food/fish/salt_water/lanternfish = 45,
+		/obj/item/food/fish/salt_water/lobster = 15,
 		/obj/item/food/fish/salt_water/smolshark = 10,
 		/obj/item/food/fish/salt_water/tuna_pallid = 10,
 		/mob/living/simple_animal/crab = 10,


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Freshwater salmon and saltwater salmon are now properly fishable in their respective water. They can also be cooked properly using the fish stove, fish oven and sushi mat.
Lobsters are now also fishable in saltwater.

## Why It's Good For The Game

Because it's a fix, accurate to the wiki as well.

## Changelog
:cl:
add: Added 2 salmons to their respective salt/freshwater loot pool. Added lobsters to the saltwater loot pool.
fix: Fixed the salmon input for the sushi mat, fish oven and fish stove. 
:cl: