### PR TITLE
adjustments to the LCL Qliphoth Suppression Fields [BUGFIX]

### DIFF
--- a/ModularTegustation/tegu_items/limbus_labs/!abno_overwrites.dm
+++ b/ModularTegustation/tegu_items/limbus_labs/!abno_overwrites.dm
@@ -8,7 +8,7 @@
 	if(SSmaptype.maptype == "limbus_labs")
 		health = 1500
 		maxHealth = 1500
-		ChangeResistances(1, 0.8, 0.8, 1.2)
+		ChangeResistances(list(RED_DAMAGE = 1, WHITE_DAMAGE = 0.8, BLACK_DAMAGE = 0.8, PALE_DAMAGE = 1.2))
 
 /mob/living/simple_animal/hostile/abnormality/scorched_girl/Initialize()
 	. = ..()
@@ -21,7 +21,7 @@
 	if(SSmaptype.maptype == "limbus_labs")
 		health = 2000
 		maxHealth = 2000
-		ChangeResistances(0.7, 0.6, 0.8, 1)
+		ChangeResistances(list(RED_DAMAGE = 0.7, WHITE_DAMAGE = 0.6, BLACK_DAMAGE = 0.8, PALE_DAMAGE = 1))
 		melee_damage_lower = 35
 		melee_damage_upper = 47
 
@@ -35,4 +35,4 @@
 /mob/living/simple_animal/hostile/abnormality/steam/Initialize()
 	. = ..()
 	if(SSmaptype.maptype == "limbus_labs")
-		ChangeResistances(1, 1, 2, 1.5)
+		ChangeResistances(list(RED_DAMAGE = 1, WHITE_DAMAGE = 1, BLACK_DAMAGE = 2, PALE_DAMAGE = 1.5))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes the issue which made the resistance nerfs given to LCL abnos not do anything for 11 months.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
If these nerfs were made they were needed, especially with how weak security truly is in LCL
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixed LCL abno overwrites not working for resists
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
