### PR TITLE
Minor Cargo Update

### DIFF
--- a/ModularTegustation/tegu_items/refinery/refinery.dm
+++ b/ModularTegustation/tegu_items/refinery/refinery.dm
@@ -74,7 +74,7 @@
 		loaded = FALSE
 	else if(blackjack == 0)
 		timeleft -= round(refine_timer/3)
-		to_chat(user, span_notice("You correctly filter the PE, speeding up refining."))
+		to_chat(user, span_notice("You correctly filter the PE, speeding up refining, and giving a chance for double output."))
 
 /obj/structure/refinery/proc/counter()
 	timeleft--
@@ -82,6 +82,10 @@
 		loaded = FALSE
 		new /obj/item/refinedpe(get_turf(src))
 		visible_message(span_notice("The refinery finishes refining a box."))
+
+		//If you complete the refinery minigame, you can
+		if(!blackjack && prob(30))
+			new /obj/item/refinedpe(get_turf(src))
 
 	if(loaded)
 		addtimer(CALLBACK(src, PROC_REF(counter)), 1 SECONDS)

--- a/code/game/machinery/computer/extraction_cargo.dm
+++ b/code/game/machinery/computer/extraction_cargo.dm
@@ -57,15 +57,15 @@
 		new /datum/data/extraction_cargo("Mental-Stabilizer Medi-Pen ",	/obj/item/reagent_containers/hypospray/medipen/mental,				50, CAT_MEDICAL) = 1,
 		new /datum/data/extraction_cargo("Standard First-Aid Kit ",		/obj/item/storage/firstaid/regular,									250, CAT_MEDICAL) = 1,
 		new /datum/data/extraction_cargo("Naked Nest Cure Vial ",		/obj/item/serpentspoison,											400, CAT_MEDICAL) = 1,
-		new /datum/data/extraction_cargo("Orange Tree Flamer",			/obj/item/ego_weapon/ranged/flammenwerfer,								500, CAT_MEDICAL) = 1,
+		new /datum/data/extraction_cargo("Orange Tree Flamer",			/obj/item/ego_weapon/ranged/flammenwerfer,							500, CAT_MEDICAL) = 1,
 		new /datum/data/extraction_cargo("Prosthetic Limb Crate ",		/obj/structure/closet/crate/freezer/surplus_limbs,					500, CAT_MEDICAL) = 1,
 		new /datum/data/extraction_cargo("Assorted Medi-Pen Kit ",		/obj/item/storage/firstaid/revival,									500, CAT_MEDICAL) = 1,
 
 		//Resources - Raw PE, ETC. Abnochem stuff goes here too. This is one use items to further LC13 systems
-		new /datum/data/extraction_cargo("Blue Filter ",				/obj/item/refiner_filter/blue,										10, CAT_RESOURCE) = 1,
-		new /datum/data/extraction_cargo("Green Filter ",				/obj/item/refiner_filter/green,										10, CAT_RESOURCE) = 1,
-		new /datum/data/extraction_cargo("Red Filter ",					/obj/item/refiner_filter/red,										10, CAT_RESOURCE) = 1,
-		new /datum/data/extraction_cargo("Yellow Filter ",				/obj/item/refiner_filter/yellow,									10, CAT_RESOURCE) = 1,
+		new /datum/data/extraction_cargo("Blue Filter ",				/obj/item/refiner_filter/blue,										5, CAT_RESOURCE) = 1,
+		new /datum/data/extraction_cargo("Green Filter ",				/obj/item/refiner_filter/green,										5, CAT_RESOURCE) = 1,
+		new /datum/data/extraction_cargo("Red Filter ",					/obj/item/refiner_filter/red,										5, CAT_RESOURCE) = 1,
+		new /datum/data/extraction_cargo("Yellow Filter ",				/obj/item/refiner_filter/yellow,									5, CAT_RESOURCE) = 1,
 		new /datum/data/extraction_cargo("Raw PE Box ",					/obj/item/rawpe,													50, CAT_RESOURCE) = 1,
 		new /datum/data/extraction_cargo("Chemical Extraction Upgrade ",/obj/item/work_console_upgrade/chemical_extraction_attachment,		150, CAT_RESOURCE) = 1,
 		new /datum/data/extraction_cargo("Workchance Calculator Upgrade ",/obj/item/work_console_upgrade/work_prediction_attachment,		200, CAT_RESOURCE) = 1,
@@ -163,7 +163,11 @@
 				playsound(get_turf(src), 'sound/machines/terminal_prompt_deny.ogg', 50, TRUE)
 				return FALSE
 			new product_datum.equipment_path(get_turf(src))
+
+			//So we have to adjust the available boxes down but adjust the goal boxes up. Why?
+			//Adjusting the available boxes adjusts the goal. This is just the best way to do it
 			SSlobotomy_corp.AdjustAvailableBoxes(-1 * product_datum.cost)
+			SSlobotomy_corp.AdjustGoalBoxes(product_datum.cost)
 			playsound(get_turf(src), 'sound/machines/terminal_prompt_confirm.ogg', 50, TRUE)
 			updateUsrDialog()
 			return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes some minor changes to Cargo.
- Buying things with Cargo no longer lowers the quota. Just takes from available to spend boxes.
- Filtering PE boxes gives you a 30% chance for a double payout
- Filter cost has been halved.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Cargo as a mechanic right now is heavily underutilized system because it takes away from quota, and the blackjack minigame was underutilized. 
I believe that by encouraging players to use both Cargo and filters would be good for the game; two underutilized mechanics

This may require us to rebalance cargo in the near future.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Cargo no longer lowers the quota, just available boxes
balance: Filter cost has been halved, and filtering may double output.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
