### PR TITLE
Xicorp update

### DIFF
--- a/_maps/map_files/Xi/xicommand.dmm
+++ b/_maps/map_files/Xi/xicommand.dmm
@@ -789,22 +789,6 @@
 	},
 /turf/open/floor/mineral/titanium/tiled/white,
 /area/city/shop)
-"cU" = (
-/obj/structure/filingcabinet/chestdrawer,
-/obj/structure/closet/mini_fridge{
-	desc = "A small contraption designed to imbue a few drinks with a pleasant chill.";
-	name = "Mini-fridge";
-	pixel_y = 12
-	},
-/obj/item/reagent_containers/food/drinks/bottle/champagne{
-	pixel_y = 17
-	},
-/obj/machinery/light/cold/no_nightlight{
-	brightness = 16;
-	dir = 8
-	},
-/turf/open/floor/carpet/royalblue,
-/area/facility_hallway/manager)
 "cW" = (
 /obj/effect/turf_decal/siding/wood/end{
 	dir = 4
@@ -884,13 +868,6 @@
 /obj/item/storage/firstaid/revival,
 /turf/open/floor/mineral/titanium/blue,
 /area/city/shop)
-"dh" = (
-/obj/machinery/door/window/northright{
-	name = "Bathroom Door";
-	opacity = 1
-	},
-/turf/open/floor/carpet/royalblue,
-/area/facility_hallway/manager)
 "dl" = (
 /obj/structure/window/reinforced/spawner/north{
 	max_integrity = 25;
@@ -945,19 +922,9 @@
 /turf/open/floor/plasteel/dark,
 /area/city/shop)
 "ds" = (
-/obj/item/soap/ncorporation,
-/obj/machinery/shower{
-	dir = 4
-	},
-/obj/structure/window/reinforced/spawner/east{
-	max_integrity = 25;
-	name = "Glass";
-	opacity = 1
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/noslip,
+/obj/structure/rack,
+/obj/item/storage/belt/ego,
+/turf/open/floor/carpet/royalblack,
 /area/facility_hallway/manager)
 "dt" = (
 /obj/structure/window/reinforced/spawner/west,
@@ -1680,7 +1647,9 @@
 /turf/open/floor/wood,
 /area/city/shop)
 "gk" = (
-/turf/open/floor/carpet/royalblue,
+/obj/machinery/vending/lobotomyuniform,
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/facility/dark,
 /area/facility_hallway/manager)
 "gl" = (
 /obj/structure/table/glass,
@@ -1954,13 +1923,11 @@
 /turf/open/floor/plating,
 /area/city/shop)
 "hs" = (
-/obj/structure/table/wood/fancy,
-/obj/item/flashlight/lamp/green,
 /obj/machinery/light/cold/no_nightlight{
 	brightness = 16;
 	dir = 4
 	},
-/turf/open/floor/carpet/red,
+/turf/open/floor/carpet/royalblack,
 /area/facility_hallway/manager)
 "ht" = (
 /obj/structure/reagent_dispensers/water_cooler,
@@ -2060,16 +2027,10 @@
 /turf/open/floor/plating,
 /area/city/shop)
 "hL" = (
-/obj/structure/window/reinforced/spawner/west,
-/obj/effect/turf_decal/tile/blue{
-	color = "#3234B9";
+/obj/machinery/computer/abnormality_logs{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#3234B9";
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/carpet/black,
 /area/facility_hallway/manager)
 "hM" = (
 /turf/closed/indestructible/fakedoor{
@@ -2162,16 +2123,6 @@
 /obj/machinery/light/cold/no_nightlight,
 /turf/open/floor/carpet,
 /area/city/house)
-"if" = (
-/obj/structure/toilet{
-	dir = 8
-	},
-/obj/machinery/light/cold/no_nightlight{
-	brightness = 16;
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/facility_hallway/manager)
 "ig" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#3234B9"
@@ -2456,10 +2407,9 @@
 /turf/open/floor/facility/dark,
 /area/city/backstreets_checkpoint)
 "jg" = (
-/obj/structure/chair/comfy/teal{
-	dir = 8
-	},
-/turf/open/floor/carpet/royalblue,
+/obj/machinery/vending/lobotomyheadset,
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/facility/dark,
 /area/facility_hallway/manager)
 "ji" = (
 /obj/structure/filingcabinet,
@@ -2678,18 +2628,6 @@
 	},
 /turf/open/floor/facility,
 /area/city)
-"km" = (
-/obj/structure/filingcabinet/chestdrawer,
-/obj/structure/closet/mini_fridge{
-	desc = "A small contraption designed to imbue a few drinks with a pleasant chill.";
-	name = "Mini-fridge";
-	pixel_y = 12
-	},
-/obj/item/reagent_containers/food/drinks/bottle/champagne{
-	pixel_y = 17
-	},
-/turf/open/floor/carpet/red,
-/area/facility_hallway/manager)
 "kn" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -2721,13 +2659,6 @@
 "kr" = (
 /turf/open/floor/mineral/titanium/yellow,
 /area/city/shop)
-"kw" = (
-/obj/structure/table/wood,
-/obj/machinery/computer/bookmanagement{
-	pixel_y = 7
-	},
-/turf/open/floor/carpet/red,
-/area/facility_hallway/manager)
 "ky" = (
 /obj/structure/table/reinforced{
 	max_integrity = 25
@@ -2737,6 +2668,10 @@
 	},
 /turf/open/floor/stone,
 /area/city/house)
+"kz" = (
+/obj/machinery/smartfridge/extraction_storage/ego_weapon,
+/turf/closed/indestructible/reinforced,
+/area/facility_hallway/manager)
 "kA" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -2865,6 +2800,10 @@
 /area/city/shop)
 "kV" = (
 /obj/structure/sign/departments/safety,
+/turf/closed/indestructible/reinforced,
+/area/facility_hallway/manager)
+"kW" = (
+/obj/machinery/smartfridge/extraction_storage/ego_armor,
 /turf/closed/indestructible/reinforced,
 /area/facility_hallway/manager)
 "kX" = (
@@ -3575,12 +3514,9 @@
 /turf/open/floor/facility/dark,
 /area/city/backstreets_room)
 "nR" = (
-/obj/structure/table/wood/fancy/blue,
-/obj/machinery/light/cold/no_nightlight{
-	brightness = 16;
-	dir = 8
-	},
-/turf/open/floor/carpet/royalblue,
+/obj/effect/turf_decal/bot_white,
+/obj/machinery/vending/modularpc,
+/turf/open/floor/facility/dark,
 /area/facility_hallway/manager)
 "nU" = (
 /obj/machinery/light{
@@ -3754,21 +3690,6 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/mineral/titanium/tiled/white,
 /area/city/shop)
-"oL" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = 12;
-	pixel_y = -6
-	},
-/obj/structure/mirror{
-	pixel_x = 27
-	},
-/obj/machinery/door/window/southright{
-	name = "Shower Door";
-	opacity = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/facility_hallway/manager)
 "oM" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/machinery/light/cold/no_nightlight{
@@ -3964,6 +3885,11 @@
 	name = "Bolted Door"
 	},
 /area/city/backstreets_checkpoint)
+"pz" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/siding/white,
+/turf/open/floor/plasteel/elevatorshaft,
+/area/facility_hallway/manager)
 "pA" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#3234B9";
@@ -4088,37 +4014,19 @@
 	name = "Grass"
 	},
 /area/facility_hallway/manager)
-"pU" = (
-/obj/structure/easel,
-/obj/item/canvas/nineteen_nineteen,
-/obj/item/canvas/nineteen_nineteen,
-/obj/item/storage/crayons,
-/obj/item/storage/crayons,
-/obj/item/toy/crayon/spraycan/infinite,
-/obj/item/toy/crayon/spraycan/infinite,
-/obj/structure/sign/painting/library{
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/siding/yellow/end{
-	dir = 4
-	},
-/obj/machinery/light/cold/no_nightlight{
-	brightness = 16;
-	dir = 4
-	},
-/turf/open/floor/carpet/stellar,
-/area/facility_hallway/manager)
 "pW" = (
 /obj/structure/closet,
 /turf/open/floor/mineral/titanium/blue,
 /area/city/fixers)
 "qa" = (
-/obj/structure/showcase/machinery/tv,
+/obj/machinery/computer/abnormality_logs{
+	dir = 8
+	},
 /obj/machinery/light/cold/no_nightlight{
 	brightness = 16;
 	dir = 4
 	},
-/turf/open/floor/carpet/red,
+/turf/open/floor/facility/dark,
 /area/facility_hallway/manager)
 "qd" = (
 /obj/effect/turf_decal/siding/wood{
@@ -4376,10 +4284,6 @@
 /obj/item/bedsheet/wiz,
 /turf/open/floor/wood,
 /area/city/shop)
-"ri" = (
-/obj/structure/showcase/machinery/tv,
-/turf/open/floor/carpet/royalblue,
-/area/facility_hallway/manager)
 "rj" = (
 /obj/structure/rack{
 	pixel_x = -1
@@ -4934,6 +4838,16 @@
 	},
 /turf/open/floor/mineral/titanium/tiled/white,
 /area/city/shop)
+"sL" = (
+/obj/structure/filingcabinet/heinfo{
+	pixel_x = 10
+	},
+/obj/structure/filingcabinet/tethinfo,
+/obj/structure/filingcabinet/zayininfo{
+	pixel_x = -10
+	},
+/turf/open/floor/facility/dark,
+/area/facility_hallway/manager)
 "sM" = (
 /obj/structure/lattice/catwalk,
 /obj/effect/turf_decal/loading_area/white,
@@ -5168,12 +5082,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/facility/dark,
 /area/facility_hallway/manager)
-"tG" = (
-/obj/structure/closet/secure_closet/personal/cabinet{
-	anchored = 1
-	},
-/turf/open/floor/carpet/red,
-/area/facility_hallway/manager)
 "tH" = (
 /obj/structure/sign/departments/extraction,
 /turf/closed/indestructible/reinforced,
@@ -5364,16 +5272,18 @@
 /turf/open/floor/carpet,
 /area/city/house)
 "uq" = (
-/obj/structure/window/reinforced/spawner/north{
-	max_integrity = 25;
-	opacity = 1
+/obj/structure/rack,
+/obj/item/toner/extreme,
+/obj/item/toner/extreme,
+/obj/item/toner/extreme,
+/obj/item/toy/crayon/spraycan/infinite,
+/obj/item/toy/crayon/spraycan/infinite{
+	pixel_x = 8
 	},
-/obj/structure/closet,
-/obj/machinery/light/cold/no_nightlight{
-	brightness = 16;
-	dir = 4
+/obj/item/toy/crayon/spraycan/infinite{
+	pixel_x = -8
 	},
-/turf/open/floor/carpet/royalblue,
+/turf/open/floor/carpet/black,
 /area/facility_hallway/manager)
 "us" = (
 /obj/structure/railing{
@@ -5874,9 +5784,9 @@
 /turf/open/floor/mineral/titanium/tiled/white,
 /area/city/shop)
 "vZ" = (
-/obj/structure/bed,
-/obj/item/bedsheet/wiz,
-/turf/open/floor/carpet/royalblue,
+/obj/machinery/vending/lobotomyarmband,
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/facility/dark,
 /area/facility_hallway/manager)
 "wb" = (
 /obj/effect/turf_decal/siding/wood/end{
@@ -6280,12 +6190,6 @@
 	},
 /turf/open/floor/mineral/silver,
 /area/city/shop)
-"xI" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin,
-/obj/item/pen/fourcolor,
-/turf/open/floor/carpet/red,
-/area/facility_hallway/manager)
 "xJ" = (
 /obj/machinery/light{
 	dir = 8
@@ -6388,7 +6292,7 @@
 	brightness = 16;
 	dir = 8
 	},
-/obj/machinery/vending/lobotomyarmband,
+/obj/structure/extraction_belt,
 /turf/open/floor/facility/dark,
 /area/facility_hallway/manager)
 "xW" = (
@@ -6402,10 +6306,10 @@
 /turf/open/floor/facility/dark,
 /area/facility_hallway/manager)
 "yg" = (
-/obj/structure/chair/comfy/brown{
-	dir = 1
+/obj/structure/chair/office{
+	dir = 4
 	},
-/turf/open/floor/carpet/red,
+/turf/open/floor/carpet/royalblack,
 /area/facility_hallway/manager)
 "yh" = (
 /obj/effect/turf_decal/tile/brown{
@@ -6477,9 +6381,8 @@
 /turf/open/floor/mineral/titanium/tiled/white,
 /area/city/shop)
 "yr" = (
-/obj/structure/bed,
-/obj/item/bedsheet/hos,
-/turf/open/floor/carpet/red,
+/obj/machinery/text_adventure_console,
+/turf/open/floor/facility/dark,
 /area/facility_hallway/manager)
 "ys" = (
 /obj/machinery/grill,
@@ -6697,6 +6600,18 @@
 /obj/item/pen/blue,
 /turf/open/floor/facility,
 /area/city)
+"za" = (
+/obj/structure/filingcabinet/alephinfo{
+	pixel_x = 1
+	},
+/obj/structure/filingcabinet/wawinfo{
+	pixel_x = -9
+	},
+/obj/structure/filingcabinet/toolinfo{
+	pixel_x = 11
+	},
+/turf/open/floor/facility/dark,
+/area/facility_hallway/manager)
 "zb" = (
 /obj/machinery/griddle{
 	pixel_y = 1
@@ -6923,22 +6838,6 @@
 	},
 /turf/open/floor/plating/grass,
 /area/city)
-"zR" = (
-/obj/structure/easel,
-/obj/item/canvas/nineteen_nineteen,
-/obj/item/canvas/nineteen_nineteen,
-/obj/item/storage/crayons,
-/obj/item/storage/crayons,
-/obj/item/toy/crayon/spraycan/infinite,
-/obj/item/toy/crayon/spraycan/infinite,
-/obj/structure/sign/painting/library{
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/siding/yellow/end{
-	dir = 8
-	},
-/turf/open/floor/carpet/stellar,
-/area/facility_hallway/manager)
 "zS" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/disposalpipe/segment{
@@ -7032,10 +6931,10 @@
 /turf/open/floor/carpet/cyan,
 /area/city/shop)
 "Ah" = (
-/obj/machinery/door/airlock/sandstone{
-	name = "Captain Agent Bedroom"
-	},
-/turf/open/floor/facility/halls,
+/obj/structure/table/reinforced,
+/obj/item/clipboard,
+/obj/effect/turf_decal/siding/white,
+/turf/open/floor/plasteel/elevatorshaft,
 /area/facility_hallway/manager)
 "Ai" = (
 /obj/effect/turf_decal/tile/blue{
@@ -7429,6 +7328,12 @@
 	},
 /turf/open/floor/plating,
 /area/city/shop)
+"BR" = (
+/obj/machinery/door/airlock/sandstone{
+	name = "Ground-Floor Records Office"
+	},
+/turf/open/floor/facility/halls,
+/area/facility_hallway/manager)
 "BU" = (
 /obj/structure/chair/pew/left{
 	desc = "Sit here and relax";
@@ -7821,16 +7726,10 @@
 /turf/open/indestructible/white,
 /area/city/shop)
 "Dd" = (
-/obj/structure/window/reinforced/spawner/east{
-	max_integrity = 25;
-	name = "Glass";
-	opacity = 1
-	},
-/obj/effect/turf_decal/tile/bar{
+/obj/machinery/computer/ego_purchase{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/bar,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/carpet/royalblack,
 /area/facility_hallway/manager)
 "De" = (
 /obj/machinery/computer/operating{
@@ -7893,16 +7792,6 @@
 	dir = 1
 	},
 /turf/open/floor/facility/white,
-/area/facility_hallway/manager)
-"Dk" = (
-/obj/effect/turf_decal/tile/blue{
-	color = "#3234B9"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#3234B9";
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/facility_hallway/manager)
 "Dl" = (
 /turf/open/floor/carpet/purple,
@@ -8446,15 +8335,6 @@
 	},
 /turf/open/floor/mineral/titanium/tiled/white,
 /area/city/shop)
-"Fx" = (
-/obj/item/soap/ncorporation,
-/obj/machinery/shower{
-	dir = 8
-	},
-/obj/structure/window/reinforced/spawner/west,
-/obj/machinery/light/small,
-/turf/open/floor/noslip,
-/area/facility_hallway/manager)
 "FC" = (
 /obj/structure/table/reinforced,
 /obj/structure/railing{
@@ -8464,16 +8344,12 @@
 /turf/open/floor/eighties,
 /area/city/shop)
 "FE" = (
-/obj/structure/window/reinforced/spawner{
-	max_integrity = 25;
-	name = "Shower Glass";
-	opacity = 1
-	},
+/obj/effect/landmark/refinerspawn,
 /obj/machinery/light/cold/no_nightlight{
 	brightness = 16;
 	dir = 8
 	},
-/turf/open/floor/carpet/red,
+/turf/open/floor/carpet/royalblack,
 /area/facility_hallway/manager)
 "FF" = (
 /obj/structure/closet/secure_closet/freezer/fridge{
@@ -9318,6 +9194,13 @@
 /obj/machinery/vending/fixer,
 /turf/open/floor/facility,
 /area/city)
+"IF" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/belt/ego,
+/obj/item/storage/belt/ego,
+/obj/item/storage/belt/ego,
+/turf/open/floor/facility/dark,
+/area/facility_hallway/manager)
 "IG" = (
 /obj/structure/fence{
 	dir = 4
@@ -9505,6 +9388,10 @@
 /obj/structure/table/wood,
 /turf/open/floor/facility,
 /area/city)
+"Jv" = (
+/obj/structure/rack,
+/turf/open/floor/carpet/royalblack,
+/area/facility_hallway/manager)
 "JB" = (
 /obj/structure/toilet{
 	dir = 4;
@@ -9806,15 +9693,6 @@
 	},
 /turf/open/floor/mineral/titanium/tiled/white,
 /area/city/fixers)
-"KO" = (
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/facility_hallway/manager)
 "KR" = (
 /obj/structure/table/bronze,
 /obj/item/reagent_containers/food/condiment/peppermill{
@@ -9976,26 +9854,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/city/shop)
-"Lz" = (
-/obj/structure/easel,
-/obj/item/canvas/nineteen_nineteen,
-/obj/item/canvas/nineteen_nineteen,
-/obj/item/storage/crayons,
-/obj/item/storage/crayons,
-/obj/item/toy/crayon/spraycan/infinite,
-/obj/item/toy/crayon/spraycan/infinite,
-/obj/structure/sign/painting/library{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/siding/yellow/end{
-	dir = 8
-	},
-/obj/machinery/light/cold/no_nightlight{
-	brightness = 16;
-	dir = 8
-	},
-/turf/open/floor/carpet/stellar,
-/area/facility_hallway/manager)
 "LB" = (
 /obj/structure/table/anvil,
 /turf/open/floor/mineral/titanium/tiled/white,
@@ -10036,8 +9894,10 @@
 /turf/open/floor/carpet/cyan,
 /area/facility_hallway/manager)
 "LK" = (
-/obj/structure/closet,
-/turf/open/floor/carpet/royalblue,
+/obj/machinery/computer/camera_advanced/manager/sephirah{
+	dir = 4
+	},
+/turf/open/floor/carpet/black,
 /area/facility_hallway/manager)
 "LL" = (
 /obj/effect/turf_decal/tile/blue{
@@ -10542,13 +10402,6 @@
 /obj/item/melee/classic_baton,
 /turf/open/floor/mineral/titanium/tiled/white,
 /area/city/shop)
-"NZ" = (
-/obj/machinery/door/window/southleft{
-	name = "Bathroom Door";
-	opacity = 1
-	},
-/turf/open/floor/carpet/red,
-/area/facility_hallway/manager)
 "Oa" = (
 /obj/machinery/computer/security,
 /turf/open/floor/facility/dark,
@@ -10657,6 +10510,13 @@
 	dir = 1
 	},
 /turf/open/floor/facility/dark,
+/area/facility_hallway/manager)
+"OF" = (
+/obj/structure/chair/comfy{
+	dir = 1
+	},
+/obj/item/toy/plush/hokma,
+/turf/open/floor/carpet/black,
 /area/facility_hallway/manager)
 "OG" = (
 /obj/structure/flora/ausbushes/reedbush,
@@ -10824,11 +10684,6 @@
 	},
 /turf/open/floor/circuit/telecomms,
 /area/city/backstreets_checkpoint)
-"Ps" = (
-/obj/structure/table/wood/fancy/blue,
-/obj/item/modular_computer/laptop,
-/turf/open/floor/carpet/royalblue,
-/area/facility_hallway/manager)
 "Px" = (
 /obj/effect/turf_decal/siding/blue/end,
 /turf/open/floor/carpet/cyan,
@@ -10945,6 +10800,13 @@
 /obj/item/reagent_containers/food/drinks/bottle/champagne,
 /turf/open/floor/facility,
 /area/city)
+"PT" = (
+/obj/structure/table/reinforced,
+/obj/item/paper_bin/carbon,
+/obj/item/pen/fourcolor,
+/obj/effect/turf_decal/siding/white,
+/turf/open/floor/plasteel/elevatorshaft,
+/area/facility_hallway/manager)
 "PW" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 8
@@ -11500,19 +11362,6 @@
 	},
 /turf/open/floor/carpet/cyan,
 /area/city/shop)
-"Sl" = (
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/sepia,
-/area/facility_hallway/manager)
 "Sn" = (
 /obj/machinery/announcement_system,
 /obj/effect/turf_decal/bot,
@@ -11529,22 +11378,6 @@
 /obj/item/pen,
 /turf/open/floor/plasteel/dark,
 /area/city/shop)
-"Ss" = (
-/obj/structure/easel,
-/obj/item/canvas/nineteen_nineteen,
-/obj/item/canvas/nineteen_nineteen,
-/obj/item/storage/crayons,
-/obj/item/storage/crayons,
-/obj/item/toy/crayon/spraycan/infinite,
-/obj/item/toy/crayon/spraycan/infinite,
-/obj/structure/sign/painting/library{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/siding/yellow/end{
-	dir = 4
-	},
-/turf/open/floor/carpet/stellar,
-/area/facility_hallway/manager)
 "St" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -12191,6 +12024,12 @@
 	opacity = 0
 	},
 /area/city)
+"UY" = (
+/obj/machinery/door/airlock/sandstone{
+	name = "Ground-Floor Extraction Office"
+	},
+/turf/open/floor/facility/halls,
+/area/facility_hallway/manager)
 "Va" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -12521,6 +12360,7 @@
 /obj/machinery/light/cold/no_nightlight{
 	brightness = 16
 	},
+/obj/machinery/vending/lobotomyarmband,
 /turf/open/floor/facility/dark,
 /area/facility_hallway/manager)
 "Wv" = (
@@ -12681,7 +12521,8 @@
 	},
 /area/city/shop)
 "WO" = (
-/turf/open/floor/carpet/red,
+/obj/structure/chair/office,
+/turf/open/floor/carpet/royalblack,
 /area/facility_hallway/manager)
 "WP" = (
 /turf/closed/indestructible/fakedoor{
@@ -12816,24 +12657,6 @@
 	dir = 5
 	},
 /turf/open/floor/carpet/black,
-/area/facility_hallway/manager)
-"Xn" = (
-/obj/effect/turf_decal/tile/blue{
-	color = "#3234B9";
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#3234B9"
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#3234B9";
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	color = "#3234B9";
-	dir = 4
-	},
-/turf/open/floor/sepia,
 /area/facility_hallway/manager)
 "Xp" = (
 /obj/structure/table/reinforced,
@@ -13137,6 +12960,12 @@
 	},
 /turf/open/floor/mineral/titanium/tiled/white,
 /area/city/shop)
+"Yz" = (
+/obj/machinery/computer/extraction_cargo{
+	dir = 8
+	},
+/turf/open/floor/facility/dark,
+/area/facility_hallway/manager)
 "YB" = (
 /turf/open/floor/facility/dark,
 /area/city/backstreets_room)
@@ -19385,9 +19214,9 @@ aq
 aq
 aq
 eL
-Sl
-Sl
-Sl
+zN
+zN
+zN
 JE
 Ck
 Gi
@@ -21441,9 +21270,9 @@ bI
 aq
 aq
 eL
-Xn
-Xn
-Xn
+xK
+xK
+xK
 JE
 Ck
 Gi
@@ -23481,9 +23310,9 @@ JE
 JE
 JE
 JE
-JE
-JE
-Lz
+tH
+Mc
+Mc
 Mc
 li
 Mc
@@ -23736,12 +23565,12 @@ JE
 JE
 FE
 ds
-sY
-aV
-JE
-JE
-Ss
-Mc
+qB
+xQ
+UY
+HC
+aq
+aq
 aq
 Mc
 ZG
@@ -23990,12 +23819,12 @@ Jh
 aq
 Kd
 JE
-km
-NZ
+Jv
+qB
+Jv
+qB
 Dd
-Dd
-Dd
-JE
+kW
 Mc
 Mc
 Mc
@@ -24247,15 +24076,15 @@ jX
 aq
 yL
 Ji
-xI
+ds
+qB
+Jv
+qB
 WO
-WO
-WO
-WO
-Ah
-KO
-aq
-aq
+Xp
+Mc
+Mc
+Mc
 aq
 aq
 aq
@@ -24504,12 +24333,12 @@ jX
 aq
 tZ
 Ji
-kw
+qB
 yg
-WO
-WO
-tG
-JE
+qB
+qB
+qB
+IF
 Mc
 Mc
 Mc
@@ -24762,11 +24591,11 @@ aq
 hX
 JE
 qa
-WO
+Yz
 yr
 hs
 JE
-JE
+kz
 Mc
 MD
 Mc
@@ -25022,7 +24851,7 @@ JE
 JE
 JE
 JE
-JE
+tH
 xU
 Mc
 Mc
@@ -27344,11 +27173,11 @@ aq
 Mc
 MD
 Mc
+fN
 JE
-JE
-cU
-gk
-Ps
+IY
+IY
+IY
 nR
 JE
 NC
@@ -27601,11 +27430,11 @@ aq
 Mc
 Mc
 Mc
-JE
+pz
 LK
-ri
-gk
-gk
+IY
+sL
+IY
 jg
 Ji
 GX
@@ -27855,14 +27684,14 @@ HC
 aq
 aq
 aq
-aq
-aq
-Dk
+Mc
+Mc
+Mc
 Ah
-gk
-gk
-gk
-gk
+OF
+IY
+za
+IY
 gk
 Ji
 iM
@@ -28114,12 +27943,12 @@ Mc
 aq
 Mc
 Mc
-ss
-JE
+Mc
+PT
 hL
-hL
-hL
-dh
+IY
+IY
+IY
 vZ
 JE
 ws
@@ -28370,12 +28199,12 @@ qV
 Mc
 aq
 Mc
-zR
-JE
-JE
-if
-oL
-Fx
+Mc
+Mc
+BR
+IY
+IY
+IY
 uq
 JE
 JE
@@ -28627,7 +28456,7 @@ Ad
 Mc
 pO
 Mc
-pU
+Mc
 JE
 JE
 JE
@@ -30693,9 +30522,9 @@ jX
 jX
 aq
 eL
-Sl
-Sl
-Sl
+zN
+zN
+zN
 JE
 Gi
 jo
@@ -32749,9 +32578,9 @@ aq
 aq
 aq
 eL
-Xn
-Xn
-Xn
+xK
+xK
+xK
 JE
 Ck
 Gi

--- a/_maps/map_files/Xi/xicommand.dmm
+++ b/_maps/map_files/Xi/xicommand.dmm
@@ -57,7 +57,7 @@
 	max_integrity = 25;
 	opacity = 1
 	},
-/turf/open/floor/mineral/titanium/tiled/yellow/airless,
+/turf/open/floor/mineral/titanium/tiled/white,
 /area/city/shop)
 "ap" = (
 /obj/structure/railing{
@@ -153,7 +153,7 @@
 /obj/structure/chair/comfy/brown{
 	dir = 4
 	},
-/turf/open/floor/wood,
+/turf/open/floor/facility,
 /area/city)
 "aF" = (
 /obj/machinery/door/airlock/hatch{
@@ -178,7 +178,7 @@
 /area/city/shop)
 "aK" = (
 /obj/structure/chair/wood/wings,
-/turf/open/floor/wood,
+/turf/open/floor/facility,
 /area/city)
 "aN" = (
 /obj/machinery/modular_computer/console{
@@ -262,7 +262,7 @@
 /obj/effect/turf_decal/siding/wood/end{
 	dir = 8
 	},
-/turf/open/floor/wood,
+/turf/open/floor/facility,
 /area/city)
 "bf" = (
 /obj/effect/turf_decal/plaque{
@@ -282,6 +282,9 @@
 /obj/machinery/door/airlock/sandstone,
 /turf/open/floor/facility/halls,
 /area/facility_hallway/manager)
+"bn" = (
+/turf/open/floor/plating,
+/area/facility_hallway/south)
 "br" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -463,7 +466,7 @@
 /obj/effect/turf_decal/arrows/red{
 	dir = 4
 	},
-/turf/open/floor/mineral/titanium/tiled/yellow/airless,
+/turf/open/floor/mineral/titanium/tiled/white,
 /area/city/shop)
 "bX" = (
 /obj/machinery/light/cold/no_nightlight{
@@ -546,7 +549,7 @@
 	brightness = 16;
 	dir = 8
 	},
-/turf/open/floor/wood,
+/turf/open/floor/facility,
 /area/city)
 "ck" = (
 /obj/effect/turf_decal/siding/wood/corner,
@@ -661,7 +664,7 @@
 /obj/structure/toilet{
 	dir = 1
 	},
-/turf/open/floor/sepia,
+/turf/open/floor/material,
 /area/city/house)
 "cC" = (
 /obj/machinery/modular_computer/console,
@@ -778,7 +781,7 @@
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 8
 	},
-/turf/open/floor/wood,
+/turf/open/floor/facility,
 /area/city)
 "cT" = (
 /obj/structure/chair/sofa/corp/right{
@@ -817,7 +820,8 @@
 	brightness = 16;
 	dir = 1
 	},
-/turf/open/floor/wood,
+/obj/machinery/vending/city,
+/turf/open/floor/facility,
 /area/city)
 "dc" = (
 /obj/structure/closet/crate,
@@ -983,7 +987,7 @@
 /turf/open/floor/circuit/telecomms,
 /area/city/fixers)
 "dw" = (
-/turf/open/floor/sepia,
+/turf/open/floor/material,
 /area/city/house)
 "dx" = (
 /obj/structure/bookcase/random,
@@ -1144,7 +1148,7 @@
 	brightness = 16;
 	dir = 1
 	},
-/turf/open/floor/wood,
+/turf/open/floor/facility,
 /area/city)
 "dY" = (
 /obj/effect/turf_decal/siding/blue/corner{
@@ -1204,7 +1208,7 @@
 /area/facility_hallway/manager)
 "em" = (
 /obj/effect/turf_decal/delivery/red,
-/turf/open/floor/plasteel/airless/white,
+/turf/open/floor/plasteel/white,
 /area/city/backstreets_checkpoint)
 "eo" = (
 /obj/effect/turf_decal/tile/blue{
@@ -1290,12 +1294,6 @@
 	opacity = 1
 	},
 /area/city)
-"eK" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/turf/open/floor/plating/grass/jungle{
-	name = "Grass"
-	},
-/area/facility_hallway/manager)
 "eL" = (
 /obj/machinery/door/airlock{
 	name = "Agent Barracks"
@@ -1468,6 +1466,29 @@
 	},
 /turf/open/floor/plating/grass,
 /area/facility_hallway/manager)
+"fs" = (
+/obj/effect/turf_decal/tile{
+	color = "#333333";
+	dir = 1
+	},
+/obj/effect/turf_decal/tile{
+	color = "#333333"
+	},
+/obj/effect/turf_decal/tile{
+	color = "#333333";
+	dir = 8
+	},
+/obj/effect/turf_decal/tile{
+	color = "#333333";
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/old,
+/obj/structure/kitchenspike,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/kitchen_coldroom,
+/area/city/shop)
 "ft" = (
 /obj/machinery/door/airlock/wood{
 	name = "Welfare Head Office"
@@ -1560,6 +1581,10 @@
 /area/facility_hallway/manager)
 "fO" = (
 /obj/structure/table/anvil,
+/obj/machinery/light/cold/no_nightlight{
+	brightness = 16;
+	dir = 4
+	},
 /turf/open/floor/mineral/plastitanium,
 /area/city/house)
 "fP" = (
@@ -1657,6 +1682,14 @@
 "gk" = (
 /turf/open/floor/carpet/royalblue,
 /area/facility_hallway/manager)
+"gl" = (
+/obj/structure/table/glass,
+/obj/structure/window/reinforced/spawner/east{
+	max_integrity = 25
+	},
+/obj/machinery/cell_charger,
+/turf/open/floor/mineral/titanium/white,
+/area/city/shop)
 "gm" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -1850,7 +1883,7 @@
 /obj/structure/chair/plastic{
 	dir = 1
 	},
-/turf/open/floor/plasteel/airless/white,
+/turf/open/floor/plasteel/white,
 /area/city/backstreets_checkpoint)
 "hf" = (
 /obj/effect/turf_decal/tile{
@@ -1944,7 +1977,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/caution/red,
-/turf/open/floor/plasteel/airless/white,
+/turf/open/floor/plasteel/white,
 /area/city/backstreets_checkpoint)
 "hx" = (
 /obj/structure/table/reinforced{
@@ -1992,7 +2025,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/box/red,
-/turf/open/floor/plasteel/airless/white,
+/turf/open/floor/plasteel/white,
 /area/city/backstreets_checkpoint)
 "hD" = (
 /obj/machinery/door/airlock/grunge,
@@ -2066,7 +2099,7 @@
 	},
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/box/red,
-/turf/open/floor/mineral/titanium/tiled/yellow/airless,
+/turf/open/floor/mineral/titanium/tiled/white,
 /area/city/shop)
 "hV" = (
 /obj/effect/turf_decal/tile/red,
@@ -2115,7 +2148,7 @@
 /obj/structure/sink/kitchen{
 	pixel_y = 14
 	},
-/turf/open/floor/mineral/titanium/tiled/yellow/airless,
+/turf/open/floor/mineral/titanium/tiled/white,
 /area/city/shop)
 "id" = (
 /obj/structure/sink/kitchen{
@@ -2123,7 +2156,7 @@
 	pixel_x = 11;
 	pixel_y = 14
 	},
-/turf/open/floor/sepia,
+/turf/open/floor/material,
 /area/city/house)
 "ie" = (
 /obj/machinery/light/cold/no_nightlight,
@@ -2480,8 +2513,20 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
 	},
-/turf/open/floor/wood,
+/turf/open/floor/facility,
 /area/city)
+"ju" = (
+/obj/docking_port/stationary{
+	dheight = 10;
+	dir = 2;
+	dwidth = 1;
+	height = 23;
+	id = "emergency_home";
+	name = "Alphacorp emergency evac bay";
+	width = 8
+	},
+/turf/open/floor/plating,
+/area/facility_hallway/south)
 "jv" = (
 /obj/machinery/computer/slot_machine,
 /obj/effect/turf_decal/siding/blue{
@@ -2498,11 +2543,11 @@
 	pixel_x = -1
 	},
 /obj/item/storage/belt/ego,
-/turf/open/floor/mineral/titanium/blue/airless,
+/turf/open/floor/mineral/titanium/tiled/white,
 /area/city/shop)
 "jD" = (
 /obj/structure/table/anvil,
-/turf/open/floor/wood,
+/turf/open/floor/facility,
 /area/city)
 "jE" = (
 /obj/structure/chair/pew/left,
@@ -2536,6 +2581,10 @@
 /area/city/shop)
 "jN" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
+/obj/machinery/light/cold/no_nightlight{
+	brightness = 16;
+	dir = 8
+	},
 /turf/open/floor/wood,
 /area/city/house)
 "jP" = (
@@ -2573,7 +2622,7 @@
 /obj/structure/toilet{
 	pixel_y = 2
 	},
-/turf/open/floor/sepia,
+/turf/open/floor/material,
 /area/city/house)
 "jX" = (
 /obj/effect/decal/cleanable/dirt,
@@ -2596,6 +2645,10 @@
 /area/city/shop)
 "ke" = (
 /obj/structure/forge,
+/obj/machinery/light/cold/no_nightlight{
+	brightness = 16;
+	dir = 4
+	},
 /turf/open/floor/mineral/plastitanium,
 /area/city/house)
 "kf" = (
@@ -2623,7 +2676,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/turf/open/floor/wood,
+/turf/open/floor/facility,
 /area/city)
 "km" = (
 /obj/structure/filingcabinet/chestdrawer,
@@ -2698,7 +2751,7 @@
 /obj/effect/turf_decal/loading_area{
 	dir = 8
 	},
-/turf/open/floor/plasteel/sepia,
+/turf/open/floor/mineral/titanium/tiled/white,
 /area/city/shop)
 "kB" = (
 /obj/effect/turf_decal/siding/wood/corner{
@@ -2858,7 +2911,7 @@
 /obj/structure/sink{
 	pixel_y = 16
 	},
-/turf/open/floor/mineral/titanium/tiled/yellow/airless,
+/turf/open/floor/mineral/titanium/tiled/white,
 /area/city/shop)
 "lf" = (
 /obj/structure/table/wood,
@@ -2929,7 +2982,7 @@
 /obj/item/choice_beacon/ingredient,
 /obj/item/choice_beacon/ingredient,
 /obj/item/choice_beacon/ingredient,
-/turf/open/floor/mineral/titanium/tiled/yellow/airless,
+/turf/open/floor/mineral/titanium/tiled/white,
 /area/city/shop)
 "lo" = (
 /obj/item/modular_computer/laptop{
@@ -3010,7 +3063,8 @@
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
 	},
-/turf/open/floor/wood,
+/obj/machinery/body_preservation_unit,
+/turf/open/floor/facility,
 /area/city)
 "lC" = (
 /obj/machinery/computer/secure_data{
@@ -3153,7 +3207,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/turf/open/floor/wood,
+/turf/open/floor/facility,
 /area/city)
 "mo" = (
 /obj/structure/flora/ausbushes/ppflowers,
@@ -3182,7 +3236,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/brown,
-/turf/open/floor/mineral/titanium/tiled/yellow/airless,
+/turf/open/floor/mineral/titanium/tiled/white,
 /area/city/shop)
 "ms" = (
 /obj/effect/turf_decal/arrows/red{
@@ -3198,7 +3252,7 @@
 /obj/effect/turf_decal/caution/red{
 	dir = 1
 	},
-/turf/open/floor/plasteel/airless/white,
+/turf/open/floor/plasteel/white,
 /area/city/backstreets_checkpoint)
 "mt" = (
 /obj/effect/turf_decal/siding/wood{
@@ -3431,7 +3485,7 @@
 /obj/machinery/scanner_gate{
 	scangate_mode = "Guns"
 	},
-/turf/open/floor/plasteel/airless/white,
+/turf/open/floor/plasteel/white,
 /area/city/backstreets_checkpoint)
 "nw" = (
 /obj/structure/flora/ausbushes/ywflowers,
@@ -3491,7 +3545,7 @@
 /obj/effect/turf_decal/arrows/red{
 	dir = 1
 	},
-/turf/open/floor/plasteel/airless/white,
+/turf/open/floor/plasteel/white,
 /area/city/backstreets_checkpoint)
 "nL" = (
 /obj/machinery/door/window/northright,
@@ -3503,7 +3557,7 @@
 	scangate_mode = "Guns"
 	},
 /obj/effect/turf_decal/caution/red,
-/turf/open/floor/plasteel/airless/white,
+/turf/open/floor/plasteel/white,
 /area/city/backstreets_checkpoint)
 "nO" = (
 /obj/structure/flora/ausbushes/ywflowers,
@@ -3583,6 +3637,14 @@
 	},
 /turf/open/floor/wood,
 /area/city)
+"oj" = (
+/obj/structure/window/reinforced/spawner/east{
+	max_integrity = 25
+	},
+/obj/item/defibrillator,
+/obj/structure/table/glass,
+/turf/open/floor/mineral/titanium/white,
+/area/city/shop)
 "ol" = (
 /obj/effect/turf_decal/plaque{
 	alpha = 230;
@@ -3703,7 +3765,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
-/turf/open/floor/plasteel/sepia,
+/turf/open/floor/mineral/titanium/tiled/white,
 /area/city/shop)
 "oL" = (
 /obj/structure/sink{
@@ -3744,7 +3806,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/box,
-/turf/open/floor/plasteel/sepia,
+/turf/open/floor/mineral/titanium/tiled/white,
 /area/city/shop)
 "oQ" = (
 /obj/effect/light_emitter{
@@ -3774,13 +3836,13 @@
 /area/city/shop)
 "oT" = (
 /obj/machinery/vending/forge,
-/turf/open/floor/wood,
+/turf/open/floor/facility,
 /area/city)
 "oV" = (
 /obj/effect/turf_decal/siding/blue/end{
 	dir = 4
 	},
-/turf/open/floor/carpet/cyan,
+/turf/open/floor/facility,
 /area/city)
 "oW" = (
 /obj/structure/closet/secure_closet/freezer/fridge{
@@ -3806,6 +3868,9 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/city/house)
+"oX" = (
+/turf/open/floor/facility,
+/area/space)
 "oY" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 1
@@ -4092,7 +4157,7 @@
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
 	},
-/turf/open/floor/wood,
+/turf/open/floor/facility,
 /area/city)
 "qh" = (
 /obj/structure/railing{
@@ -4131,6 +4196,19 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
+/area/city)
+"qn" = (
+/obj/effect/turf_decal/siding/wood/corner,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
+	},
+/turf/open/floor/facility,
 /area/city)
 "qo" = (
 /obj/machinery/door/window/eastright,
@@ -4198,7 +4276,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/turf/open/floor/wood,
+/turf/open/floor/facility,
 /area/city)
 "qI" = (
 /obj/effect/turf_decal/siding/wood,
@@ -4206,7 +4284,7 @@
 /obj/item/stack/spacecash/c1000,
 /obj/item/stack/spacecash/c1000,
 /obj/item/storage/box/miscarmor/two,
-/turf/open/floor/wood,
+/turf/open/floor/facility,
 /area/city)
 "qL" = (
 /obj/structure/flora/ausbushes/ywflowers,
@@ -4326,7 +4404,7 @@
 	dir = 4
 	},
 /obj/machinery/light/cold/no_nightlight,
-/turf/open/floor/wood,
+/turf/open/floor/facility,
 /area/city)
 "rn" = (
 /obj/structure/table/bronze,
@@ -4413,7 +4491,7 @@
 /obj/structure/window/reinforced/spawner{
 	max_integrity = 25
 	},
-/turf/open/floor/plasteel/airless/white,
+/turf/open/floor/plasteel/white,
 /area/city/backstreets_checkpoint)
 "rF" = (
 /obj/effect/turf_decal/caution/red,
@@ -4430,11 +4508,11 @@
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
+/obj/machinery/light/cold/no_nightlight{
+	brightness = 16;
+	dir = 4
+	},
 /turf/open/floor/mineral/plastitanium,
-/area/city/house)
-"rP" = (
-/obj/machinery/door/airlock/wood,
-/turf/open/floor/sepia,
 /area/city/house)
 "rQ" = (
 /obj/structure/rack{
@@ -4993,7 +5071,7 @@
 	},
 /obj/effect/turf_decal/tile/brown,
 /obj/machinery/smartfridge/food,
-/turf/closed/indestructible/iron,
+/turf/open/floor/mineral/titanium/tiled/white,
 /area/city/shop)
 "tj" = (
 /obj/structure/sign/poster/random{
@@ -5026,13 +5104,6 @@
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/city/fixers)
-"tl" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/sparsegrass,
-/turf/open/floor/plating/grass/jungle{
-	name = "Grass"
-	},
-/area/facility_hallway/manager)
 "tm" = (
 /obj/effect/spawner/randomcolavend,
 /obj/structure/sign/poster/random{
@@ -5081,7 +5152,7 @@
 	dir = 5
 	},
 /obj/item/bedsheet/red,
-/turf/open/floor/wood,
+/turf/open/floor/facility,
 /area/city)
 "tA" = (
 /obj/structure/table/reinforced{
@@ -5272,7 +5343,7 @@
 	max_integrity = 25;
 	opacity = 1
 	},
-/turf/open/floor/mineral/titanium/tiled/yellow/airless,
+/turf/open/floor/mineral/titanium/tiled/white,
 /area/city/shop)
 "uj" = (
 /obj/structure/flora/tree/jungle/small,
@@ -5467,7 +5538,7 @@
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
 	},
-/turf/open/floor/wood,
+/turf/open/floor/facility,
 /area/city)
 "uQ" = (
 /obj/structure/fluff/paper{
@@ -5551,7 +5622,7 @@
 	dir = 4;
 	pixel_x = -10
 	},
-/turf/open/floor/sepia,
+/turf/open/floor/material,
 /area/city/house)
 "va" = (
 /obj/structure/chair/office/light,
@@ -5622,7 +5693,7 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
-/turf/open/floor/plasteel/sepia,
+/turf/open/floor/mineral/titanium/tiled/white,
 /area/city/shop)
 "vm" = (
 /obj/structure/chair/wood/wings{
@@ -5715,6 +5786,13 @@
 	},
 /turf/open/floor/wood,
 /area/city/shop)
+"vD" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/obj/machinery/cryopod,
+/turf/open/floor/facility,
+/area/city)
 "vG" = (
 /obj/structure/chair/sofa/corp/right{
 	dir = 4
@@ -5758,9 +5836,7 @@
 "vS" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/ausbushes/sparsegrass,
-/turf/open/floor/plating/grass/jungle{
-	name = "Grass"
-	},
+/turf/open/floor/plating/grass,
 /area/facility_hallway/manager)
 "vT" = (
 /obj/machinery/light/cold/no_nightlight{
@@ -5808,7 +5884,7 @@
 	brightness = 16;
 	dir = 4
 	},
-/turf/open/floor/plasteel/sepia,
+/turf/open/floor/mineral/titanium/tiled/white,
 /area/city/shop)
 "vZ" = (
 /obj/structure/bed,
@@ -5854,7 +5930,7 @@
 /obj/effect/turf_decal/arrows/red{
 	dir = 8
 	},
-/turf/open/floor/plasteel/airless/white,
+/turf/open/floor/plasteel/white,
 /area/city/backstreets_checkpoint)
 "wm" = (
 /obj/effect/turf_decal/siding/wood{
@@ -5885,7 +5961,7 @@
 /obj/structure/window/reinforced/spawner{
 	max_integrity = 25
 	},
-/turf/open/floor/plasteel/airless/white,
+/turf/open/floor/plasteel/white,
 /area/city/backstreets_checkpoint)
 "wp" = (
 /obj/machinery/computer/extraction_cargo{
@@ -6128,6 +6204,7 @@
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
 	},
+/obj/machinery/body_preservation_unit,
 /turf/open/floor/wood,
 /area/city/shop)
 "xj" = (
@@ -6311,7 +6388,7 @@
 /area/facility_hallway/manager)
 "xW" = (
 /obj/effect/turf_decal/siding/wood,
-/turf/open/floor/wood,
+/turf/open/floor/facility,
 /area/city)
 "yf" = (
 /obj/machinery/computer/abnormality_auxiliary{
@@ -6360,7 +6437,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
 	},
-/turf/open/floor/wood,
+/turf/open/floor/facility,
 /area/city)
 "yl" = (
 /obj/structure/flora/ausbushes/brflowers,
@@ -6392,7 +6469,7 @@
 	},
 /obj/machinery/icecream_vat,
 /obj/machinery/light/floor,
-/turf/open/floor/plasteel/sepia,
+/turf/open/floor/mineral/titanium/tiled/white,
 /area/city/shop)
 "yr" = (
 /obj/structure/bed,
@@ -6452,7 +6529,7 @@
 	dir = 6
 	},
 /obj/item/bedsheet/red,
-/turf/open/floor/wood,
+/turf/open/floor/facility,
 /area/city)
 "yA" = (
 /obj/machinery/vending/cola/blue{
@@ -6613,7 +6690,7 @@
 /obj/structure/table/wood,
 /obj/item/paper_bin,
 /obj/item/pen/blue,
-/turf/open/floor/wood,
+/turf/open/floor/facility,
 /area/city)
 "zb" = (
 /obj/machinery/griddle{
@@ -6960,6 +7037,14 @@
 /obj/effect/turf_decal,
 /turf/open/floor/plasteel/dark,
 /area/facility_hallway/manager)
+"Ar" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/obj/machinery/light/cold/no_nightlight,
+/obj/structure/itemselling,
+/turf/open/floor/facility,
+/area/city)
 "As" = (
 /obj/structure/sign/departments/restroom{
 	pixel_y = -32
@@ -7115,7 +7200,7 @@
 	brightness = 16;
 	dir = 8
 	},
-/turf/open/floor/wood,
+/turf/open/floor/facility,
 /area/city)
 "AP" = (
 /obj/structure/table/wood/fancy/orange,
@@ -7297,8 +7382,16 @@
 /obj/effect/turf_decal/caution/red{
 	dir = 1
 	},
-/turf/open/floor/plasteel/airless/white,
+/turf/open/floor/plasteel/white,
 /area/city/backstreets_checkpoint)
+"BL" = (
+/obj/effect/turf_decal/siding/yellow,
+/obj/machinery/light/cold/no_nightlight{
+	brightness = 16;
+	dir = 4
+	},
+/turf/open/floor/carpet/black,
+/area/city/house)
 "BM" = (
 /obj/structure/railing{
 	dir = 5
@@ -7387,7 +7480,7 @@
 	dir = 9
 	},
 /obj/structure/showcase/machinery/tv,
-/turf/open/floor/wood,
+/turf/open/floor/facility,
 /area/city)
 "Cc" = (
 /obj/machinery/light/floor,
@@ -7434,7 +7527,7 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
-/turf/open/floor/plasteel/sepia,
+/turf/open/floor/mineral/titanium/tiled/white,
 /area/city/shop)
 "Cm" = (
 /obj/structure/rack{
@@ -7544,7 +7637,7 @@
 	brightness = 16;
 	dir = 1
 	},
-/turf/open/floor/mineral/titanium/tiled/yellow/airless,
+/turf/open/floor/mineral/titanium/tiled/white,
 /area/city/shop)
 "Cy" = (
 /obj/effect/turf_decal/siding/blue{
@@ -7626,6 +7719,13 @@
 	},
 /turf/open/floor/carpet/cyan,
 /area/city/shop)
+"CN" = (
+/obj/machinery/vending/fixer,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/facility,
+/area/space)
 "CQ" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/effect/turf_decal/siding/thinplating/dark,
@@ -7688,7 +7788,7 @@
 	dir = 10
 	},
 /obj/structure/closet/secure_closet/personal/cabinet,
-/turf/open/floor/wood,
+/turf/open/floor/facility,
 /area/city)
 "Dc" = (
 /obj/effect/turf_decal/tile/green{
@@ -7757,7 +7857,7 @@
 	scangate_mode = "Guns"
 	},
 /obj/effect/turf_decal/caution/red,
-/turf/open/floor/plasteel/airless/white,
+/turf/open/floor/plasteel/white,
 /area/city/backstreets_checkpoint)
 "Dh" = (
 /obj/effect/turf_decal/plaque{
@@ -7870,7 +7970,7 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
-/turf/open/floor/plasteel/sepia,
+/turf/open/floor/mineral/titanium/tiled/white,
 /area/city/shop)
 "DI" = (
 /obj/structure/riser/dark,
@@ -7946,6 +8046,11 @@
 "DQ" = (
 /turf/closed/indestructible/fakeglass,
 /area/facility_hallway/manager)
+"DR" = (
+/obj/structure/rack,
+/obj/item/soap,
+/turf/open/floor/facility,
+/area/space)
 "DU" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#3234B9";
@@ -7991,7 +8096,7 @@
 	brightness = 16;
 	dir = 8
 	},
-/turf/open/floor/sepia,
+/turf/open/floor/material,
 /area/city/house)
 "Ea" = (
 /obj/machinery/door/airlock/sandstone{
@@ -8123,13 +8228,20 @@
 "EJ" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/siding/wood,
-/turf/open/floor/wood,
+/turf/open/floor/facility,
 /area/city)
 "EK" = (
 /obj/effect/turf_decal/delivery/red,
 /obj/structure/table,
-/turf/open/floor/plasteel/airless/white,
+/turf/open/floor/plasteel/white,
 /area/city/backstreets_checkpoint)
+"EL" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/obj/machinery/cryopod,
+/turf/open/floor/wood,
+/area/city/shop)
 "EO" = (
 /turf/open/space/basic,
 /area/space)
@@ -8139,7 +8251,7 @@
 	},
 /obj/effect/turf_decal/tile/brown,
 /obj/machinery/chem_master/condimaster,
-/turf/open/floor/mineral/titanium/tiled/yellow/airless,
+/turf/open/floor/mineral/titanium/tiled/white,
 /area/city/shop)
 "ER" = (
 /obj/structure/chair/office,
@@ -8181,7 +8293,7 @@
 /turf/open/floor/facility/dark,
 /area/facility_hallway/manager)
 "EY" = (
-/turf/open/floor/wood,
+/turf/open/floor/facility,
 /area/city)
 "EZ" = (
 /obj/structure/railing{
@@ -8270,7 +8382,7 @@
 	brightness = 16;
 	dir = 8
 	},
-/turf/open/floor/wood,
+/turf/open/floor/facility,
 /area/city)
 "Fi" = (
 /obj/effect/landmark/salesspawn,
@@ -8408,7 +8520,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
 	},
-/turf/open/floor/wood,
+/turf/open/floor/facility,
 /area/city)
 "FQ" = (
 /obj/effect/light_emitter{
@@ -8448,7 +8560,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
 	},
-/turf/open/floor/wood,
+/turf/open/floor/facility,
 /area/city)
 "FV" = (
 /obj/effect/turf_decal/siding/wood{
@@ -8490,7 +8602,7 @@
 /obj/machinery/scanner_gate{
 	scangate_mode = "Guns"
 	},
-/turf/open/floor/plasteel/airless/white,
+/turf/open/floor/plasteel/white,
 /area/city/backstreets_checkpoint)
 "Ga" = (
 /obj/structure/table,
@@ -8664,6 +8776,14 @@
 /obj/machinery/door/window/northleft,
 /turf/open/floor/mineral/titanium/tiled/blue,
 /area/city/shop)
+"GK" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/obj/machinery/light/cold/no_nightlight,
+/obj/structure/itemselling,
+/turf/open/floor/wood,
+/area/city/shop)
 "GL" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
@@ -8708,7 +8828,7 @@
 /obj/item/reagent_containers/glass/bowl,
 /obj/item/kitchen/rollingpin,
 /obj/item/kitchen/knife,
-/turf/open/floor/mineral/titanium/tiled/yellow/airless,
+/turf/open/floor/mineral/titanium/tiled/white,
 /area/city/shop)
 "GT" = (
 /obj/machinery/door/window/northright,
@@ -8821,7 +8941,7 @@
 	opacity = 1
 	},
 /obj/effect/turf_decal/caution/red,
-/turf/open/floor/plasteel/airless/white,
+/turf/open/floor/plasteel/white,
 /area/city/backstreets_checkpoint)
 "Hj" = (
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -8875,7 +8995,7 @@
 /obj/effect/turf_decal/caution/red{
 	dir = 1
 	},
-/turf/open/floor/plasteel/airless/white,
+/turf/open/floor/plasteel/white,
 /area/city/backstreets_checkpoint)
 "Hs" = (
 /turf/closed/indestructible/fakeglass,
@@ -8915,7 +9035,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/caution/red,
-/turf/open/floor/plasteel/airless/white,
+/turf/open/floor/plasteel/white,
 /area/city/backstreets_checkpoint)
 "Hy" = (
 /turf/open/floor/mineral/titanium/tiled/blue,
@@ -9176,6 +9296,13 @@
 	},
 /turf/open/floor/plating/grass,
 /area/city)
+"ID" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/obj/machinery/vending/fixer,
+/turf/open/floor/facility,
+/area/city)
 "IG" = (
 /obj/structure/fence{
 	dir = 4
@@ -9195,7 +9322,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/turf/open/floor/wood,
+/turf/open/floor/facility,
 /area/city)
 "IN" = (
 /obj/effect/turf_decal/siding/wood{
@@ -9336,7 +9463,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
 	},
-/turf/open/floor/wood,
+/turf/open/floor/facility,
 /area/city)
 "Jl" = (
 /obj/machinery/vending/cola/blue{
@@ -9365,16 +9492,9 @@
 	},
 /turf/open/floor/plasteel/kitchen_coldroom,
 /area/city/shop)
-"Jt" = (
-/obj/structure/flora/tree/jungle/small,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/plating/grass/jungle{
-	name = "Grass"
-	},
-/area/facility_hallway/manager)
 "Ju" = (
 /obj/structure/table/wood,
-/turf/open/floor/wood,
+/turf/open/floor/facility,
 /area/city)
 "JB" = (
 /obj/structure/toilet{
@@ -9385,7 +9505,7 @@
 	brightness = 16;
 	dir = 4
 	},
-/turf/open/floor/sepia,
+/turf/open/floor/material,
 /area/city/house)
 "JD" = (
 /obj/effect/turf_decal/siding/wood{
@@ -9448,7 +9568,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/box/red,
-/turf/open/floor/plasteel/airless/white,
+/turf/open/floor/plasteel/white,
 /area/city/backstreets_checkpoint)
 "JR" = (
 /obj/machinery/light/cold/no_nightlight{
@@ -9605,7 +9725,7 @@
 /area/facility_hallway/manager)
 "Kq" = (
 /obj/structure/forge,
-/turf/open/floor/wood,
+/turf/open/floor/facility,
 /area/city)
 "Ks" = (
 /obj/structure/flora/ausbushes/reedbush,
@@ -9635,7 +9755,7 @@
 /obj/effect/turf_decal/siding/blue/end{
 	dir = 8
 	},
-/turf/open/floor/carpet/cyan,
+/turf/open/floor/facility,
 /area/city)
 "KE" = (
 /obj/effect/turf_decal/bot,
@@ -9734,7 +9854,7 @@
 	dir = 4
 	},
 /obj/item/bedsheet/red,
-/turf/open/floor/wood,
+/turf/open/floor/facility,
 /area/city)
 "Lc" = (
 /obj/effect/turf_decal/tile/blue{
@@ -9751,7 +9871,7 @@
 /obj/machinery/light/cold/no_nightlight,
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green,
-/turf/open/floor/wood,
+/turf/open/floor/facility,
 /area/city)
 "Lf" = (
 /obj/structure/closet/crate/trashcart,
@@ -9869,7 +9989,7 @@
 /area/facility_hallway/manager)
 "LB" = (
 /obj/structure/table/anvil,
-/turf/open/floor/mineral/titanium/tiled/blue,
+/turf/open/floor/mineral/titanium/tiled/white,
 /area/city/shop)
 "LC" = (
 /obj/machinery/door/airlock/grunge{
@@ -9886,7 +10006,7 @@
 	brightness = 16;
 	dir = 4
 	},
-/turf/open/floor/wood,
+/turf/open/floor/facility,
 /area/city)
 "LF" = (
 /obj/effect/turf_decal/siding/wood/corner,
@@ -9932,6 +10052,10 @@
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
+/obj/machinery/light/cold/no_nightlight{
+	brightness = 16;
+	dir = 8
+	},
 /turf/open/floor/mineral/plastitanium,
 /area/city/house)
 "LP" = (
@@ -9971,7 +10095,7 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
-/turf/open/floor/plasteel/sepia,
+/turf/open/floor/mineral/titanium/tiled/white,
 /area/city/shop)
 "LT" = (
 /obj/structure/curtain/cloth,
@@ -9998,6 +10122,11 @@
 	},
 /turf/open/floor/plating/grass,
 /area/facility_hallway/manager)
+"Ma" = (
+/obj/machinery/body_preservation_unit,
+/obj/machinery/light,
+/turf/open/floor/facility,
+/area/space)
 "Mc" = (
 /turf/open/floor/facility/dark,
 /area/facility_hallway/manager)
@@ -10052,7 +10181,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
 	},
-/turf/open/floor/wood,
+/turf/open/floor/facility,
 /area/city)
 "Ml" = (
 /obj/effect/decal/cleanable/oil,
@@ -10071,14 +10200,8 @@
 	desc = "Appears to be a fixers laptop.";
 	name = "Fixer Laptop"
 	},
-/turf/open/floor/wood,
+/turf/open/floor/facility,
 /area/city)
-"Mp" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/plating/grass/jungle{
-	name = "Grass"
-	},
-/area/facility_hallway/manager)
 "Mu" = (
 /obj/structure/fence/corner{
 	dir = 4
@@ -10119,7 +10242,7 @@
 	brightness = 16;
 	dir = 8
 	},
-/turf/open/floor/sepia,
+/turf/open/floor/material,
 /area/city/house)
 "MD" = (
 /obj/machinery/light/floor{
@@ -10143,7 +10266,7 @@
 /obj/effect/turf_decal/arrows/red{
 	dir = 4
 	},
-/turf/open/floor/plasteel/airless/white,
+/turf/open/floor/plasteel/white,
 /area/city/backstreets_checkpoint)
 "MI" = (
 /obj/effect/turf_decal/siding/yellow/corner{
@@ -10160,7 +10283,7 @@
 	pixel_x = 0;
 	pixel_y = 3
 	},
-/turf/open/floor/wood,
+/turf/open/floor/facility,
 /area/city)
 "ML" = (
 /obj/machinery/door/airlock/silver{
@@ -10347,6 +10470,10 @@
 	},
 /turf/open/floor/wood,
 /area/facility_hallway/manager)
+"NG" = (
+/obj/machinery/cryopod,
+/turf/open/floor/facility,
+/area/space)
 "NK" = (
 /turf/open/floor/stone,
 /area/city)
@@ -10404,7 +10531,7 @@
 	pixel_x = -1
 	},
 /obj/item/melee/classic_baton,
-/turf/open/floor/mineral/titanium/blue/airless,
+/turf/open/floor/mineral/titanium/tiled/white,
 /area/city/shop)
 "NZ" = (
 /obj/machinery/door/window/southleft{
@@ -10423,7 +10550,7 @@
 	},
 /obj/structure/bed,
 /obj/item/bedsheet/wiz,
-/turf/open/floor/wood,
+/turf/open/floor/facility,
 /area/city)
 "Od" = (
 /obj/machinery/door/airlock/silver{
@@ -10463,7 +10590,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/turf/open/floor/wood,
+/turf/open/floor/facility,
 /area/city)
 "Om" = (
 /obj/machinery/shower{
@@ -10502,6 +10629,10 @@
 /obj/item/bedsheet/blue,
 /turf/open/floor/plasteel/white,
 /area/city/fixers)
+"OA" = (
+/obj/structure/itemselling,
+/turf/open/floor/facility,
+/area/space)
 "OB" = (
 /turf/open/floor/facility/halls,
 /area/city/fixers)
@@ -10573,7 +10704,7 @@
 /turf/open/floor/facility/dark,
 /area/city/backstreets_room)
 "OT" = (
-/turf/open/floor/plasteel/airless/white,
+/turf/open/floor/plasteel/white,
 /area/city/backstreets_checkpoint)
 "OU" = (
 /obj/machinery/vending/cigarette,
@@ -10590,15 +10721,13 @@
 /obj/effect/turf_decal/loading_area/red{
 	dir = 8
 	},
-/turf/open/floor/mineral/titanium/tiled/yellow/airless,
+/turf/open/floor/mineral/titanium/tiled/white,
 /area/city/shop)
 "OW" = (
 /obj/structure/flora/tree/jungle,
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/ausbushes/sparsegrass,
-/turf/open/floor/plating/grass/jungle{
-	name = "Grass"
-	},
+/turf/open/floor/plating/grass,
 /area/facility_hallway/manager)
 "OX" = (
 /obj/effect/turf_decal/siding/wood{
@@ -10636,6 +10765,14 @@
 	},
 /turf/open/floor/carpet/stellar,
 /area/facility_hallway/manager)
+"Pj" = (
+/obj/effect/turf_decal/siding/yellow,
+/obj/machinery/light/cold/no_nightlight{
+	brightness = 16;
+	dir = 8
+	},
+/turf/open/floor/carpet/black,
+/area/city/house)
 "Pk" = (
 /turf/open/floor/holofloor/white,
 /area/city/shop)
@@ -10722,38 +10859,6 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/city/house)
-"PB" = (
-/obj/effect/turf_decal/tile{
-	color = "#333333";
-	dir = 1
-	},
-/obj/effect/turf_decal/tile{
-	color = "#333333"
-	},
-/obj/effect/turf_decal/tile{
-	color = "#333333";
-	dir = 8
-	},
-/obj/effect/turf_decal/tile{
-	color = "#333333";
-	dir = 4
-	},
-/obj/structure/kitchenspike,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/kitchen_coldroom,
-/area/city/shop)
-"PC" = (
-/obj/effect/mermaid_water{
-	desc = "Not a drop of drinkable water, just a body of salty brine";
-	name = "Coastal Waters"
-	},
-/obj/machinery/modular_computer/console/preset/civilian{
-	dir = 8
-	},
-/turf/open/floor/plating/grass,
-/area/city)
 "PE" = (
 /obj/structure/window/reinforced/spawner/east{
 	max_integrity = 25
@@ -10829,7 +10934,7 @@
 	},
 /obj/item/food/meat/steak/crimson,
 /obj/item/reagent_containers/food/drinks/bottle/champagne,
-/turf/open/floor/wood,
+/turf/open/floor/facility,
 /area/city)
 "PW" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -10909,7 +11014,7 @@
 	pixel_x = 16;
 	pixel_y = 16
 	},
-/turf/open/floor/plasteel/sepia,
+/turf/open/floor/mineral/titanium/tiled/white,
 /area/city/shop)
 "Qk" = (
 /obj/machinery/computer/slot_machine,
@@ -10955,7 +11060,7 @@
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 8
 	},
-/turf/open/floor/wood,
+/turf/open/floor/facility,
 /area/city)
 "Qx" = (
 /obj/structure/table/wood,
@@ -10980,7 +11085,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/turf/open/floor/wood,
+/turf/open/floor/facility,
 /area/city)
 "QC" = (
 /obj/effect/turf_decal/siding/yellow{
@@ -11060,6 +11165,17 @@
 /obj/item/bedsheet/hop,
 /turf/open/floor/wood,
 /area/facility_hallway/manager)
+"QX" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/obj/machinery/light/cold/no_nightlight{
+	brightness = 16;
+	dir = 1
+	},
+/obj/machinery/vending/city,
+/turf/open/floor/wood,
+/area/city/shop)
 "Ra" = (
 /obj/effect/turf_decal/siding/blue/end,
 /turf/open/floor/carpet/cyan,
@@ -11140,6 +11256,13 @@
 	},
 /turf/open/floor/facility/dark,
 /area/city/backstreets_room)
+"Rr" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/obj/machinery/vending/fixer,
+/turf/open/floor/wood,
+/area/city/shop)
 "Rs" = (
 /obj/structure/sink/kitchen{
 	dir = 8;
@@ -11234,7 +11357,7 @@
 /area/facility_hallway/manager)
 "RG" = (
 /obj/effect/turf_decal/siding/wood/corner,
-/turf/open/floor/wood,
+/turf/open/floor/facility,
 /area/city)
 "RH" = (
 /obj/structure/table/wood,
@@ -11277,7 +11400,7 @@
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
 	},
-/turf/open/floor/wood,
+/turf/open/floor/facility,
 /area/city)
 "RR" = (
 /obj/structure/table/reinforced{
@@ -11305,7 +11428,7 @@
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
 	},
-/turf/open/floor/wood,
+/turf/open/floor/facility,
 /area/city)
 "RY" = (
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -11758,7 +11881,7 @@
 	brightness = 16;
 	dir = 1
 	},
-/turf/open/floor/wood,
+/turf/open/floor/facility,
 /area/city)
 "TO" = (
 /obj/structure/railing{
@@ -11823,7 +11946,7 @@
 	brightness = 16;
 	dir = 8
 	},
-/turf/open/floor/sepia,
+/turf/open/floor/material,
 /area/city/house)
 "TW" = (
 /obj/effect/turf_decal/siding/yellow{
@@ -11831,6 +11954,9 @@
 	},
 /turf/open/floor/carpet/stellar,
 /area/facility_hallway/manager)
+"TX" = (
+/turf/closed/indestructible/reinforced,
+/area/facility_hallway/south)
 "TZ" = (
 /obj/structure/closet/secure_closet/personal/cabinet{
 	anchored = 1
@@ -11933,7 +12059,7 @@
 	color = "#FF0000";
 	dir = 1
 	},
-/turf/open/floor/plasteel/airless/white,
+/turf/open/floor/plasteel/white,
 /area/city/backstreets_checkpoint)
 "Uw" = (
 /obj/machinery/griddle{
@@ -11952,7 +12078,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/turf/open/floor/wood,
+/turf/open/floor/facility,
 /area/city)
 "Uz" = (
 /obj/machinery/light/cold/no_nightlight,
@@ -12260,7 +12386,7 @@
 	pixel_x = -11;
 	pixel_y = 14
 	},
-/turf/open/floor/sepia,
+/turf/open/floor/material,
 /area/city/house)
 "VS" = (
 /obj/effect/turf_decal/tile/green{
@@ -12309,7 +12435,7 @@
 	dir = 6
 	},
 /obj/machinery/light/cold/no_nightlight,
-/turf/open/floor/wood,
+/turf/open/floor/facility,
 /area/city)
 "VX" = (
 /obj/effect/turf_decal/siding/wood{
@@ -12767,7 +12893,7 @@
 	color = "#FF0000";
 	dir = 3
 	},
-/turf/open/floor/plasteel/airless/white,
+/turf/open/floor/plasteel/white,
 /area/city/backstreets_checkpoint)
 "XA" = (
 /obj/structure/chair/pew/left,
@@ -12826,6 +12952,14 @@
 	},
 /turf/open/floor/plating/grass,
 /area/city)
+"XJ" = (
+/obj/machinery/sleeper/syndie,
+/turf/open/floor/mineral/titanium/blue,
+/area/city/shop)
+"XK" = (
+/obj/machinery/vending/city,
+/turf/open/floor/facility,
+/area/space)
 "XO" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/mineral/titanium/tiled/white,
@@ -12964,7 +13098,7 @@
 	desc = "Used to grind things up into raw materials and liquids.";
 	pixel_y = 10
 	},
-/turf/open/floor/mineral/titanium/tiled/yellow/airless,
+/turf/open/floor/mineral/titanium/tiled/white,
 /area/city/shop)
 "Yr" = (
 /obj/effect/turf_decal/siding/thinplating/dark,
@@ -12998,7 +13132,7 @@
 /obj/machinery/chem_dispenser/drinks{
 	dir = 1
 	},
-/turf/open/floor/mineral/titanium/tiled/yellow/airless,
+/turf/open/floor/mineral/titanium/tiled/white,
 /area/city/shop)
 "YB" = (
 /turf/open/floor/facility/dark,
@@ -13088,7 +13222,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/brown,
-/turf/open/floor/mineral/titanium/tiled/yellow/airless,
+/turf/open/floor/mineral/titanium/tiled/white,
 /area/city/shop)
 "YX" = (
 /obj/structure/sink/kitchen{
@@ -13103,7 +13237,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/siding/wood,
-/turf/open/floor/wood,
+/turf/open/floor/facility,
 /area/city)
 "YZ" = (
 /obj/effect/turf_decal/siding/blue{
@@ -13215,13 +13349,6 @@
 /obj/effect/turf_decal/siding/thinplating/dark,
 /turf/open/floor/plating/grass,
 /area/city)
-"ZA" = (
-/obj/structure/flora/tree/jungle,
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/plating/grass/jungle{
-	name = "Grass"
-	},
-/area/facility_hallway/manager)
 "ZB" = (
 /obj/structure/rack{
 	pixel_x = -1
@@ -13358,7 +13485,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/siding/wood/corner,
-/turf/open/floor/wood,
+/turf/open/floor/facility,
 /area/city)
 "ZQ" = (
 /obj/effect/turf_decal/siding/wood/end{
@@ -17426,42 +17553,42 @@ jq
 jq
 sf
 JE
-Mp
-Mp
-tl
-Mp
-Mp
-Jt
-tl
-Mp
-tl
+jo
+jo
+PH
+jo
+jo
+uj
+PH
+jo
+PH
 Gi
 Gi
-Mp
-Mp
-Mp
-Mp
-ZA
-Mp
-tl
-Mp
+jo
+jo
+jo
+jo
+PR
+jo
+PH
+jo
 jo
 Gi
 Gi
 jo
 vS
-eK
-eK
-eK
+Gi
+Gi
+Gi
 OW
 jo
 Gi
 Ck
 Ck
 Gi
-Mp
-tl
-tl
+jo
+PH
+PH
 JE
 sf
 jq
@@ -17683,22 +17810,22 @@ jq
 jq
 sf
 JE
-Mp
-Mp
-ZA
-tl
-tl
-Mp
-Mp
+jo
+jo
+PR
+PH
+PH
+jo
+jo
 jo
 Ck
 Ck
 Ck
 Gi
 Gi
-Mp
-tl
-tl
+jo
+PH
+PH
 jo
 Gi
 Gi
@@ -17717,8 +17844,8 @@ Ck
 Ck
 Ck
 jo
-ZA
-tl
+PR
+PH
 JE
 sf
 jq
@@ -17940,9 +18067,9 @@ jq
 jq
 sf
 JE
-Mp
-tl
-Mp
+jo
+PH
+jo
 jo
 Gi
 Gi
@@ -17974,8 +18101,8 @@ Ck
 Ck
 Ck
 Gi
-Mp
-Mp
+jo
+jo
 JE
 sf
 jq
@@ -18197,7 +18324,7 @@ jq
 jq
 sf
 JE
-Mp
+jo
 jo
 Gi
 fF
@@ -18232,7 +18359,7 @@ Ck
 Ck
 fF
 jo
-tl
+PH
 JE
 sf
 jq
@@ -18454,7 +18581,7 @@ jq
 jq
 sf
 JE
-tl
+PH
 Gi
 Bw
 JE
@@ -18489,7 +18616,7 @@ Wj
 Wj
 JE
 rZ
-tl
+PH
 JE
 sf
 jq
@@ -18711,7 +18838,7 @@ jq
 jq
 sf
 JE
-Mp
+jo
 Gi
 Ck
 JE
@@ -18968,7 +19095,7 @@ jq
 jq
 sf
 JE
-Mp
+jo
 Ck
 Ck
 JE
@@ -19225,7 +19352,7 @@ jq
 jq
 sf
 JE
-Mp
+jo
 Gi
 Ck
 JE
@@ -19482,7 +19609,7 @@ jq
 jq
 sf
 JE
-Jt
+uj
 Gi
 Ck
 JE
@@ -19739,7 +19866,7 @@ jq
 jq
 sf
 JE
-tl
+PH
 Gi
 Ck
 JE
@@ -19996,7 +20123,7 @@ jq
 jq
 sf
 JE
-Mp
+jo
 Gi
 Bw
 JE
@@ -20031,7 +20158,7 @@ JE
 JE
 JE
 eU
-tl
+PH
 JE
 sf
 jq
@@ -20253,7 +20380,7 @@ jq
 jq
 sf
 JE
-Mp
+jo
 pm
 Ck
 EF
@@ -20288,7 +20415,7 @@ sl
 nw
 oM
 Gi
-Jt
+uj
 JE
 sf
 jq
@@ -20545,7 +20672,7 @@ JE
 JE
 JE
 eU
-Mp
+jo
 JE
 sf
 jq
@@ -20802,7 +20929,7 @@ sY
 OH
 JE
 Gi
-tl
+PH
 JE
 sf
 HR
@@ -22344,7 +22471,7 @@ Ck
 Ck
 JR
 Gi
-tl
+PH
 JE
 sf
 RT
@@ -22540,16 +22667,16 @@ jq
 jq
 jq
 Hk
-Tz
-Tz
-Tz
-Tz
-Tz
-Tz
-Tz
-Tz
-Tz
-Tz
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -22601,7 +22728,7 @@ FW
 nw
 Ck
 Gi
-tl
+PH
 JE
 sf
 RT
@@ -22797,16 +22924,16 @@ jq
 jq
 jq
 Hk
-Tz
-HP
-pc
-an
-jr
-Rq
-Rq
-xJ
-Cr
-Tz
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -22857,8 +22984,8 @@ aq
 Zs
 FW
 Ck
-Mp
-Mp
+jo
+jo
 JE
 sf
 RT
@@ -23054,16 +23181,16 @@ jq
 jq
 jq
 Hk
-Tz
-YO
-YB
-Tz
-OR
-fM
-YB
-SY
-mE
-Tz
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -23114,8 +23241,8 @@ jX
 aq
 la
 Ck
-Mp
-ZA
+jo
+PR
 JE
 sf
 RT
@@ -23311,16 +23438,16 @@ jq
 jq
 jq
 Hk
-Tz
-YO
-nP
-gz
-CR
-Tz
-ru
-YB
-dc
-Tz
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -23371,8 +23498,8 @@ jX
 lG
 la
 Ck
-Mp
-Mp
+jo
+jo
 JE
 sf
 RT
@@ -23568,16 +23695,16 @@ jq
 jq
 jq
 Hk
-Tz
-ES
-nP
-gw
-jm
-TA
-sG
-Bu
-lY
-Tz
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -23628,8 +23755,8 @@ aq
 aq
 la
 Gi
-Mp
-tl
+jo
+PH
 JE
 sf
 RK
@@ -23825,16 +23952,16 @@ jq
 jq
 jq
 HR
-Tz
-aF
-Tz
-Tz
-Tz
-Tz
-Tz
-Tz
-Tz
-Tz
+HR
+HR
+HR
+HR
+HR
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -23886,7 +24013,7 @@ aq
 la
 Gi
 jo
-Mp
+jo
 JE
 sf
 RK
@@ -24858,16 +24985,16 @@ Tt
 Tt
 Tt
 HR
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
+Tz
+Tz
+Tz
+Tz
+Tz
+Tz
+Tz
+Tz
+Tz
+Tz
 jq
 jq
 jq
@@ -25115,16 +25242,16 @@ Tt
 Tt
 Tt
 HR
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
+Tz
+HP
+pc
+an
+jr
+Rq
+Rq
+xJ
+Cr
+Tz
 jq
 jq
 jq
@@ -25372,16 +25499,16 @@ RT
 RT
 RT
 HR
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
+Tz
+YO
+YB
+Tz
+OR
+fM
+YB
+SY
+mE
+Tz
 jq
 jq
 jq
@@ -25629,16 +25756,16 @@ RT
 RT
 RT
 HR
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
+Tz
+YO
+nP
+gz
+CR
+Tz
+ru
+YB
+dc
+Tz
 jq
 jq
 jq
@@ -25886,16 +26013,16 @@ RT
 RT
 RT
 HR
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
+Tz
+ES
+nP
+gw
+jm
+TA
+sG
+Bu
+lY
+Tz
 jq
 jq
 jq
@@ -26143,16 +26270,16 @@ RT
 RT
 RT
 HR
-UW
-HR
-HR
-HR
-HR
-HR
-HR
-HR
-HR
-UW
+Tz
+aF
+Tz
+Tz
+Tz
+Tz
+Tz
+Tz
+Tz
+Tz
 HR
 HR
 HR
@@ -31012,9 +31139,9 @@ GI
 Ha
 Uv
 BK
-Hs
-Hs
-Hs
+OT
+OT
+OT
 hw
 OT
 Xz
@@ -36175,7 +36302,7 @@ Sw
 oY
 Jr
 Jr
-Bl
+Pj
 fU
 RK
 NK
@@ -36461,10 +36588,10 @@ gA
 nz
 Sd
 ML
-Hy
-Hy
-Hy
-Hy
+Sd
+Sd
+Sd
+Sd
 uG
 RK
 NK
@@ -36718,10 +36845,10 @@ Lh
 nz
 Sd
 Rb
-Hy
+Sd
 jB
 NX
-Hy
+Sd
 uG
 RK
 NK
@@ -36975,10 +37102,10 @@ Qc
 nz
 Sd
 GU
-Hy
+Sd
 NX
 jB
-Hy
+Sd
 lu
 RK
 NK
@@ -37203,7 +37330,7 @@ zA
 cq
 Jr
 Jr
-Bl
+BL
 fU
 RK
 NK
@@ -37232,10 +37359,10 @@ sC
 nz
 va
 wp
-Hy
-Hy
-Hy
-Hy
+Sd
+Sd
+Sd
+Sd
 ML
 ik
 NK
@@ -37489,10 +37616,10 @@ hr
 nz
 Sd
 Rb
-Hy
+Sd
 NX
 jB
-Hy
+Sd
 lu
 RK
 NK
@@ -37746,7 +37873,7 @@ Ih
 nz
 Sd
 GU
-Hy
+Sd
 jB
 NX
 LB
@@ -37967,11 +38094,11 @@ We
 Oh
 Dl
 Dl
-rP
+Nh
 id
 fU
 id
-rP
+Nh
 Dl
 Dl
 Vt
@@ -38003,10 +38130,10 @@ Lh
 nz
 Sd
 ML
-Hy
-Hy
-Hy
-Hy
+Sd
+Sd
+Sd
+Sd
 uG
 RK
 NK
@@ -39027,11 +39154,11 @@ We
 iU
 Dl
 Dl
-rP
+Nh
 id
 fU
 id
-rP
+Nh
 Dl
 Dl
 Dl
@@ -40279,13 +40406,13 @@ Yr
 We
 zm
 Ue
-rP
+Nh
 id
 JB
 fU
 JB
 id
-rP
+Nh
 Ue
 zm
 fU
@@ -40569,11 +40696,11 @@ We
 Dl
 Dl
 Dl
-rP
+Nh
 id
 fU
 id
-rP
+Nh
 Dl
 Dl
 Az
@@ -40793,13 +40920,13 @@ Yr
 We
 Jr
 Jr
-rP
+Nh
 dw
 TU
 fU
 DZ
 VR
-rP
+Nh
 Jr
 Jr
 fU
@@ -41071,7 +41198,7 @@ yl
 gH
 Vu
 gH
-PC
+gH
 CQ
 NK
 Kz
@@ -41103,7 +41230,7 @@ VF
 WZ
 VS
 rB
-QT
+fs
 Js
 Ub
 hA
@@ -41359,8 +41486,8 @@ Dc
 Dc
 so
 Mg
-rB
-PB
+ML
+Js
 Js
 Js
 Ub
@@ -41854,12 +41981,12 @@ We
 Jr
 Gr
 Jr
-rP
+Nh
 cB
 fU
 jV
 VR
-rP
+Nh
 Gr
 Jr
 fU
@@ -43363,13 +43490,13 @@ Yr
 We
 JO
 Ue
-rP
+Nh
 uZ
 DZ
 fU
 DZ
 uZ
-rP
+Nh
 Ue
 JO
 fU
@@ -44141,8 +44268,8 @@ Ec
 iR
 Qv
 Qv
-xg
-xg
+Qv
+Qv
 lu
 RK
 NK
@@ -44398,8 +44525,8 @@ RR
 lD
 PE
 qo
-Vm
-If
+gl
+oj
 lu
 RK
 NK
@@ -45934,11 +46061,11 @@ lu
 kM
 gq
 TS
-gq
+XJ
 eM
 Sd
 bd
-gq
+XJ
 TS
 gq
 Fe
@@ -47487,16 +47614,16 @@ vz
 lu
 RK
 NK
-Yr
-HR
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
+TX
+TX
+TX
+TX
+TX
+TX
+TX
+TX
+TX
+TX
 jq
 jq
 jq
@@ -47744,16 +47871,16 @@ XW
 lu
 RK
 NK
-Yr
-HR
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
+TX
+bn
+bn
+bn
+bn
+bn
+bn
+bn
+bn
+TX
 jq
 jq
 jq
@@ -48001,16 +48128,16 @@ wm
 lu
 RK
 NK
-Yr
-HR
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
+TX
+bn
+bn
+bn
+bn
+bn
+bn
+bn
+bn
+TX
 jq
 jq
 jq
@@ -48024,7 +48151,7 @@ EY
 EY
 Qw
 Od
-oh
+qn
 Od
 Jk
 Ux
@@ -48247,7 +48374,7 @@ lu
 mz
 xA
 QK
-Nj
+EL
 lu
 cW
 lu
@@ -48258,16 +48385,16 @@ Ra
 lu
 RK
 NK
-Yr
-HR
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
+TX
+bn
+bn
+bn
+bn
+bn
+bn
+bn
+bn
+TX
 jq
 jq
 jq
@@ -48279,7 +48406,7 @@ HR
 qH
 EY
 RG
-jt
+vD
 HR
 rl
 HR
@@ -48515,16 +48642,16 @@ Qx
 lu
 RK
 NK
-Yr
-HR
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
+TX
+bn
+bn
+bn
+bn
+bn
+bn
+bn
+bn
+TX
 jq
 jq
 jq
@@ -48762,9 +48889,9 @@ lu
 lu
 lu
 lu
-qd
+QX
 Uq
-vz
+Rr
 lu
 lu
 lu
@@ -48772,16 +48899,16 @@ lu
 lu
 RK
 NK
-Yr
-HR
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
+TX
+bn
+bn
+bn
+bn
+bn
+bn
+bn
+bn
+TX
 jq
 jq
 jq
@@ -48796,7 +48923,7 @@ HR
 HR
 cX
 qg
-FT
+ID
 HR
 HR
 HR
@@ -49029,16 +49156,16 @@ tE
 XV
 AB
 NK
-Yr
-HR
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
+TX
+bn
+bn
+bn
+bn
+bn
+bn
+bn
+bn
+TX
 jq
 jq
 jq
@@ -49286,16 +49413,16 @@ vC
 lw
 JY
 NK
-Yr
-HR
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
+bn
+bn
+bn
+bn
+bn
+bn
+bn
+bn
+bn
+TX
 jq
 jq
 jq
@@ -49535,7 +49662,7 @@ lu
 lu
 xi
 lI
-wm
+GK
 lu
 lu
 lu
@@ -49543,16 +49670,16 @@ lu
 lu
 RK
 NK
-mL
-UW
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
+bn
+bn
+bn
+bn
+bn
+bn
+bn
+bn
+bn
+TX
 jq
 jq
 jq
@@ -49567,7 +49694,7 @@ HR
 HR
 lA
 ZP
-VW
+Ar
 HR
 HR
 HR
@@ -49800,16 +49927,16 @@ dJ
 lu
 RK
 NK
-Yr
-HR
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
+bn
+bn
+bn
+bn
+bn
+bn
+bn
+bn
+bn
+TX
 jq
 jq
 jq
@@ -50057,16 +50184,16 @@ Jc
 lu
 RK
 NK
-Yr
-HR
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
+bn
+bn
+bn
+bn
+bn
+bn
+bn
+bn
+bn
+TX
 jq
 jq
 jq
@@ -50314,16 +50441,16 @@ wK
 lu
 RK
 NK
-Yr
-HR
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
+bn
+bn
+bn
+bn
+bn
+bn
+bn
+bn
+bn
+TX
 jq
 jq
 jq
@@ -50571,16 +50698,16 @@ Zj
 lu
 RK
 NK
-Yr
-HR
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
+bn
+ju
+bn
+bn
+bn
+bn
+bn
+bn
+bn
+TX
 jq
 jq
 jq
@@ -50828,16 +50955,16 @@ Ge
 lu
 RK
 NK
-Yr
-HR
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
+bn
+bn
+bn
+bn
+bn
+bn
+bn
+bn
+bn
+TX
 jq
 jq
 jq
@@ -51085,16 +51212,16 @@ lu
 lu
 RK
 NK
-Yr
-HR
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
+bn
+bn
+bn
+bn
+bn
+bn
+bn
+bn
+bn
+TX
 jq
 jq
 jq
@@ -51342,16 +51469,16 @@ HZ
 HZ
 AB
 NK
-Yr
-HR
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
+bn
+bn
+bn
+bn
+bn
+bn
+bn
+bn
+bn
+TX
 jq
 jq
 jq
@@ -51599,8 +51726,16 @@ NK
 NK
 NK
 th
-Yr
-HR
+bn
+bn
+bn
+bn
+bn
+bn
+bn
+bn
+bn
+TX
 jq
 jq
 jq
@@ -51615,18 +51750,10 @@ jq
 jq
 jq
 jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
+CN
+oX
+oX
+Ma
 jq
 jq
 jq
@@ -51856,8 +51983,16 @@ Lk
 Lk
 JY
 NK
-Yr
-HR
+bn
+bn
+bn
+bn
+bn
+bn
+bn
+bn
+bn
+TX
 jq
 jq
 jq
@@ -51872,18 +52007,10 @@ jq
 jq
 jq
 jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
+XK
+EO
+oX
+DR
 jq
 jq
 jq
@@ -52113,8 +52240,16 @@ HR
 HR
 RT
 RT
-RT
-UW
+TX
+bn
+bn
+bn
+bn
+bn
+bn
+bn
+bn
+TX
 jq
 jq
 jq
@@ -52129,18 +52264,10 @@ jq
 jq
 jq
 jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
+OA
+oX
+oX
+NG
 jq
 jq
 jq
@@ -52370,16 +52497,16 @@ Io
 HR
 RT
 RT
-RT
-HR
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
+TX
+bn
+bn
+bn
+bn
+bn
+bn
+bn
+bn
+TX
 jq
 jq
 jq
@@ -52627,16 +52754,16 @@ Io
 HR
 RT
 RT
-RT
-HR
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
+TX
+bn
+bn
+bn
+bn
+bn
+bn
+bn
+bn
+TX
 jq
 jq
 jq
@@ -52884,16 +53011,16 @@ Io
 HR
 RT
 RT
-RT
-HR
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
+TX
+bn
+bn
+bn
+bn
+bn
+bn
+bn
+bn
+TX
 jq
 jq
 jq
@@ -53141,16 +53268,16 @@ Io
 HR
 Tt
 Tt
-Tt
-HR
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
+TX
+bn
+bn
+bn
+bn
+bn
+bn
+bn
+bn
+TX
 jq
 jq
 jq
@@ -53398,16 +53525,16 @@ Io
 UW
 Tt
 Tt
-Tt
-HR
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
+TX
+bn
+bn
+bn
+bn
+bn
+bn
+bn
+bn
+TX
 jq
 jq
 jq
@@ -53655,16 +53782,16 @@ Io
 HR
 Tt
 Tt
-Tt
-HR
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
+TX
+bn
+bn
+bn
+bn
+bn
+bn
+bn
+bn
+TX
 jq
 jq
 jq
@@ -53912,16 +54039,16 @@ Io
 HR
 Tt
 Tt
-Tt
-HR
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
+TX
+bn
+bn
+bn
+bn
+bn
+bn
+bn
+bn
+TX
 jq
 jq
 jq
@@ -54169,16 +54296,16 @@ Io
 HR
 Tt
 Tt
-Tt
-UW
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
+TX
+bn
+bn
+bn
+bn
+bn
+bn
+bn
+bn
+TX
 jq
 jq
 jq
@@ -54426,16 +54553,16 @@ HR
 HR
 HR
 HR
-HR
-HR
-Hk
-Hk
-Hk
-Hk
-Hk
-Hk
-Hk
-Hk
+TX
+TX
+TX
+TX
+TX
+TX
+TX
+TX
+TX
+TX
 Hk
 Hk
 Hk

--- a/_maps/map_files/Xi/xicommand.dmm
+++ b/_maps/map_files/Xi/xicommand.dmm
@@ -33,6 +33,21 @@
 /obj/machinery/light/cold/no_nightlight,
 /turf/open/floor/facility/dark,
 /area/city/backstreets_checkpoint)
+"aj" = (
+/obj/machinery/telecomms/server/presets/engineering,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/city)
+"an" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Staff Only";
+	req_access_txt = "31"
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/turf/open/floor/facility/dark,
+/area/city/backstreets_room)
 "ao" = (
 /obj/structure/toilet,
 /obj/machinery/light/small{
@@ -134,6 +149,21 @@
 	},
 /turf/open/floor/oldshuttle,
 /area/city/fixers)
+"aE" = (
+/obj/structure/chair/comfy/brown{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/city)
+"aF" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Carnival"
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
+	},
+/turf/open/floor/facility/dark,
+/area/city/backstreets_room)
 "aH" = (
 /obj/structure/bed,
 /obj/item/bedsheet/mime,
@@ -149,7 +179,7 @@
 "aK" = (
 /obj/structure/chair/wood/wings,
 /turf/open/floor/wood,
-/area/space)
+/area/city)
 "aN" = (
 /obj/machinery/modular_computer/console{
 	dir = 1
@@ -233,7 +263,7 @@
 	dir = 8
 	},
 /turf/open/floor/wood,
-/area/space)
+/area/city)
 "bf" = (
 /obj/effect/turf_decal/plaque{
 	alpha = 230;
@@ -353,7 +383,7 @@
 "bI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/sepia,
+/turf/open/floor/plasteel/dark,
 /area/facility_hallway/manager)
 "bJ" = (
 /obj/effect/turf_decal/tile/red{
@@ -517,7 +547,7 @@
 	dir = 8
 	},
 /turf/open/floor/wood,
-/area/space)
+/area/city)
 "ck" = (
 /obj/effect/turf_decal/siding/wood/corner,
 /obj/effect/turf_decal/siding/wood/corner{
@@ -616,6 +646,12 @@
 	},
 /turf/open/floor/carpet/black,
 /area/facility_hallway/manager)
+"cz" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/telecomms/bus/preset_four,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/city)
 "cB" = (
 /obj/structure/sink/kitchen{
 	dir = 4;
@@ -743,7 +779,7 @@
 	dir = 8
 	},
 /turf/open/floor/wood,
-/area/space)
+/area/city)
 "cT" = (
 /obj/structure/chair/sofa/corp/right{
 	dir = 8
@@ -782,13 +818,39 @@
 	dir = 1
 	},
 /turf/open/floor/wood,
-/area/space)
+/area/city)
+"dc" = (
+/obj/structure/closet/crate,
+/obj/item/storage/box/papersack{
+	pixel_x = -6
+	},
+/obj/item/storage/box/papersack{
+	pixel_x = -6
+	},
+/obj/item/storage/box/papersack{
+	pixel_x = -6
+	},
+/obj/item/storage/box/papersack{
+	pixel_x = -6
+	},
+/obj/item/storage/box/papersack{
+	pixel_x = -6
+	},
+/obj/item/storage/box/papersack{
+	pixel_x = -6
+	},
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/facility/dark,
+/area/city/backstreets_room)
 "dd" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/modular_computer/console/preset/civilian,
 /turf/open/floor/plating,
 /area/city/shop)
+"de" = (
+/turf/closed/indestructible/reinforced,
+/area/city)
 "df" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/tile/red,
@@ -1083,7 +1145,7 @@
 	dir = 1
 	},
 /turf/open/floor/wood,
-/area/space)
+/area/city)
 "dY" = (
 /obj/effect/turf_decal/siding/blue/corner{
 	dir = 8
@@ -1192,7 +1254,7 @@
 	brightness = 16;
 	dir = 1
 	},
-/turf/open/floor/sepia,
+/turf/open/floor/plasteel/dark,
 /area/facility_hallway/manager)
 "eE" = (
 /obj/machinery/button{
@@ -1257,9 +1319,11 @@
 /obj/item/pen/fourcolor,
 /turf/open/space/basic,
 /area/facility_hallway/manager)
-"eR" = (
-/turf/open/floor/plating/dirt/dark,
-/area/city/backstreets_alley)
+"eS" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/telecomms/bus/preset_three,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/city)
 "eT" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#3234B9";
@@ -1366,7 +1430,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/space)
+/area/city)
 "fm" = (
 /obj/structure/sign/departments/medbay/alt,
 /turf/closed/wall/mineral/silver{
@@ -1404,12 +1468,6 @@
 	},
 /turf/open/floor/plating/grass,
 /area/facility_hallway/manager)
-"fs" = (
-/obj/machinery/door/airlock/silver{
-	name = "white-washed airlock"
-	},
-/turf/open/floor/facility/halls,
-/area/space)
 "ft" = (
 /obj/machinery/door/airlock/wood{
 	name = "Welfare Head Office"
@@ -1492,6 +1550,10 @@
 /obj/structure/chair/sofa/corp/right,
 /turf/open/floor/mineral/titanium/blue,
 /area/city/fixers)
+"fM" = (
+/obj/machinery/vending/weaving,
+/turf/closed/indestructible/reinforced,
+/area/city/backstreets_room)
 "fN" = (
 /obj/structure/sign/departments/records,
 /turf/closed/indestructible/reinforced,
@@ -1543,19 +1605,14 @@
 	dir = 8
 	},
 /obj/structure/closet,
-/obj/item/tresmetal,
-/obj/item/tresmetal,
-/obj/item/tresmetal,
-/obj/item/tresmetal,
-/obj/item/tresmetal,
-/obj/item/tresmetal,
-/obj/item/tresmetal,
-/obj/item/tresmetal,
-/obj/item/tresmetal,
-/obj/item/tresmetal,
 /obj/item/forginghammer,
 /turf/open/floor/mineral/plastitanium,
 /area/city/house)
+"gb" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/telecomms/processor/preset_two,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/city)
 "gc" = (
 /obj/structure/table/wood,
 /obj/item/toy/plush/gebura,
@@ -1673,6 +1730,23 @@
 	},
 /turf/open/floor/wood,
 /area/city/shop)
+"gw" = (
+/obj/structure/table/reinforced,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/facility/dark,
+/area/city/backstreets_room)
+"gz" = (
+/obj/structure/table/reinforced,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/facility/dark,
+/area/city/backstreets_room)
 "gA" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/closet/crate,
@@ -1799,6 +1873,11 @@
 	},
 /turf/open/floor/wood,
 /area/city/shop)
+"hh" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/telecomms/hub/preset,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/city)
 "hk" = (
 /obj/structure/chair/comfy/brown{
 	dir = 1
@@ -1932,7 +2011,7 @@
 	dir = 8
 	},
 /turf/open/floor/carpet/cyan,
-/area/space)
+/area/city)
 "hH" = (
 /obj/structure/chair/sofa/corp/left{
 	dir = 1
@@ -1947,10 +2026,6 @@
 	},
 /turf/open/floor/plating,
 /area/city/shop)
-"hK" = (
-/obj/machinery/door/airlock/glass_large,
-/turf/open/floor/facility/halls,
-/area/space)
 "hL" = (
 /obj/structure/window/reinforced/spawner/west,
 /obj/effect/turf_decal/tile/blue{
@@ -2130,6 +2205,11 @@
 	},
 /turf/open/floor/eighties,
 /area/city/shop)
+"iu" = (
+/obj/machinery/telecomms/broadcaster/preset_left,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/city)
 "iv" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#3234B9";
@@ -2269,6 +2349,10 @@
 /obj/machinery/door/window/southright,
 /turf/open/floor/mineral/titanium/tiled/white,
 /area/city/shop)
+"iS" = (
+/obj/machinery/telecomms/message_server/preset,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/city)
 "iT" = (
 /obj/structure/chair/comfy/black{
 	dir = 1
@@ -2353,7 +2437,7 @@
 	pixel_x = 10
 	},
 /turf/open/floor/facility/white,
-/area/space)
+/area/city)
 "jk" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -2361,6 +2445,10 @@
 	},
 /turf/open/floor/plating/grass,
 /area/city)
+"jm" = (
+/obj/effect/turf_decal/box/red/corners,
+/turf/open/floor/facility/dark,
+/area/city/backstreets_room)
 "jo" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/plating/grass,
@@ -2381,12 +2469,19 @@
 "jq" = (
 /turf/closed/indestructible/rock,
 /area/space)
+"jr" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/turf/open/floor/facility/dark,
+/area/city/backstreets_room)
 "jt" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
 	},
 /turf/open/floor/wood,
-/area/space)
+/area/city)
 "jv" = (
 /obj/machinery/computer/slot_machine,
 /obj/effect/turf_decal/siding/blue{
@@ -2405,6 +2500,10 @@
 /obj/item/storage/belt/ego,
 /turf/open/floor/mineral/titanium/blue/airless,
 /area/city/shop)
+"jD" = (
+/obj/structure/table/anvil,
+/turf/open/floor/wood,
+/area/city)
 "jE" = (
 /obj/structure/chair/pew/left,
 /turf/open/floor/plasteel/chapel{
@@ -2476,6 +2575,15 @@
 	},
 /turf/open/floor/sepia,
 /area/city/house)
+"jX" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/facility_hallway/manager)
+"kc" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/telecomms/receiver/preset_right,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/city)
 "kd" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -2516,7 +2624,7 @@
 	dir = 8
 	},
 /turf/open/floor/wood,
-/area/space)
+/area/city)
 "km" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/structure/closet/mini_fridge{
@@ -2903,7 +3011,7 @@
 	dir = 1
 	},
 /turf/open/floor/wood,
-/area/space)
+/area/city)
 "lC" = (
 /obj/machinery/computer/secure_data{
 	dir = 1
@@ -2929,7 +3037,7 @@
 	set_cap = 3;
 	set_luminosity = 24
 	},
-/turf/open/floor/sepia,
+/turf/open/floor/plasteel/dark,
 /area/facility_hallway/manager)
 "lI" = (
 /obj/effect/turf_decal/siding/wood/corner{
@@ -2989,6 +3097,14 @@
 	name = "Grass"
 	},
 /area/facility_hallway/manager)
+"lY" = (
+/obj/structure/closet/crate,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
+	},
+/turf/open/floor/facility/dark,
+/area/city/backstreets_room)
 "mc" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 10
@@ -3038,7 +3154,7 @@
 	dir = 1
 	},
 /turf/open/floor/wood,
-/area/space)
+/area/city)
 "mo" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -3148,10 +3264,19 @@
 	name = "Grass"
 	},
 /area/facility_hallway/manager)
+"mC" = (
+/obj/machinery/telecomms/server/presets/science,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/city)
 "mD" = (
 /obj/machinery/chem_master/condimaster,
 /turf/open/floor/plasteel/checker,
 /area/city/shop)
+"mE" = (
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/facility/dark,
+/area/city/backstreets_room)
 "mG" = (
 /obj/machinery/vending/boozeomat,
 /turf/open/floor/mineral/silver,
@@ -3224,13 +3349,6 @@
 	set_luminosity = 24
 	},
 /turf/open/floor/plating/grass,
-/area/facility_hallway/manager)
-"mZ" = (
-/obj/machinery/light/cold/no_nightlight{
-	brightness = 16;
-	dir = 8
-	},
-/turf/open/floor/sepia,
 /area/facility_hallway/manager)
 "nd" = (
 /obj/effect/turf_decal/siding/wood{
@@ -3362,6 +3480,12 @@
 	},
 /turf/open/floor/facility/halls,
 /area/city/fixers)
+"nF" = (
+/obj/machinery/door/airlock/silver{
+	name = "east fixer office"
+	},
+/turf/open/floor/facility/halls,
+/area/city)
 "nI" = (
 /obj/effect/turf_decal/arrows/red,
 /obj/effect/turf_decal/arrows/red{
@@ -3389,6 +3513,13 @@
 	},
 /turf/open/floor/plating/grass,
 /area/facility_hallway/manager)
+"nP" = (
+/obj/effect/turf_decal/loading_area/red{
+	dir = 1
+	},
+/obj/structure/chair,
+/turf/open/floor/facility/dark,
+/area/city/backstreets_room)
 "nR" = (
 /obj/structure/table/wood/fancy/blue,
 /obj/machinery/light/cold/no_nightlight{
@@ -3417,7 +3548,7 @@
 	dir = 5
 	},
 /turf/open/floor/carpet/cyan,
-/area/space)
+/area/city)
 "nY" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#3234B9";
@@ -3451,7 +3582,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood,
-/area/space)
+/area/city)
 "ol" = (
 /obj/effect/turf_decal/plaque{
 	alpha = 230;
@@ -3459,6 +3590,13 @@
 	},
 /turf/open/floor/facility/dark,
 /area/facility_hallway/manager)
+"om" = (
+/obj/machinery/door/airlock/grunge{
+	name = "association director's office";
+	req_access_txt = "69"
+	},
+/turf/open/floor/facility/halls,
+/area/city/fixers)
 "oo" = (
 /obj/structure/rack{
 	pixel_x = -1
@@ -3542,6 +3680,10 @@
 /obj/effect/spawner/randomsnackvend,
 /turf/open/floor/carpet/stellar,
 /area/facility_hallway/manager)
+"oG" = (
+/obj/machinery/telecomms/server/presets/medical,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/city)
 "oH" = (
 /obj/machinery/light{
 	dir = 8
@@ -3630,12 +3772,16 @@
 	},
 /turf/open/floor/facility/dark,
 /area/city/shop)
+"oT" = (
+/obj/machinery/vending/forge,
+/turf/open/floor/wood,
+/area/city)
 "oV" = (
 /obj/effect/turf_decal/siding/blue/end{
 	dir = 4
 	},
 /turf/open/floor/carpet/cyan,
-/area/space)
+/area/city)
 "oW" = (
 /obj/structure/closet/secure_closet/freezer/fridge{
 	pixel_x = -8;
@@ -3689,6 +3835,13 @@
 /obj/structure/table/wood/poker,
 /turf/open/floor/mineral/silver,
 /area/city/shop)
+"pc" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/facility/dark,
+/area/city/backstreets_room)
 "pg" = (
 /obj/effect/spawner/randomsnackvend,
 /obj/machinery/light/cold/no_nightlight{
@@ -3940,7 +4093,7 @@
 	dir = 1
 	},
 /turf/open/floor/wood,
-/area/space)
+/area/city)
 "qh" = (
 /obj/structure/railing{
 	dir = 8
@@ -3978,7 +4131,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/space)
+/area/city)
 "qo" = (
 /obj/machinery/door/window/eastright,
 /turf/open/floor/mineral/titanium/white,
@@ -4046,7 +4199,7 @@
 	dir = 1
 	},
 /turf/open/floor/wood,
-/area/space)
+/area/city)
 "qI" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/table/wood,
@@ -4054,7 +4207,7 @@
 /obj/item/stack/spacecash/c1000,
 /obj/item/storage/box/miscarmor/two,
 /turf/open/floor/wood,
-/area/space)
+/area/city)
 "qL" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/effect/turf_decal/siding/wood/corner{
@@ -4174,7 +4327,7 @@
 	},
 /obj/machinery/light/cold/no_nightlight,
 /turf/open/floor/wood,
-/area/space)
+/area/city)
 "rn" = (
 /obj/structure/table/bronze,
 /obj/item/reagent_containers/food/condiment/saltshaker{
@@ -4206,6 +4359,10 @@
 	},
 /turf/open/floor/mineral/gold,
 /area/city/shop)
+"ru" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/facility/dark,
+/area/city/backstreets_room)
 "rw" = (
 /obj/structure/railing/corner{
 	dir = 1
@@ -4310,7 +4467,7 @@
 /obj/structure/lattice/catwalk,
 /obj/item/toy/plush/bongbong,
 /turf/open/floor/plating,
-/area/space)
+/area/city)
 "rZ" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/effect/light_emitter{
@@ -4335,6 +4492,10 @@
 	dir = 1
 	},
 /turf/open/floor/plating/grass,
+/area/city)
+"sb" = (
+/obj/machinery/telecomms/server/presets/security,
+/turf/open/floor/circuit/telecomms/mainframe,
 /area/city)
 "sd" = (
 /obj/machinery/griddle{
@@ -4530,6 +4691,12 @@
 	},
 /turf/open/floor/mineral/titanium/tiled/white,
 /area/city/shop)
+"sG" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/turf/open/floor/facility/dark,
+/area/city/backstreets_room)
 "sH" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -4915,7 +5082,7 @@
 	},
 /obj/item/bedsheet/red,
 /turf/open/floor/wood,
-/area/space)
+/area/city)
 "tA" = (
 /obj/structure/table/reinforced{
 	max_integrity = 25
@@ -4981,6 +5148,11 @@
 	},
 /turf/open/floor/facility/dark,
 /area/city/shop)
+"tL" = (
+/obj/machinery/telecomms/server/presets/service,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/city)
 "tM" = (
 /obj/machinery/button/door/indestructible{
 	id = "facilitylockdown";
@@ -5057,6 +5229,11 @@
 	name = "Grass"
 	},
 /area/facility_hallway/manager)
+"ub" = (
+/obj/machinery/telecomms/server/presets/supply,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/city)
 "ud" = (
 /obj/structure/window/reinforced/spawner/west{
 	max_integrity = 25;
@@ -5291,7 +5468,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood,
-/area/space)
+/area/city)
 "uQ" = (
 /obj/structure/fluff/paper{
 	dir = 8
@@ -5367,7 +5544,7 @@
 	brightness = 16;
 	dir = 4
 	},
-/turf/open/floor/sepia,
+/turf/open/floor/plasteel/dark,
 /area/facility_hallway/manager)
 "uZ" = (
 /obj/structure/sink/kitchen{
@@ -5595,7 +5772,7 @@
 "vV" = (
 /obj/structure/lattice/catwalk,
 /turf/open/floor/plating,
-/area/space)
+/area/city)
 "vW" = (
 /obj/structure/railing,
 /obj/item/grown/sunflower,
@@ -5728,13 +5905,6 @@
 	name = "Grass"
 	},
 /area/facility_hallway/manager)
-"wt" = (
-/obj/machinery/door/airlock/wood{
-	icon = 'icons/obj/doors/airlocks/station/command.dmi';
-	name = "Zwei Association Airlock"
-	},
-/turf/open/floor/facility/halls,
-/area/city/fixers)
 "wu" = (
 /obj/effect/turf_decal/tile/neutral{
 	color = "#000000"
@@ -5780,6 +5950,12 @@
 	},
 /turf/open/floor/carpet/stellar,
 /area/facility_hallway/manager)
+"wA" = (
+/obj/machinery/door/airlock/glass_large{
+	name = "east fixer office"
+	},
+/turf/open/floor/facility/halls,
+/area/city)
 "wB" = (
 /obj/effect/turf_decal/tile/neutral{
 	color = "#000000";
@@ -5877,6 +6053,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/city/shop)
+"wO" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/telecomms/receiver/preset_left,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/city)
 "wQ" = (
 /obj/structure/table/glass,
 /obj/structure/window/reinforced/spawner/east{
@@ -5915,7 +6096,7 @@
 /obj/structure/closet/crate,
 /obj/structure/lattice/catwalk,
 /turf/open/floor/plating,
-/area/space)
+/area/city)
 "xa" = (
 /obj/structure/railing{
 	dir = 1
@@ -5983,6 +6164,11 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/city/house)
+"xq" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/telecomms/processor/preset_four,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/city)
 "xr" = (
 /obj/effect/turf_decal{
 	dir = 1
@@ -6036,6 +6222,19 @@
 /obj/item/pen/fourcolor,
 /turf/open/floor/carpet/red,
 /area/facility_hallway/manager)
+"xJ" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/item/ego_weapon/city/carnival_spear,
+/obj/item/paper/fluff/silk_guide,
+/obj/item/paper/fluff/silk_guide,
+/turf/open/floor/facility/dark,
+/area/city/backstreets_room)
 "xL" = (
 /obj/structure/railing,
 /obj/item/grown/novaflower,
@@ -6113,7 +6312,7 @@
 "xW" = (
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood,
-/area/space)
+/area/city)
 "yf" = (
 /obj/machinery/computer/abnormality_auxiliary{
 	dir = 8
@@ -6162,7 +6361,7 @@
 	dir = 9
 	},
 /turf/open/floor/wood,
-/area/space)
+/area/city)
 "yl" = (
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/plating/grass,
@@ -6254,7 +6453,7 @@
 	},
 /obj/item/bedsheet/red,
 /turf/open/floor/wood,
-/area/space)
+/area/city)
 "yA" = (
 /obj/machinery/vending/cola/blue{
 	name = "\improper Crane Game Machine"
@@ -6262,6 +6461,22 @@
 /obj/machinery/light/cold/no_nightlight,
 /turf/open/floor/eighties,
 /area/city/shop)
+"yC" = (
+/obj/machinery/door/airlock/grunge{
+	name = "association office";
+	req_access_txt = "67"
+	},
+/obj/machinery/door/airlock/grunge{
+	name = "association office";
+	req_access_txt = "67"
+	},
+/turf/open/floor/facility/halls,
+/area/city/fixers)
+"yD" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/telecomms/relay/preset/telecomms,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/city)
 "yF" = (
 /obj/structure/railing/corner,
 /obj/structure/flora/ausbushes/brflowers,
@@ -6399,7 +6614,7 @@
 /obj/item/paper_bin,
 /obj/item/pen/blue,
 /turf/open/floor/wood,
-/area/space)
+/area/city)
 "zb" = (
 /obj/machinery/griddle{
 	pixel_y = 1
@@ -6414,7 +6629,7 @@
 	dir = 8
 	},
 /turf/open/floor/carpet/cyan,
-/area/space)
+/area/city)
 "zf" = (
 /obj/effect/turf_decal/siding/thinplating/dark,
 /obj/machinery/newscaster{
@@ -6444,7 +6659,7 @@
 /area/city/house)
 "zl" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/sepia,
+/turf/open/floor/plasteel/dark,
 /area/facility_hallway/manager)
 "zm" = (
 /obj/structure/bed,
@@ -6500,7 +6715,7 @@
 	brightness = 16;
 	dir = 1
 	},
-/turf/open/floor/sepia,
+/turf/open/floor/plasteel/dark,
 /area/facility_hallway/manager)
 "zw" = (
 /obj/structure/chair/wood{
@@ -6901,7 +7116,7 @@
 	dir = 8
 	},
 /turf/open/floor/wood,
-/area/space)
+/area/city)
 "AP" = (
 /obj/structure/table/wood/fancy/orange,
 /turf/open/floor/oldshuttle,
@@ -7018,6 +7233,22 @@
 "Bt" = (
 /turf/open/floor/sepia,
 /area/facility_hallway/manager)
+"Bu" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/closet/crate,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/obj/item/clothing/suit/armor/ego_gear/city/carnival_robes,
+/obj/item/clothing/suit/armor/ego_gear/city/carnival_robes,
+/obj/item/clothing/suit/armor/ego_gear/city/carnival_robes,
+/obj/item/clothing/mask/carnival_mask,
+/obj/item/clothing/mask/carnival_mask,
+/obj/item/clothing/mask/carnival_mask,
+/turf/open/floor/facility/dark,
+/area/city/backstreets_room)
 "Bv" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -7157,7 +7388,7 @@
 	},
 /obj/structure/showcase/machinery/tv,
 /turf/open/floor/wood,
-/area/space)
+/area/city)
 "Cc" = (
 /obj/machinery/light/floor,
 /obj/effect/turf_decal/tile/neutral{
@@ -7274,6 +7505,25 @@
 /obj/machinery/vending/lobotomyuniform,
 /turf/open/floor/facility/dark,
 /area/facility_hallway/manager)
+"Cr" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table/reinforced,
+/obj/item/storage/box/bodybags{
+	pixel_x = -5;
+	pixel_y = -4
+	},
+/obj/item/storage/firstaid{
+	pixel_x = 9;
+	pixel_y = -7
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/item/ego_weapon/city/carnival_spear{
+	pixel_y = 17
+	},
+/turf/open/floor/facility/dark,
+/area/city/backstreets_room)
 "Cs" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/tree/jungle/small,
@@ -7363,6 +7613,11 @@
 	},
 /turf/open/floor/mineral/titanium/tiled/white,
 /area/city/fixers)
+"CJ" = (
+/obj/machinery/telecomms/broadcaster/preset_right,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/city)
 "CM" = (
 /obj/machinery/computer/slot_machine,
 /obj/effect/turf_decal/siding/blue,
@@ -7376,6 +7631,13 @@
 /obj/effect/turf_decal/siding/thinplating/dark,
 /turf/open/floor/plating/grass,
 /area/city)
+"CR" = (
+/obj/machinery/light,
+/obj/effect/turf_decal/box/red/corners{
+	dir = 8
+	},
+/turf/open/floor/facility/dark,
+/area/city/backstreets_room)
 "CS" = (
 /obj/effect/turf_decal/siding/yellow,
 /obj/machinery/door/airlock/wood/glass{
@@ -7427,7 +7689,7 @@
 	},
 /obj/structure/closet/secure_closet/personal/cabinet,
 /turf/open/floor/wood,
-/area/space)
+/area/city)
 "Dc" = (
 /obj/effect/turf_decal/tile/green{
 	color = "#006400";
@@ -7750,7 +8012,7 @@
 	dir = 9
 	},
 /turf/open/floor/carpet/cyan,
-/area/space)
+/area/city)
 "Eh" = (
 /obj/machinery/computer/abnormality_archive{
 	dir = 4
@@ -7788,6 +8050,17 @@
 	},
 /turf/open/floor/plating/grass,
 /area/city)
+"En" = (
+/obj/machinery/telecomms/server/presets/common,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/city)
+"Ep" = (
+/obj/machinery/door/airlock/wood{
+	name = "Hana Office Admin";
+	req_access_txt = "20"
+	},
+/turf/open/floor/facility/halls,
+/area/city/fixers)
 "Eq" = (
 /obj/machinery/light/cold/no_nightlight{
 	brightness = 16;
@@ -7821,7 +8094,7 @@
 	dir = 6
 	},
 /turf/open/floor/carpet/cyan,
-/area/space)
+/area/city)
 "Ey" = (
 /obj/structure/chair/wood/wings,
 /obj/effect/turf_decal/siding/wood{
@@ -7851,7 +8124,7 @@
 /obj/structure/table/wood,
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood,
-/area/space)
+/area/city)
 "EK" = (
 /obj/effect/turf_decal/delivery/red,
 /obj/structure/table,
@@ -7872,6 +8145,13 @@
 /obj/structure/chair/office,
 /turf/open/floor/plasteel/dark,
 /area/facility_hallway/manager)
+"ES" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/facility/dark,
+/area/city/backstreets_room)
 "EU" = (
 /obj/structure/table/reinforced,
 /obj/machinery/button/door/indestructible{
@@ -7902,7 +8182,7 @@
 /area/facility_hallway/manager)
 "EY" = (
 /turf/open/floor/wood,
-/area/space)
+/area/city)
 "EZ" = (
 /obj/structure/railing{
 	dir = 4
@@ -7991,7 +8271,7 @@
 	dir = 8
 	},
 /turf/open/floor/wood,
-/area/space)
+/area/city)
 "Fi" = (
 /obj/effect/landmark/salesspawn,
 /turf/closed/wall/mineral/silver{
@@ -8094,7 +8374,7 @@
 /obj/machinery/light/cold/no_nightlight{
 	brightness = 16
 	},
-/turf/open/floor/sepia,
+/turf/open/floor/plasteel/dark,
 /area/facility_hallway/manager)
 "FH" = (
 /obj/structure/flora/ausbushes/ppflowers,
@@ -8129,7 +8409,7 @@
 	dir = 10
 	},
 /turf/open/floor/wood,
-/area/space)
+/area/city)
 "FQ" = (
 /obj/effect/light_emitter{
 	light_power = 4;
@@ -8169,7 +8449,7 @@
 	dir = 10
 	},
 /turf/open/floor/wood,
-/area/space)
+/area/city)
 "FV" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
@@ -8296,6 +8576,11 @@
 	},
 /turf/open/indestructible/white,
 /area/city/shop)
+"Gz" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/telecomms/bus/preset_two,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/city)
 "GB" = (
 /obj/structure/closet/secure_closet/freezer/fridge/open{
 	anchored = 1;
@@ -8684,9 +8969,30 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/facility_hallway/manager)
+"HH" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/telecomms/processor/preset_three,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/city)
+"HJ" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/telecomms/processor/preset_one,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/city)
 "HM" = (
 /turf/open/floor/plasteel/dark,
 /area/city/shop)
+"HP" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 9
+	},
+/turf/open/floor/facility/dark,
+/area/city/backstreets_room)
 "HR" = (
 /turf/closed/wall/mineral/silver{
 	desc = "A wall with unmistable white coloring. Iconic sight in N Corp's Nest!";
@@ -8749,6 +9055,12 @@
 	},
 /turf/open/floor/facility/dark,
 /area/facility_hallway/manager)
+"Ie" = (
+/obj/machinery/telecomms/relay/preset/telecomms,
+/obj/structure/emergency_shield,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/city)
 "If" = (
 /obj/structure/window/reinforced/spawner/east{
 	max_integrity = 25
@@ -8873,9 +9185,7 @@
 "IH" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/tree/jungle/small,
-/turf/open/floor/plating/grass/jungle{
-	name = "Grass"
-	},
+/turf/open/floor/plating/grass,
 /area/facility_hallway/manager)
 "IJ" = (
 /obj/structure/fence,
@@ -8886,7 +9196,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood,
-/area/space)
+/area/city)
 "IN" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -8965,7 +9275,7 @@
 	dir = 10
 	},
 /turf/open/floor/carpet/cyan,
-/area/space)
+/area/city)
 "IX" = (
 /obj/structure/table/reinforced{
 	max_integrity = 25
@@ -9009,7 +9319,7 @@
 	set_cap = 3;
 	set_luminosity = 24
 	},
-/turf/open/floor/sepia,
+/turf/open/floor/plasteel/dark,
 /area/facility_hallway/manager)
 "Ji" = (
 /obj/structure/curtain/cloth/fancy,
@@ -9027,7 +9337,7 @@
 	dir = 5
 	},
 /turf/open/floor/wood,
-/area/space)
+/area/city)
 "Jl" = (
 /obj/machinery/vending/cola/blue{
 	name = "\improper Crane Game Machine"
@@ -9065,7 +9375,7 @@
 "Ju" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood,
-/area/space)
+/area/city)
 "JB" = (
 /obj/structure/toilet{
 	dir = 4;
@@ -9250,7 +9560,7 @@
 	pixel_y = 4
 	},
 /turf/open/floor/facility/white,
-/area/space)
+/area/city)
 "Kj" = (
 /obj/machinery/vending/lobotomyarmband,
 /turf/open/floor/facility/dark,
@@ -9293,6 +9603,10 @@
 	},
 /turf/open/floor/noslip,
 /area/facility_hallway/manager)
+"Kq" = (
+/obj/structure/forge,
+/turf/open/floor/wood,
+/area/city)
 "Ks" = (
 /obj/structure/flora/ausbushes/reedbush,
 /turf/open/floor/plating/grass,
@@ -9322,7 +9636,13 @@
 	dir = 8
 	},
 /turf/open/floor/carpet/cyan,
-/area/space)
+/area/city)
+"KE" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/telecomms/bus/preset_one,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/city)
 "KG" = (
 /obj/machinery/computer/camera_advanced/manager,
 /obj/machinery/light/cold/no_nightlight{
@@ -9415,7 +9735,7 @@
 	},
 /obj/item/bedsheet/red,
 /turf/open/floor/wood,
-/area/space)
+/area/city)
 "Lc" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#3234B9"
@@ -9432,7 +9752,7 @@
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green,
 /turf/open/floor/wood,
-/area/space)
+/area/city)
 "Lf" = (
 /obj/structure/closet/crate/trashcart,
 /obj/item/storage/bag/trash/bluespace,
@@ -9551,6 +9871,13 @@
 /obj/structure/table/anvil,
 /turf/open/floor/mineral/titanium/tiled/blue,
 /area/city/shop)
+"LC" = (
+/obj/machinery/door/airlock/grunge{
+	name = "association office";
+	req_access_txt = "67"
+	},
+/turf/open/floor/facility/halls,
+/area/city/fixers)
 "LE" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
@@ -9560,7 +9887,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood,
-/area/space)
+/area/city)
 "LF" = (
 /obj/effect/turf_decal/siding/wood/corner,
 /obj/effect/turf_decal/siding/wood/corner{
@@ -9568,9 +9895,6 @@
 	},
 /turf/open/floor/wood,
 /area/city/fixers)
-"LG" = (
-/turf/open/floor/facility/halls,
-/area/space)
 "LI" = (
 /obj/structure/chair/sofa/left{
 	dir = 8
@@ -9729,7 +10053,7 @@
 	dir = 9
 	},
 /turf/open/floor/wood,
-/area/space)
+/area/city)
 "Ml" = (
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/eighties,
@@ -9748,7 +10072,7 @@
 	name = "Fixer Laptop"
 	},
 /turf/open/floor/wood,
-/area/space)
+/area/city)
 "Mp" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/plating/grass/jungle{
@@ -9837,7 +10161,7 @@
 	pixel_y = 3
 	},
 /turf/open/floor/wood,
-/area/space)
+/area/city)
 "ML" = (
 /obj/machinery/door/airlock/silver{
 	name = "white-washed airlock"
@@ -10100,7 +10424,7 @@
 /obj/structure/bed,
 /obj/item/bedsheet/wiz,
 /turf/open/floor/wood,
-/area/space)
+/area/city)
 "Od" = (
 /obj/machinery/door/airlock/silver{
 	name = "white-washed airlock"
@@ -10140,7 +10464,7 @@
 	dir = 1
 	},
 /turf/open/floor/wood,
-/area/space)
+/area/city)
 "Om" = (
 /obj/machinery/shower{
 	dir = 1
@@ -10242,6 +10566,12 @@
 	},
 /turf/open/floor/plating,
 /area/city/shop)
+"OR" = (
+/obj/machinery/door/airlock/hatch{
+	req_access_txt = "31"
+	},
+/turf/open/floor/facility/dark,
+/area/city/backstreets_room)
 "OT" = (
 /turf/open/floor/plasteel/airless/white,
 /area/city/backstreets_checkpoint)
@@ -10356,7 +10686,7 @@
 "Px" = (
 /obj/effect/turf_decal/siding/blue/end,
 /turf/open/floor/carpet/cyan,
-/area/space)
+/area/city)
 "Py" = (
 /obj/machinery/door/window/westright,
 /turf/open/floor/facility/white,
@@ -10446,6 +10776,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/city/shop)
+"PH" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/open/floor/plating/grass,
+/area/facility_hallway/manager)
 "PI" = (
 /obj/structure/sign/barsign,
 /turf/closed/wall/mineral/silver{
@@ -10477,6 +10812,11 @@
 	},
 /turf/open/floor/plating/grass,
 /area/city)
+"PR" = (
+/obj/structure/flora/tree/jungle,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plating/grass,
+/area/facility_hallway/manager)
 "PS" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -10490,7 +10830,7 @@
 /obj/item/food/meat/steak/crimson,
 /obj/item/reagent_containers/food/drinks/bottle/champagne,
 /turf/open/floor/wood,
-/area/space)
+/area/city)
 "PW" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 8
@@ -10602,6 +10942,11 @@
 "Qr" = (
 /turf/open/floor/plasteel/checker,
 /area/city/shop)
+"Qs" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/ntnet_relay,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/city)
 "Qv" = (
 /turf/open/floor/mineral/titanium/white,
 /area/city/shop)
@@ -10611,7 +10956,7 @@
 	dir = 8
 	},
 /turf/open/floor/wood,
-/area/space)
+/area/city)
 "Qx" = (
 /obj/structure/table/wood,
 /obj/machinery/photocopier{
@@ -10636,7 +10981,7 @@
 	dir = 8
 	},
 /turf/open/floor/wood,
-/area/space)
+/area/city)
 "QC" = (
 /obj/effect/turf_decal/siding/yellow{
 	dir = 5
@@ -10715,11 +11060,6 @@
 /obj/item/bedsheet/hop,
 /turf/open/floor/wood,
 /area/facility_hallway/manager)
-"QZ" = (
-/turf/open/floor/plating/grass/jungle{
-	name = "Grass"
-	},
-/area/facility_hallway/manager)
 "Ra" = (
 /obj/effect/turf_decal/siding/blue/end,
 /turf/open/floor/carpet/cyan,
@@ -10794,6 +11134,12 @@
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/city/fixers)
+"Rq" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/turf/open/floor/facility/dark,
+/area/city/backstreets_room)
 "Rs" = (
 /obj/structure/sink/kitchen{
 	dir = 8;
@@ -10889,7 +11235,7 @@
 "RG" = (
 /obj/effect/turf_decal/siding/wood/corner,
 /turf/open/floor/wood,
-/area/space)
+/area/city)
 "RH" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/tile/red,
@@ -10932,7 +11278,7 @@
 	dir = 1
 	},
 /turf/open/floor/wood,
-/area/space)
+/area/city)
 "RR" = (
 /obj/structure/table/reinforced{
 	max_integrity = 25
@@ -10960,7 +11306,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood,
-/area/space)
+/area/city)
 "RY" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -11035,6 +11381,11 @@
 	},
 /turf/open/floor/sepia,
 /area/facility_hallway/manager)
+"Sn" = (
+/obj/machinery/announcement_system,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/city)
 "So" = (
 /obj/effect/turf_decal/delivery/red,
 /obj/machinery/light/small,
@@ -11071,7 +11422,7 @@
 	set_cap = 3;
 	set_luminosity = 24
 	},
-/turf/open/floor/sepia,
+/turf/open/floor/plasteel/dark,
 /area/facility_hallway/manager)
 "Su" = (
 /obj/machinery/hydroponics/constructable,
@@ -11188,6 +11539,14 @@
 	},
 /turf/open/floor/facility/halls,
 /area/city/shop)
+"SY" = (
+/obj/effect/decal/cleanable/blood/drip{
+	pixel_x = 12;
+	pixel_y = 12
+	},
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/floor/facility/dark,
+/area/city/backstreets_room)
 "SZ" = (
 /obj/structure/bed,
 /obj/item/bedsheet/hop,
@@ -11328,6 +11687,18 @@
 	},
 /turf/open/floor/wood,
 /area/city/shop)
+"Tz" = (
+/turf/closed/indestructible/reinforced,
+/area/city/backstreets_room)
+"TA" = (
+/obj/machinery/door/airlock/hatch{
+	req_access_txt = "31"
+	},
+/obj/effect/turf_decal/trimline/red/filled/shrink_cw{
+	dir = 8
+	},
+/turf/open/floor/facility/dark,
+/area/city/backstreets_room)
 "TB" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -11388,7 +11759,7 @@
 	dir = 1
 	},
 /turf/open/floor/wood,
-/area/space)
+/area/city)
 "TO" = (
 /obj/structure/railing{
 	dir = 1
@@ -11582,7 +11953,7 @@
 	dir = 4
 	},
 /turf/open/floor/wood,
-/area/space)
+/area/city)
 "Uz" = (
 /obj/machinery/light/cold/no_nightlight,
 /turf/open/floor/mineral/titanium/tiled/white,
@@ -11882,7 +12253,7 @@
 	dir = 1
 	},
 /turf/open/floor/carpet/cyan,
-/area/space)
+/area/city)
 "VR" = (
 /obj/structure/sink/kitchen{
 	dir = 4;
@@ -11939,7 +12310,7 @@
 	},
 /obj/machinery/light/cold/no_nightlight,
 /turf/open/floor/wood,
-/area/space)
+/area/city)
 "VX" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
@@ -12549,7 +12920,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/space)
+/area/city)
 "Yd" = (
 /obj/effect/turf_decal/siding/blue{
 	dir = 4
@@ -12629,6 +13000,9 @@
 	},
 /turf/open/floor/mineral/titanium/tiled/yellow/airless,
 /area/city/shop)
+"YB" = (
+/turf/open/floor/facility/dark,
+/area/city/backstreets_room)
 "YD" = (
 /obj/effect/turf_decal/siding/blue{
 	dir = 8
@@ -12656,7 +13030,7 @@
 "YI" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/facility/white,
-/area/space)
+/area/city)
 "YJ" = (
 /obj/structure/chair/comfy/brown,
 /obj/effect/turf_decal/siding/blue{
@@ -12682,6 +13056,12 @@
 /obj/item/reagent_containers/food/drinks/waterbottle,
 /turf/open/floor/plasteel/cafeteria,
 /area/city/house)
+"YO" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/turf/open/floor/facility/dark,
+/area/city/backstreets_room)
 "YQ" = (
 /obj/structure/sink/kitchen{
 	dir = 1;
@@ -12724,7 +13104,7 @@
 	},
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood,
-/area/space)
+/area/city)
 "YZ" = (
 /obj/effect/turf_decal/siding/blue{
 	dir = 6
@@ -12874,6 +13254,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/city/fixers)
+"ZC" = (
+/obj/machinery/telecomms/server/presets/command{
+	name = "Command Server"
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/city)
 "ZE" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -12972,14 +13359,14 @@
 	},
 /obj/effect/turf_decal/siding/wood/corner,
 /turf/open/floor/wood,
-/area/space)
+/area/city)
 "ZQ" = (
 /obj/effect/turf_decal/siding/wood/end{
 	dir = 8
 	},
 /obj/machinery/light/cold/no_nightlight,
 /turf/open/floor/wood,
-/area/space)
+/area/city)
 "ZU" = (
 /obj/structure/chair/office{
 	desc = "A rather boring gaming chair.";
@@ -18081,15 +18468,15 @@ IN
 IN
 Cf
 Tn
-Bt
-Bt
-Bt
-Bt
-Bt
-Bt
+aq
+aq
+aq
+aq
+aq
+aq
 bI
 bI
-In
+jX
 Zs
 Cf
 IN
@@ -18333,25 +18720,25 @@ gc
 Ko
 JE
 Ir
-Bt
-Bt
-Bt
-Bt
-In
+aq
+aq
+aq
+aq
+jX
 bI
-In
-Bt
-Bt
-In
-In
+jX
+aq
+aq
+jX
+jX
 bI
-Bt
-Bt
-Bt
-Bt
-In
-In
-Bt
+aq
+aq
+aq
+aq
+jX
+jX
+aq
 la
 JE
 TZ
@@ -18590,12 +18977,12 @@ Of
 SZ
 JE
 Tn
-Bt
+aq
 bI
 bI
-In
-Bt
-Bt
+jX
+aq
+aq
 RB
 qh
 UO
@@ -18603,12 +18990,12 @@ OJ
 vw
 Ns
 gu
-In
-In
+jX
+jX
 bI
 bI
-Bt
-Bt
+aq
+aq
 Zs
 JE
 JI
@@ -18847,8 +19234,8 @@ Sl
 Ui
 eL
 Bt
-Bt
-Bt
+aq
+aq
 ZM
 np
 Bs
@@ -18864,9 +19251,9 @@ ly
 OJ
 Ns
 gu
-Bt
-Bt
-Bt
+aq
+aq
+aq
 eL
 Sl
 Sl
@@ -19105,7 +19492,7 @@ Th
 JE
 VY
 bI
-Bt
+aq
 XF
 JE
 JE
@@ -19121,8 +19508,8 @@ JE
 JE
 JE
 HB
-Bt
-In
+aq
+jX
 dE
 JE
 gf
@@ -19362,7 +19749,7 @@ yS
 JE
 xm
 bI
-Bt
+aq
 Mx
 Sv
 Cc
@@ -19378,8 +19765,8 @@ JE
 JE
 JE
 ws
-Bt
-In
+aq
+jX
 la
 JE
 cr
@@ -19619,7 +20006,7 @@ JE
 JE
 fr
 bI
-Bt
+aq
 DP
 Sv
 LU
@@ -19635,7 +20022,7 @@ JE
 JE
 JE
 Eu
-Bt
+aq
 bI
 uu
 JE
@@ -19876,7 +20263,7 @@ Ck
 EF
 Ir
 Jh
-Bt
+aq
 tZ
 Sv
 KG
@@ -19892,7 +20279,7 @@ Mc
 SU
 JE
 NC
-In
+jX
 bI
 Ff
 Tr
@@ -20132,8 +20519,8 @@ JE
 JE
 JE
 fr
-In
-Bt
+jX
+aq
 tZ
 Sv
 ho
@@ -20389,8 +20776,8 @@ sY
 OH
 JE
 xm
-Bt
-Bt
+aq
+aq
 xs
 Sv
 nr
@@ -20407,7 +20794,7 @@ UB
 Sv
 vW
 bI
-In
+jX
 la
 JE
 Kp
@@ -20646,8 +21033,8 @@ IZ
 Qp
 JE
 Tn
-Bt
-In
+aq
+jX
 rx
 JE
 JE
@@ -20664,7 +21051,7 @@ JE
 JE
 My
 bI
-In
+jX
 Zs
 JE
 Qp
@@ -20903,7 +21290,7 @@ Xn
 Xn
 eL
 Bt
-Bt
+aq
 bI
 rx
 Sv
@@ -20921,8 +21308,8 @@ SU
 JE
 iq
 bI
-Bt
-Bt
+aq
+aq
 eL
 Xn
 Xn
@@ -21160,7 +21547,7 @@ XQ
 QV
 JE
 eW
-Bt
+aq
 bI
 cb
 Sv
@@ -21177,8 +21564,8 @@ MR
 OD
 Sv
 pR
-In
-Bt
+jX
+aq
 dE
 JE
 QV
@@ -21417,7 +21804,7 @@ wS
 KI
 JE
 Ir
-Bt
+aq
 bI
 kO
 Sv
@@ -21434,8 +21821,8 @@ tF
 UB
 Sv
 iw
-In
-Bt
+jX
+aq
 la
 JE
 KI
@@ -21674,8 +22061,8 @@ Wj
 Wj
 JE
 fr
-Bt
-In
+aq
+jX
 tZ
 JE
 JE
@@ -21691,7 +22078,7 @@ JE
 JE
 JE
 My
-In
+jX
 lG
 Va
 JE
@@ -21922,7 +22309,7 @@ jq
 jq
 sf
 JE
-tl
+PH
 Gi
 Ck
 JR
@@ -21931,8 +22318,8 @@ Ck
 qL
 Ro
 Tn
-Bt
-Bt
+aq
+aq
 DP
 Sv
 aZ
@@ -21948,8 +22335,8 @@ Mc
 SU
 JE
 go
-Bt
-Bt
+aq
+aq
 Zs
 Ro
 FW
@@ -22153,16 +22540,16 @@ jq
 jq
 jq
 Hk
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
+Tz
+Tz
+Tz
+Tz
+Tz
+Tz
+Tz
+Tz
+Tz
+Tz
 jq
 jq
 jq
@@ -22179,7 +22566,7 @@ jq
 jq
 sf
 JE
-tl
+PH
 jo
 Gi
 Ck
@@ -22187,9 +22574,9 @@ Ck
 fJ
 Tn
 bI
-In
-Bt
-Bt
+jX
+aq
+aq
 yL
 Sv
 ZL
@@ -22205,10 +22592,10 @@ MR
 OD
 Sv
 Eu
-Bt
-Bt
-Bt
-In
+aq
+aq
+aq
+jX
 Zs
 FW
 nw
@@ -22410,16 +22797,16 @@ jq
 jq
 jq
 Hk
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
+Tz
+HP
+pc
+an
+jr
+Rq
+Rq
+xJ
+Cr
+Tz
 jq
 jq
 jq
@@ -22436,17 +22823,17 @@ jq
 jq
 sf
 JE
-tl
-tl
+PH
+PH
 Gi
 Ck
 fJ
 Tn
 bI
-Bt
-Bt
-Bt
-Bt
+aq
+aq
+aq
+aq
 Oj
 Sv
 my
@@ -22462,11 +22849,11 @@ tF
 UB
 Sv
 pR
-In
+jX
 bI
 bI
-In
-Bt
+jX
+aq
 Zs
 FW
 Ck
@@ -22667,16 +23054,16 @@ jq
 jq
 jq
 Hk
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
+Tz
+YO
+YB
+Tz
+OR
+fM
+YB
+SY
+mE
+Tz
 jq
 jq
 jq
@@ -22693,14 +23080,14 @@ jq
 jq
 sf
 JE
-Mp
-Jt
+jo
+uj
 Gi
 Ck
 xm
 bI
-In
-Bt
+jX
+aq
 HV
 Ns
 bG
@@ -22723,8 +23110,8 @@ OJ
 bK
 gu
 bI
-In
-Bt
+jX
+aq
 la
 Ck
 Mp
@@ -22924,16 +23311,16 @@ jq
 jq
 jq
 Hk
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
+Tz
+YO
+nP
+gz
+CR
+Tz
+ru
+YB
+dc
+Tz
 jq
 jq
 jq
@@ -22950,13 +23337,13 @@ jq
 jq
 sf
 JE
-Mp
-tl
+jo
+PH
 Gi
 Ck
 Ir
 bI
-In
+jX
 RB
 rw
 JE
@@ -22980,7 +23367,7 @@ JE
 JE
 ZE
 us
-In
+jX
 lG
 la
 Ck
@@ -23181,16 +23568,16 @@ jq
 jq
 jq
 Hk
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
+Tz
+ES
+nP
+gw
+jm
+TA
+sG
+Bu
+lY
+Tz
 jq
 jq
 jq
@@ -23207,13 +23594,13 @@ jq
 jq
 sf
 JE
-tl
-Mp
+PH
+jo
 Gi
 Ck
 Ir
-In
-In
+jX
+jX
 kO
 JE
 JE
@@ -23237,8 +23624,8 @@ dl
 JE
 JE
 iw
-Bt
-Bt
+aq
+aq
 la
 Gi
 Mp
@@ -23438,16 +23825,16 @@ jq
 jq
 jq
 HR
-HR
-HR
-HR
-HR
-HR
-jq
-jq
-jq
-jq
-jq
+Tz
+aF
+Tz
+Tz
+Tz
+Tz
+Tz
+Tz
+Tz
+Tz
 jq
 jq
 jq
@@ -23464,13 +23851,13 @@ HR
 HR
 sf
 JE
-ZA
-tl
+PR
+PH
 Gi
 Ck
 Ir
 Jh
-Bt
+aq
 Kd
 JE
 km
@@ -23494,8 +23881,8 @@ iP
 Km
 JE
 go
-Bt
-Bt
+aq
+aq
 la
 Gi
 jo
@@ -23721,13 +24108,13 @@ Tt
 Tt
 sf
 JE
-tl
-Mp
+PH
+jo
 Gi
 Ck
 Ir
-In
-Bt
+jX
+aq
 yL
 Ji
 xI
@@ -23751,8 +24138,8 @@ Zo
 uQ
 Ji
 Eu
-Bt
-Bt
+aq
+aq
 jT
 Ck
 Gi
@@ -23978,13 +24365,13 @@ Tt
 Tt
 sf
 JE
-Mp
+jo
 jo
 Gi
 Ck
 Ir
-In
-Bt
+jX
+aq
 tZ
 Ji
 kw
@@ -24008,7 +24395,7 @@ Yv
 TL
 Ji
 My
-In
+jX
 FG
 JE
 JE
@@ -24235,13 +24622,13 @@ Tt
 Tt
 sf
 JE
-tl
+PH
 Gi
 Ck
 nO
 Ir
-Bt
-Bt
+aq
+aq
 hX
 JE
 qa
@@ -24265,8 +24652,8 @@ Gu
 Km
 JE
 go
-In
-Bt
+jX
+aq
 BD
 aq
 fj
@@ -24492,7 +24879,7 @@ Tt
 Tt
 sf
 JE
-Mp
+jo
 Gi
 Bw
 JE
@@ -24749,7 +25136,7 @@ Tt
 Tt
 sf
 JE
-tl
+PH
 Gi
 Ck
 JE
@@ -24780,7 +25167,7 @@ ER
 lC
 JE
 bI
-Bt
+aq
 JE
 Oa
 Xm
@@ -25006,7 +25393,7 @@ RT
 RT
 sf
 JE
-Jt
+uj
 Gi
 Ck
 JE
@@ -25263,7 +25650,7 @@ RT
 RT
 sf
 JE
-Mp
+jo
 Gi
 Ck
 JE
@@ -25293,13 +25680,13 @@ Mc
 Mc
 ex
 DQ
-In
-Bt
-mZ
-Bt
+jX
+aq
+fj
+aq
 bI
-Bt
-Bt
+aq
+aq
 Fo
 AB
 NK
@@ -25550,13 +25937,13 @@ aq
 aq
 Ur
 sx
-Bt
+aq
 lG
-In
+jX
 bI
 zl
-Bt
-Bt
+aq
+aq
 Fo
 NK
 NK
@@ -25807,13 +26194,13 @@ Mc
 Mc
 Hv
 DQ
-Bt
-Bt
+aq
+aq
 uY
-Bt
-Bt
-Bt
-Bt
+aq
+aq
+aq
+aq
 Fo
 JY
 NK
@@ -26321,8 +26708,8 @@ Nd
 ER
 lC
 JE
-Bt
-Bt
+aq
+aq
 JE
 Oa
 cy
@@ -26548,7 +26935,7 @@ th
 Yr
 sf
 JE
-Mp
+jo
 Gi
 Bw
 JE
@@ -26805,13 +27192,13 @@ NK
 Yr
 sf
 JE
-Mp
+jo
 Gi
 Gi
 JR
 Ir
-Bt
-Bt
+aq
+aq
 yL
 JE
 GZ
@@ -26835,8 +27222,8 @@ Ps
 nR
 JE
 NC
-Bt
-Bt
+aq
+aq
 BD
 aq
 bU
@@ -27062,13 +27449,13 @@ NK
 Yr
 sf
 JE
-Mp
+jo
 uj
 Gi
 Ck
 Ir
-In
-Bt
+jX
+aq
 Kd
 Ji
 qB
@@ -27319,13 +27706,13 @@ NK
 Yr
 sf
 JE
-Mp
-tl
+jo
+PH
 Gi
 Ck
 Ir
-In
-Bt
+jX
+aq
 kH
 Ji
 TK
@@ -27350,7 +27737,7 @@ gk
 Ji
 iM
 bI
-In
+jX
 vd
 Ck
 Ck
@@ -27576,13 +27963,13 @@ NK
 Yr
 sf
 JE
-tl
-Mp
+PH
+jo
 Gi
 nw
 Ir
-In
-In
+jX
+jX
 tZ
 JE
 uw
@@ -27607,7 +27994,7 @@ vZ
 JE
 ws
 bI
-In
+jX
 la
 nw
 Ck
@@ -27833,13 +28220,13 @@ NK
 Yr
 sf
 JE
-Mp
-Mp
+jo
+jo
 Gi
 Ck
 Ir
 St
-In
+jX
 TO
 JE
 JE
@@ -27863,8 +28250,8 @@ uq
 JE
 JE
 YT
-In
-In
+jX
+jX
 mY
 Ck
 Gi
@@ -28090,13 +28477,13 @@ NK
 Yr
 sf
 JE
-Mp
-ZA
+jo
+PR
 Gi
 Ck
 Ir
 bI
-In
+jX
 BM
 mk
 JE
@@ -28121,11 +28508,11 @@ JE
 CE
 vi
 bI
-In
+jX
 la
 Gi
 jo
-tl
+PH
 JE
 sf
 RK
@@ -28347,14 +28734,14 @@ NK
 Yr
 sf
 JE
-tl
-Mp
+PH
+jo
 Gi
 Ck
 Ir
 bI
 bI
-In
+jX
 JV
 wc
 jp
@@ -28378,11 +28765,11 @@ Fc
 ej
 bI
 bI
-In
+jX
 la
 Gi
-QZ
-Jt
+Ck
+uj
 JE
 sf
 RK
@@ -28604,7 +28991,7 @@ NK
 Yr
 sf
 JE
-Mp
+jo
 jo
 Gi
 Ck
@@ -28612,9 +28999,9 @@ qp
 VY
 bI
 bI
-In
-Bt
-Bt
+jX
+aq
+aq
 lV
 Sv
 iV
@@ -28630,16 +29017,16 @@ AC
 iV
 Sv
 lt
-In
-In
-In
+jX
+jX
+jX
 bI
-In
+jX
 dE
 Wb
 Gi
 Gi
-Mp
+jo
 JE
 sf
 RK
@@ -28842,17 +29229,17 @@ Yr
 fD
 Lx
 Lx
-Di
+om
 Lx
 Lx
 Lx
-Di
+LC
 Lx
-Di
+LC
 Lx
 Lx
 Lx
-Di
+LC
 Lx
 Lx
 fD
@@ -28861,17 +29248,17 @@ NK
 Yr
 sf
 JE
-tl
+PH
 Gi
 Ck
 Ck
 Ck
 CW
 VY
-In
-In
-In
-In
+jX
+jX
+jX
+jX
 lV
 Sv
 yh
@@ -28888,9 +29275,9 @@ yh
 Sv
 My
 bI
-Bt
-Bt
-In
+aq
+aq
+jX
 dE
 Or
 Ck
@@ -29127,8 +29514,8 @@ Ck
 qp
 LP
 VY
-Bt
-Bt
+aq
+aq
 DP
 JE
 mt
@@ -29144,8 +29531,8 @@ iI
 GL
 JE
 go
-Bt
-Bt
+aq
+aq
 dE
 IQ
 Wb
@@ -29384,8 +29771,8 @@ JE
 JE
 JE
 xm
-Bt
-Bt
+aq
+aq
 yL
 JE
 ph
@@ -29587,12 +29974,12 @@ jq
 jq
 jq
 jq
-eR
 JX
 JX
-eR
-eR
-eR
+JX
+JX
+JX
+JX
 JX
 wn
 wn
@@ -29613,18 +30000,18 @@ Yr
 fD
 Lx
 Lx
-Di
+LC
 Lx
 Lx
 Lx
 Lx
-Di
+LC
 Lx
 Lx
 Lx
 Lx
 Lx
-Di
+LC
 Lx
 fD
 RK
@@ -29641,8 +30028,8 @@ mW
 mW
 JE
 Tn
-Bt
-In
+aq
+jX
 xM
 JE
 JE
@@ -29659,7 +30046,7 @@ JE
 JE
 YT
 bI
-Bt
+aq
 Ff
 JE
 TZ
@@ -29844,13 +30231,13 @@ jq
 jq
 jq
 jq
-eR
 JX
 JX
-eR
 JX
 JX
-eR
+JX
+JX
+JX
 wn
 OT
 wo
@@ -29897,9 +30284,9 @@ Dj
 mW
 mW
 WD
-Bt
-Bt
-In
+aq
+aq
+jX
 kH
 JE
 Vs
@@ -29916,7 +30303,7 @@ Om
 JE
 Eu
 bI
-Bt
+aq
 Zs
 JE
 JI
@@ -29924,7 +30311,7 @@ Of
 SZ
 JE
 Gi
-tl
+PH
 JE
 sf
 RK
@@ -30101,8 +30488,8 @@ jq
 jq
 jq
 jq
-eR
-eR
+JX
+JX
 JX
 JX
 JX
@@ -30155,8 +30542,8 @@ mW
 mW
 JE
 VY
-Bt
-In
+aq
+jX
 rx
 JE
 hm
@@ -30172,16 +30559,16 @@ pn
 Xw
 JE
 iM
-In
-In
-Bt
+jX
+jX
+aq
 eL
 Sl
 Sl
 Sl
 JE
 Gi
-Mp
+jo
 JE
 sf
 RK
@@ -30358,8 +30745,8 @@ jq
 jq
 jq
 jq
-eR
-eR
+JX
+JX
 JX
 JX
 JX
@@ -30412,7 +30799,7 @@ mW
 AF
 JE
 Ir
-In
+jX
 bI
 hX
 JE
@@ -30429,7 +30816,7 @@ Ip
 cK
 JE
 go
-In
+jX
 bI
 dE
 JE
@@ -30615,7 +31002,7 @@ jq
 jq
 jq
 jq
-eR
+JX
 JX
 JX
 oQ
@@ -30669,7 +31056,7 @@ mW
 mW
 JE
 Ir
-In
+jX
 bI
 Po
 JE
@@ -30686,7 +31073,7 @@ JE
 JE
 JE
 iw
-In
+jX
 bI
 la
 JE
@@ -30695,7 +31082,7 @@ Xt
 yS
 JE
 Gi
-tl
+PH
 JE
 sf
 RK
@@ -30872,7 +31259,7 @@ jq
 jq
 jq
 jq
-eR
+JX
 JX
 JX
 JX
@@ -30926,7 +31313,7 @@ mW
 mW
 JE
 Ir
-In
+jX
 bI
 rx
 JE
@@ -30943,8 +31330,8 @@ sH
 GL
 JE
 lt
-In
-In
+jX
+jX
 uu
 JE
 JE
@@ -30952,7 +31339,7 @@ JE
 JE
 JE
 eU
-tl
+PH
 JE
 sf
 RK
@@ -31129,7 +31516,7 @@ jq
 jq
 jq
 jq
-eR
+JX
 JX
 JX
 JX
@@ -31183,7 +31570,7 @@ mW
 mW
 JE
 Ir
-Bt
+aq
 Jh
 cb
 JE
@@ -31200,8 +31587,8 @@ Of
 nd
 JE
 lt
-Bt
-In
+aq
+jX
 Ff
 EF
 sl
@@ -31209,7 +31596,7 @@ nw
 Gi
 oM
 uj
-Mp
+jo
 JE
 sf
 RK
@@ -31386,13 +31773,13 @@ jq
 jq
 jq
 jq
-eR
-eR
 JX
 JX
 JX
-eR
-eR
+JX
+JX
+JX
+JX
 wn
 OT
 rD
@@ -31440,8 +31827,8 @@ OC
 AF
 JE
 Ir
-Bt
-In
+aq
+jX
 Oj
 Sv
 Ny
@@ -31457,7 +31844,7 @@ Uf
 Uf
 Sv
 lt
-Bt
+aq
 bI
 uu
 JE
@@ -31644,11 +32031,11 @@ jq
 jq
 jq
 JX
-eR
-eR
-eR
 JX
-eR
+JX
+JX
+JX
+JX
 JX
 wn
 wn
@@ -31668,19 +32055,19 @@ NK
 Yr
 fD
 Lx
-wt
+yC
 Lx
 Lx
 Lx
 Lx
 Lx
-Di
+LC
 Lx
 Lx
 Lx
 Lx
 Lx
-Di
+LC
 Lx
 fD
 RK
@@ -31697,8 +32084,8 @@ mW
 mW
 JE
 Ir
-Bt
-In
+aq
+jX
 tZ
 Sv
 AJ
@@ -31714,8 +32101,8 @@ df
 AJ
 Sv
 pR
-Bt
-In
+aq
+jX
 la
 JE
 Kp
@@ -31902,9 +32289,9 @@ jq
 jq
 jq
 jq
-eR
-eR
-eR
+JX
+JX
+JX
 jq
 jq
 jq
@@ -31954,8 +32341,8 @@ JE
 WD
 JE
 xm
-Bt
-Bt
+aq
+aq
 TO
 JE
 JE
@@ -31971,8 +32358,8 @@ JE
 JE
 JE
 xL
-Bt
-Bt
+aq
+aq
 Zs
 JE
 Qp
@@ -32159,9 +32546,9 @@ jq
 jq
 jq
 jq
-eR
-eR
-eR
+JX
+JX
+JX
 jq
 jq
 jq
@@ -32211,8 +32598,8 @@ sX
 Np
 JE
 Ir
-Bt
-Bt
+aq
+aq
 JV
 Fc
 cP
@@ -32228,9 +32615,9 @@ cP
 ua
 cM
 gG
-Bt
-Bt
-Bt
+aq
+aq
+aq
 eL
 Xn
 Xn
@@ -32416,9 +32803,9 @@ jq
 jq
 jq
 jq
-eR
-eR
-eR
+JX
+JX
+JX
 jq
 jq
 jq
@@ -32440,17 +32827,17 @@ Yr
 fD
 Lx
 Lx
-Di
+yC
 Lx
 Lx
 Lx
-fc
+Ep
 Lx
-fc
+Ep
 Lx
 Lx
 Lx
-Di
+LC
 Lx
 Lx
 fD
@@ -32468,12 +32855,12 @@ Xj
 DM
 JE
 Ir
-Bt
-Bt
-Bt
-Bt
+aq
+aq
+aq
+aq
 bI
-In
+jX
 wJ
 ap
 ch
@@ -32481,12 +32868,12 @@ jp
 bR
 XX
 Nk
-Bt
-In
+aq
+jX
 bI
-In
-In
-Bt
+jX
+jX
+aq
 dE
 JE
 QV
@@ -32673,9 +33060,9 @@ jq
 jq
 jq
 jq
-eR
-eR
-eR
+JX
+JX
+JX
 jq
 jq
 jq
@@ -32726,24 +33113,24 @@ JE
 JE
 Ir
 bI
-In
-Bt
-Bt
-Bt
-In
+jX
+aq
+aq
+aq
+jX
 bI
-In
-Bt
-Bt
-Bt
-Bt
-Bt
+jX
+aq
+aq
+aq
+aq
+aq
 bI
-In
-In
-Bt
-Bt
-Bt
+jX
+jX
+aq
+aq
+aq
 la
 JE
 KI
@@ -32751,7 +33138,7 @@ wS
 KI
 JE
 Gi
-tl
+PH
 JE
 sf
 RK
@@ -32930,9 +33317,9 @@ jq
 jq
 jq
 jq
-eR
-eR
-eR
+JX
+JX
+JX
 jq
 jq
 jq
@@ -32987,13 +33374,13 @@ LP
 dB
 LP
 VY
-In
-In
-In
-In
-Bt
-Bt
-In
+jX
+jX
+jX
+jX
+aq
+aq
+jX
 bI
 bI
 dE
@@ -33008,7 +33395,7 @@ Wj
 Wj
 JE
 eU
-Mp
+jo
 JE
 sf
 RK
@@ -33187,9 +33574,9 @@ jq
 jq
 jq
 jq
-eR
-eR
-eR
+JX
+JX
+JX
 jq
 jq
 jq
@@ -33265,7 +33652,7 @@ Gi
 Gi
 FX
 jo
-Jt
+uj
 JE
 sf
 RK
@@ -33444,9 +33831,9 @@ jq
 jq
 jq
 jq
-eR
-eR
-eR
+JX
+JX
+JX
 jq
 jq
 jq
@@ -33478,7 +33865,7 @@ Do
 br
 Lx
 Lx
-Di
+LC
 Lx
 Lx
 fD
@@ -33521,8 +33908,8 @@ Gi
 Gi
 Gi
 jo
-tl
-Mp
+PH
+jo
 JE
 sf
 RK
@@ -33701,9 +34088,9 @@ jq
 jq
 jq
 jq
-eR
-eR
-eR
+JX
+JX
+JX
 jq
 jq
 jq
@@ -33754,10 +34141,10 @@ IJ
 Mu
 Ck
 jo
-Mp
-Mp
-tl
-tl
+jo
+jo
+PH
+PH
 jo
 Ck
 NP
@@ -33768,18 +34155,18 @@ Gi
 Gi
 Gi
 jo
-Mp
-Mp
-Mp
-ZA
-tl
-Mp
-Mp
-Mp
-Mp
-tl
-tl
-Mp
+jo
+jo
+jo
+PR
+PH
+jo
+jo
+jo
+jo
+PH
+PH
+jo
 JE
 sf
 RK
@@ -33958,9 +34345,9 @@ jq
 jq
 jq
 jq
-eR
-eR
-eR
+JX
+JX
+JX
 jq
 jq
 jq
@@ -34010,33 +34397,33 @@ Gi
 Gi
 Gi
 jo
-Mp
-Mp
-Mp
-ZA
-Mp
-tl
-tl
-Mp
+jo
+jo
+jo
+PR
+jo
+PH
+PH
+jo
 Gi
 Gi
 Gi
-Mp
-Jt
-tl
-tl
-Mp
-Mp
-Mp
-tl
-tl
-Mp
-Mp
-Mp
-Mp
-ZA
-Mp
-Mp
+jo
+uj
+PH
+PH
+jo
+jo
+jo
+PH
+PH
+jo
+jo
+jo
+jo
+PR
+jo
+jo
 JE
 sf
 RK
@@ -34215,9 +34602,9 @@ jq
 jq
 jq
 jq
-eR
-eR
-eR
+JX
+JX
+JX
 jq
 jq
 jq
@@ -34472,9 +34859,9 @@ jq
 jq
 jq
 jq
-eR
-eR
-eR
+JX
+JX
+JX
 jq
 jq
 jq
@@ -34729,9 +35116,9 @@ jq
 jq
 jq
 jq
-eR
-eR
-eR
+JX
+JX
+JX
 jq
 jq
 jq
@@ -34986,9 +35373,9 @@ jq
 jq
 jq
 jq
-eR
-eR
-eR
+JX
+JX
+JX
 jq
 jq
 jq
@@ -35243,9 +35630,9 @@ jq
 jq
 jq
 jq
-eR
-eR
-eR
+JX
+JX
+JX
 jq
 jq
 jq
@@ -35500,9 +35887,9 @@ jq
 jq
 jq
 jq
-eR
-eR
-eR
+JX
+JX
+JX
 jq
 jq
 jq
@@ -35757,9 +36144,9 @@ jq
 jq
 jq
 jq
-eR
-eR
-eR
+JX
+JX
+JX
 jq
 jq
 jq
@@ -36014,9 +36401,9 @@ jq
 jq
 jq
 jq
-eR
-eR
-eR
+JX
+JX
+JX
 jq
 jq
 jq
@@ -36271,9 +36658,9 @@ jq
 jq
 jq
 jq
-eR
-eR
-eR
+JX
+JX
+JX
 jq
 jq
 jq
@@ -36528,9 +36915,9 @@ jq
 jq
 jq
 jq
-eR
-eR
-eR
+JX
+JX
+JX
 jq
 jq
 jq
@@ -36785,9 +37172,9 @@ jq
 jq
 jq
 jq
-eR
-eR
-eR
+JX
+JX
+JX
 jq
 jq
 jq
@@ -37042,9 +37429,9 @@ jq
 jq
 jq
 jq
-eR
-eR
-eR
+JX
+JX
+JX
 jq
 jq
 jq
@@ -37299,9 +37686,9 @@ jq
 jq
 jq
 jq
-eR
-eR
-eR
+JX
+JX
+JX
 jq
 jq
 jq
@@ -37556,9 +37943,9 @@ jq
 jq
 jq
 jq
-eR
-eR
-eR
+JX
+JX
+JX
 jq
 jq
 jq
@@ -37813,9 +38200,9 @@ jq
 jq
 jq
 jq
-eR
-eR
-eR
+JX
+JX
+JX
 jq
 jq
 jq
@@ -38070,9 +38457,9 @@ jq
 jq
 jq
 jq
-eR
-eR
-eR
+JX
+JX
+JX
 jq
 jq
 jq
@@ -38327,9 +38714,9 @@ jq
 jq
 jq
 jq
-eR
-eR
-eR
+JX
+JX
+JX
 jq
 jq
 jq
@@ -38584,9 +38971,9 @@ jq
 jq
 jq
 jq
-eR
-eR
-eR
+JX
+JX
+JX
 jq
 jq
 jq
@@ -38841,9 +39228,9 @@ jq
 jq
 jq
 jq
-eR
-eR
-eR
+JX
+JX
+JX
 jq
 jq
 jq
@@ -39098,9 +39485,9 @@ jq
 jq
 jq
 jq
-eR
-eR
-eR
+JX
+JX
+JX
 jq
 jq
 jq
@@ -39355,9 +39742,9 @@ jq
 jq
 jq
 jq
-eR
-eR
-eR
+JX
+JX
+JX
 jq
 jq
 jq
@@ -39612,9 +39999,9 @@ jq
 jq
 jq
 jq
-eR
-eR
-eR
+JX
+JX
+JX
 jq
 jq
 jq
@@ -39869,9 +40256,9 @@ jq
 jq
 jq
 jq
-eR
-eR
-eR
+JX
+JX
+JX
 jq
 jq
 jq
@@ -40126,9 +40513,9 @@ jq
 jq
 jq
 jq
-eR
-eR
-eR
+JX
+JX
+JX
 jq
 jq
 jq
@@ -40383,9 +40770,9 @@ jq
 jq
 jq
 jq
-eR
-eR
-eR
+JX
+JX
+JX
 jq
 jq
 jq
@@ -40640,9 +41027,9 @@ jq
 jq
 jq
 jq
-eR
-eR
-eR
+JX
+JX
+JX
 jq
 jq
 jq
@@ -40897,9 +41284,9 @@ jq
 jq
 jq
 jq
-eR
-eR
-eR
+JX
+JX
+JX
 jq
 jq
 jq
@@ -41154,9 +41541,9 @@ jq
 jq
 jq
 jq
-eR
-eR
-eR
+JX
+JX
+JX
 jq
 jq
 jq
@@ -41411,9 +41798,9 @@ jq
 jq
 jq
 jq
-eR
-eR
-eR
+JX
+JX
+JX
 jq
 jq
 jq
@@ -41668,9 +42055,9 @@ jq
 jq
 jq
 jq
-eR
-eR
-eR
+JX
+JX
+JX
 jq
 jq
 jq
@@ -41925,9 +42312,9 @@ jq
 jq
 jq
 jq
-eR
-eR
-eR
+JX
+JX
+JX
 jq
 jq
 jq
@@ -42182,9 +42569,9 @@ jq
 jq
 jq
 jq
-eR
-eR
-eR
+JX
+JX
+JX
 jq
 jq
 jq
@@ -42439,9 +42826,9 @@ jq
 jq
 jq
 jq
-eR
-eR
-eR
+JX
+JX
+JX
 jq
 jq
 jq
@@ -42696,9 +43083,9 @@ jq
 jq
 jq
 jq
-eR
-eR
-eR
+JX
+JX
+JX
 jq
 jq
 jq
@@ -42953,9 +43340,9 @@ jq
 jq
 jq
 jq
-eR
-eR
-eR
+JX
+JX
+JX
 jq
 jq
 jq
@@ -43210,9 +43597,9 @@ jq
 jq
 jq
 jq
-eR
-eR
-eR
+JX
+JX
+JX
 jq
 jq
 jq
@@ -43467,9 +43854,9 @@ jq
 jq
 jq
 jq
-eR
-eR
-eR
+JX
+JX
+JX
 jq
 jq
 jq
@@ -43724,9 +44111,9 @@ jq
 jq
 jq
 jq
-eR
-eR
-eR
+JX
+JX
+JX
 jq
 jq
 jq
@@ -43981,9 +44368,9 @@ jq
 jq
 jq
 jq
-eR
-eR
-eR
+JX
+JX
+JX
 jq
 jq
 jq
@@ -44238,9 +44625,9 @@ jq
 jq
 jq
 jq
-eR
-eR
-eR
+JX
+JX
+JX
 jq
 jq
 jq
@@ -44495,9 +44882,9 @@ jq
 jq
 jq
 jq
-eR
-eR
-eR
+JX
+JX
+JX
 jq
 jq
 jq
@@ -44752,9 +45139,9 @@ jq
 jq
 jq
 jq
-eR
-eR
-eR
+JX
+JX
+JX
 jq
 jq
 jq
@@ -45009,9 +45396,9 @@ jq
 jq
 jq
 jq
-eR
-eR
-eR
+JX
+JX
+JX
 jq
 jq
 jq
@@ -45266,14 +45653,14 @@ jq
 jq
 jq
 jq
-eR
-eR
-eR
-eR
-eR
-eR
-eR
-eR
+JX
+JX
+JX
+JX
+JX
+JX
+JX
+JX
 jq
 jq
 jq
@@ -45523,14 +45910,14 @@ jq
 jq
 jq
 jq
-eR
-eR
-eR
-eR
-eR
-eR
-eR
-eR
+JX
+JX
+JX
+JX
+JX
+JX
+JX
+JX
 jq
 jq
 jq
@@ -45780,14 +46167,14 @@ jq
 jq
 jq
 jq
-eR
-eR
-eR
-eR
-eR
-eR
-eR
-eR
+JX
+JX
+JX
+JX
+JX
+JX
+JX
+JX
 jq
 jq
 jq
@@ -46042,9 +46429,9 @@ jq
 jq
 jq
 jq
-eR
-eR
-eR
+JX
+JX
+JX
 jq
 jq
 jq
@@ -46299,9 +46686,9 @@ jq
 jq
 jq
 jq
-eR
-eR
-eR
+JX
+JX
+JX
 jq
 jq
 jq
@@ -46556,9 +46943,9 @@ jq
 jq
 jq
 jq
-eR
-eR
-eR
+JX
+JX
+JX
 jq
 jq
 jq
@@ -46813,9 +47200,9 @@ jq
 jq
 jq
 jq
-eR
-eR
-eR
+JX
+JX
+JX
 jq
 jq
 jq
@@ -46866,7 +47253,7 @@ HR
 HR
 HR
 HR
-Od
+nF
 HR
 HR
 HR
@@ -47070,9 +47457,9 @@ jq
 jq
 jq
 jq
-eR
-eR
-eR
+JX
+JX
+JX
 jq
 jq
 jq
@@ -47122,9 +47509,9 @@ yk
 AN
 QB
 FO
-Hk
+HR
 be
-Hk
+HR
 Mk
 cj
 kk
@@ -47327,9 +47714,9 @@ jq
 jq
 jq
 jq
-eR
-eR
-eR
+JX
+JX
+JX
 jq
 jq
 jq
@@ -47379,9 +47766,9 @@ Ol
 EY
 aK
 EJ
-Hk
+HR
 TN
-Hk
+HR
 mn
 Ju
 Ju
@@ -47584,9 +47971,9 @@ jq
 jq
 jq
 jq
-eR
-eR
-eR
+JX
+JX
+JX
 jq
 jq
 jq
@@ -47636,9 +48023,9 @@ dW
 EY
 EY
 Qw
-fs
+Od
 oh
-fs
+Od
 Jk
 Ux
 Ux
@@ -47841,9 +48228,9 @@ jq
 jq
 jq
 jq
-eR
-eR
-eR
+JX
+JX
+JX
 jq
 jq
 jq
@@ -47893,9 +48280,9 @@ qH
 EY
 RG
 jt
-Hk
+HR
 rl
-Hk
+HR
 VP
 hF
 zc
@@ -48098,9 +48485,9 @@ jq
 jq
 jq
 jq
-eR
-eR
-eR
+JX
+JX
+JX
 jq
 jq
 jq
@@ -48149,11 +48536,11 @@ HR
 tz
 Lb
 yz
-Hk
-Hk
-fs
-Hk
-Hk
+HR
+HR
+Od
+HR
+HR
 ji
 YI
 Ki
@@ -48355,16 +48742,16 @@ jq
 jq
 jq
 jq
-eR
-eR
-eR
+JX
+JX
+JX
 jq
 jq
 jq
 jq
 jq
-eR
-eR
+JX
+JX
 jq
 HR
 RK
@@ -48403,17 +48790,17 @@ RT
 RT
 RT
 HR
-Hk
-Hk
-Hk
-Hk
+HR
+HR
+HR
+HR
 cX
 qg
 FT
-Hk
-Hk
-Hk
-Hk
+HR
+HR
+HR
+HR
 HR
 RT
 RT
@@ -48612,15 +48999,15 @@ jq
 jq
 jq
 jq
-eR
-eR
-eR
-eR
-eR
-eR
-eR
-eR
-eR
+JX
+JX
+JX
+JX
+JX
+JX
+JX
+JX
+JX
 JX
 wn
 wn
@@ -48660,18 +49047,18 @@ RT
 RT
 RT
 HR
-jq
-jq
-jq
-Hk
+EY
+aE
+EY
+EY
 RQ
 KD
 cS
 FT
-hK
+AD
 Mk
 Fh
-AD
+wA
 RT
 RT
 RT
@@ -48869,15 +49256,15 @@ jq
 jq
 jq
 jq
-eR
-eR
-eR
-eR
-eR
-eR
-eR
-eR
-eR
+JX
+JX
+JX
+JX
+JX
+JX
+JX
+JX
+JX
 oQ
 Mf
 Mf
@@ -48917,15 +49304,15 @@ RT
 RT
 RT
 HR
-jq
-jq
-jq
-Hk
+Kq
+jD
+oT
+EY
 uM
 oV
 RG
 jt
-LG
+AG
 Jk
 LE
 AG
@@ -49118,22 +49505,22 @@ jq
 jq
 jq
 jq
-jq
-eR
-eR
-eR
-eR
-eR
-eR
-eR
-eR
-eR
-eR
-eR
-eR
-eR
-eR
-eR
+JX
+JX
+JX
+JX
+JX
+JX
+JX
+JX
+JX
+JX
+JX
+JX
+JX
+JX
+JX
+JX
 JX
 JX
 wn
@@ -49174,17 +49561,17 @@ Tt
 NM
 Tt
 HR
-Hk
-Hk
-Hk
-Hk
+HR
+HR
+HR
+HR
 lA
 ZP
 VW
-Hk
-Hk
-Hk
-Hk
+HR
+HR
+HR
+HR
 HR
 RT
 RT
@@ -49375,24 +49762,24 @@ jq
 jq
 jq
 jq
-jq
-eR
-eR
-eR
-eR
-eR
-eR
-eR
-eR
-eR
-eR
-jq
-jq
+JX
+JX
+JX
+JX
+JX
+JX
+JX
+JX
+JX
+JX
+JX
 jq
 jq
 jq
-eR
-eR
+jq
+jq
+JX
+JX
 jq
 HR
 RK
@@ -49434,11 +49821,11 @@ HR
 wY
 fl
 vV
-Hk
-Hk
-fs
-Hk
-Hk
+HR
+HR
+Od
+HR
+HR
 Oc
 PS
 Db
@@ -49632,17 +50019,17 @@ jq
 jq
 jq
 jq
-jq
-eR
-eR
-eR
-eR
-eR
-eR
-eR
-eR
-eR
-eR
+JX
+JX
+JX
+JX
+JX
+JX
+JX
+JX
+JX
+JX
+JX
 jq
 jq
 jq
@@ -49692,9 +50079,9 @@ vV
 wY
 vV
 vV
-Hk
+HR
 ZQ
-Hk
+HR
 BY
 RQ
 EY
@@ -49897,9 +50284,9 @@ jq
 jq
 jq
 jq
-eR
-eR
-eR
+JX
+JX
+JX
 jq
 jq
 jq
@@ -49949,9 +50336,9 @@ qm
 rX
 wY
 vV
-fs
+Od
 oh
-fs
+Od
 RU
 Ee
 IW
@@ -50206,9 +50593,9 @@ wY
 wY
 vV
 vV
-Hk
-Hk
-Hk
+HR
+HR
+HR
 MK
 nX
 Ew
@@ -50463,9 +50850,9 @@ vV
 XZ
 wY
 vV
-Hk
-jq
-Hk
+HR
+Io
+HR
 Jk
 IK
 Mm
@@ -50715,18 +51102,18 @@ jq
 jq
 jq
 jq
-Hk
-Hk
-Hk
-Hk
-Hk
-Hk
-jq
-Hk
-Hk
-Hk
-Hk
-Hk
+HR
+HR
+HR
+HR
+HR
+HR
+Io
+HR
+HR
+HR
+HR
+HR
 HR
 HR
 HR
@@ -57665,7 +58052,7 @@ jq
 jq
 jq
 jq
-jq
+Io
 jq
 jq
 jq
@@ -61254,13 +61641,13 @@ jq
 jq
 jq
 jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
+Io
+de
+de
+de
+de
+de
+de
 jq
 jq
 jq
@@ -61511,13 +61898,13 @@ jq
 jq
 jq
 jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
+Io
+de
+oG
+iS
+de
+Sn
+de
 jq
 jq
 jq
@@ -61768,13 +62155,13 @@ jq
 jq
 jq
 jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
+Io
+de
+gb
+HJ
+Gz
+mC
+de
 jq
 jq
 jq
@@ -62025,13 +62412,13 @@ jq
 jq
 jq
 jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
+Io
+de
+hh
+wO
+KE
+aj
+de
 jq
 jq
 jq
@@ -62282,13 +62669,13 @@ jq
 jq
 jq
 jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
+Io
+de
+xq
+HH
+eS
+ub
+de
 jq
 jq
 jq
@@ -62539,13 +62926,13 @@ jq
 jq
 jq
 jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
+Io
+de
+yD
+kc
+cz
+tL
+de
 jq
 jq
 jq
@@ -62796,13 +63183,13 @@ jq
 jq
 jq
 jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
+Io
+de
+iu
+Qs
+CJ
+ZC
+de
 jq
 jq
 jq
@@ -63053,13 +63440,13 @@ jq
 jq
 jq
 jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
+Io
+de
+En
+sb
+de
+Ie
+de
 jq
 jq
 jq
@@ -63310,13 +63697,13 @@ jq
 jq
 jq
 jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
+Io
+de
+de
+de
+de
+de
+de
 jq
 jq
 jq

--- a/_maps/map_files/Xi/xicommand.dmm
+++ b/_maps/map_files/Xi/xicommand.dmm
@@ -875,7 +875,7 @@
 	brightness = 16;
 	dir = 4
 	},
-/turf/open/floor/sepia,
+/turf/open/floor/plasteel/dark,
 /area/facility_hallway/manager)
 "dg" = (
 /obj/structure/table/glass,
@@ -1930,7 +1930,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/open/floor/sepia,
+/turf/open/floor/plasteel/white,
 /area/facility_hallway/manager)
 "hn" = (
 /obj/effect/turf_decal/siding{
@@ -2415,7 +2415,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue,
-/turf/open/floor/sepia,
+/turf/open/floor/plasteel/dark,
 /area/facility_hallway/manager)
 "iW" = (
 /obj/effect/turf_decal/tile{
@@ -3624,19 +3624,6 @@
 	},
 /turf/open/floor/facility/white,
 /area/city/shop)
-"oh" = (
-/obj/effect/turf_decal/siding/wood/corner,
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/city)
 "oj" = (
 /obj/structure/window/reinforced/spawner/east{
 	max_integrity = 25
@@ -3842,7 +3829,7 @@
 /obj/effect/turf_decal/siding/blue/end{
 	dir = 4
 	},
-/turf/open/floor/facility,
+/turf/open/floor/carpet/cyan,
 /area/city)
 "oW" = (
 /obj/structure/closet/secure_closet/freezer/fridge{
@@ -6312,6 +6299,24 @@
 /obj/item/paper/fluff/silk_guide,
 /turf/open/floor/facility/dark,
 /area/city/backstreets_room)
+"xK" = (
+/obj/effect/turf_decal/tile/blue{
+	color = "#3234B9";
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#3234B9"
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#3234B9";
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	color = "#3234B9";
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/facility_hallway/manager)
 "xL" = (
 /obj/structure/railing,
 /obj/item/grown/novaflower,
@@ -6413,7 +6418,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/turf/open/floor/sepia,
+/turf/open/floor/plasteel/dark,
 /area/facility_hallway/manager)
 "yj" = (
 /obj/structure/closet/secure_closet/freezer/fridge{
@@ -6898,6 +6903,19 @@
 	},
 /turf/open/floor/wood,
 /area/city/shop)
+"zN" = (
+/obj/effect/turf_decal/tile/bar{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/facility_hallway/manager)
 "zP" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/effect/turf_decal/siding/thinplating/dark/corner{
@@ -7111,7 +7129,7 @@
 	brightness = 16;
 	dir = 8
 	},
-/turf/open/floor/sepia,
+/turf/open/floor/plasteel/dark,
 /area/facility_hallway/manager)
 "AD" = (
 /obj/machinery/door/airlock/glass_large,
@@ -7163,7 +7181,7 @@
 	dir = 1
 	},
 /obj/item/toy/plush/lisa,
-/turf/open/floor/sepia,
+/turf/open/floor/plasteel/dark,
 /area/facility_hallway/manager)
 "AK" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
@@ -7314,9 +7332,6 @@
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/manager)
-"Bt" = (
-/turf/open/floor/sepia,
 /area/facility_hallway/manager)
 "Bu" = (
 /obj/machinery/light{
@@ -8502,8 +8517,8 @@
 /turf/open/floor/plating/grass,
 /area/city)
 "FK" = (
-/obj/machinery/door/airlock/silver{
-	name = "Female Restroom"
+/obj/machinery/door/airlock/hatch{
+	name = "Restroom"
 	},
 /turf/open/floor/facility/halls,
 /area/facility_hallway/manager)
@@ -9219,7 +9234,7 @@
 /area/city/fixers)
 "In" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/sepia,
+/turf/open/floor/plasteel/white,
 /area/facility_hallway/manager)
 "Io" = (
 /turf/closed/indestructible/rock,
@@ -9391,12 +9406,6 @@
 	},
 /turf/open/indestructible/white,
 /area/city/shop)
-"IV" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Male Restroom"
-	},
-/turf/open/floor/facility/halls,
-/area/facility_hallway/manager)
 "IW" = (
 /obj/effect/turf_decal/siding/blue{
 	dir = 10
@@ -9755,7 +9764,7 @@
 /obj/effect/turf_decal/siding/blue/end{
 	dir = 8
 	},
-/turf/open/floor/facility,
+/turf/open/floor/carpet/cyan,
 /area/city)
 "KE" = (
 /obj/effect/turf_decal/bot,
@@ -10440,7 +10449,7 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
-/turf/open/floor/sepia,
+/turf/open/floor/plasteel/dark,
 /area/facility_hallway/manager)
 "NB" = (
 /obj/structure/chair/wood/wings{
@@ -10951,7 +10960,7 @@
 /obj/structure/mirror{
 	pixel_x = -27
 	},
-/turf/open/floor/sepia,
+/turf/open/floor/plasteel/white,
 /area/facility_hallway/manager)
 "PY" = (
 /obj/structure/sign/barsign,
@@ -11379,7 +11388,7 @@
 	brightness = 16;
 	dir = 4
 	},
-/turf/open/floor/sepia,
+/turf/open/floor/plasteel/dark,
 /area/facility_hallway/manager)
 "RK" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -12009,7 +12018,7 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
-/turf/open/floor/sepia,
+/turf/open/floor/plasteel/dark,
 /area/facility_hallway/manager)
 "Ui" = (
 /obj/effect/turf_decal/tile/bar{
@@ -12022,7 +12031,7 @@
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
-/turf/open/floor/sepia,
+/turf/open/floor/plasteel/dark,
 /area/facility_hallway/manager)
 "Un" = (
 /obj/machinery/vending/cola/shamblers,
@@ -12265,7 +12274,7 @@
 /obj/structure/toilet{
 	dir = 4
 	},
-/turf/open/floor/sepia,
+/turf/open/floor/plasteel/white,
 /area/facility_hallway/manager)
 "Vt" = (
 /obj/structure/table/wood,
@@ -12682,12 +12691,6 @@
 	opacity = 0
 	},
 /area/city/shop)
-"WQ" = (
-/obj/machinery/door/airlock/wood{
-	name = "Female Clerk Quarters"
-	},
-/turf/open/floor/facility/halls,
-/area/facility_hallway/manager)
 "WU" = (
 /obj/effect/turf_decal/siding/blue{
 	dir = 5
@@ -12838,7 +12841,7 @@
 /area/facility_hallway/manager)
 "Xq" = (
 /obj/machinery/door/airlock/wood{
-	name = "Male Clerk Quarters"
+	name = "Clerk Quarters"
 	},
 /turf/open/floor/facility/halls,
 /area/facility_hallway/manager)
@@ -13492,7 +13495,7 @@
 	dir = 8
 	},
 /obj/machinery/light/cold/no_nightlight,
-/turf/open/floor/wood,
+/turf/open/floor/facility,
 /area/city)
 "ZU" = (
 /obj/structure/chair/office{
@@ -19356,11 +19359,11 @@ jo
 Gi
 Ck
 JE
-Sl
-Sl
+zN
+zN
 Ui
 eL
-Bt
+aq
 aq
 aq
 ZM
@@ -21412,11 +21415,11 @@ Gi
 Ck
 Ck
 JE
-Xn
-Xn
-Xn
+xK
+xK
+xK
 eL
-Bt
+aq
 aq
 bI
 rx
@@ -30675,7 +30678,7 @@ rx
 JE
 hm
 In
-IV
+FK
 LL
 aq
 aq
@@ -31447,11 +31450,11 @@ JE
 TZ
 sH
 NE
-WQ
+Xq
 AQ
 aq
 iA
-WQ
+Xq
 CF
 sH
 GL
@@ -50464,7 +50467,7 @@ rX
 wY
 vV
 Od
-oh
+qn
 Od
 RU
 Ee

--- a/_maps/map_files/Xi/xicommand.dmm
+++ b/_maps/map_files/Xi/xicommand.dmm
@@ -1,13 +1,4 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"aa" = (
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 10
-	},
-/obj/effect/turf_decal/starfury/seven,
-/obj/structure/flora/rock/pile,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
 "ab" = (
 /obj/structure/window/reinforced/spawner/east{
 	max_integrity = 25
@@ -26,17 +17,6 @@
 	},
 /turf/open/floor/holofloor/white,
 /area/city/fixers)
-"ac" = (
-/obj/structure/sign/warning/securearea,
-/turf/closed/indestructible/reinforced,
-/area/city/backstreets_room)
-"ad" = (
-/obj/effect/decal/cleanable/blood/gibs/down,
-/obj/effect/decal/cleanable/blood,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
 "ae" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -49,60 +29,10 @@
 	},
 /turf/open/floor/oldshuttle,
 /area/city/fixers)
-"af" = (
-/obj/machinery/door/airlock/grunge,
-/obj/structure/barricade/wooden/crude,
-/turf/open/floor/plasteel/shuttle,
-/area/city/backstreets_room)
 "ag" = (
 /obj/machinery/light/cold/no_nightlight,
 /turf/open/floor/facility/dark,
 /area/city/backstreets_checkpoint)
-"ah" = (
-/turf/closed/indestructible/fakedoor{
-	name = "Malfunctioning Door"
-	},
-/area/city/backstreets_alley)
-"ai" = (
-/obj/effect/decal/cleanable/blood,
-/obj/structure/table/reinforced,
-/obj/effect/decal/cleanable/blood/gibs/limb{
-	dir = 4;
-	layer = 4;
-	pixel_x = 12;
-	pixel_y = 10
-	},
-/obj/effect/spawner/lootdrop/maint_drugs{
-	pixel_x = -6;
-	pixel_y = 5
-	},
-/obj/effect/spawner/lootdrop/maint_drugs,
-/turf/open/floor/stone,
-/area/city/backstreets_room)
-"aj" = (
-/obj/machinery/vending/medical,
-/turf/open/floor/holofloor/white,
-/area/city/backstreets_room)
-"ak" = (
-/obj/machinery/light/dim{
-	dir = 4
-	},
-/turf/open/floor/facility/dark,
-/area/city/backstreets_room)
-"al" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 10
-	},
-/turf/open/floor/plating/asteroid/basalt,
-/area/city/backstreets_alley)
-"am" = (
-/obj/structure/flora/ausbushes/sparsegrass{
-	pixel_x = 10;
-	pixel_y = -7
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
 "ao" = (
 /obj/structure/toilet,
 /obj/machinery/light/small{
@@ -124,40 +54,22 @@
 	dir = 4
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "aq" = (
 /turf/open/floor/plasteel/dark,
-/area/facility_hallway/command)
-"as" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 5
-	},
-/obj/structure/curtain/cloth{
-	pixel_y = 32
-	},
-/turf/open/floor/carpet/black,
-/area/city/backstreets_room)
-"at" = (
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 10
-	},
-/obj/effect/turf_decal/starfury/seven,
-/obj/structure/flora/rock/pile/largejungle{
-	pixel_x = -2;
-	pixel_y = -10
-	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"au" = (
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
+"ar" = (
+/obj/structure/bed,
+/obj/item/bedsheet/mime,
+/obj/effect/landmark/latejoin,
+/turf/open/floor/carpet/purple,
+/area/city/house)
 "av" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
@@ -179,14 +91,6 @@
 	},
 /turf/open/floor/mineral/titanium/tiled/white,
 /area/city/shop)
-"ax" = (
-/obj/structure/fence{
-	dir = 4;
-	pixel_x = -9;
-	pixel_y = 6
-	},
-/turf/closed/indestructible/reinforced,
-/area/city/backstreets_room)
 "ay" = (
 /obj/machinery/modular_computer/console{
 	dir = 4
@@ -211,15 +115,6 @@
 	dir = 8
 	},
 /area/city/shop)
-"aB" = (
-/obj/structure/chair/greyscale{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/city/backstreets_room)
 "aC" = (
 /obj/structure/closet/crate,
 /obj/structure/window/reinforced/spawner/north,
@@ -239,40 +134,11 @@
 	},
 /turf/open/floor/oldshuttle,
 /area/city/fixers)
-"aE" = (
-/obj/effect/turf_decal/siding/wideplating/light{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/city/backstreets_room)
-"aF" = (
-/obj/structure/cursed_money,
-/obj/effect/light_emitter{
-	light_power = 4;
-	light_range = 25;
-	set_cap = 3;
-	set_luminosity = 24
-	},
-/turf/open/floor/mineral/gold,
-/area/city/backstreets_room)
-"aG" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/sign/warning/securearea{
-	pixel_x = 32
-	},
-/turf/open/floor/stone,
-/area/city/backstreets_room)
 "aH" = (
 /obj/structure/bed,
 /obj/item/bedsheet/mime,
 /turf/open/floor/carpet/purple,
 /area/city/house)
-"aI" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 3
-	},
-/turf/open/floor/plating/asteroid/basalt,
-/area/city/backstreets_alley)
 "aJ" = (
 /obj/structure/window/reinforced/spawner{
 	max_integrity = 25
@@ -280,103 +146,42 @@
 /obj/structure/closet/crate/freezer/surplus_limbs,
 /turf/open/floor/mineral/titanium/blue,
 /area/city/shop)
-"aL" = (
-/obj/effect/turf_decal/siding/wideplating/light{
-	dir = 8
-	},
-/obj/machinery/door/window/brigdoor/westleft,
-/obj/effect/turf_decal{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/city/backstreets_room)
-"aM" = (
-/obj/effect/turf_decal{
-	dir = 9
-	},
-/obj/structure/closet/crate/large,
-/obj/item/ego_weapon/city/ncorp_mark,
-/obj/item/ego_weapon/city/ncorp_mark/black,
-/obj/item/ego_weapon/city/ncorp_mark/pale,
-/obj/item/ego_weapon/city/ncorp_mark/white,
-/obj/item/soap/ncorporation,
-/turf/open/floor/engine,
-/area/city/backstreets_room)
+"aK" = (
+/obj/structure/chair/wood/wings,
+/turf/open/floor/wood,
+/area/space)
 "aN" = (
 /obj/machinery/modular_computer/console{
 	dir = 1
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /turf/open/floor/facility/dark,
 /area/city/fixers)
-"aO" = (
-/mob/living/simple_animal/hostile/ordeal/green_bot{
-	name = "clerk bot"
-	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_checkpoint)
-"aP" = (
-/obj/effect/turf_decal/siding/yellow{
-	dir = 4
-	},
-/obj/machinery/modular_computer/console{
-	desc = "A corporate computer for private communications between persons of interest. This one appears to have its memory reset, however.";
-	dir = 8;
-	name = "communications console"
-	},
-/obj/machinery/button/door/indestructible{
-	id = "armoryinnerinterest";
-	name = "Inner Armory Lockdown Button";
-	pixel_x = 28
-	},
-/turf/open/floor/carpet/green,
-/area/city/backstreets_room)
-"aQ" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/obj/structure/barricade/wooden,
-/obj/structure/barricade/wooden/crude,
-/turf/open/floor/plating/asteroid/basalt,
-/area/city/backstreets_alley)
 "aR" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/westleft,
 /obj/machinery/door/window/eastright,
 /turf/open/floor/mineral/titanium/tiled/white,
 /area/city/shop)
-"aS" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
+"aT" = (
+/obj/machinery/door/airlock/wood{
+	name = "Training Head Office"
 	},
-/turf/open/floor/plating/asteroid/basalt,
-/area/city/backstreets_room)
-"aU" = (
-/obj/effect/turf_decal/siding/purple{
-	dir = 6
-	},
-/obj/structure/filingcabinet{
-	pixel_x = 10
-	},
-/obj/structure/filingcabinet,
-/obj/structure/filingcabinet{
-	pixel_x = -9
-	},
-/turf/open/floor/carpet/purple,
-/area/city/backstreets_room)
+/turf/open/floor/facility/dark,
+/area/facility_hallway/manager)
 "aV" = (
 /obj/structure/toilet{
 	dir = 4
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "aW" = (
 /obj/effect/turf_decal/siding/yellow{
 	dir = 10
@@ -388,7 +193,7 @@
 	brightness = 16
 	},
 /turf/open/floor/carpet/stellar,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "aX" = (
 /obj/effect/spawner/randomarcade{
 	dir = 1
@@ -398,29 +203,14 @@
 	},
 /turf/open/floor/eighties,
 /area/city/shop)
-"aY" = (
-/obj/structure/chair/sofa/right{
-	dir = 4
-	},
-/obj/structure/curtain/cloth{
-	pixel_x = -32
-	},
-/turf/open/floor/wood,
-/area/city/backstreets_room)
 "aZ" = (
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
-/turf/open/floor/plasteel/white,
-/area/facility_hallway/command)
-"ba" = (
-/obj/structure/chair/sofa/corp/right{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/holofloor/dark,
-/area/city/backstreets_room)
+/obj/machinery/computer/camera_advanced/manager/sephirah,
+/turf/open/floor/facility/dark,
+/area/facility_hallway/manager)
 "bb" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
 /obj/effect/turf_decal/siding/wood{
@@ -428,34 +218,29 @@
 	},
 /turf/open/floor/wood,
 /area/city/shop)
-"bc" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/sepia,
-/area/city/backstreets_room)
 "bd" = (
 /obj/structure/window/reinforced/spawner{
 	max_integrity = 25
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /turf/open/floor/mineral/titanium/tiled/white,
 /area/city/shop)
+"be" = (
+/obj/effect/turf_decal/siding/wood/end{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/space)
 "bf" = (
 /obj/effect/turf_decal/plaque{
 	alpha = 230;
 	icon_state = "LC18"
 	},
 /turf/open/floor/facility/dark,
-/area/facility_hallway/command)
-"bg" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/stone,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "bh" = (
 /obj/structure/toilet{
 	dir = 4;
@@ -463,80 +248,10 @@
 	},
 /turf/open/floor/holofloor/white,
 /area/city/fixers)
-"bi" = (
-/obj/effect/turf_decal/trimline/white/filled/line,
-/obj/effect/turf_decal/trimline/white/filled/line{
-	dir = 1
-	},
-/obj/item/folder/syndicate/red{
-	desc = "A folder belonging to one of the City's corporations. What this specific one is doing in a dodgeball game is beyond you.";
-	name = "Corporation Folder";
-	pixel_x = 15
-	},
-/obj/item/toy/beach_ball/holoball/dodgeball,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"bj" = (
-/obj/structure/table/wood/fancy/black,
-/obj/effect/spawner/lootdrop/gloves,
-/turf/open/indestructible/necropolis,
-/area/city/backstreets_room)
-"bk" = (
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/paper/crumpled{
-	pixel_x = 5;
-	pixel_y = 7
-	},
-/turf/open/floor/wood,
-/area/city/backstreets_room)
-"bl" = (
-/obj/structure/chair/office{
-	desc = "A rather boring gaming chair.";
-	dir = 4;
-	name = "gaming chair"
-	},
-/turf/open/floor/wood,
-/area/city/backstreets_room)
 "bm" = (
 /obj/machinery/door/airlock/sandstone,
 /turf/open/floor/facility/halls,
-/area/facility_hallway/command)
-"bn" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp{
-	pixel_x = -5;
-	pixel_y = 10
-	},
-/obj/item/folder/syndicate/red{
-	desc = "A folder belonging to one of the City's corporations.";
-	name = "Corporation Folder";
-	pixel_x = 5;
-	pixel_y = -2
-	},
-/turf/open/indestructible/cult,
-/area/city/backstreets_room)
-"bo" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/obj/structure/sign/warning{
-	desc = "A warning sign, something about killer robots.";
-	pixel_x = -30
-	},
-/turf/open/floor/plating/asteroid/basalt,
-/area/city/backstreets_alley)
-"bq" = (
-/obj/structure/table/wood,
-/obj/effect/mob_spawn/human/corpse/damaged,
-/obj/machinery/light/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/sepia,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "br" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -553,32 +268,17 @@
 	},
 /turf/open/floor/oldshuttle,
 /area/city/fixers)
-"bs" = (
-/obj/structure/table/wood,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/broken{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/city/backstreets_room)
 "bt" = (
 /obj/effect/turf_decal/tile/neutral{
-	dir = 8;
-	color = "#000000"
+	color = "#000000";
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral{
-	dir = 1;
-	color = "#000000"
+	color = "#000000";
+	dir = 1
 	},
 /turf/open/floor/mineral/titanium/tiled/white,
 /area/city/fixers)
-"bu" = (
-/obj/effect/turf_decal/siding/wideplating/corner{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
 "bv" = (
 /obj/structure/railing{
 	dir = 4
@@ -591,27 +291,17 @@
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
-"bw" = (
-/obj/effect/spawner/randomcolavend,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "bx" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/city/fixers)
-"by" = (
-/obj/effect/decal/cleanable/blood/footprints{
-	pixel_x = -3
-	},
-/turf/open/floor/sepia,
-/area/city/backstreets_room)
 "bz" = (
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /turf/open/floor/plasteel/checker,
 /area/city/house)
@@ -626,8 +316,8 @@
 	dir = 8
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /turf/open/floor/mineral/titanium/tiled/white,
 /area/city/shop)
@@ -642,12 +332,7 @@
 	dir = 6
 	},
 /turf/open/floor/carpet/black,
-/area/facility_hallway/command)
-"bE" = (
-/obj/structure/table/wood/fancy/black,
-/obj/item/book/codex_gigas,
-/turf/open/floor/carpet/black,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "bF" = (
 /obj/structure/altar_of_gods,
 /turf/open/floor/plasteel/dark,
@@ -664,25 +349,12 @@
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
-"bH" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/cobweb{
-	dir = 3
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 9
-	},
-/obj/structure/curtain/cloth{
-	pixel_y = 32
-	},
-/turf/open/floor/carpet/black,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "bI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/sepia,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "bJ" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -707,13 +379,13 @@
 	dir = 8
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "bL" = (
 /obj/machinery/griddle{
 	pixel_y = 1
@@ -727,35 +399,12 @@
 	},
 /turf/open/floor/plasteel/checker,
 /area/city/house)
-"bM" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 8
-	},
-/turf/open/floor/carpet/black,
-/area/city/backstreets_room)
-"bN" = (
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/blood/gibs/down,
-/turf/open/floor/plasteel/shuttle{
-	name = "floor"
-	},
-/area/city/backstreets_room)
 "bO" = (
 /obj/machinery/light{
 	dir = 8
 	},
 /turf/open/floor/facility/white,
 /area/city/shop)
-"bP" = (
-/obj/machinery/door/airlock/wood/glass,
-/turf/open/floor/plasteel/sepia,
-/area/city/backstreets_room)
-"bQ" = (
-/obj/structure/reagent_dispensers/water_cooler,
-/turf/open/floor/plasteel/showroomfloor,
-/area/city/backstreets_room)
 "bR" = (
 /obj/structure/railing{
 	dir = 4
@@ -768,28 +417,14 @@
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
-"bT" = (
-/obj/machinery/light/dim{
-	dir = 8;
-	pixel_x = null;
-	pixel_y = null
-	},
-/turf/open/floor/facility/dark,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "bU" = (
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/facility_hallway/command)
-"bV" = (
-/obj/structure/table/reinforced,
-/obj/effect/spawner/lootdrop/organ_spawner,
-/obj/effect/spawner/lootdrop/armory_contraband/cybersun,
-/turf/open/floor/stone,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "bW" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -802,26 +437,14 @@
 /area/city/shop)
 "bX" = (
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /obj/structure/closet{
 	icon_state = "hop"
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/city/fixers)
-"bY" = (
-/mob/living/simple_animal/hostile/ordeal/green_bot_big{
-	name = "gun bot"
-	},
-/obj/item/stack/sheet/mineral/wood,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_alley)
-"bZ" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal,
-/turf/open/floor/plasteel/dark,
-/area/city/backstreets_room)
 "ca" = (
 /obj/machinery/door/airlock/wood,
 /turf/open/floor/facility/halls,
@@ -838,7 +461,7 @@
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "cc" = (
 /obj/machinery/light/floor{
 	pixel_x = 15
@@ -864,23 +487,6 @@
 	},
 /turf/open/floor/mineral/gold,
 /area/city/shop)
-"ce" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 10
-	},
-/turf/open/floor/carpet/black,
-/area/city/backstreets_room)
-"cf" = (
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 10
-	},
-/obj/effect/turf_decal/starfury/ten{
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
 "cg" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/effect/turf_decal/siding/thinplating/dark,
@@ -898,19 +504,20 @@
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
-"ci" = (
-/obj/effect/decal/cleanable/blood/tracks{
+/area/facility_hallway/manager)
+"cj" = (
+/obj/structure/chair/wood/wings{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/paper/crumpled{
-	pixel_x = -5;
-	pixel_y = 7
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/machinery/light/cold/no_nightlight{
+	brightness = 16;
+	dir = 8
 	},
 /turf/open/floor/wood,
-/area/city/backstreets_room)
+/area/space)
 "ck" = (
 /obj/effect/turf_decal/siding/wood/corner,
 /obj/effect/turf_decal/siding/wood/corner{
@@ -927,15 +534,11 @@
 "cm" = (
 /obj/effect/decal/cleanable/glitter,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /turf/open/floor/eighties,
 /area/city/shop)
-"cn" = (
-/obj/structure/mineral_door/wood,
-/turf/open/floor/plasteel/shuttle,
-/area/city/backstreets_room)
 "co" = (
 /obj/structure/window/reinforced/spawner/east{
 	max_integrity = 25
@@ -945,7 +548,7 @@
 	},
 /obj/item/flashlight/lamp,
 /turf/open/floor/plasteel/dark,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "cq" = (
 /obj/effect/turf_decal/siding/thinplating/dark/corner{
 	dir = 4
@@ -962,14 +565,14 @@
 	},
 /obj/structure/window/reinforced/spawner/west,
 /turf/open/floor/noslip,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "cs" = (
 /obj/structure/chair/office,
 /obj/effect/turf_decal/siding{
 	dir = 10
 	},
 /turf/open/floor/carpet/black,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "ct" = (
 /obj/structure/window/reinforced/spawner/north{
 	max_integrity = 25;
@@ -993,23 +596,17 @@
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "cv" = (
 /turf/open/floor/mineral/titanium/white,
 /area/city/fixers)
-"cw" = (
-/obj/effect/turf_decal/siding{
-	dir = 6
-	},
-/turf/open/floor/carpet/black,
-/area/city/backstreets_room)
 "cx" = (
 /obj/structure/table/reinforced{
 	max_integrity = 25
 	},
 /obj/item/flashlight/lamp,
 /turf/open/floor/plasteel/dark,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "cy" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -1018,17 +615,12 @@
 	dir = 9
 	},
 /turf/open/floor/carpet/black,
-/area/facility_hallway/command)
-"cz" = (
-/obj/structure/table/glass,
-/obj/item/trait_injector/shrimp_injector,
-/turf/open/floor/plasteel/vaporwave,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "cB" = (
 /obj/structure/sink/kitchen{
-	pixel_y = 14;
 	dir = 4;
-	pixel_x = -11
+	pixel_x = -11;
+	pixel_y = 14
 	},
 /obj/structure/toilet{
 	dir = 1
@@ -1038,8 +630,8 @@
 "cC" = (
 /obj/machinery/modular_computer/console,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /turf/open/floor/facility/dark,
 /area/city/fixers)
@@ -1086,28 +678,6 @@
 	},
 /turf/open/floor/mineral/silver,
 /area/city/shop)
-"cG" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/turf/open/floor/sepia,
-/area/facility_hallway/command)
-"cH" = (
-/obj/effect/turf_decal{
-	dir = 5
-	},
-/turf/open/floor/engine,
-/area/city/backstreets_room)
-"cI" = (
-/turf/open/floor/carpet/purple,
-/area/city/backstreets_room)
 "cJ" = (
 /obj/structure/chair/sofa{
 	dir = 8
@@ -1118,12 +688,11 @@
 /turf/open/floor/eighties,
 /area/city/shop)
 "cK" = (
-/obj/machinery/shower{
+/obj/structure/toilet{
 	dir = 8
 	},
-/obj/item/soap/homemade,
-/turf/open/floor/mineral/titanium/tiled/yellow,
-/area/facility_hallway/command)
+/turf/open/floor/plasteel/white,
+/area/facility_hallway/manager)
 "cL" = (
 /obj/structure/table/reinforced{
 	pixel_y = 2
@@ -1143,26 +712,13 @@
 	dir = 4
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
-"cN" = (
-/obj/structure/displaycase/trophy{
-	alert = 0
-	},
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/city/backstreets_room)
-"cO" = (
-/obj/effect/turf_decal/siding/thinplating/dark/corner,
-/turf/open/indestructible/cult,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "cP" = (
 /obj/structure/railing{
 	dir = 4
@@ -1175,17 +731,19 @@
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
-"cQ" = (
-/obj/structure/table/reinforced,
-/turf/open/floor/facility/white,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "cR" = (
 /obj/effect/turf_decal/siding/thinplating/dark/corner{
 	dir = 8
 	},
 /turf/open/floor/stone,
 /area/city)
+"cS" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/space)
 "cT" = (
 /obj/structure/chair/sofa/corp/right{
 	dir = 8
@@ -1203,17 +761,11 @@
 	pixel_y = 17
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /turf/open/floor/carpet/royalblue,
-/area/facility_hallway/command)
-"cV" = (
-/obj/effect/turf_decal/siding/yellow{
-	dir = 9
-	},
-/turf/open/floor/carpet/green,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "cW" = (
 /obj/effect/turf_decal/siding/wood/end{
 	dir = 4
@@ -1221,79 +773,44 @@
 /obj/machinery/light/cold/no_nightlight,
 /turf/open/floor/wood,
 /area/city/shop)
-"cY" = (
-/obj/structure/chair/plastic{
+"cX" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/obj/machinery/light/cold/no_nightlight{
+	brightness = 16;
 	dir = 1
 	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"cZ" = (
-/obj/structure/flora/tree/jungle{
-	pixel_x = -30
-	},
-/turf/open/floor/grass,
-/area/city/backstreets_room)
-"da" = (
-/obj/effect/turf_decal/siding/wood,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/blood/gibs{
-	pixel_x = 11
-	},
-/turf/open/floor/sepia,
-/area/city/backstreets_room)
-"db" = (
-/obj/item/storage/secure/safe{
-	pixel_x = 30
-	},
-/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood,
-/area/city/backstreets_room)
-"dc" = (
-/obj/effect/turf_decal/trimline/neutral/corner{
-	dir = 8;
-	pixel_x = -7;
-	pixel_y = -6
-	},
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/holofloor/dark,
-/area/city/backstreets_room)
+/area/space)
 "dd" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/modular_computer/console/preset/civilian,
 /turf/open/floor/plating,
 /area/city/shop)
-"de" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 6
-	},
-/turf/open/indestructible/cult,
-/area/city/backstreets_room)
 "df" = (
 /obj/structure/table/wood,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/item/flashlight/lamp,
+/obj/item/toy/plush/moth,
 /obj/structure/sign/poster/lobotomycorp/random{
 	pixel_x = 32
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /turf/open/floor/sepia,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "dg" = (
 /obj/structure/table/glass,
 /obj/machinery/door/window/eastright,
@@ -1307,17 +824,7 @@
 	opacity = 1
 	},
 /turf/open/floor/carpet/royalblue,
-/area/facility_hallway/command)
-"dj" = (
-/obj/effect/spawner/lootdrop/garbage_spawner,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"dk" = (
-/mob/living/simple_animal/hostile/ordeal/indigo_dawn{
-	name = "sweeper scout"
-	},
-/turf/open/indestructible/cult,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "dl" = (
 /obj/structure/window/reinforced/spawner/north{
 	max_integrity = 25;
@@ -1332,7 +839,7 @@
 	pixel_x = 10
 	},
 /turf/open/floor/carpet/black,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "dm" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -1345,8 +852,8 @@
 "dn" = (
 /obj/structure/closet/crate,
 /obj/structure/window/reinforced/spawner/east{
-	pixel_x = 3;
-	max_integrity = 25
+	max_integrity = 25;
+	pixel_x = 3
 	},
 /obj/effect/turf_decal/delivery/red,
 /obj/machinery/light/cold/no_nightlight,
@@ -1358,13 +865,11 @@
 	icon_state = "LC9"
 	},
 /turf/open/floor/facility/dark,
-/area/facility_hallway/command)
-"dq" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/city/backstreets_checkpoint)
+/area/facility_hallway/manager)
+"dp" = (
+/obj/machinery/vending/lobotomyheadset,
+/turf/open/floor/facility/dark,
+/area/facility_hallway/manager)
 "dr" = (
 /obj/structure/bed,
 /obj/item/bedsheet/grey,
@@ -1380,14 +885,14 @@
 	},
 /obj/structure/window/reinforced/spawner/east{
 	max_integrity = 25;
-	opacity = 1;
-	name = "Glass"
+	name = "Glass";
+	opacity = 1
 	},
 /obj/machinery/light/small{
 	dir = 1
 	},
 /turf/open/floor/noslip,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "dt" = (
 /obj/structure/window/reinforced/spawner/west,
 /obj/effect/turf_decal/tile/yellow{
@@ -1397,7 +902,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "du" = (
 /obj/structure/window/reinforced/spawner/west{
 	max_integrity = 25
@@ -1406,8 +911,8 @@
 	color = "#3234B9"
 	},
 /obj/effect/turf_decal/tile/neutral{
-	dir = 1;
-	color = "#000000"
+	color = "#000000";
+	dir = 1
 	},
 /turf/open/floor/mineral/titanium/tiled/white,
 /area/city/fixers)
@@ -1427,8 +932,8 @@
 	pixel_y = -5
 	},
 /obj/item/flashlight/lamp/green{
-	pixel_y = 16;
-	pixel_x = -7
+	pixel_x = -7;
+	pixel_y = 16
 	},
 /turf/open/floor/carpet/purple,
 /area/city/house)
@@ -1438,54 +943,30 @@
 	icon_state = "LC23"
 	},
 /turf/open/floor/facility/dark,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "dz" = (
 /obj/structure/table/reinforced{
 	pixel_y = 2
 	},
 /obj/item/storage/box/drinkingglasses{
-	pixel_y = 16;
-	pixel_x = -5
+	pixel_x = -5;
+	pixel_y = 16
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/city/house)
-"dA" = (
-/obj/structure/dresser,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
 "dB" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/plating/grass,
-/area/facility_hallway/command)
-"dC" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 3
-	},
-/mob/living/simple_animal/hostile/ordeal/amber_bug{
-	name = "carnivorous worm"
-	},
-/turf/open/floor/wood,
-/area/city/backstreets_room)
-"dD" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/sepia,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "dE" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
 	},
 /turf/open/floor/plating/grass,
-/area/facility_hallway/command)
-"dF" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 8
-	},
-/turf/open/indestructible/cult,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "dG" = (
 /obj/structure/table/glass,
 /obj/machinery/computer/med_data/laptop{
@@ -1510,13 +991,6 @@
 	},
 /turf/open/floor/mineral/gold,
 /area/city/shop)
-"dI" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal{
-	dir = 6
-	},
-/turf/open/floor/engine,
-/area/city/backstreets_room)
 "dJ" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
@@ -1540,17 +1014,13 @@
 	},
 /turf/open/floor/stone,
 /area/city/house)
-"dM" = (
-/mob/living/simple_animal/hostile/ordeal/indigo_noon,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
 "dN" = (
 /obj/machinery/door/window/westright{
 	name = "Bathroom Door";
 	opacity = 1
 	},
 /turf/open/floor/plasteel/white,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "dO" = (
 /obj/structure/window/reinforced/spawner/east{
 	max_integrity = 25
@@ -1560,27 +1030,11 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral{
-	dir = 4;
-	color = "#000000"
+	color = "#000000";
+	dir = 4
 	},
 /turf/open/floor/mineral/titanium/tiled/white,
 /area/city/fixers)
-"dP" = (
-/obj/machinery/iv_drip,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/showroomfloor,
-/area/city/backstreets_room)
-"dQ" = (
-/obj/structure/table/glass,
-/obj/item/kirbyplants/random{
-	pixel_y = 10
-	},
-/turf/open/floor/wood,
-/area/city/backstreets_room)
-"dR" = (
-/obj/structure/chair/sofa/corp/left,
-/turf/open/floor/carpet/black,
-/area/city/backstreets_room)
 "dS" = (
 /obj/effect/turf_decal/tile{
 	color = "#333333"
@@ -1595,8 +1049,8 @@
 	pixel_y = 11
 	},
 /obj/item/reagent_containers/glass/rag{
-	pixel_y = 2;
-	pixel_x = 5
+	pixel_x = 5;
+	pixel_y = 2
 	},
 /obj/item/reagent_containers/food/drinks/shaker{
 	pixel_x = -7
@@ -1618,40 +1072,24 @@
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
-"dU" = (
-/obj/structure/chair/office{
-	dir = 4
+/area/facility_hallway/manager)
+"dW" = (
+/obj/structure/closet/secure_closet/personal/cabinet,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
 	},
-/mob/living/simple_animal/hostile/ordeal/green_bot{
-	name = "clerk bot"
+/obj/machinery/light/cold/no_nightlight{
+	brightness = 16;
+	dir = 1
 	},
-/turf/open/floor/holofloor/dark,
-/area/city/backstreets_room)
-"dV" = (
-/mob/living/simple_animal/hostile/ordeal/green_bot{
-	name = "clerk bot"
-	},
-/turf/open/floor/plasteel/dark,
-/area/city/backstreets_room)
-"dX" = (
-/mob/living/simple_animal/hostile/ordeal/indigo_noon,
-/turf/open/indestructible/necropolis,
-/area/city/backstreets_room)
+/turf/open/floor/wood,
+/area/space)
 "dY" = (
 /obj/effect/turf_decal/siding/blue/corner{
 	dir = 8
 	},
 /turf/open/floor/carpet/cyan,
 /area/city/shop)
-"dZ" = (
-/obj/machinery/door/airlock/gold,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"ea" = (
-/obj/effect/turf_decal/weather/dirt,
-/turf/open/floor/plating/asteroid/basalt,
-/area/city/backstreets_alley)
 "eb" = (
 /obj/structure/table/optable,
 /turf/open/floor/mineral/titanium/blue,
@@ -1664,6 +1102,7 @@
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 10
 	},
+/obj/effect/landmark/latejoin,
 /turf/open/floor/plating/grass,
 /area/city)
 "ed" = (
@@ -1677,37 +1116,17 @@
 	pixel_y = 2
 	},
 /obj/item/reagent_containers/food/drinks/waterbottle{
-	pixel_y = 13;
-	pixel_x = -4
+	pixel_x = -4;
+	pixel_y = 13
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/city/house)
-"ef" = (
-/obj/structure/table/rolling,
-/obj/effect/spawner/lootdrop/minor/kittyears_or_rabbitears,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
 "eg" = (
-/obj/machinery/vending/lobotomyarmband,
+/obj/machinery/computer/camera_advanced/manager/sephirah{
+	dir = 4
+	},
 /turf/open/floor/facility/dark,
-/area/facility_hallway/command)
-"eh" = (
-/obj/structure/fence{
-	dir = 4;
-	pixel_x = 23;
-	pixel_y = -3
-	},
-/obj/structure/fence/cut/large{
-	dir = 8;
-	pixel_x = -9;
-	pixel_y = -3
-	},
-/turf/closed/indestructible/reinforced,
-/area/city/backstreets_room)
-"ei" = (
-/obj/machinery/vending/wardrobe/gene_wardrobe,
-/turf/open/floor/holofloor/white,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "ej" = (
 /obj/structure/railing{
 	dir = 6
@@ -1720,25 +1139,11 @@
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
-"ek" = (
-/turf/open/floor/plasteel/white,
-/area/facility_hallway/command)
-"el" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/maint_drugs,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "em" = (
 /obj/effect/turf_decal/delivery/red,
 /turf/open/floor/plasteel/airless/white,
 /area/city/backstreets_checkpoint)
-"en" = (
-/mob/living/simple_animal/hostile/ordeal/amber_bug{
-	name = "carnivorous worm"
-	},
-/turf/open/floor/wood,
-/area/city/backstreets_room)
 "eo" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#3234B9";
@@ -1750,37 +1155,10 @@
 	},
 /turf/open/floor/mineral/silver,
 /area/city/shop)
-"ep" = (
-/obj/structure/table/greyscale,
-/obj/machinery/computer/libraryconsole{
-	desc = "For a store in the backstreets, quite progressive.";
-	name = "ecash register";
-	pixel_y = 10
-	},
-/turf/open/floor/eighties,
-/area/city/backstreets_room)
-"eq" = (
-/obj/structure/fence/corner{
-	dir = 4
-	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_checkpoint)
 "er" = (
 /obj/machinery/door/airlock/grunge,
 /turf/open/floor/plasteel/dark,
-/area/facility_hallway/command)
-"es" = (
-/obj/structure/fence/corner{
-	pixel_x = 16;
-	pixel_y = -3
-	},
-/turf/closed/indestructible/reinforced,
-/area/city/backstreets_room)
-"et" = (
-/obj/structure/table/glass,
-/obj/item/ego_weapon/ranged/pistol/soda,
-/turf/open/floor/plasteel/vaporwave,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "eu" = (
 /obj/effect/spawner/randomarcade,
 /turf/open/floor/eighties,
@@ -1793,168 +1171,95 @@
 /obj/machinery/modular_computer/console/preset/civilian,
 /turf/open/floor/plating,
 /area/city/shop)
-"ew" = (
-/obj/effect/decal/cleanable/blood,
-/obj/structure/closet/crate/trashcart,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
 "ex" = (
 /obj/effect/turf_decal,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /turf/open/floor/facility/dark,
-/area/facility_hallway/command)
-"ey" = (
-/obj/effect/turf_decal/siding/wideplating/corner{
-	dir = 1
+/area/facility_hallway/manager)
+"eC" = (
+/obj/machinery/door/airlock/highsecurity{
+	name = "command hallway"
 	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"ez" = (
-/obj/structure/chair/greyscale{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/shuttle{
-	name = "floor"
-	},
-/area/city/backstreets_room)
-"eB" = (
-/turf/open/floor/wood,
-/area/city/backstreets_room)
+/turf/open/floor/facility/halls,
+/area/facility_hallway/manager)
 "eD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /turf/open/floor/sepia,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "eE" = (
 /obj/machinery/button{
 	device_type = /obj/item/assembly/signaler
 	},
 /turf/closed/wall/mineral/silver{
+	desc = "A wall with unmistable white coloring. Iconic sight in N Corp's Nest!";
 	explosion_block = 50;
-	name = "N Corporation Nest Wall";
-	desc = "A wall with unmistable white coloring. Iconic sight in N Corp's Nest!"
+	name = "N Corporation Nest Wall"
 	},
 /area/city/backstreets_checkpoint)
-"eF" = (
-/obj/item/bodypart/chest{
-	layer = 1.9;
-	pixel_x = 13;
-	pixel_y = -5
-	},
-/obj/structure/lootcrate{
-	layer = 2;
-	pixel_y = 2
-	},
-/obj/effect/decal/cleanable/blood/gibs/old{
-	pixel_x = 19
-	},
-/turf/open/floor/stone,
-/area/city/backstreets_room)
 "eG" = (
 /obj/structure/toilet{
 	pixel_y = 2
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /obj/machinery/door/window/southleft{
-	opacity = 1;
-	name = "Bathroom Door"
+	name = "Bathroom Door";
+	opacity = 1
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/city/fixers)
-"eH" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/rack,
-/obj/item/stack/sheet/titaniumglass,
-/obj/item/stack/sheet/titaniumglass,
-/obj/item/stack/sheet/titaniumglass,
-/obj/item/stack/sheet/titaniumglass,
-/obj/item/stack/sheet/titaniumglass,
-/turf/open/floor/holofloor/dark,
-/area/city/backstreets_room)
 "eI" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/tree/jungle/small,
 /turf/open/floor/plating/grass{
 	color = "#00A36C";
-	opacity = 1;
-	name = "Dense Forest Undergrowth"
+	name = "Dense Forest Undergrowth";
+	opacity = 1
 	},
 /area/city)
-"eJ" = (
-/obj/structure/table/wood,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/flashlight/lamp/green,
-/turf/open/floor/plasteel/shuttle{
-	name = "floor"
-	},
-/area/city/backstreets_room)
 "eK" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "eL" = (
 /obj/machinery/door/airlock{
 	name = "Agent Barracks"
 	},
 /turf/open/floor/facility/halls,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "eM" = (
 /obj/structure/window/reinforced/spawner/north{
 	max_integrity = 25;
 	opacity = 1
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /turf/open/floor/mineral/titanium/tiled/white,
 /area/city/shop)
-"eN" = (
-/obj/structure/table/glass,
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 10
-	},
-/turf/open/floor/carpet/black,
-/area/city/backstreets_room)
-"eO" = (
-/obj/structure/table/glass,
-/obj/item/dnainjector/m2h,
-/obj/machinery/door/window{
-	dir = 1
-	},
-/turf/open/floor/plasteel/freezer,
-/area/city/backstreets_room)
 "eP" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
 /obj/item/pen/fourcolor,
 /turf/open/space/basic,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "eR" = (
 /turf/open/floor/plating/dirt/dark,
 /area/city/backstreets_alley)
-"eS" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/structure/closet/secure_closet/freezer/meat/open,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/sepia,
-/area/city/backstreets_room)
 "eT" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#3234B9";
@@ -1977,47 +1282,26 @@
 "eU" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /turf/open/floor/plating/grass,
-/area/facility_hallway/command)
-"eV" = (
-/obj/effect/turf_decal{
-	dir = 3
-	},
-/turf/open/floor/engine,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "eW" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
 	},
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/plating/grass,
-/area/facility_hallway/command)
-"eX" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/blood/tracks,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "eY" = (
 /obj/structure/bookcase/random,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /turf/open/floor/carpet,
 /area/city/house)
-"eZ" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/turf/open/floor/plating/asteroid/basalt,
-/area/city/backstreets_alley)
 "fa" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -2027,24 +1311,12 @@
 	},
 /turf/open/floor/wood,
 /area/city/shop)
-"fb" = (
-/obj/structure/flora/rock/pile,
-/obj/effect/decal/cleanable/blood/gibs/torso,
-/obj/effect/decal/cleanable/blood/tracks,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/city/backstreets_room)
 "fc" = (
 /obj/machinery/door/airlock/shuttle{
 	name = "Hana Association Office"
 	},
 /turf/open/floor/facility/halls,
 /area/city/fixers)
-"fd" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/lattice/catwalk,
-/turf/open/lava/smooth,
-/area/city/backstreets_room)
 "fe" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -2056,8 +1328,8 @@
 /area/city/fixers)
 "ff" = (
 /obj/machinery/light/floor{
-	pixel_y = 9;
-	pixel_x = -9
+	pixel_x = -9;
+	pixel_y = 9
 	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
@@ -2068,36 +1340,18 @@
 /obj/effect/decal/cleanable/oil,
 /obj/effect/decal/cleanable/glitter,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /turf/open/floor/eighties,
 /area/city/shop)
-"fh" = (
-/obj/machinery/computer/security/wooden_tv{
-	desc = "An old television that does not seem to work as intended.";
-	name = "television"
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/curtain/cloth{
-	pixel_y = 32
-	},
-/turf/open/floor/wood,
-/area/city/backstreets_room)
-"fi" = (
-/obj/structure/grille/broken,
-/obj/item/shard,
-/turf/open/floor/plating,
-/area/city/backstreets_room)
 "fj" = (
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "fk" = (
 /obj/structure/chair/comfy/brown,
 /obj/effect/turf_decal/siding/wood{
@@ -2105,12 +1359,20 @@
 	},
 /turf/open/floor/wood,
 /area/city/shop)
+"fl" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/light/cold/no_nightlight{
+	brightness = 16;
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/space)
 "fm" = (
 /obj/structure/sign/departments/medbay/alt,
 /turf/closed/wall/mineral/silver{
+	desc = "A wall with unmistable white coloring. Iconic sight in N Corp's Nest!";
 	explosion_block = 50;
-	name = "N Corporation Nest Wall";
-	desc = "A wall with unmistable white coloring. Iconic sight in N Corp's Nest!"
+	name = "N Corporation Nest Wall"
 	},
 /area/city/shop)
 "fn" = (
@@ -2120,13 +1382,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/city/shop)
-"fo" = (
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 8
-	},
-/obj/item/ego_weapon/ranged/clerk,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
 "fp" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -2141,37 +1396,31 @@
 /obj/item/reagent_containers/food/drinks/bottle/champagne,
 /turf/open/floor/wood,
 /area/city/shop)
-"fq" = (
-/mob/living/simple_animal/hostile/ordeal/green_bot{
-	name = "spear bot"
-	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_alley)
 "fr" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /turf/open/floor/plating/grass,
-/area/facility_hallway/command)
-"fu" = (
-/obj/effect/spawner/lootdrop/crate_spawner,
-/obj/structure/chair/pew,
-/obj/item/instrument/glockenspiel,
-/turf/open/floor/carpet/black,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
+"fs" = (
+/obj/machinery/door/airlock/silver{
+	name = "white-washed airlock"
+	},
+/turf/open/floor/facility/halls,
+/area/space)
+"ft" = (
+/obj/machinery/door/airlock/wood{
+	name = "Welfare Head Office"
+	},
+/turf/open/floor/facility/dark,
+/area/facility_hallway/manager)
 "fv" = (
 /obj/structure/table/wood/fancy/black,
 /obj/item/toy/plush/binah,
 /turf/open/floor/carpet/royalblack,
-/area/facility_hallway/command)
-"fw" = (
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "fx" = (
 /obj/machinery/door/window/southleft,
 /turf/open/floor/mineral/titanium/tiled/blue,
@@ -2203,51 +1452,24 @@
 	},
 /turf/open/floor/mineral/titanium/tiled/white,
 /area/city/fixers)
-"fA" = (
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 5
-	},
-/turf/open/floor/plating/asteroid/basalt,
-/area/city/backstreets_room)
-"fB" = (
-/obj/structure/window/shuttle{
-	name = "window"
-	},
-/obj/structure/grille/broken,
-/turf/open/floor/plating,
-/area/city/backstreets_room)
 "fC" = (
 /obj/effect/turf_decal/siding/thinplating/dark,
 /turf/open/floor/plating/grass,
 /area/city)
 "fD" = (
 /turf/closed/wall/mineral/silver{
+	desc = "A wall with unmistable white coloring. Iconic sight in N Corp's Nest!";
 	explosion_block = 50;
-	name = "N Corporation Nest Wall";
-	desc = "A wall with unmistable white coloring. Iconic sight in N Corp's Nest!"
+	name = "N Corporation Nest Wall"
 	},
 /area/city/fixers)
-"fE" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/lootdrop/space/cashmoney,
-/obj/effect/spawner/lootdrop/space/cashmoney,
-/obj/effect/spawner/lootdrop/space/cashmoney,
-/obj/effect/spawner/lootdrop/space/cashmoney,
-/obj/effect/spawner/lootdrop/space/cashmoney,
-/obj/structure/table/greyscale,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
 "fF" = (
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /turf/open/floor/plating/grass,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "fG" = (
 /obj/structure/chair/sofa/corp/right{
 	dir = 4;
@@ -2256,20 +1478,6 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/city/house)
-"fH" = (
-/obj/structure/table/glass,
-/obj/item/flashlight/lamp{
-	pixel_x = -5;
-	pixel_y = 10
-	},
-/obj/item/folder/syndicate/red{
-	desc = "A folder belonging to one of the City's corporations.";
-	name = "Corporation Folder";
-	pixel_x = 5;
-	pixel_y = -2
-	},
-/turf/open/floor/plasteel/dark,
-/area/city/backstreets_room)
 "fI" = (
 /obj/machinery/door/airlock/glass_large,
 /turf/open/floor/facility/halls,
@@ -2279,30 +1487,15 @@
 	dir = 5
 	},
 /turf/open/floor/plating/grass,
-/area/facility_hallway/command)
-"fK" = (
-/obj/structure/table/wood,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/kirbyplants/dead{
-	desc = "A sad, dead plant";
-	name = "dead potted plant";
-	pixel_y = 10
-	},
-/turf/open/floor/wood,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "fL" = (
 /obj/structure/chair/sofa/corp/right,
 /turf/open/floor/mineral/titanium/blue,
 /area/city/fixers)
-"fM" = (
-/obj/effect/turf_decal/siding/wideplating,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
 "fN" = (
 /obj/structure/sign/departments/records,
 /turf/closed/indestructible/reinforced,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "fO" = (
 /obj/structure/table/anvil,
 /turf/open/floor/mineral/plastitanium,
@@ -2317,73 +1510,34 @@
 	icon_state = "LC28"
 	},
 /turf/open/floor/facility/dark,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "fR" = (
 /obj/structure/chair/office{
 	dir = 1
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/city/fixers)
-"fS" = (
-/obj/effect/spawner/structure/window/reinforced/tinted,
-/turf/open/floor/plating,
-/area/city/backstreets_room)
 "fT" = (
 /obj/effect/turf_decal/caution/red,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "fU" = (
 /turf/closed/wall/mineral/silver,
 /area/city/house)
 "fV" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/light/cold/no_nightlight{
+	brightness = 16;
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
-/area/facility_hallway/command)
+/turf/open/floor/facility/dark,
+/area/facility_hallway/manager)
 "fW" = (
 /turf/closed/indestructible/iron,
 /area/city)
-"fX" = (
-/obj/structure/grille/broken,
-/obj/item/shard,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/shuttle,
-/area/city/backstreets_room)
-"fY" = (
-/obj/structure/table/wood,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/item/toy/plush/pkplush,
-/obj/structure/sign/poster/lobotomycorp/random{
-	pixel_x = 32
-	},
-/obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
-	},
-/turf/open/floor/sepia,
-/area/facility_hallway/command)
-"fZ" = (
-/obj/structure/table/wood,
-/obj/item/toy/plush/pierre,
-/turf/open/floor/plasteel/sepia,
-/area/city/backstreets_room)
 "ga" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 8
@@ -2402,16 +1556,6 @@
 /obj/item/forginghammer,
 /turf/open/floor/mineral/plastitanium,
 /area/city/house)
-"gb" = (
-/obj/structure/chair/sofa/corp/left{
-	dir = 1
-	},
-/mob/living/simple_animal/hostile/ordeal/indigo_noon{
-	dir = 1;
-	name = "Prost"
-	},
-/turf/open/floor/wood,
-/area/city/backstreets_room)
 "gc" = (
 /obj/structure/table/wood,
 /obj/item/toy/plush/gebura,
@@ -2419,38 +1563,23 @@
 	dir = 8
 	},
 /turf/open/floor/wood,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "gd" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/city/shop)
-"ge" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/turf/open/floor/plating/asteroid/basalt,
-/area/city/backstreets_checkpoint)
 "gf" = (
 /obj/structure/window/reinforced/spawner/west{
 	max_integrity = 25;
-	opacity = 1;
-	name = "Shower Glass"
+	name = "Shower Glass";
+	opacity = 1
 	},
 /turf/open/floor/plasteel/white,
-/area/facility_hallway/command)
-"gg" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 3
-	},
-/turf/open/floor/plating/asteroid/basalt,
-/area/city/backstreets_checkpoint)
+/area/facility_hallway/manager)
 "gh" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
@@ -2469,16 +1598,8 @@
 /turf/open/floor/wood,
 /area/city/shop)
 "gk" = (
-/obj/effect/landmark/latejoin,
 /turf/open/floor/carpet/royalblue,
-/area/facility_hallway/command)
-"gl" = (
-/obj/structure/table/greyscale,
-/obj/effect/spawner/lootdrop/donkpockets,
-/obj/effect/spawner/lootdrop/donkpockets,
-/obj/effect/spawner/lootdrop/donkpockets,
-/turf/open/floor/plasteel/checker,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "gm" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -2486,15 +1607,6 @@
 	},
 /turf/open/floor/plating/grass,
 /area/city)
-"gn" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 6
-	},
-/turf/open/floor/plating/asteroid/basalt,
-/area/city/backstreets_checkpoint)
 "go" = (
 /obj/structure/railing,
 /obj/item/grown/sunflower,
@@ -2503,7 +1615,7 @@
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "gp" = (
 /turf/open/floor/plasteel/dark,
 /area/city/fixers)
@@ -2517,8 +1629,8 @@
 /obj/structure/table/wood,
 /obj/item/trash/plate,
 /obj/item/reagent_containers/food/drinks/waterbottle{
-	pixel_y = 13;
-	pixel_x = -4
+	pixel_x = -4;
+	pixel_y = 13
 	},
 /obj/machinery/light/cold/no_nightlight,
 /turf/open/floor/carpet,
@@ -2549,7 +1661,7 @@
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "gv" = (
 /obj/structure/table/bronze,
 /obj/item/reagent_containers/food/condiment/peppermill{
@@ -2561,31 +1673,6 @@
 	},
 /turf/open/floor/wood,
 /area/city/shop)
-"gw" = (
-/obj/effect/turf_decal/starfury/three{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	pixel_y = -6
-	},
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/railing,
-/turf/open/floor/plating/dirt/dark,
-/area/city/backstreets_room)
-"gx" = (
-/obj/structure/sign/warning{
-	desc = "A warning sign, something about killer robots.";
-	pixel_y = -30
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 10
-	},
-/turf/open/floor/plating/asteroid/basalt,
-/area/city/backstreets_alley)
-"gz" = (
-/obj/item/instrument/violin/golden,
-/turf/open/floor/carpet/orange,
-/area/city/backstreets_room)
 "gA" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/closet/crate,
@@ -2607,24 +1694,7 @@
 	dir = 6
 	},
 /turf/open/floor/carpet/black,
-/area/facility_hallway/command)
-"gC" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/window/reinforced/survival_pod{
-	desc = "Shrimply too strong.";
-	max_integrity = 10000;
-	name = "shrimp display window"
-	},
-/obj/structure/lootcrate/s_corp,
-/turf/open/floor/plasteel/vaporwave,
-/area/city/backstreets_room)
-"gD" = (
-/obj/structure/barricade/wooden,
-/obj/structure/barricade/wooden/crude,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_alley)
+/area/facility_hallway/manager)
 "gE" = (
 /obj/structure/fireplace{
 	pixel_x = 0;
@@ -2644,7 +1714,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "gG" = (
 /obj/structure/railing{
 	dir = 6
@@ -2657,11 +1727,11 @@
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "gH" = (
 /obj/effect/mermaid_water{
-	name = "Coastal Waters";
-	desc = "Not a drop of drinkable water, just a body of salty brine"
+	desc = "Not a drop of drinkable water, just a body of salty brine";
+	name = "Coastal Waters"
 	},
 /turf/open/floor/plating/grass,
 /area/city)
@@ -2671,20 +1741,6 @@
 	},
 /turf/open/floor/mineral/titanium/tiled/white,
 /area/city/shop)
-"gK" = (
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 8;
-	pixel_x = -6
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	pixel_y = -6
-	},
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/railing{
-	dir = 10
-	},
-/turf/open/floor/plating/dirt/dark,
-/area/city/backstreets_room)
 "gL" = (
 /obj/structure/chair/comfy/brown{
 	dir = 1
@@ -2706,115 +1762,22 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/facility_hallway/command)
-"gO" = (
-/obj/machinery/door/airlock/centcom{
-	desc = "A bit too sturdy...";
-	name = "Strange Airlock"
-	},
-/turf/open/floor/plasteel/airless/dark,
-/area/city/backstreets_room)
-"gP" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 8
-	},
-/obj/structure/chair/pew/left{
-	dir = 1
-	},
-/turf/open/indestructible/cult,
-/area/city/backstreets_room)
-"gQ" = (
-/obj/structure/chair/plastic{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "gR" = (
 /obj/machinery/cryopod,
 /turf/open/floor/oldshuttle,
 /area/city/fixers)
-"gS" = (
-/obj/effect/turf_decal/trimline/neutral/line{
-	pixel_y = -6
-	},
-/obj/structure/flora/rock/jungle,
-/obj/structure/lootcrate/seven,
-/turf/open/floor/plating/dirt/dark,
-/area/city/backstreets_room)
-"gT" = (
-/obj/item/stack/sheet/plastic{
-	pixel_x = 5
-	},
-/obj/item/stack/sheet/runed_metal{
-	pixel_x = -10;
-	pixel_y = -5
-	},
-/obj/item/stack/sheet/mineral/wood,
-/obj/item/stack/sheet/silk,
-/turf/open/floor/carpet/black,
-/area/city/backstreets_room)
 "gU" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/tree/jungle/small,
 /turf/open/floor/plating/grass,
 /area/city)
-"gW" = (
-/mob/living/simple_animal/hostile/ordeal/indigo_noon,
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 7
-	},
-/turf/open/floor/carpet/black,
-/area/city/backstreets_room)
 "gY" = (
 /obj/structure/chair/plastic{
 	dir = 1
 	},
 /turf/open/floor/plasteel/airless/white,
 /area/city/backstreets_checkpoint)
-"gZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/fireaxe,
-/obj/effect/decal/cleanable/blood/gibs/old,
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/plasteel/shuttle,
-/area/city/backstreets_room)
-"ha" = (
-/obj/structure/table/wood,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/folder/syndicate/red{
-	desc = "A folder belonging to one of the City's corporations.";
-	name = "Corporation Folder"
-	},
-/turf/open/floor/carpet/green,
-/area/city/backstreets_room)
-"hb" = (
-/obj/item/stack/sheet/mineral/gold,
-/turf/open/floor/carpet/orange,
-/area/city/backstreets_room)
-"hc" = (
-/obj/machinery/light/dim{
-	dir = 8;
-	pixel_x = null;
-	pixel_y = null
-	},
-/turf/open/floor/plasteel/shuttle{
-	name = "floor"
-	},
-/area/city/backstreets_room)
-"hd" = (
-/obj/effect/turf_decal/siding/purple{
-	dir = 4
-	},
-/mob/living/simple_animal/hostile/shrimp,
-/obj/structure/chair/comfy/lime{
-	dir = 8
-	},
-/turf/open/floor/carpet/purple,
-/area/city/backstreets_room)
-"he" = (
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_alley)
 "hf" = (
 /obj/effect/turf_decal/tile{
 	color = "#333333"
@@ -2831,40 +1794,11 @@
 	dir = 9
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /turf/open/floor/wood,
 /area/city/shop)
-"hh" = (
-/obj/structure/closet/crate/large,
-/obj/effect/turf_decal/siding/thinplating/dark/corner,
-/turf/open/indestructible/cult,
-/area/city/backstreets_room)
-"hi" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/turf/open/floor/plating/asteroid/basalt,
-/area/city/backstreets_checkpoint)
-"hj" = (
-/obj/structure/table/wood,
-/obj/item/paper/crumpled,
-/obj/item/paper{
-	pixel_x = 8;
-	pixel_y = -14
-	},
-/obj/item/paper{
-	pixel_x = -9;
-	pixel_y = -6
-	},
-/obj/effect/spawner/lootdrop/space/cashmoney,
-/obj/effect/spawner/lootdrop/space/cashmoney,
-/obj/effect/spawner/lootdrop/space/cashmoney,
-/turf/open/floor/plasteel/shuttle{
-	name = "floor"
-	},
-/area/city/backstreets_room)
 "hk" = (
 /obj/structure/chair/comfy/brown{
 	dir = 1
@@ -2885,32 +1819,17 @@
 	dir = 1
 	},
 /turf/open/floor/sepia,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "hn" = (
 /obj/effect/turf_decal/siding{
 	dir = 5
 	},
 /turf/open/floor/carpet/black,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "ho" = (
-/obj/structure/closet/secure_closet/personal/cabinet{
-	anchored = 1
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 5
-	},
-/turf/open/floor/wood,
-/area/facility_hallway/command)
-"hp" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 5
-	},
-/obj/effect/spawner/lootdrop/space/cashmoney,
-/obj/effect/spawner/lootdrop/space/cashmoney,
-/obj/effect/spawner/lootdrop/space/cashmoney,
-/obj/effect/spawner/lootdrop/space/cashmoney,
-/turf/open/floor/grass,
-/area/city/backstreets_room)
+/obj/machinery/computer/crew,
+/turf/open/floor/facility/dark,
+/area/facility_hallway/manager)
 "hq" = (
 /obj/effect/turf_decal/siding/thinplating/dark/corner{
 	dir = 4
@@ -2926,22 +1845,15 @@
 /obj/structure/table/wood/fancy,
 /obj/item/flashlight/lamp/green,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /turf/open/floor/carpet/red,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "ht" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/facility/white,
 /area/city/shop)
-"hu" = (
-/obj/structure/dresser,
-/obj/item/reagent_containers/syringe/contraband/space_drugs{
-	pixel_y = 13
-	},
-/turf/open/floor/wood,
-/area/city/backstreets_room)
 "hv" = (
 /obj/machinery/door/window/westright,
 /turf/open/floor/mineral/titanium/white,
@@ -2949,8 +1861,8 @@
 "hw" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/effect/turf_decal{
-	dir = 1;
-	color = "#FF0000"
+	color = "#FF0000";
+	dir = 1
 	},
 /obj/effect/turf_decal/caution/red,
 /turf/open/floor/plasteel/airless/white,
@@ -2968,10 +1880,6 @@
 	},
 /turf/open/floor/mineral/silver,
 /area/city/shop)
-"hy" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/city/backstreets_room)
 "hz" = (
 /obj/structure/lattice/catwalk,
 /turf/open/floor/plating,
@@ -3012,27 +1920,25 @@
 /obj/machinery/door/airlock/grunge,
 /turf/open/space/basic,
 /area/city/shop)
-"hE" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
+"hF" = (
+/obj/structure/chair/office{
+	dir = 1;
+	pixel_y = 8
+	},
+/obj/effect/turf_decal/siding/blue{
 	dir = 4
 	},
-/obj/structure/chair/pew/right{
-	dir = 1
+/obj/effect/turf_decal/siding/blue{
+	dir = 8
 	},
-/turf/open/indestructible/cult,
-/area/city/backstreets_room)
-"hG" = (
-/obj/structure/dresser,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
+/turf/open/floor/carpet/cyan,
+/area/space)
 "hH" = (
 /obj/structure/chair/sofa/corp/left{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "hI" = (
 /obj/structure/lattice/catwalk,
 /obj/effect/turf_decal/loading_area/white,
@@ -3041,12 +1947,10 @@
 	},
 /turf/open/floor/plating,
 /area/city/shop)
-"hJ" = (
-/obj/structure/fence{
-	dir = 4
-	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
+"hK" = (
+/obj/machinery/door/airlock/glass_large,
+/turf/open/floor/facility/halls,
+/area/space)
 "hL" = (
 /obj/structure/window/reinforced/spawner/west,
 /obj/effect/turf_decal/tile/blue{
@@ -3058,7 +1962,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "hM" = (
 /turf/closed/indestructible/fakedoor{
 	name = "Bolted Door"
@@ -3074,26 +1978,7 @@
 	dir = 1
 	},
 /turf/open/floor/noslip,
-/area/facility_hallway/command)
-"hO" = (
-/obj/effect/turf_decal{
-	dir = 1
-	},
-/mob/living/simple_animal/hostile/ordeal/green_bot{
-	name = "clerk bot"
-	},
-/turf/open/floor/engine,
-/area/city/backstreets_room)
-"hP" = (
-/obj/structure/fence/end,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"hQ" = (
-/obj/structure/fence/corner{
-	dir = 8
-	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_checkpoint)
+/area/facility_hallway/manager)
 "hR" = (
 /obj/effect/turf_decal/siding/blue{
 	dir = 5
@@ -3108,10 +1993,6 @@
 /obj/effect/turf_decal/box/red,
 /turf/open/floor/mineral/titanium/tiled/yellow/airless,
 /area/city/shop)
-"hU" = (
-/obj/structure/barricade/sandbags,
-/turf/open/floor/plating/asteroid/basalt,
-/area/city/backstreets_alley)
 "hV" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -3125,17 +2006,6 @@
 	},
 /turf/open/floor/mineral/gold,
 /area/city/shop)
-"hW" = (
-/obj/effect/turf_decal/siding{
-	dir = 9
-	},
-/obj/structure/table/rolling,
-/obj/machinery/computer/secure_data/laptop{
-	desc = "An interestingly high-tech laptop, wonder who owned this.";
-	name = "high-tech laptop"
-	},
-/turf/open/floor/carpet/black,
-/area/city/backstreets_room)
 "hX" = (
 /obj/structure/railing{
 	dir = 1
@@ -3148,7 +2018,7 @@
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "hY" = (
 /obj/structure/sign/departments/restroom{
 	pixel_y = 32
@@ -3162,10 +2032,6 @@
 	},
 /turf/open/floor/mineral/titanium/tiled/white,
 /area/city/shop)
-"hZ" = (
-/obj/effect/spawner/randomsnackvend,
-/turf/open/floor/plasteel/sepia,
-/area/city/backstreets_room)
 "ib" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -3176,15 +2042,11 @@
 	},
 /turf/open/floor/mineral/titanium/tiled/yellow/airless,
 /area/city/shop)
-"ic" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
 "id" = (
 /obj/structure/sink/kitchen{
-	pixel_y = 14;
 	dir = 8;
-	pixel_x = 11
+	pixel_x = 11;
+	pixel_y = 14
 	},
 /turf/open/floor/sepia,
 /area/city/house)
@@ -3197,11 +2059,11 @@
 	dir = 8
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "ig" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#3234B9"
@@ -3212,21 +2074,9 @@
 	},
 /turf/open/floor/mineral/titanium/tiled/white,
 /area/city/fixers)
-"ih" = (
-/obj/structure/chair/sofa/right,
-/obj/effect/turf_decal/siding/yellow/corner{
-	dir = 1
-	},
-/turf/open/floor/carpet/green,
-/area/city/backstreets_room)
-"ii" = (
-/obj/structure/chair/sofa/left{
-	dir = 1
-	},
-/turf/open/floor/carpet/green,
-/area/city/backstreets_room)
 "ij" = (
 /obj/structure/chair/pew/left,
+/obj/effect/landmark/latejoin,
 /turf/open/floor/plasteel/chapel{
 	dir = 4
 	},
@@ -3240,39 +2090,15 @@
 	},
 /turf/open/floor/stone,
 /area/city)
-"il" = (
-/obj/effect/turf_decal/siding/yellow/corner,
-/turf/open/floor/carpet/green,
-/area/city/backstreets_room)
 "in" = (
 /obj/structure/closet/crate,
 /obj/effect/turf_decal/delivery/red,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /turf/open/floor/facility/white,
 /area/city/fixers)
-"io" = (
-/obj/structure/flora/rock/pile,
-/obj/effect/decal/cleanable/blood/tracks,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/city/backstreets_room)
-"ip" = (
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 5
-	},
-/obj/effect/turf_decal/starfury/three{
-	dir = 4
-	},
-/obj/structure/flora/rock/pile/largejungle{
-	pixel_x = -27;
-	pixel_y = -28
-	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
 "iq" = (
 /obj/structure/railing,
 /obj/item/grown/novaflower,
@@ -3280,14 +2106,7 @@
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
-"ir" = (
-/obj/effect/decal/cleanable/blood/splatter{
-	pixel_x = 10;
-	pixel_y = 11
-	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "is" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -3311,18 +2130,6 @@
 	},
 /turf/open/floor/eighties,
 /area/city/shop)
-"iu" = (
-/obj/effect/light_emitter{
-	light_power = 4;
-	light_range = 25;
-	set_cap = 3;
-	set_luminosity = 24
-	},
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 7
-	},
-/turf/open/indestructible/cult,
-/area/city/backstreets_room)
 "iv" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#3234B9";
@@ -3347,37 +2154,33 @@
 /obj/item/food/grown/moonflower,
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "ix" = (
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/siding/yellow{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown,
-/turf/open/floor/sepia,
-/area/facility_hallway/command)
+/turf/open/floor/carpet/royalblack,
+/area/facility_hallway/manager)
 "iz" = (
 /obj/effect/turf_decal/plaque{
 	alpha = 230;
 	icon_state = "LC4"
 	},
 /turf/open/floor/facility/dark,
-/area/facility_hallway/command)
-"iB" = (
-/obj/structure/table/glass,
-/turf/open/floor/holofloor/white,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
+"iA" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/facility_hallway/manager)
 "iC" = (
 /obj/effect/turf_decal/tile{
 	color = "#333333"
@@ -3399,68 +2202,37 @@
 	},
 /turf/open/floor/plating/grass,
 /area/city)
-"iE" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/siding/yellow{
-	dir = 10
-	},
-/turf/open/floor/carpet/green,
-/area/city/backstreets_room)
-"iF" = (
-/obj/structure/rack,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/cane,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
 "iG" = (
 /obj/effect/turf_decal/tile/neutral{
-	dir = 4;
-	color = "#000000"
+	color = "#000000";
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral{
 	color = "#000000"
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /turf/open/floor/mineral/titanium/tiled/white,
 /area/city/fixers)
-"iH" = (
-/obj/structure/chair/sofa/left{
-	dir = 4
-	},
-/turf/open/floor/plasteel/checker,
-/area/city/backstreets_room)
 "iI" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
 /turf/open/floor/wood,
-/area/facility_hallway/command)
-"iJ" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/maint_drugs,
-/obj/structure/curtain/cloth{
-	pixel_y = 32
-	},
-/turf/open/floor/wood,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "iK" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /turf/open/floor/wood,
 /area/city/shop)
-"iL" = (
-/obj/structure/table/glass,
-/turf/open/floor/holofloor/dark,
-/area/city/backstreets_room)
 "iM" = (
 /obj/structure/railing,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -3469,11 +2241,7 @@
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
-"iN" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "iO" = (
 /obj/structure/chair/wood/wings{
 	dir = 4
@@ -3485,12 +2253,12 @@
 /area/city/shop)
 "iP" = (
 /obj/machinery/door/window/northleft{
-	opacity = 1;
-	name = "Bathroom Door"
+	name = "Bathroom Door";
+	opacity = 1
 	},
 /obj/structure/fluff/paper,
 /turf/open/floor/carpet/black,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "iQ" = (
 /obj/effect/turf_decal/siding/blue{
 	dir = 10
@@ -3505,6 +2273,7 @@
 /obj/structure/chair/comfy/black{
 	dir = 1
 	},
+/obj/effect/landmark/latejoin,
 /turf/open/floor/carpet/royalblack,
 /area/city/house)
 "iU" = (
@@ -3530,7 +2299,7 @@
 	},
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/sepia,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "iW" = (
 /obj/effect/turf_decal/tile{
 	color = "#333333"
@@ -3549,33 +2318,6 @@
 /obj/effect/turf_decal/siding/blue,
 /turf/open/floor/carpet/cyan,
 /area/city/shop)
-"iZ" = (
-/obj/structure/chair/sofa/corp/left,
-/turf/open/floor/plasteel/showroomfloor,
-/area/city/backstreets_room)
-"ja" = (
-/obj/effect/turf_decal/siding/purple{
-	dir = 1
-	},
-/obj/structure/table/wood/fancy/purple,
-/obj/item/reagent_containers/food/drinks/soda_cans/wellcheers_purple{
-	pixel_x = 5
-	},
-/obj/item/reagent_containers/food/drinks/soda_cans/wellcheers_purple{
-	pixel_x = -5
-	},
-/obj/item/reagent_containers/food/drinks/soda_cans/wellcheers_purple,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/carpet/purple,
-/area/city/backstreets_room)
-"jb" = (
-/obj/structure/chair/sofa/left{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/city/backstreets_room)
 "jc" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/effect/light_emitter{
@@ -3585,60 +2327,33 @@
 	set_luminosity = 24
 	},
 /turf/open/floor/plating/grass,
-/area/facility_hallway/command)
-"jd" = (
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 4;
-	pixel_x = 7
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 1;
-	pixel_y = 6
-	},
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/railing{
-	dir = 1
-	},
-/mob/living/simple_animal/hostile/ordeal/green_bot{
-	name = "spear bot"
-	},
-/turf/open/floor/plating/dirt,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "je" = (
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /obj/structure/chair/comfy{
 	dir = 8
 	},
 /turf/open/floor/facility/dark,
 /area/city/backstreets_checkpoint)
-"jf" = (
-/obj/structure/closet/ammunitionlocker,
-/obj/item/storage/belt/grenade/full,
-/obj/item/storage/belt/grenade/full,
-/turf/open/floor/engine,
-/area/city/backstreets_room)
 "jg" = (
 /obj/structure/chair/comfy/teal{
 	dir = 8
 	},
 /turf/open/floor/carpet/royalblue,
-/area/facility_hallway/command)
-"jh" = (
-/obj/structure/table/reinforced,
-/obj/item/kirbyplants/dead{
-	desc = "A sad, dead plant";
-	name = "dead potted plant";
-	pixel_y = 10
+/area/facility_hallway/manager)
+"ji" = (
+/obj/structure/filingcabinet,
+/obj/structure/filingcabinet{
+	pixel_x = -10
 	},
-/turf/open/floor/engine,
-/area/city/backstreets_room)
-"jj" = (
-/obj/structure/curtain/bounty,
-/turf/closed/indestructible/fakeglass,
-/area/facility_hallway/command)
+/obj/structure/filingcabinet{
+	pixel_x = 10
+	},
+/turf/open/floor/facility/white,
+/area/space)
 "jk" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -3646,26 +2361,10 @@
 	},
 /turf/open/floor/plating/grass,
 /area/city)
-"jl" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/bed,
-/obj/item/bedsheet/ian,
-/obj/effect/mob_spawn/human/corpse/charredskeleton,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
-"jm" = (
-/mob/living/simple_animal/hostile/ordeal/indigo_dusk/red{
-	name = "\proper Lieutenant Maledy"
-	},
-/turf/open/indestructible/necropolis,
-/area/city/backstreets_room)
-"jn" = (
-/turf/open/floor/plasteel/freezer,
-/area/city/backstreets_room)
 "jo" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/plating/grass,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "jp" = (
 /obj/structure/railing{
 	dir = 4
@@ -3678,69 +2377,27 @@
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "jq" = (
 /turf/closed/indestructible/rock,
 /area/space)
-"jr" = (
-/obj/structure/chair/plastic{
-	dir = 4
+"jt" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
 	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"js" = (
-/obj/structure/chair/office/light,
-/turf/open/floor/holofloor/white,
-/area/city/backstreets_room)
-"ju" = (
-/obj/structure/table/reinforced,
-/obj/effect/spawner/lootdrop/organ_spawner{
-	pixel_x = -6;
-	pixel_y = 8
-	},
-/obj/effect/spawner/lootdrop/maint_drugs{
-	pixel_x = 1;
-	pixel_y = 2
-	},
-/turf/open/floor/stone,
-/area/city/backstreets_room)
+/turf/open/floor/wood,
+/area/space)
 "jv" = (
 /obj/machinery/computer/slot_machine,
 /obj/effect/turf_decal/siding/blue{
 	dir = 4
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /turf/open/floor/carpet/cyan,
 /area/city/shop)
-"jw" = (
-/obj/structure/bookcase/random/religion,
-/turf/open/indestructible/cult,
-/area/city/backstreets_room)
-"jy" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/table/wood,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
-"jz" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/holofloor/dark,
-/area/city/backstreets_room)
-"jA" = (
-/obj/structure/fence{
-	dir = 4;
-	pixel_x = 23;
-	pixel_y = -3
-	},
-/obj/structure/fence/corner{
-	dir = 8;
-	pixel_x = -9;
-	pixel_y = -3
-	},
-/turf/closed/indestructible/reinforced,
-/area/city/backstreets_room)
 "jB" = (
 /obj/structure/rack{
 	pixel_x = -1
@@ -3748,25 +2405,6 @@
 /obj/item/storage/belt/ego,
 /turf/open/floor/mineral/titanium/blue/airless,
 /area/city/shop)
-"jC" = (
-/mob/living/simple_animal/hostile/ordeal/indigo_noon,
-/turf/open/indestructible/cult,
-/area/city/backstreets_room)
-"jD" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/rack,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/effect/spawner/lootdrop/food_packaging,
-/obj/effect/spawner/lootdrop/food_packaging,
-/turf/open/floor/plasteel/shuttle{
-	name = "floor"
-	},
-/area/city/backstreets_room)
 "jE" = (
 /obj/structure/chair/pew/left,
 /turf/open/floor/plasteel/chapel{
@@ -3781,53 +2419,11 @@
 	},
 /turf/open/floor/plating,
 /area/city/shop)
-"jG" = (
-/obj/effect/turf_decal/siding/wideplating/end{
-	dir = 8
-	},
-/obj/effect/turf_decal/starfury/ten,
-/obj/structure/flora/rock/pile{
-	pixel_x = 12;
-	pixel_y = -1
-	},
-/obj/structure/flora/rock/jungle,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"jI" = (
-/obj/structure/mineral_door/wood,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"jJ" = (
-/obj/structure/stone_tile/slab/cracked,
-/turf/open/floor/plating/dirt/jungle/wasteland,
-/area/city/backstreets_room)
-"jK" = (
-/obj/item/paper/crumpled,
-/obj/item/paper/crumpled{
-	pixel_x = 5;
-	pixel_y = -5
-	},
-/obj/item/paper/crumpled{
-	pixel_x = -10
-	},
-/obj/item/paper/crumpled/muddy{
-	pixel_x = -15;
-	pixel_y = 10
-	},
-/obj/item/paper/crumpled/muddy{
-	pixel_x = 10
-	},
-/obj/item/paper/crumpled/muddy{
-	pixel_x = -8;
-	pixel_y = -7
-	},
-/turf/open/floor/wood,
-/area/city/backstreets_room)
 "jL" = (
 /obj/item/candle,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /turf/open/floor/plasteel/chapel{
 	dir = 1
@@ -3843,18 +2439,13 @@
 /obj/structure/closet/secure_closet/personal/cabinet,
 /turf/open/floor/wood,
 /area/city/house)
-"jO" = (
-/turf/open/floor/wood,
-/area/facility_hallway/command)
-"jQ" = (
-/obj/effect/turf_decal/siding/wood{
+"jP" = (
+/obj/machinery/light/cold/no_nightlight{
+	brightness = 16;
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 7
-	},
-/turf/open/floor/carpet/black,
-/area/city/backstreets_room)
+/turf/open/floor/facility/dark,
+/area/facility_hallway/manager)
 "jR" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -3874,95 +2465,17 @@
 	},
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /turf/open/floor/plating/grass,
-/area/facility_hallway/command)
-"jU" = (
-/obj/effect/decal/cleanable/blood/footprints{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/blood/footprints{
-	dir = 8;
-	pixel_x = -20
-	},
-/obj/effect/decal/cleanable/blood/footprints{
-	dir = 8;
-	pixel_x = -9
-	},
-/mob/living/simple_animal/hostile/ordeal/indigo_dawn{
-	name = "sweeper scout"
-	},
-/obj/effect/turf_decal/trimline/white/filled/line{
-	dir = 3
-	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "jV" = (
 /obj/structure/toilet{
 	pixel_y = 2
 	},
 /turf/open/floor/sepia,
 /area/city/house)
-"jW" = (
-/obj/structure/chair/wood{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/city/backstreets_room)
-"jX" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/turf/open/floor/plating/asteroid/basalt,
-/area/city/backstreets_room)
-"jY" = (
-/obj/item/cultivator,
-/obj/item/cultivator,
-/obj/item/cultivator,
-/obj/item/cultivator,
-/obj/item/shovel/spade,
-/obj/item/shovel/spade,
-/obj/item/shovel/spade,
-/obj/item/shovel/spade,
-/obj/item/hatchet,
-/obj/item/hatchet,
-/obj/item/hatchet,
-/obj/item/hatchet,
-/obj/item/storage/bag/plants,
-/obj/item/storage/bag/plants,
-/obj/item/storage/bag/plants,
-/obj/item/storage/bag/plants,
-/obj/item/plant_analyzer,
-/obj/item/plant_analyzer,
-/obj/item/plant_analyzer,
-/obj/item/plant_analyzer,
-/obj/item/clothing/suit/apron,
-/obj/item/clothing/gloves/botanic_leather,
-/obj/structure/closet{
-	icon_state = "hydro"
-	},
-/turf/open/floor/plating/grass,
-/area/facility_hallway/command)
-"ka" = (
-/obj/structure/mineral_door/wood,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
-"kb" = (
-/obj/structure/fence/cut/large{
-	dir = 8;
-	pixel_x = -9;
-	pixel_y = 6
-	},
-/turf/closed/indestructible/reinforced,
-/area/city/backstreets_room)
-"kc" = (
-/mob/living/simple_animal/hostile/ordeal/indigo_dawn{
-	name = "sweeper scout"
-	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
 "kd" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -3980,31 +2493,11 @@
 "kf" = (
 /obj/machinery/door/window/northright,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /turf/open/floor/holofloor/white,
 /area/city/fixers)
-"kg" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 4
-	},
-/turf/open/indestructible/cult,
-/area/city/backstreets_room)
-"kh" = (
-/obj/structure/curtain/cloth,
-/obj/machinery/shower{
-	pixel_y = 15
-	},
-/obj/item/soap/deluxe,
-/turf/open/floor/noslip,
-/area/facility_hallway/command)
-"ki" = (
-/obj/machinery/door/poddoor/shutters/indestructible{
-	name = "Malfunctioning Backstreets Shutters"
-	},
-/turf/open/space/basic,
-/area/city/backstreets_alley)
 "kj" = (
 /obj/machinery/light/floor{
 	pixel_x = 8;
@@ -4015,6 +2508,15 @@
 	},
 /turf/open/floor/wood,
 /area/city/shop)
+"kk" = (
+/obj/structure/chair/wood/wings{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/space)
 "km" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/structure/closet/mini_fridge{
@@ -4026,7 +2528,7 @@
 	pixel_y = 17
 	},
 /turf/open/floor/carpet/red,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "kn" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -4044,54 +2546,27 @@
 	dir = 4
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/city/shop)
-"kq" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 8
+"kp" = (
+/obj/structure/sign/departments/restroom{
+	pixel_y = 32
 	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
+/turf/open/floor/facility/dark,
+/area/facility_hallway/manager)
 "kr" = (
 /turf/open/floor/mineral/titanium/yellow,
 /area/city/shop)
-"ks" = (
-/mob/living/simple_animal/hostile/ordeal/green_bot{
-	name = "clerk bot"
-	},
-/turf/open/floor/engine,
-/area/city/backstreets_room)
-"kt" = (
-/obj/structure/lootcrate/k_corp,
-/turf/open/floor/engine,
-/area/city/backstreets_room)
-"ku" = (
-/obj/structure/closet/crate/trashcart/filled{
-	anchored = 1
-	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"kv" = (
-/turf/closed/indestructible/fakedoor{
-	name = "Malfunctioning Door"
-	},
-/area/city/backstreets_room)
 "kw" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/bookmanagement{
 	pixel_y = 7
 	},
 /turf/open/floor/carpet/red,
-/area/facility_hallway/command)
-"kx" = (
-/obj/structure/closet/secure_closet/freezer/gulag_fridge,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/sepia,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "ky" = (
 /obj/structure/table/reinforced{
 	max_integrity = 25
@@ -4126,18 +2601,6 @@
 	},
 /turf/open/floor/wood,
 /area/city/shop)
-"kC" = (
-/turf/open/floor/plasteel/shuttle,
-/area/city/backstreets_room)
-"kE" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 3
-	},
-/turf/open/floor/plating/asteroid/basalt,
-/area/city/backstreets_checkpoint)
 "kF" = (
 /obj/structure/chair/stool,
 /turf/open/floor/oldshuttle,
@@ -4167,25 +2630,18 @@
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
-"kI" = (
-/obj/effect/spawner/randomsnackvend,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/eighties,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "kJ" = (
 /obj/structure/rack{
 	pixel_x = -1
 	},
 /obj/structure/window/reinforced/spawner/east{
-	pixel_x = 3;
-	max_integrity = 25
+	max_integrity = 25;
+	pixel_x = 3
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/city/fixers)
@@ -4196,30 +2652,18 @@
 	},
 /turf/open/floor/mineral/titanium/tiled/white,
 /area/city/shop)
-"kL" = (
-/obj/effect/turf_decal/raven{
-	dir = 7
-	},
-/turf/open/floor/holofloor/dark,
-/area/city/backstreets_room)
 "kM" = (
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/city/shop)
-"kN" = (
-/obj/structure/table/wood,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/clothing/head/collectable/petehat,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
 "kO" = (
 /obj/structure/railing{
 	dir = 1
@@ -4235,7 +2679,7 @@
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "kP" = (
 /obj/effect/turf_decal/siding/blue/end{
 	dir = 4
@@ -4258,73 +2702,34 @@
 	},
 /turf/open/floor/carpet/cyan,
 /area/city/shop)
-"kS" = (
-/obj/structure/table/glass,
-/obj/item/folder/white{
-	desc = "Looks to be remnants of the old G-Corp.";
-	name = "Outdated G-Corp Folder"
-	},
-/turf/open/floor/holofloor/white,
-/area/city/backstreets_room)
-"kT" = (
-/obj/structure/barricade/wooden,
-/obj/structure/barricade/wooden/crude,
-/turf/closed/indestructible/fakeglass,
-/area/city/backstreets_room)
-"kU" = (
-/obj/structure/table/glass,
-/obj/item/dnainjector/m2h,
-/obj/machinery/door/window{
-	dir = 1
-	},
-/obj/structure/window{
-	dir = 8
-	},
-/turf/open/floor/plasteel/freezer,
-/area/city/backstreets_room)
-"kW" = (
-/obj/item/chair/wood,
-/mob/living/simple_animal/hostile/ordeal/amber_bug{
-	name = "carnivorous worm"
-	},
-/turf/open/floor/wood,
-/area/city/backstreets_room)
+"kV" = (
+/obj/structure/sign/departments/safety,
+/turf/closed/indestructible/reinforced,
+/area/facility_hallway/manager)
 "kX" = (
 /obj/machinery/door/window/southleft,
 /obj/structure/sign/poster/random{
 	pixel_x = -32
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /turf/open/floor/eighties,
 /area/city/shop)
-"kY" = (
-/obj/item/seeds/apple/gold,
-/turf/open/floor/carpet/orange,
-/area/city/backstreets_room)
-"kZ" = (
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 8
-	},
-/obj/structure/table_frame,
-/obj/item/shard,
-/turf/open/floor/carpet/black,
-/area/city/backstreets_room)
 "la" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
 /turf/open/floor/plating/grass,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "lb" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /turf/open/floor/wood,
 /area/city/shop)
@@ -4334,13 +2739,6 @@
 	},
 /turf/open/floor/mineral/titanium/tiled/white,
 /area/city/shop)
-"ld" = (
-/obj/structure/lootcrate/k_corp,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 32
-	},
-/turf/open/floor/wood,
-/area/city/backstreets_room)
 "le" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -4367,16 +2765,7 @@
 	icon_state = "LC19"
 	},
 /turf/open/floor/facility/dark,
-/area/facility_hallway/command)
-"lh" = (
-/obj/effect/turf_decal/siding/purple{
-	dir = 8
-	},
-/obj/structure/chair/sofa{
-	dir = 4
-	},
-/turf/open/floor/carpet/purple,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "li" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -4385,7 +2774,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "lj" = (
 /obj/structure/lattice/catwalk,
 /obj/effect/turf_decal/loading_area/white,
@@ -4393,8 +2782,8 @@
 	dir = 4
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/city/shop)
@@ -4404,17 +2793,6 @@
 	},
 /turf/open/floor/stone,
 /area/city)
-"ll" = (
-/obj/structure/bed,
-/obj/item/bedsheet/clown,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
-"lm" = (
-/obj/machinery/door/airlock/grunge,
-/turf/open/floor/holofloor/dark,
-/area/city/backstreets_room)
 "ln" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -4484,12 +2862,7 @@
 	icon_state = "LC2"
 	},
 /turf/open/floor/facility/dark,
-/area/facility_hallway/command)
-"ls" = (
-/obj/structure/barricade/wooden,
-/obj/structure/barricade/wooden/crude,
-/turf/open/floor/plating/asteroid/basalt,
-/area/city/backstreets_alley)
+/area/facility_hallway/manager)
 "lt" = (
 /obj/structure/railing,
 /obj/structure/flora/ausbushes/brflowers,
@@ -4498,33 +2871,17 @@
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "lu" = (
 /turf/closed/wall/mineral/silver{
+	desc = "A wall with unmistable white coloring. Iconic sight in N Corp's Nest!";
 	explosion_block = 50;
-	name = "N Corporation Nest Wall";
-	desc = "A wall with unmistable white coloring. Iconic sight in N Corp's Nest!"
+	name = "N Corporation Nest Wall"
 	},
 /area/city/shop)
-"lv" = (
-/obj/structure/table/optable,
-/obj/effect/decal/cleanable/blood,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/city/backstreets_room)
 "lw" = (
 /turf/open/floor/facility/halls,
 /area/city/shop)
-"lx" = (
-/obj/machinery/door/poddoor{
-	id = "armoryinnerinterest";
-	name = "Inner Armory Door"
-	},
-/obj/machinery/door/airlock/hatch,
-/turf/open/floor/engine,
-/area/city/backstreets_room)
 "ly" = (
 /obj/structure/railing{
 	dir = 8
@@ -4537,27 +2894,22 @@
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
-"lz" = (
-/obj/structure/lootcrate/limbus,
-/turf/open/floor/engine,
-/area/city/backstreets_room)
-"lB" = (
-/obj/structure/table/wood/fancy/green,
-/obj/effect/turf_decal/siding/yellow{
-	dir = 9
+/area/facility_hallway/manager)
+"lA" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
 	},
-/obj/item/paper_bin{
-	pixel_y = 5
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
 	},
-/turf/open/floor/carpet/green,
-/area/city/backstreets_room)
+/turf/open/floor/wood,
+/area/space)
 "lC" = (
 /obj/machinery/computer/secure_data{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "lD" = (
 /obj/structure/window/reinforced/spawner{
 	max_integrity = 25
@@ -4567,12 +2919,6 @@
 	},
 /turf/open/floor/mineral/titanium/tiled/blue,
 /area/city/shop)
-"lE" = (
-/obj/effect/turf_decal/siding/yellow{
-	dir = 4
-	},
-/turf/open/floor/carpet/green,
-/area/city/backstreets_room)
 "lF" = (
 /turf/open/floor/facility/dark,
 /area/city/backstreets_checkpoint)
@@ -4584,11 +2930,7 @@
 	set_luminosity = 24
 	},
 /turf/open/floor/sepia,
-/area/facility_hallway/command)
-"lH" = (
-/obj/effect/spawner/randomsnackvend,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "lI" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
@@ -4596,17 +2938,12 @@
 /obj/effect/turf_decal/siding/wood/corner,
 /turf/open/floor/wood,
 /area/city/shop)
-"lJ" = (
-/turf/open/floor/plasteel/stairs/left{
-	dir = 8
-	},
-/area/city/backstreets_room)
 "lK" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
 /obj/item/pen/fourcolor,
 /turf/open/floor/facility/dark,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "lL" = (
 /obj/machinery/door/airlock/sandstone,
 /turf/open/floor/mineral/titanium/tiled/white,
@@ -4614,14 +2951,6 @@
 "lM" = (
 /turf/open/floor/mineral/plastitanium,
 /area/city/house)
-"lN" = (
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/plasteel/showroomfloor,
-/area/city/backstreets_room)
-"lO" = (
-/obj/effect/decal/cleanable/blood/splatter,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
 "lP" = (
 /obj/machinery/light/small,
 /turf/open/floor/wood,
@@ -4631,35 +2960,22 @@
 	color = "#000000"
 	},
 /obj/effect/turf_decal/tile/neutral{
-	dir = 8;
-	color = "#000000"
+	color = "#000000";
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral{
-	dir = 4;
-	color = "#000000"
+	color = "#000000";
+	dir = 4
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /obj/machinery/scanner_gate{
 	scangate_mode = "Guns"
 	},
 /turf/open/floor/mineral/titanium/tiled/white,
 /area/city/fixers)
-"lR" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/turf/open/floor/plating/asteroid/basalt,
-/area/city/backstreets_alley)
-"lT" = (
-/obj/effect/decal/cleanable/blood/gibs/torso,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"lU" = (
-/turf/open/floor/carpet/royalblack,
-/area/facility_hallway/command)
 "lV" = (
 /obj/structure/railing{
 	dir = 1
@@ -4672,64 +2988,13 @@
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
-"lW" = (
-/mob/living/simple_animal/hostile/ordeal/indigo_noon,
-/obj/effect/turf_decal/trimline/white/filled/line{
-	dir = 3
-	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"lX" = (
-/obj/machinery/light/dim,
-/turf/open/floor/facility/dark,
-/area/city/backstreets_room)
-"lY" = (
-/obj/structure/table/greyscale,
-/obj/machinery/computer/libraryconsole{
-	desc = "For a store in the backstreets, quite progressive.";
-	name = "ecash register";
-	pixel_y = 10
-	},
-/turf/open/floor/wood,
-/area/city/backstreets_room)
-"lZ" = (
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 5
-	},
-/obj/effect/turf_decal/starfury/ten{
-	dir = 8
-	},
-/obj/structure/flora/grass/jungle,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"ma" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/effect/decal/cleanable/blood/gibs/core{
-	pixel_x = -8;
-	pixel_y = 2
-	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"mb" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/tree/jungle/small,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "mc" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 10
 	},
 /turf/open/floor/plating/grass,
 /area/city)
-"md" = (
-/obj/effect/decal/cleanable/blood,
-/obj/structure/table/reinforced,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/city/backstreets_room)
 "me" = (
 /obj/effect/turf_decal/tile{
 	color = "#333333"
@@ -4740,39 +3005,12 @@
 	},
 /turf/open/floor/mineral/titanium/tiled/white,
 /area/city/shop)
-"mf" = (
-/obj/structure/chair/sofa/corp/left{
-	dir = 8
-	},
-/turf/open/floor/holofloor/white,
-/area/city/backstreets_room)
-"mg" = (
-/obj/effect/decal/cleanable/blood/old{
-	pixel_y = -20
-	},
-/obj/structure/table/wood,
-/obj/item/folder/syndicate/red{
-	desc = "A folder belonging to one of the City's corporations.";
-	name = "Corporation Folder";
-	pixel_x = 5;
-	pixel_y = -2
-	},
-/obj/item/pen/edagger{
-	desc = "This pen looks sharper than usual...";
-	name = "Sharp Pen"
-	},
-/turf/open/floor/wood,
-/area/city/backstreets_room)
 "mh" = (
 /obj/structure/railing{
 	dir = 8
 	},
 /turf/open/floor/facility/dark,
 /area/city/shop)
-"mi" = (
-/obj/structure/table/wood,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
 "mj" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
@@ -4793,20 +3031,14 @@
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
-"ml" = (
-/obj/structure/table/glass,
-/obj/item/kirbyplants/random{
-	pixel_y = 10
+/area/facility_hallway/manager)
+"mn" = (
+/obj/structure/chair/wood/wings,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
 	},
-/turf/open/floor/holofloor/white,
-/area/city/backstreets_room)
-"mm" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/turf/open/floor/plating/asteroid/basalt,
-/area/city/backstreets_alley)
+/turf/open/floor/wood,
+/area/space)
 "mo" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -4823,8 +3055,8 @@
 	opacity = 1
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /turf/open/floor/facility/dark,
 /area/city/fixers)
@@ -4836,20 +3068,13 @@
 /obj/effect/turf_decal/tile/brown,
 /turf/open/floor/mineral/titanium/tiled/yellow/airless,
 /area/city/shop)
-"mr" = (
-/obj/effect/turf_decal{
-	dir = 8
-	},
-/obj/structure/lootcrate/n_corp,
-/turf/open/floor/engine,
-/area/city/backstreets_room)
 "ms" = (
 /obj/effect/turf_decal/arrows/red{
 	dir = 4
 	},
 /obj/effect/turf_decal{
-	dir = 3;
-	color = "#FF0000"
+	color = "#FF0000";
+	dir = 3
 	},
 /obj/structure/window/reinforced/spawner{
 	max_integrity = 25
@@ -4867,7 +3092,7 @@
 	anchored = 1
 	},
 /turf/open/floor/wood,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "mu" = (
 /obj/structure/chair/sofa/corp/left,
 /turf/open/floor/mineral/titanium/blue,
@@ -4896,6 +3121,14 @@
 /obj/effect/turf_decal/siding/thinplating/dark,
 /turf/open/floor/stone,
 /area/city)
+"my" = (
+/obj/machinery/computer/crew,
+/obj/machinery/light/cold/no_nightlight{
+	brightness = 16;
+	dir = 4
+	},
+/turf/open/floor/facility/dark,
+/area/facility_hallway/manager)
 "mz" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -4914,39 +3147,11 @@
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
-"mB" = (
-/turf/closed/indestructible/fakedoor{
-	name = "Malfunctioned Door"
-	},
-/area/city/backstreets_room)
-"mC" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/structure/window/reinforced/spawner{
-	dir = 8
-	},
-/turf/open/floor/sepia,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "mD" = (
 /obj/machinery/chem_master/condimaster,
 /turf/open/floor/plasteel/checker,
 /area/city/shop)
-"mE" = (
-/mob/living/simple_animal/hostile/ordeal/green_bot_big{
-	name = "gun bot"
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/turf/open/floor/plating/asteroid/basalt,
-/area/city/backstreets_alley)
-"mF" = (
-/obj/effect/decal/cleanable/blood/gibs/torso,
-/obj/effect/decal/cleanable/blood/gibs/limb,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
 "mG" = (
 /obj/machinery/vending/boozeomat,
 /turf/open/floor/mineral/silver,
@@ -4957,8 +3162,8 @@
 	},
 /obj/effect/turf_decal/siding/blue,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /turf/open/floor/carpet/cyan,
 /area/city/shop)
@@ -4969,27 +3174,6 @@
 	},
 /turf/open/floor/wood,
 /area/city/shop)
-"mJ" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 10
-	},
-/obj/effect/spawner/lootdrop/space/cashmoney,
-/obj/effect/spawner/lootdrop/space/cashmoney,
-/obj/effect/spawner/lootdrop/space/cashmoney,
-/turf/open/floor/grass,
-/area/city/backstreets_room)
-"mK" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 4
-	},
-/obj/structure/dresser,
-/obj/item/kirbyplants/dead{
-	desc = "A sad, dead plant";
-	name = "dead potted plant";
-	pixel_y = 20
-	},
-/turf/open/floor/carpet/black,
-/area/city/backstreets_room)
 "mL" = (
 /obj/effect/turf_decal/siding/thinplating/dark/corner,
 /obj/effect/turf_decal/siding/thinplating/dark/corner{
@@ -4997,36 +3181,18 @@
 	},
 /turf/open/floor/stone,
 /area/city)
-"mM" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/blood/gibs/down,
-/obj/effect/decal/cleanable/blood{
-	pixel_x = 11
-	},
-/obj/effect/decal/cleanable/blood/old{
-	pixel_y = -20
-	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
 "mN" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel/dark,
-/area/facility_hallway/command)
-"mO" = (
-/obj/effect/turf_decal{
-	dir = 1
-	},
-/obj/structure/lootcrate/k_corp,
-/turf/open/floor/engine,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "mP" = (
 /obj/structure/chair/office,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /turf/open/floor/eighties,
 /area/city/shop)
@@ -5035,35 +3201,14 @@
 /obj/machinery/computer/secure_data/laptop,
 /turf/open/floor/oldshuttle,
 /area/city/fixers)
-"mS" = (
-/obj/machinery/door/poddoor,
-/turf/open/floor/plating/dirt/dark,
-/area/city/backstreets_room)
-"mT" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/eighties,
-/area/city/backstreets_room)
-"mU" = (
-/obj/item/storage/bag/money,
-/obj/item/storage/bag/money,
-/turf/open/floor/carpet/orange,
-/area/city/backstreets_room)
-"mV" = (
-/obj/structure/table/wood,
-/obj/machinery/computer/med_data/laptop{
-	desc = "A laptop with indescribable markings all around. Strangely, it contains medical records of sorts.";
-	name = "Strange Laptop"
-	},
-/turf/open/indestructible/cult,
-/area/city/backstreets_room)
 "mW" = (
 /turf/open/floor/carpet/cyan,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "mX" = (
 /obj/structure/closet/crate,
 /obj/structure/window/reinforced/spawner/east{
-	pixel_x = 3;
-	max_integrity = 25
+	max_integrity = 25;
+	pixel_x = 3
 	},
 /obj/effect/turf_decal/delivery/red,
 /turf/open/floor/facility/white,
@@ -5079,48 +3224,23 @@
 	set_luminosity = 24
 	},
 /turf/open/floor/plating/grass,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "mZ" = (
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /turf/open/floor/sepia,
-/area/facility_hallway/command)
-"na" = (
-/obj/machinery/camera{
-	dir = 4;
-	pixel_y = -3
+/area/facility_hallway/manager)
+"nd" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
 	},
-/obj/structure/fluff/broken_flooring,
-/turf/open/floor/plasteel/shuttle{
-	name = "floor"
+/obj/structure/closet/secure_closet/personal/cabinet{
+	anchored = 1
 	},
-/area/city/backstreets_room)
-"nb" = (
-/mob/living/simple_animal/hostile/ordeal/indigo_dawn,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_alley)
-"nc" = (
-/obj/structure/table/greyscale,
-/turf/open/floor/plasteel/shuttle{
-	name = "floor"
-	},
-/area/city/backstreets_room)
-"ne" = (
-/obj/effect/turf_decal/siding/purple{
-	dir = 1
-	},
-/obj/structure/table/wood/fancy/purple,
-/obj/item/reagent_containers/food/drinks/soda_cans/wellcheers_purple{
-	pixel_x = 5
-	},
-/obj/item/reagent_containers/food/drinks/soda_cans/wellcheers_purple{
-	pixel_x = -5
-	},
-/obj/item/reagent_containers/food/drinks/soda_cans/wellcheers_purple,
-/turf/open/floor/carpet/purple,
-/area/city/backstreets_room)
+/turf/open/floor/wood,
+/area/facility_hallway/manager)
 "nf" = (
 /turf/open/floor/plasteel/chapel,
 /area/city/shop)
@@ -5130,36 +3250,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/city/shop)
-"nh" = (
-/obj/machinery/door/poddoor/shutters/indestructible,
-/turf/closed/indestructible/reinforced,
-/area/city/backstreets_room)
-"ni" = (
-/obj/effect/turf_decal/siding/yellow,
-/turf/open/floor/carpet/green,
-/area/city/backstreets_room)
-"nj" = (
-/obj/machinery/door/airlock/wood/glass,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
-"nk" = (
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 10
-	},
-/obj/machinery/light/floor,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
 "nl" = (
 /obj/structure/table/reinforced,
 /turf/open/space/basic,
-/area/facility_hallway/command)
-"nm" = (
-/obj/item/target/clown,
-/obj/effect/turf_decal{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "nn" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -5176,13 +3270,6 @@
 	},
 /turf/open/floor/mineral/gold,
 /area/city/shop)
-"no" = (
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 8
-	},
-/obj/structure/flora/ausbushes/sparsegrass,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
 "np" = (
 /obj/structure/railing{
 	dir = 8
@@ -5193,33 +3280,34 @@
 	dir = 8
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
-"nq" = (
-/obj/structure/closet/crate/necropolis,
-/obj/effect/turf_decal/siding/thinplating/dark/corner{
-	dir = 8
+/area/facility_hallway/manager)
+"nr" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
-/turf/open/indestructible/cult,
-/area/city/backstreets_room)
-"ns" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 6
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/light/floor,
+/obj/structure/displaycase/trophy{
+	alert = 0
 	},
 /turf/open/floor/plasteel/dark,
-/area/city/backstreets_checkpoint)
+/area/facility_hallway/manager)
 "nt" = (
 /obj/effect/turf_decal/caution/red{
 	dir = 1
 	},
 /obj/effect/turf_decal{
-	dir = 3;
-	color = "#FF0000"
+	color = "#FF0000";
+	dir = 3
 	},
 /obj/machinery/door/window/southright,
 /obj/machinery/scanner_gate{
@@ -5227,43 +3315,19 @@
 	},
 /turf/open/floor/plasteel/airless/white,
 /area/city/backstreets_checkpoint)
-"nu" = (
-/obj/structure/fence/corner{
-	dir = 4
-	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"nv" = (
-/obj/structure/fence/door{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 4
-	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
 "nw" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/plating/grass,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "nx" = (
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /turf/open/floor/plasteel/chapel{
 	dir = 1
 	},
 /area/city/shop)
-"ny" = (
-/obj/structure/table/glass,
-/obj/item/dnainjector/h2m,
-/obj/machinery/door/window,
-/obj/structure/window{
-	dir = 8
-	},
-/turf/open/floor/plasteel/freezer,
-/area/city/backstreets_room)
 "nz" = (
 /obj/effect/turf_decal/tile{
 	color = "#333333";
@@ -5280,32 +3344,24 @@
 /area/city/shop)
 "nB" = (
 /turf/open/floor/facility/white,
-/area/facility_hallway/command)
-"nC" = (
-/obj/structure/table,
-/turf/open/floor/plasteel/showroomfloor,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "nD" = (
 /obj/effect/turf_decal/plaque{
 	alpha = 230;
 	icon_state = "LC12"
 	},
 /turf/open/floor/facility/dark,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "nE" = (
-/obj/machinery/door/airlock/wood{
-	icon = 'icons/obj/doors/airlocks/station/command.dmi';
-	name = "Zwei Association Airlock"
-	},
 /obj/machinery/door/poddoor/shutters/window/preopen{
 	id = "Zwei"
 	},
+/obj/machinery/door/airlock/wood{
+	icon = 'icons/obj/doors/airlocks/station/command.dmi';
+	name = "Association Airlock"
+	},
 /turf/open/floor/facility/halls,
 /area/city/fixers)
-"nH" = (
-/obj/machinery/door/airlock/hatch,
-/turf/open/floor/facility/dark,
-/area/city/backstreets_room)
 "nI" = (
 /obj/effect/turf_decal/arrows/red,
 /obj/effect/turf_decal/arrows/red{
@@ -5313,21 +3369,11 @@
 	},
 /turf/open/floor/plasteel/airless/white,
 /area/city/backstreets_checkpoint)
-"nJ" = (
-/obj/machinery/door/airlock/wood/glass,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/blood/footprints,
-/turf/open/floor/sepia,
-/area/city/backstreets_room)
-"nK" = (
-/obj/structure/flora/rock/jungle,
-/turf/open/floor/plating/dirt,
-/area/city/backstreets_room)
 "nL" = (
 /obj/machinery/door/window/northright,
 /obj/effect/turf_decal{
-	dir = 1;
-	color = "#FF0000"
+	color = "#FF0000";
+	dir = 1
 	},
 /obj/machinery/scanner_gate{
 	scangate_mode = "Guns"
@@ -5335,64 +3381,22 @@
 /obj/effect/turf_decal/caution/red,
 /turf/open/floor/plasteel/airless/white,
 /area/city/backstreets_checkpoint)
-"nM" = (
-/mob/living/simple_animal/hostile/ordeal/indigo_dawn{
-	name = "sweeper scout"
-	},
-/obj/effect/turf_decal/trimline/white/filled/line{
-	dir = 3
-	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"nN" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/broken{
-	dir = 1
-	},
-/turf/open/floor/plasteel/shuttle{
-	name = "floor"
-	},
-/area/city/backstreets_room)
 "nO" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
-	},
-/turf/open/floor/plating/grass,
-/area/facility_hallway/command)
-"nP" = (
-/obj/structure/table/glass,
-/obj/item/dnainjector/firemut,
-/turf/open/floor/plasteel/freezer,
-/area/city/backstreets_room)
-"nQ" = (
-/obj/effect/turf_decal/weather/dirt{
+	brightness = 16;
 	dir = 4
 	},
-/mob/living/simple_animal/hostile/ordeal/green_bot_big{
-	name = "gun bot"
-	},
-/turf/open/floor/plating/asteroid/basalt,
-/area/city/backstreets_alley)
+/turf/open/floor/plating/grass,
+/area/facility_hallway/manager)
 "nR" = (
 /obj/structure/table/wood/fancy/blue,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /turf/open/floor/carpet/royalblue,
-/area/facility_hallway/command)
-"nS" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/obj/structure/sign/warning{
-	desc = "A warning sign, something about killer robots.";
-	pixel_x = 30
-	},
-/turf/open/floor/plating/asteroid/basalt,
-/area/city/backstreets_alley)
+/area/facility_hallway/manager)
 "nU" = (
 /obj/machinery/light{
 	dir = 8
@@ -5408,30 +3412,20 @@
 	},
 /turf/open/floor/eighties,
 /area/city/shop)
-"nW" = (
-/obj/structure/filingcabinet{
-	pixel_x = -11
+"nX" = (
+/obj/effect/turf_decal/siding/blue{
+	dir = 5
 	},
-/obj/structure/filingcabinet{
-	pixel_x = -11
-	},
-/obj/structure/filingcabinet,
-/obj/structure/filingcabinet{
-	pixel_x = 11
-	},
-/obj/machinery/light/dim{
-	dir = 4
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/city/backstreets_room)
+/turf/open/floor/carpet/cyan,
+/area/space)
 "nY" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#3234B9";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
-	dir = 8;
-	color = "#000000"
+	color = "#000000";
+	dir = 8
 	},
 /turf/open/floor/mineral/titanium/tiled/blue,
 /area/city/fixers)
@@ -5445,66 +3439,26 @@
 	},
 /turf/open/floor/facility/white,
 /area/city/shop)
-"oa" = (
-/obj/structure/table/wood,
-/obj/item/gun/magic/hook,
-/turf/open/floor/plasteel/sepia,
-/area/city/backstreets_room)
-"ob" = (
-/obj/machinery/door/airlock/hatch,
-/turf/open/floor/holofloor/dark,
-/area/city/backstreets_room)
-"od" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"oe" = (
-/obj/structure/table/reinforced,
-/obj/effect/spawner/lootdrop/space/fancytool,
-/obj/effect/spawner/lootdrop/space/fancytool,
-/obj/effect/spawner/lootdrop/space/fancytool,
-/obj/effect/spawner/lootdrop/space/fancytool,
-/obj/effect/spawner/lootdrop/space/fancytool,
-/obj/effect/spawner/lootdrop/space/fancytool,
-/turf/open/floor/engine,
-/area/city/backstreets_room)
-"of" = (
-/obj/effect/decal/cleanable/blood/gibs/limb,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"og" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/mob/living/simple_animal/hostile/ordeal/indigo_noon{
+"oh" = (
+/obj/effect/turf_decal/siding/wood/corner,
+/obj/effect/turf_decal/siding/wood/corner{
 	dir = 8
 	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"oi" = (
-/obj/structure/closet/crate/large,
-/turf/open/floor/engine,
-/area/city/backstreets_room)
-"ok" = (
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/sepia,
-/area/city/backstreets_room)
+/turf/open/floor/wood,
+/area/space)
 "ol" = (
 /obj/effect/turf_decal/plaque{
 	alpha = 230;
 	icon_state = "LC30"
 	},
 /turf/open/floor/facility/dark,
-/area/facility_hallway/command)
-"on" = (
-/obj/item/food/meat/slab/sweeper,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/blood/gibs/down,
-/turf/open/floor/plasteel/stairs/right{
-	dir = 8
-	},
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "oo" = (
 /obj/structure/rack{
 	pixel_x = -1
@@ -5515,21 +3469,6 @@
 	},
 /turf/open/floor/facility/dark,
 /area/city/fixers)
-"op" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/closet/secure_closet/mechanicus/augs,
-/turf/open/floor/holofloor/dark,
-/area/city/backstreets_room)
-"oq" = (
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 4
-	},
-/obj/item/stack/sheet/mineral/wood,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
-"or" = (
-/turf/open/floor/plating/asteroid/basalt,
-/area/city/backstreets_alley)
 "os" = (
 /obj/structure/table/reinforced{
 	color = "#00a86b"
@@ -5548,23 +3487,11 @@
 	pixel_y = 6
 	},
 /obj/item/flashlight/lamp{
-	pixel_y = 20;
-	pixel_x = -1
+	pixel_x = -1;
+	pixel_y = 20
 	},
 /turf/open/floor/carpet/royalblack,
 /area/city/house)
-"ov" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/blood/gibs/up,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"ow" = (
-/obj/structure/table/greyscale,
-/obj/item/kirbyplants/random{
-	pixel_y = 10
-	},
-/turf/open/floor/eighties,
-/area/city/backstreets_room)
 "ox" = (
 /obj/effect/turf_decal/siding/blue{
 	dir = 1
@@ -5572,31 +3499,15 @@
 /turf/open/floor/carpet/cyan,
 /area/city/shop)
 "oy" = (
-/obj/structure/table/wood,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/computer/communications{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/item/toy/plush/lizardplushie,
-/obj/structure/sign/poster/lobotomycorp/random{
-	pixel_x = -32
-	},
-/obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
-	},
-/turf/open/floor/sepia,
-/area/facility_hallway/command)
+/turf/open/floor/facility/dark,
+/area/facility_hallway/manager)
 "oz" = (
 /obj/structure/closet/secure_closet/freezer/fridge{
-	pixel_y = -1;
-	pixel_x = -8
+	pixel_x = -8;
+	pixel_y = -1
 	},
 /obj/item/food/meat/slab{
 	pixel_x = -8;
@@ -5614,28 +3525,10 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/city/house)
-"oA" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/sepia,
-/area/city/backstreets_room)
 "oB" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/facility_hallway/command)
+/obj/structure/sign/departments/discipline,
+/turf/closed/indestructible/reinforced,
+/area/facility_hallway/manager)
 "oC" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/eastright,
@@ -5648,21 +3541,7 @@
 	},
 /obj/effect/spawner/randomsnackvend,
 /turf/open/floor/carpet/stellar,
-/area/facility_hallway/command)
-"oE" = (
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/plating/asteroid/basalt,
-/area/city/backstreets_room)
-"oF" = (
-/obj/machinery/door/airlock/hatch,
-/turf/open/floor/plasteel/shuttle{
-	name = "floor"
-	},
-/area/city/backstreets_room)
-"oG" = (
-/obj/machinery/dna_scannernew,
-/turf/open/floor/holofloor/white,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "oH" = (
 /obj/machinery/light{
 	dir = 8
@@ -5684,23 +3563,6 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel/sepia,
 /area/city/shop)
-"oJ" = (
-/obj/machinery/door/airlock/cult/friendly,
-/turf/open/indestructible/cult,
-/area/city/backstreets_room)
-"oK" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/turf/open/floor/sepia,
-/area/facility_hallway/command)
 "oL" = (
 /obj/structure/sink{
 	dir = 8;
@@ -5715,23 +3577,19 @@
 	opacity = 1
 	},
 /turf/open/floor/plasteel/white,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "oM" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /turf/open/floor/plating/grass,
-/area/facility_hallway/command)
-"oN" = (
-/obj/effect/decal/cleanable/blood/gibs/body,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "oO" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -5746,13 +3604,6 @@
 /obj/effect/turf_decal/box,
 /turf/open/floor/plasteel/sepia,
 /area/city/shop)
-"oP" = (
-/obj/effect/turf_decal/siding/wideplating/corner,
-/obj/effect/turf_decal/siding/wideplating/corner{
-	dir = 4
-	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
 "oQ" = (
 /obj/effect/light_emitter{
 	light_power = 4;
@@ -5765,35 +3616,30 @@
 "oR" = (
 /obj/effect/turf_decal/caution/red,
 /turf/open/floor/plasteel/dark,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "oS" = (
 /obj/structure/closet/crate/trashcart,
 /obj/item/storage/bag/trash/bluespace,
 /obj/effect/turf_decal/bot,
 /obj/structure/window/reinforced/spawner/east{
-	pixel_x = 3;
-	max_integrity = 25
+	max_integrity = 25;
+	pixel_x = 3
 	},
 /obj/machinery/light/small{
 	dir = 1
 	},
 /turf/open/floor/facility/dark,
 /area/city/shop)
-"oT" = (
-/obj/effect/decal/cleanable/blood/tracks,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"oU" = (
-/obj/structure/chair/greyscale,
-/obj/machinery/light{
-	dir = 8
+"oV" = (
+/obj/effect/turf_decal/siding/blue/end{
+	dir = 4
 	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/city/backstreets_room)
+/turf/open/floor/carpet/cyan,
+/area/space)
 "oW" = (
 /obj/structure/closet/secure_closet/freezer/fridge{
-	pixel_y = -1;
-	pixel_x = -8
+	pixel_x = -8;
+	pixel_y = -1
 	},
 /obj/item/reagent_containers/food/condiment/milk{
 	pixel_x = -7
@@ -5814,27 +3660,19 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/city/house)
-"oX" = (
-/obj/effect/spawner/structure/window/plasma/reinforced/plastitanium,
-/turf/open/floor/plating,
-/area/city/backstreets_room)
 "oY" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 1
 	},
 /turf/open/floor/carpet/black,
 /area/city/house)
-"oZ" = (
-/obj/effect/decal/cleanable/garbage,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
 "pa" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/tree/jungle/small,
 /turf/open/floor/plating/grass{
 	color = "#00A36C";
-	opacity = 1;
-	name = "Dense Forest Undergrowth"
+	name = "Dense Forest Undergrowth";
+	opacity = 1
 	},
 /area/city)
 "pb" = (
@@ -5851,34 +3689,11 @@
 /obj/structure/table/wood/poker,
 /turf/open/floor/mineral/silver,
 /area/city/shop)
-"pc" = (
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/closed/indestructible/reinforced,
-/area/city/backstreets_room)
-"pd" = (
-/obj/structure/chair/pew/right{
-	dir = 1
-	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"pe" = (
-/mob/living/simple_animal/hostile/ordeal/amber_bug{
-	name = "carnivorous worm"
-	},
-/obj/item/food/meat/slab/human/mutant/skeleton,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"pf" = (
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 6
-	},
-/turf/open/floor/carpet/black,
-/area/city/backstreets_room)
 "pg" = (
 /obj/effect/spawner/randomsnackvend,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /turf/open/floor/eighties,
 /area/city/shop)
@@ -5890,23 +3705,7 @@
 	anchored = 1
 	},
 /turf/open/floor/wood,
-/area/facility_hallway/command)
-"pj" = (
-/obj/structure/table/glass,
-/obj/item/ego_weapon/ranged/sodasmg,
-/turf/open/floor/plasteel/vaporwave,
-/area/city/backstreets_room)
-"pk" = (
-/obj/structure/rack,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/effect/spawner/lootdrop/garbage_spawner,
-/obj/effect/spawner/lootdrop/garbage_spawner,
-/turf/open/floor/plasteel/shuttle{
-	name = "floor"
-	},
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "pl" = (
 /obj/structure/table/bronze,
 /obj/machinery/light/floor{
@@ -5925,7 +3724,10 @@
 	set_luminosity = 24
 	},
 /turf/open/floor/plating/grass,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
+"pn" = (
+/turf/open/floor/plasteel/white,
+/area/facility_hallway/manager)
 "po" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/tile{
@@ -5939,32 +3741,11 @@
 /area/city/shop)
 "pp" = (
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /turf/open/floor/mineral/titanium/tiled/white,
 /area/city/shop)
-"pq" = (
-/obj/machinery/door/airlock/survival_pod,
-/turf/open/floor/engine,
-/area/city/backstreets_room)
-"pr" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/spawner/lootdrop/garbage_spawner,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"ps" = (
-/obj/structure/filingcabinet,
-/obj/structure/filingcabinet{
-	pixel_x = -11
-	},
-/obj/structure/filingcabinet{
-	pixel_x = 11
-	},
-/turf/open/floor/plasteel/dark,
-/area/city/backstreets_room)
 "pt" = (
 /obj/structure/railing/corner,
 /turf/open/floor/plasteel/dark,
@@ -5973,43 +3754,11 @@
 /obj/effect/turf_decal/delivery/red,
 /turf/open/floor/plasteel/dark,
 /area/city/shop)
-"pv" = (
-/obj/effect/decal/cleanable/blood/gibs/old,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
 "pw" = (
 /turf/closed/indestructible/fakedoor{
 	name = "Bolted Door"
 	},
 /area/city/backstreets_checkpoint)
-"px" = (
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 1;
-	pixel_y = 6
-	},
-/obj/structure/fence/post{
-	pixel_x = 17;
-	pixel_y = 27
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/holofloor/dark,
-/area/city/backstreets_room)
-"py" = (
-/obj/structure/bookcase/random,
-/obj/effect/decal/cleanable/cobweb/cobweb2{
-	layer = 5
-	},
-/turf/open/floor/wood,
-/area/city/backstreets_room)
-"pz" = (
-/mob/living/simple_animal/hostile/ordeal/indigo_dawn{
-	name = "sweeper scout"
-	},
-/obj/structure/chair/pew{
-	dir = 1
-	},
-/turf/open/indestructible/cult,
-/area/city/backstreets_room)
 "pA" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#3234B9";
@@ -6031,27 +3780,11 @@
 /area/city/shop)
 "pB" = (
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /turf/open/floor/plating/grass,
-/area/facility_hallway/command)
-"pC" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/mob/living/simple_animal/hostile/ordeal/green_bot_big{
-	name = "gun bot"
-	},
-/turf/open/floor/plating/asteroid/basalt,
-/area/city/backstreets_alley)
-"pD" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "pE" = (
 /obj/structure/table/bronze,
 /obj/structure/table/bronze,
@@ -6063,13 +3796,6 @@
 	},
 /turf/open/floor/facility/dark,
 /area/city/backstreets_checkpoint)
-"pG" = (
-/obj/item/shard,
-/obj/item/stack/rods,
-/turf/open/floor/plasteel/shuttle{
-	name = "floor"
-	},
-/area/city/backstreets_room)
 "pH" = (
 /obj/structure/chair/wood/wings,
 /turf/open/floor/wood,
@@ -6106,57 +3832,48 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/city/house)
-"pK" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 7
-	},
-/turf/open/floor/carpet/black,
-/area/city/backstreets_room)
 "pL" = (
 /obj/structure/table/reinforced{
 	max_integrity = 25
 	},
 /obj/effect/turf_decal/tile/neutral{
-	dir = 8;
-	color = "#000000"
+	color = "#000000";
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral{
 	color = "#000000"
 	},
 /obj/effect/turf_decal/tile/neutral{
-	dir = 4;
-	color = "#000000"
+	color = "#000000";
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral{
-	dir = 1;
-	color = "#000000"
+	color = "#000000";
+	dir = 1
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/city/fixers)
-"pN" = (
-/obj/structure/table/wood/fancy/black,
-/obj/effect/spawner/lootdrop/organ_spawner,
-/turf/open/indestructible/necropolis,
-/area/city/backstreets_room)
+"pM" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/obj/item/soap/homemade,
+/turf/open/floor/mineral/titanium/tiled/yellow,
+/area/facility_hallway/manager)
 "pO" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/dark,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "pP" = (
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /turf/open/floor/carpet/purple,
 /area/city/house)
-"pQ" = (
-/turf/open/floor/plasteel/shuttle{
-	name = "floor"
-	},
-/area/city/backstreets_room)
 "pR" = (
 /obj/structure/railing,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -6165,13 +3882,7 @@
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
-"pT" = (
-/obj/structure/fence/corner{
-	dir = 8
-	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "pU" = (
 /obj/structure/easel,
 /obj/item/canvas/nineteen_nineteen,
@@ -6187,78 +3898,30 @@
 	dir = 4
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
-	},
-/turf/open/floor/carpet/stellar,
-/area/facility_hallway/command)
-"pV" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
+	brightness = 16;
 	dir = 4
 	},
-/obj/effect/landmark/latejoin,
-/turf/open/floor/sepia,
-/area/facility_hallway/command)
+/turf/open/floor/carpet/stellar,
+/area/facility_hallway/manager)
 "pW" = (
 /obj/structure/closet,
 /turf/open/floor/mineral/titanium/blue,
 /area/city/fixers)
-"pX" = (
-/mob/living/simple_animal/hostile/ordeal/indigo_dawn,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"pY" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/turf/open/floor/plating/asteroid/basalt,
-/area/city/backstreets_alley)
-"pZ" = (
-/obj/structure/table/reinforced,
-/obj/machinery/button/door/indestructible{
-	id = "armoryouterinterest";
-	name = "Outer Armory Lockdown Button"
-	},
-/turf/open/floor/plasteel/dark,
-/area/city/backstreets_room)
 "qa" = (
 /obj/structure/showcase/machinery/tv,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /turf/open/floor/carpet/red,
-/area/facility_hallway/command)
-"qb" = (
-/obj/structure/rack,
-/obj/machinery/light,
-/obj/effect/spawner/lootdrop/minor/bowler_or_that,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
-"qc" = (
-/mob/living/simple_animal/hostile/ordeal/green_bot{
-	name = "clerk bot"
-	},
-/obj/item/chair/plastic,
-/turf/open/floor/engine,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "qd" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /turf/open/floor/wood,
 /area/city/shop)
@@ -6269,14 +3932,15 @@
 	},
 /turf/open/floor/plating/grass,
 /area/city)
-"qf" = (
-/obj/structure/flora/ausbushes/sparsegrass{
-	pixel_x = 20;
-	pixel_y = -2
+"qg" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
 	},
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/space)
 "qh" = (
 /obj/structure/railing{
 	dir = 8
@@ -6287,43 +3951,34 @@
 	dir = 8
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "qi" = (
 /obj/effect/mermaid_water{
-	name = "Coastal Waters";
-	desc = "Not a drop of drinkable water, just a body of salty brine"
+	desc = "Not a drop of drinkable water, just a body of salty brine";
+	name = "Coastal Waters"
 	},
 /obj/structure/flora/ausbushes/reedbush,
 /turf/open/floor/plating/grass,
 /area/city)
-"qj" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 6
-	},
-/turf/open/floor/plating/asteroid/basalt,
-/area/city/backstreets_room)
-"qk" = (
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/paperslip{
-	pixel_x = 7;
-	pixel_y = -5
-	},
-/turf/open/floor/wood,
-/area/city/backstreets_room)
 "ql" = (
 /obj/machinery/computer/secure_data,
 /turf/open/floor/facility/dark,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
+"qm" = (
+/obj/structure/closet/crate,
+/obj/structure/lattice/catwalk,
+/obj/machinery/light/cold/no_nightlight{
+	brightness = 16;
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/space)
 "qo" = (
 /obj/machinery/door/window/eastright,
 /turf/open/floor/mineral/titanium/white,
@@ -6333,18 +3988,14 @@
 	dir = 8
 	},
 /turf/open/floor/plating/grass,
-/area/facility_hallway/command)
-"qq" = (
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "qr" = (
 /obj/structure/table/reinforced{
 	pixel_y = 2
 	},
 /obj/item/trash/plate{
-	pixel_y = 5;
-	pixel_x = -1
+	pixel_x = -1;
+	pixel_y = 5
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/city/house)
@@ -6354,7 +4005,7 @@
 	icon_state = "LC17"
 	},
 /turf/open/floor/facility/dark,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "qt" = (
 /obj/effect/turf_decal/siding/thinplating/dark/corner{
 	dir = 8
@@ -6362,23 +4013,12 @@
 /obj/effect/turf_decal/siding/thinplating/dark/corner,
 /turf/open/floor/stone,
 /area/city)
-"qu" = (
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/city/backstreets_room)
-"qx" = (
-/obj/effect/turf_decal/siding/purple{
-	dir = 5
+"qv" = (
+/obj/machinery/light/cold/no_nightlight{
+	dir = 1
 	},
-/obj/structure/filingcabinet{
-	pixel_x = 10
-	},
-/obj/structure/filingcabinet,
-/obj/structure/filingcabinet{
-	pixel_x = -9
-	},
-/turf/open/floor/carpet/purple,
-/area/city/backstreets_room)
+/turf/open/floor/facility/dark,
+/area/facility_hallway/manager)
 "qy" = (
 /turf/open/floor/mineral/titanium/tiled/blue,
 /area/city/fixers)
@@ -6391,55 +4031,37 @@
 	},
 /turf/open/floor/carpet/cyan,
 /area/city/shop)
-"qA" = (
-/obj/structure/mineral_door/wood,
-/turf/open/floor/plasteel/sepia,
-/area/city/backstreets_room)
 "qB" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 10
-	},
-/turf/open/floor/wood,
-/area/facility_hallway/command)
+/turf/open/floor/carpet/royalblack,
+/area/facility_hallway/manager)
+"qC" = (
+/obj/structure/sign/departments/welfare,
+/turf/closed/indestructible/reinforced,
+/area/facility_hallway/manager)
 "qD" = (
 /turf/open/floor/facility/white,
 /area/city/shop)
-"qE" = (
-/obj/effect/turf_decal/siding/purple{
-	dir = 6
-	},
-/obj/structure/table/glass,
-/obj/item/kirbyplants/random{
-	pixel_y = 10
-	},
-/turf/open/floor/carpet/purple,
-/area/city/backstreets_room)
-"qG" = (
-/obj/effect/turf_decal/siding/thinplating/light{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
-"qJ" = (
-/obj/effect/turf_decal/siding/thinplating/dark/corner{
-	dir = 8
-	},
-/turf/open/indestructible/cult,
-/area/city/backstreets_room)
-"qK" = (
-/obj/machinery/light/dim{
+"qH" = (
+/obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/turf/open/indestructible/hoteltile,
-/area/city/backstreets_room)
+/turf/open/floor/wood,
+/area/space)
+"qI" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/table/wood,
+/obj/item/stack/spacecash/c1000,
+/obj/item/stack/spacecash/c1000,
+/obj/item/storage/box/miscarmor/two,
+/turf/open/floor/wood,
+/area/space)
 "qL" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 5
 	},
 /turf/open/floor/plating/grass,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "qN" = (
 /obj/structure/chair/sofa,
 /obj/effect/turf_decal/siding/wood{
@@ -6455,8 +4077,8 @@
 	dir = 4
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /obj/structure/table/wood,
 /obj/item/modular_computer/laptop{
@@ -6467,9 +4089,9 @@
 /area/city/shop)
 "qQ" = (
 /obj/structure/chair/pew/right{
+	desc = "Sit here and relax";
 	dir = 8;
-	name = "Bench";
-	desc = "Sit here and relax"
+	name = "Bench"
 	},
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 8
@@ -6480,17 +4102,15 @@
 /obj/machinery/vending/wardrobe/sec_wardrobe,
 /turf/open/floor/facility/dark,
 /area/city/backstreets_checkpoint)
-"qS" = (
-/obj/item/gun/ballistic/automatic/pistol/deagle/gold,
-/turf/open/floor/carpet/orange,
-/area/city/backstreets_room)
-"qU" = (
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 5
+"qT" = (
+/obj/structure/chair/sofa/corp/right{
+	dir = 4;
+	pixel_x = -6;
+	pixel_y = 1
 	},
-/obj/item/toy/beach_ball/holoball/dodgeball,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
+/obj/effect/landmark/latejoin,
+/turf/open/floor/carpet/purple,
+/area/city/house)
 "qV" = (
 /obj/structure/easel,
 /obj/item/canvas/nineteen_nineteen,
@@ -6506,7 +4126,7 @@
 	dir = 8
 	},
 /turf/open/floor/carpet/stellar,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "qW" = (
 /turf/open/floor/plasteel/chapel{
 	dir = 1
@@ -6526,37 +4146,10 @@
 /obj/item/candle,
 /turf/open/floor/plasteel/dark,
 /area/city/shop)
-"ra" = (
-/obj/structure/table/glass,
-/obj/item/dnainjector/h2m,
-/obj/machinery/door/window,
-/turf/open/floor/plasteel/freezer,
-/area/city/backstreets_room)
-"rb" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/paper/crumpled,
-/obj/item/paper{
-	pixel_x = 7;
-	pixel_y = -6
-	},
-/obj/machinery/light/dim,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
-"rc" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 7
-	},
-/turf/open/floor/plating/asteroid/basalt,
-/area/city/backstreets_alley)
-"re" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/rack,
-/obj/item/stack/sheet/glass/fifty,
-/turf/open/floor/holofloor/dark,
-/area/city/backstreets_room)
+"rd" = (
+/obj/item/kirbyplants/random,
+/turf/open/floor/facility/dark,
+/area/facility_hallway/manager)
 "rf" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
@@ -6565,40 +4158,23 @@
 /obj/item/bedsheet/wiz,
 /turf/open/floor/wood,
 /area/city/shop)
-"rg" = (
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 6
-	},
-/obj/effect/turf_decal/starfury/three,
-/obj/structure/flora/rock/jungle,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"rh" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
 "ri" = (
 /obj/structure/showcase/machinery/tv,
 /turf/open/floor/carpet/royalblue,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "rj" = (
 /obj/structure/rack{
 	pixel_x = -1
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/city/fixers)
-"rk" = (
-/obj/structure/table/reinforced,
-/obj/item/paper_bin{
-	pixel_y = 5
+"rl" = (
+/obj/effect/turf_decal/siding/wood/end{
+	dir = 4
 	},
-/turf/open/floor/engine,
-/area/city/backstreets_room)
-"rm" = (
-/obj/item/slime_cookie/gold,
-/turf/open/floor/carpet/orange,
-/area/city/backstreets_room)
+/obj/machinery/light/cold/no_nightlight,
+/turf/open/floor/wood,
+/area/space)
 "rn" = (
 /obj/structure/table/bronze,
 /obj/item/reagent_containers/food/condiment/saltshaker{
@@ -6630,71 +4206,6 @@
 	},
 /turf/open/floor/mineral/gold,
 /area/city/shop)
-"rp" = (
-/obj/structure/closet/crate/bin,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"rq" = (
-/obj/effect/turf_decal/siding/yellow{
-	dir = 6
-	},
-/obj/structure/table/wood/fancy/green,
-/obj/item/documents/photocopy{
-	desc = "A messy stack of corporate documents pertaining to the inventory of illegal weaponry. The Head would have a field day with this one.";
-	name = "Corporate Documents"
-	},
-/turf/open/floor/carpet/green,
-/area/city/backstreets_room)
-"rr" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/rack,
-/obj/item/organ/heart/cybernetic,
-/obj/item/organ/heart/cybernetic/tier2,
-/obj/item/organ/heart/cybernetic/tier3,
-/obj/item/organ/heart/cybernetic/tier4,
-/turf/open/floor/holofloor/dark,
-/area/city/backstreets_room)
-"rs" = (
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 4;
-	pixel_x = 7
-	},
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/blood/gibs/limb{
-	dir = 8;
-	layer = 4;
-	pixel_x = 11;
-	pixel_y = 10
-	},
-/turf/open/floor/holofloor/dark,
-/area/city/backstreets_room)
-"rt" = (
-/obj/structure/curtain/bounty{
-	pixel_y = -30
-	},
-/mob/living/simple_animal/hostile/ordeal/amber_bug{
-	name = "carnivorous worm"
-	},
-/turf/open/floor/wood,
-/area/city/backstreets_room)
-"ru" = (
-/obj/structure/chair/office{
-	dir = 8
-	},
-/mob/living/simple_animal/hostile/ordeal/green_bot{
-	desc = "Looks like it went haywire along with the other robots.";
-	health = 750;
-	name = "Stoff"
-	},
-/turf/open/floor/carpet/green,
-/area/city/backstreets_room)
-"rv" = (
-/obj/effect/decal/cleanable/cobweb,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/holofloor/dark,
-/area/city/backstreets_room)
 "rw" = (
 /obj/structure/railing/corner{
 	dir = 1
@@ -6707,7 +4218,7 @@
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "rx" = (
 /obj/structure/railing{
 	dir = 1
@@ -6720,141 +4231,41 @@
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
-"ry" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/holofloor/dark,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "rz" = (
 /obj/structure/chair/pew/left,
 /turf/open/floor/plasteel/chapel{
 	dir = 8
 	},
 /area/city/shop)
-"rA" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 1
-	},
-/obj/machinery/camera{
-	dir = 9;
-	pixel_y = 3
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/paper{
-	pixel_x = -1;
-	pixel_y = 7
-	},
-/obj/item/paper{
-	pixel_x = -12;
-	pixel_y = 13
-	},
-/obj/item/paper{
-	pixel_x = -17;
-	pixel_y = -6
-	},
-/obj/item/paperslip{
-	pixel_x = -8;
-	pixel_y = 5
-	},
-/obj/item/paperslip{
-	pixel_x = -41;
-	pixel_y = -8
-	},
-/obj/item/paperslip{
-	pixel_x = 7;
-	pixel_y = -5
-	},
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/item/folder/syndicate/red{
-	desc = "A folder belonging to one of the City's corporations.";
-	name = "Corporation Folder"
-	},
-/turf/open/floor/wood,
-/area/city/backstreets_room)
 "rB" = (
 /turf/closed/indestructible/iron,
 /area/city/shop)
-"rC" = (
-/turf/open/floor/grass,
-/area/city/backstreets_room)
 "rD" = (
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /obj/effect/turf_decal/caution/red{
 	dir = 1
 	},
 /obj/effect/turf_decal{
-	dir = 3;
-	color = "#FF0000"
+	color = "#FF0000";
+	dir = 3
 	},
 /obj/structure/window/reinforced/spawner{
 	max_integrity = 25
 	},
 /turf/open/floor/plasteel/airless/white,
 /area/city/backstreets_checkpoint)
-"rE" = (
-/obj/structure/table/wood,
-/obj/item/modular_computer/laptop{
-	desc = "Appears to be a fixers laptop.";
-	name = "Fixer Laptop"
-	},
-/turf/open/floor/wood,
-/area/city/backstreets_room)
 "rF" = (
 /obj/effect/turf_decal/caution/red,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/facility_hallway/command)
-"rH" = (
-/turf/open/floor/stone,
-/area/city/backstreets_room)
-"rI" = (
-/turf/closed/indestructible/fakedoor{
-	name = "Bolted Door"
-	},
-/area/city/backstreets_alley)
-"rJ" = (
-/obj/machinery/door/airlock/centcom{
-	desc = "A bit too sturdy...";
-	name = "Strange Airlock"
-	},
-/turf/open/floor/wood,
-/area/city/backstreets_room)
-"rK" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/sepia,
-/area/city/backstreets_room)
-"rL" = (
-/obj/structure/bed,
-/obj/effect/spawner/lootdrop/mafia_outfit{
-	layer = 2
-	},
-/obj/effect/decal/cleanable/blood,
-/obj/structure/window/reinforced/spawner,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/folder/syndicate/red{
-	desc = "A folder belonging to one of the City's corporations.";
-	name = "Corporation Folder";
-	pixel_x = -5;
-	pixel_y = -5
-	},
-/obj/item/bedsheet/purple,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "rM" = (
 /obj/machinery/newscaster{
 	pixel_x = 27
@@ -6864,16 +4275,6 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/city/house)
-"rN" = (
-/obj/effect/turf_decal/trimline/white/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/white/filled/line,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"rO" = (
-/turf/open/floor/carpet/royalblue,
-/area/facility_hallway/command)
 "rP" = (
 /obj/machinery/door/airlock/wood,
 /turf/open/floor/sepia,
@@ -6890,17 +4291,6 @@
 	},
 /turf/open/floor/facility/white,
 /area/city/shop)
-"rS" = (
-/obj/effect/turf_decal/weather/dirt,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/turf/open/floor/plating/asteroid/basalt,
-/area/city/backstreets_alley)
-"rT" = (
-/obj/structure/table/wood,
-/turf/open/floor/plasteel/checker,
-/area/city/backstreets_room)
 "rU" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 8
@@ -6909,33 +4299,18 @@
 /area/city/house)
 "rV" = (
 /obj/machinery/door/poddoor{
-	name = "Central Blast Door";
 	id = "centralY";
+	name = "Central Blast Door";
 	resistance_flags = 64
 	},
 /turf/open/floor/facility/halls,
 /area/city/backstreets_checkpoint)
-"rW" = (
-/obj/effect/turf_decal/siding/purple{
-	dir = 8
-	},
-/obj/structure/chair/sofa/right{
-	dir = 4
-	},
-/turf/open/floor/carpet/purple,
-/area/city/backstreets_room)
-"rY" = (
-/obj/structure/chair/sofa/left{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding{
-	dir = 4
-	},
-/mob/living/simple_animal/hostile/ordeal/green_bot{
-	name = "clerk bot"
-	},
-/turf/open/floor/plasteel/checker,
-/area/city/backstreets_room)
+"rX" = (
+/obj/structure/closet/crate,
+/obj/structure/lattice/catwalk,
+/obj/item/toy/plush/bongbong,
+/turf/open/floor/plating,
+/area/space)
 "rZ" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/effect/light_emitter{
@@ -6945,36 +4320,22 @@
 	set_luminosity = 24
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /turf/open/floor/plating/grass,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "sa" = (
 /obj/structure/chair/pew/right{
+	desc = "Sit here and relax";
 	dir = 1;
-	name = "Bench";
-	desc = "Sit here and relax"
+	name = "Bench"
 	},
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 1
 	},
 /turf/open/floor/plating/grass,
 /area/city)
-"sb" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/broken{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/city/backstreets_room)
-"sc" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/mob/living/simple_animal/hostile/ordeal/green_bot{
-	name = "spear bot"
-	},
-/turf/open/floor/stone,
-/area/city/backstreets_room)
 "sd" = (
 /obj/machinery/griddle{
 	pixel_y = 1
@@ -6984,48 +4345,37 @@
 "se" = (
 /obj/machinery/chem_master/condimaster,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /turf/open/floor/mineral/silver,
 /area/city/shop)
 "sf" = (
 /turf/closed/wall/mineral/silver{
+	desc = "A wall with unmistable white coloring. Iconic sight in N Corp's Nest!";
 	explosion_block = 50;
-	name = "N Corporation Nest Wall";
-	desc = "A wall with unmistable white coloring. Iconic sight in N Corp's Nest!"
+	name = "N Corporation Nest Wall"
 	},
-/area/facility_hallway/command)
-"sh" = (
-/obj/effect/decal/cleanable/blood{
-	pixel_x = -3;
-	pixel_y = -8
-	},
-/obj/effect/decal/cleanable/blood{
-	pixel_x = -5;
-	pixel_y = 17
-	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "si" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "sj" = (
 /obj/effect/turf_decal/tile/neutral{
-	dir = 8;
-	color = "#000000"
+	color = "#000000";
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral{
-	dir = 1;
-	color = "#000000"
+	color = "#000000";
+	dir = 1
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /turf/open/floor/mineral/titanium/tiled/white,
 /area/city/fixers)
@@ -7041,31 +4391,25 @@
 	set_luminosity = 24
 	},
 /turf/open/floor/plating/grass,
-/area/facility_hallway/command)
-"sm" = (
-/obj/machinery/door/airlock/wood/glass,
-/turf/open/floor/plasteel/shuttle{
-	name = "floor"
-	},
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "sn" = (
 /obj/structure/table/reinforced{
 	max_integrity = 25
 	},
 /obj/effect/turf_decal/tile/neutral{
-	dir = 1;
+	color = "#000000";
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	color = "#000000";
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	color = "#000000"
 	},
 /obj/effect/turf_decal/tile/neutral{
-	dir = 4;
-	color = "#000000"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	color = "#000000"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8;
-	color = "#000000"
+	color = "#000000";
+	dir = 8
 	},
 /obj/machinery/light/floor,
 /turf/open/floor/mineral/titanium/white,
@@ -7076,30 +4420,22 @@
 	max_integrity = 25
 	},
 /obj/effect/turf_decal/tile/green{
-	dir = 1;
-	color = "#006400"
+	color = "#006400";
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/green{
 	color = "#006400"
 	},
 /obj/effect/turf_decal/tile/green{
-	dir = 4;
-	color = "#006400"
+	color = "#006400";
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/green{
-	dir = 8;
-	color = "#006400"
+	color = "#006400";
+	dir = 8
 	},
 /turf/open/floor/plasteel/sepia,
 /area/city/shop)
-"sp" = (
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
 "sq" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#3234B9";
@@ -7119,18 +4455,12 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/mineral/silver,
 /area/city/shop)
-"sr" = (
-/mob/living/simple_animal/hostile/ordeal/green_bot_big{
-	name = "gun bot"
-	},
-/turf/open/floor/engine,
-/area/city/backstreets_room)
 "ss" = (
 /obj/machinery/light/cold/no_nightlight{
 	brightness = 16
 	},
 /turf/open/floor/facility/dark,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "st" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
@@ -7138,12 +4468,6 @@
 /obj/machinery/vending/cigarette,
 /turf/open/floor/wood,
 /area/city/shop)
-"su" = (
-/obj/structure/chair/sofa/corp/left{
-	dir = 8
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/city/backstreets_room)
 "sv" = (
 /obj/structure/table/bronze,
 /obj/item/reagent_containers/food/condiment/saltshaker{
@@ -7163,14 +4487,14 @@
 	name = "Lobotomy Corporation Main Entrance"
 	},
 /turf/open/floor/facility/halls,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "sy" = (
 /obj/structure/table/wood/fancy/black,
 /obj/machinery/chem_dispenser/drinks{
 	dir = 4
 	},
 /turf/open/floor/carpet/royalblack,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "sz" = (
 /obj/effect/turf_decal/siding/thinplating/dark/corner,
 /turf/open/floor/stone,
@@ -7180,10 +4504,18 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/plating/grass{
 	color = "#00A36C";
-	opacity = 1;
-	name = "Dense Forest Undergrowth"
+	name = "Dense Forest Undergrowth";
+	opacity = 1
 	},
 /area/city)
+"sB" = (
+/obj/structure/chair/wood{
+	dir = 1;
+	pixel_y = 7
+	},
+/obj/effect/landmark/latejoin,
+/turf/open/floor/carpet/purple,
+/area/city/house)
 "sC" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/disposalpipe/segment{
@@ -7198,31 +4530,21 @@
 	},
 /turf/open/floor/mineral/titanium/tiled/white,
 /area/city/shop)
-"sF" = (
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 9
-	},
-/turf/open/floor/carpet/black,
-/area/city/backstreets_room)
-"sG" = (
-/mob/living/simple_animal/hostile/ordeal/indigo_noon,
-/turf/open/floor/plating/asteroid/basalt,
-/area/city/backstreets_checkpoint)
 "sH" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /turf/open/floor/wood,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "sI" = (
 /obj/structure/closet/secure_closet/freezer/fridge/open{
 	anchored = 1;
-	storage_capacity = 1000;
-	name = "Meat Storage Refrigerator"
+	name = "Meat Storage Refrigerator";
+	storage_capacity = 1000
 	},
 /obj/item/food/meat/slab,
 /obj/item/food/meat/slab,
@@ -7380,16 +4702,6 @@
 	},
 /turf/open/floor/mineral/titanium/tiled/white,
 /area/city/shop)
-"sK" = (
-/obj/machinery/door/airlock/centcom{
-	desc = "A bit too sturdy...";
-	max_integrity = 10000;
-	name = "Strange Airlock";
-	normal_integrity = 100000;
-	req_access_txt = "19"
-	},
-/turf/open/space/basic,
-/area/city/backstreets_room)
 "sM" = (
 /obj/structure/lattice/catwalk,
 /obj/effect/turf_decal/loading_area/white,
@@ -7398,17 +4710,6 @@
 	},
 /turf/open/floor/plating,
 /area/city/shop)
-"sN" = (
-/obj/structure/tutorialbox,
-/turf/open/floor/engine,
-/area/city/backstreets_room)
-"sO" = (
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 8
-	},
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
 "sP" = (
 /obj/item/modular_computer/laptop{
 	desc = "Appears to be a fixers laptop.";
@@ -7428,8 +4729,8 @@
 /obj/structure/flora/tree/jungle,
 /turf/open/floor/plating/grass{
 	color = "#00A36C";
-	opacity = 1;
-	name = "Dense Forest Undergrowth"
+	name = "Dense Forest Undergrowth";
+	opacity = 1
 	},
 /area/city)
 "sR" = (
@@ -7438,14 +4739,6 @@
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/city/fixers)
-"sS" = (
-/obj/effect/turf_decal/trimline/neutral/corner{
-	dir = 1;
-	pixel_x = -6;
-	pixel_y = 6
-	},
-/turf/open/floor/holofloor/dark,
-/area/city/backstreets_room)
 "sT" = (
 /obj/structure/closet/crate,
 /obj/effect/turf_decal/delivery/red,
@@ -7476,23 +4769,23 @@
 "sX" = (
 /obj/structure/window/reinforced/spawner/east{
 	max_integrity = 25;
-	opacity = 1;
-	name = "Glass"
+	name = "Glass";
+	opacity = 1
 	},
 /obj/machinery/door/window/southleft{
-	opacity = 1;
-	name = "Shower Door"
+	name = "Shower Door";
+	opacity = 1
 	},
 /obj/machinery/shower{
 	pixel_y = 15
 	},
 /obj/item/soap/omega,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /turf/open/floor/noslip,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "sY" = (
 /obj/structure/mirror{
 	pixel_x = -27
@@ -7503,34 +4796,11 @@
 	pixel_y = -6
 	},
 /obj/machinery/door/window/northleft{
-	opacity = 1;
-	name = "Shower Door"
+	name = "Shower Door";
+	opacity = 1
 	},
 /turf/open/floor/plasteel/white,
-/area/facility_hallway/command)
-"sZ" = (
-/obj/machinery/vending/hydronutrients,
-/turf/open/floor/plating/grass,
-/area/facility_hallway/command)
-"ta" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/city/backstreets_room)
-"tb" = (
-/obj/effect/decal/cleanable/blood/splatter,
-/obj/structure/closet/crate/trashcart,
-/mob/living/simple_animal/mouse,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"tc" = (
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 4
-	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "td" = (
 /obj/effect/turf_decal/siding/blue{
 	dir = 9
@@ -7541,12 +4811,6 @@
 /obj/structure/railing,
 /turf/open/floor/plasteel/dark,
 /area/city/shop)
-"tg" = (
-/obj/structure/table/reinforced,
-/obj/effect/spawner/lootdrop/space/fancytool,
-/obj/effect/spawner/lootdrop/space/fancytool,
-/turf/open/floor/engine,
-/area/city/backstreets_room)
 "th" = (
 /obj/effect/light_emitter{
 	light_power = 4;
@@ -7579,19 +4843,19 @@
 	max_integrity = 25
 	},
 /obj/effect/turf_decal/tile/neutral{
-	dir = 8;
-	color = "#000000"
+	color = "#000000";
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral{
 	color = "#000000"
 	},
 /obj/effect/turf_decal/tile/neutral{
-	dir = 1;
-	color = "#000000"
+	color = "#000000";
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
-	dir = 4;
-	color = "#000000"
+	color = "#000000";
+	dir = 4
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/city/fixers)
@@ -7601,7 +4865,7 @@
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "tm" = (
 /obj/effect/spawner/randomcolavend,
 /obj/structure/sign/poster/random{
@@ -7613,24 +4877,6 @@
 /obj/structure/closet/crate/trashcart/filled,
 /turf/open/floor/stone,
 /area/city)
-"to" = (
-/obj/structure/table/wood,
-/turf/open/floor/carpet/green,
-/area/city/backstreets_room)
-"tp" = (
-/obj/effect/turf_decal/siding/wideplating/corner,
-/obj/structure/flora/rock/pile{
-	pixel_x = 6;
-	pixel_y = -13
-	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"tq" = (
-/obj/effect/turf_decal{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/city/backstreets_room)
 "tr" = (
 /obj/structure/table/reinforced{
 	color = "#00a86b"
@@ -7639,54 +4885,37 @@
 	dir = 4
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /turf/open/floor/mineral/silver,
 /area/city/shop)
-"ts" = (
-/obj/structure/table/wood,
-/obj/item/food/meat/slab/human/mutant/skeleton,
-/obj/item/food/meat/slab/human/mutant/skeleton,
-/obj/item/food/meat/slab/human/mutant/skeleton,
-/turf/open/floor/plasteel/sepia,
-/area/city/backstreets_room)
-"tt" = (
-/obj/structure/chair/plastic{
-	dir = 8
-	},
-/obj/machinery/light/dim{
-	dir = 4
-	},
-/turf/open/floor/plasteel/sepia,
-/area/city/backstreets_room)
 "tu" = (
 /obj/structure/closet/crate,
 /obj/structure/window/reinforced/spawner/north,
 /obj/effect/turf_decal/delivery/red,
 /turf/open/floor/facility/white,
 /area/city/fixers)
-"tw" = (
-/obj/item/food/grown/apple/gold/abnormality,
-/turf/open/floor/carpet/orange,
-/area/city/backstreets_room)
 "tx" = (
 /obj/structure/chair/pew/left{
+	desc = "Sit here and relax";
 	dir = 1;
-	name = "Bench";
-	desc = "Sit here and relax"
+	name = "Bench"
 	},
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 1
 	},
+/obj/effect/landmark/latejoin,
 /turf/open/floor/plating/grass,
 /area/city)
-"ty" = (
-/obj/effect/decal/cleanable/blood/splatter{
-	pixel_x = -18
+"tz" = (
+/obj/structure/bed,
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
 	},
-/turf/open/floor/holofloor/dark,
-/area/city/backstreets_room)
+/obj/item/bedsheet/red,
+/turf/open/floor/wood,
+/area/space)
 "tA" = (
 /obj/structure/table/reinforced{
 	max_integrity = 25
@@ -7699,57 +4928,31 @@
 	icon_state = "LC6"
 	},
 /turf/open/floor/facility/dark,
-/area/facility_hallway/command)
-"tC" = (
-/obj/item/chair/plastic,
-/obj/effect/decal/cleanable/blood/tracks,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/paperslip{
-	pixel_x = -8;
-	pixel_y = 5
-	},
-/obj/item/paperslip{
-	pixel_x = 7;
-	pixel_y = -5
-	},
-/obj/item/paper/crumpled{
-	pixel_x = 5;
-	pixel_y = 15
-	},
-/turf/open/floor/wood,
-/area/city/backstreets_room)
-"tD" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/prison_contraband,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "tE" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /turf/open/floor/wood,
 /area/city/shop)
+"tF" = (
+/obj/structure/table/wood,
+/turf/open/floor/facility/dark,
+/area/facility_hallway/manager)
 "tG" = (
 /obj/structure/closet/secure_closet/personal/cabinet{
 	anchored = 1
 	},
 /turf/open/floor/carpet/red,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "tH" = (
 /obj/structure/sign/departments/extraction,
 /turf/closed/indestructible/reinforced,
-/area/facility_hallway/command)
-"tI" = (
-/mob/living/simple_animal/hostile/ordeal/green_bot{
-	desc = "A slim robot trying to get by in the backstreets.";
-	name = "Giuseppe"
-	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "tJ" = (
 /obj/item/reagent_containers/spray/chemsprayer/janitor,
 /obj/item/reagent_containers/spray/chemsprayer/janitor,
@@ -7762,36 +4965,22 @@
 /obj/item/reagent_containers/spray/chemsprayer/janitor,
 /obj/item/reagent_containers/spray/chemsprayer/janitor,
 /obj/structure/closet/crate{
-	storage_capacity = 100;
-	anchored = 1
+	anchored = 1;
+	storage_capacity = 100
 	},
 /obj/structure/window/reinforced/spawner/west{
 	max_integrity = 25
 	},
 /obj/effect/turf_decal/delivery,
 /obj/structure/window/reinforced/spawner/east{
-	pixel_x = 3;
-	max_integrity = 25
+	max_integrity = 25;
+	pixel_x = 3
 	},
 /obj/machinery/light/small{
 	dir = 1
 	},
 /turf/open/floor/facility/dark,
 /area/city/shop)
-"tK" = (
-/obj/item/chair,
-/mob/living/simple_animal/hostile/ordeal/green_bot{
-	name = "clerk bot"
-	},
-/turf/open/floor/engine,
-/area/city/backstreets_room)
-"tL" = (
-/obj/effect/decal/cleanable/blood/old{
-	pixel_x = -13;
-	pixel_y = -7
-	},
-/turf/open/floor/wood,
-/area/city/backstreets_room)
 "tM" = (
 /obj/machinery/button/door/indestructible{
 	id = "facilitylockdown";
@@ -7803,22 +4992,6 @@
 	},
 /turf/open/floor/stone,
 /area/city)
-"tN" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/mob/living/simple_animal/hostile/ordeal/amber_bug{
-	name = "carnivorous worm"
-	},
-/turf/open/floor/plasteel/sepia,
-/area/city/backstreets_room)
 "tO" = (
 /obj/structure/table/reinforced{
 	pixel_y = 2
@@ -7837,22 +5010,6 @@
 /obj/effect/turf_decal/caution,
 /turf/open/floor/plasteel/dark,
 /area/city/shop)
-"tQ" = (
-/obj/effect/decal/cleanable/blood/footprints{
-	dir = 8
-	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"tR" = (
-/obj/structure/stone_tile/slab/cracked,
-/mob/living/simple_animal/hostile/ordeal/indigo_noon,
-/turf/open/floor/plating/dirt/jungle/wasteland,
-/area/city/backstreets_room)
-"tS" = (
-/obj/effect/decal/cleanable/blood/gibs/old,
-/obj/machinery/vending/cigarette,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
 "tT" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
@@ -7862,28 +5019,6 @@
 	},
 /turf/open/floor/wood,
 /area/city/shop)
-"tU" = (
-/obj/structure/table/glass,
-/obj/machinery/computer/libraryconsole{
-	desc = "For a store in the backstreets, quite progressive.";
-	name = "ecash register";
-	pixel_y = 10
-	},
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 8
-	},
-/turf/open/floor/carpet/black,
-/area/city/backstreets_room)
-"tV" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 6
-	},
-/obj/effect/spawner/lootdrop/space/cashmoney,
-/obj/effect/spawner/lootdrop/space/cashmoney,
-/obj/effect/spawner/lootdrop/space/cashmoney,
-/obj/effect/spawner/lootdrop/space/cashmoney,
-/turf/open/floor/grass,
-/area/city/backstreets_room)
 "tW" = (
 /turf/open/floor/eighties,
 /area/city/shop)
@@ -7896,11 +5031,6 @@
 	},
 /turf/open/floor/carpet/cyan,
 /area/city/shop)
-"tY" = (
-/turf/closed/indestructible/fakedoor{
-	name = "Bolted Door"
-	},
-/area/city/backstreets_room)
 "tZ" = (
 /obj/structure/railing{
 	dir = 1
@@ -7913,7 +5043,7 @@
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "ua" = (
 /obj/structure/railing{
 	dir = 4
@@ -7926,37 +5056,12 @@
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
-"ub" = (
-/obj/effect/turf_decal/trimline/neutral/corner{
-	pixel_x = 7;
-	pixel_y = -5
-	},
-/obj/structure/fence/post{
-	layer = 2;
-	pixel_x = 15
-	},
-/obj/structure/railing/corner,
-/obj/machinery/light/dim{
-	dir = 4;
-	pixel_x = -2;
-	pixel_y = 3
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/holofloor/dark,
-/area/city/backstreets_room)
-"uc" = (
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 4
-	},
-/turf/open/floor/carpet/black,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "ud" = (
 /obj/structure/window/reinforced/spawner/west{
 	max_integrity = 25;
-	opacity = 1;
-	name = "Shower Glass"
+	name = "Shower Glass";
+	opacity = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -7965,7 +5070,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "ue" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 7
@@ -7974,12 +5079,6 @@
 /obj/machinery/light/cold/no_nightlight,
 /turf/open/floor/wood,
 /area/city/fixers)
-"uf" = (
-/obj/machinery/door/poddoor/shutters/indestructible{
-	name = "Malfunctioning Backstreets Shutters"
-	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_alley)
 "ug" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/effect/turf_decal/siding/thinplating/dark/corner{
@@ -7987,16 +5086,6 @@
 	},
 /turf/open/floor/plating/grass,
 /area/city)
-"uh" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/smartfridge/food{
-	pixel_y = 30
-	},
-/obj/machinery/door/window/northright,
-/turf/open/floor/plasteel/shuttle{
-	name = "floor"
-	},
-/area/city/backstreets_room)
 "ui" = (
 /obj/structure/toilet,
 /obj/machinery/light/small{
@@ -8012,21 +5101,18 @@
 /obj/structure/flora/tree/jungle/small,
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/plating/grass,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "uk" = (
 /obj/machinery/light/cold/no_nightlight{
 	brightness = 16
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
+/obj/machinery/vending/lobotomyuniform,
 /turf/open/floor/facility/dark,
-/area/facility_hallway/command)
-"ul" = (
-/obj/structure/closet/crate/wooden,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "um" = (
 /obj/structure/table/bronze,
 /obj/item/statuebust{
@@ -8037,26 +5123,11 @@
 /area/city/shop)
 "un" = (
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /turf/open/floor/carpet,
 /area/city/house)
-"uo" = (
-/obj/effect/decal/cleanable/blood{
-	pixel_x = 7;
-	pixel_y = -10
-	},
-/obj/effect/decal/cleanable/blood/gibs/up,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/stone,
-/area/city/backstreets_room)
-"up" = (
-/obj/machinery/door/airlock/silver/glass,
-/turf/open/floor/plasteel/shuttle{
-	name = "floor"
-	},
-/area/city/backstreets_room)
 "uq" = (
 /obj/structure/window/reinforced/spawner/north{
 	max_integrity = 25;
@@ -8064,21 +5135,11 @@
 	},
 /obj/structure/closet,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
-	},
-/turf/open/floor/carpet/royalblue,
-/area/facility_hallway/command)
-"ur" = (
-/mob/living/simple_animal/hostile/ordeal/indigo_noon{
+	brightness = 16;
 	dir = 4
 	},
-/obj/effect/decal/cleanable/blood/drip{
-	pixel_x = 18;
-	pixel_y = -6
-	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
+/turf/open/floor/carpet/royalblue,
+/area/facility_hallway/manager)
 "us" = (
 /obj/structure/railing{
 	dir = 10
@@ -8091,7 +5152,7 @@
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "uu" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -8100,46 +5161,26 @@
 	brightness = 16
 	},
 /turf/open/floor/plating/grass,
-/area/facility_hallway/command)
-"uv" = (
-/obj/structure/chair/sofa/corp/right{
-	dir = 8
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "uw" = (
 /obj/item/toy/plush/binah,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /turf/open/floor/carpet/royalblack,
-/area/facility_hallway/command)
-"ux" = (
-/obj/structure/chair/sofa/corp/right,
-/turf/open/floor/carpet/black,
-/area/city/backstreets_room)
-"uy" = (
-/obj/effect/turf_decal{
-	dir = 3
-	},
-/obj/structure/lootcrate/limbus,
-/turf/open/floor/engine,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "uz" = (
 /obj/effect/turf_decal/plaque{
 	alpha = 230;
 	icon_state = "LC20"
 	},
 /turf/open/floor/facility/dark,
-/area/facility_hallway/command)
-"uA" = (
-/turf/open/floor/plasteel/vaporwave,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "uB" = (
 /obj/machinery/light/floor{
-	pixel_y = 9;
-	pixel_x = 8
+	pixel_x = 8;
+	pixel_y = 9
 	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
@@ -8171,11 +5212,11 @@
 /area/city/shop)
 "uE" = (
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /turf/open/floor/carpet/cyan,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "uF" = (
 /obj/item/clothing/shoes/galoshes/dry,
 /obj/item/clothing/shoes/galoshes/dry,
@@ -8202,12 +5243,12 @@
 /obj/item/storage/bag/trash/bluespace,
 /obj/effect/turf_decal/delivery,
 /obj/structure/window/reinforced/spawner/east{
-	pixel_x = 3;
-	max_integrity = 25
+	max_integrity = 25;
+	pixel_x = 3
 	},
 /obj/structure/closet/crate{
-	storage_capacity = 100;
-	anchored = 1
+	anchored = 1;
+	storage_capacity = 100
 	},
 /obj/machinery/light/small/broken{
 	dir = 1
@@ -8222,7 +5263,7 @@
 	dir = 4
 	},
 /turf/open/floor/facility/white,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "uI" = (
 /obj/structure/bed,
 /obj/effect/turf_decal/siding/wood{
@@ -8237,7 +5278,7 @@
 	icon_state = "LC3"
 	},
 /turf/open/floor/facility/dark,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "uK" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/effect/turf_decal/siding/thinplating/dark/corner{
@@ -8245,23 +5286,12 @@
 	},
 /turf/open/floor/plating/grass,
 /area/city)
-"uN" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 9
-	},
-/obj/effect/spawner/lootdrop/space/cashmoney,
-/obj/effect/spawner/lootdrop/space/cashmoney,
-/obj/effect/spawner/lootdrop/space/cashmoney,
-/obj/effect/spawner/lootdrop/space/cashmoney,
-/obj/effect/spawner/lootdrop/space/cashmoney,
-/turf/open/floor/grass,
-/area/city/backstreets_room)
-"uP" = (
-/obj/effect/turf_decal/siding{
+"uM" = (
+/obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel/checker,
-/area/city/backstreets_room)
+/turf/open/floor/wood,
+/area/space)
 "uQ" = (
 /obj/structure/fluff/paper{
 	dir = 8
@@ -8277,11 +5307,11 @@
 	brightness = 16
 	},
 /turf/open/floor/carpet/black,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "uR" = (
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /turf/open/floor/plasteel/chapel{
 	dir = 4
@@ -8295,39 +5325,26 @@
 /area/city)
 "uT" = (
 /obj/effect/turf_decal/tile/neutral{
-	dir = 4;
-	color = "#000000"
+	color = "#000000";
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral{
-	dir = 1;
-	color = "#000000"
+	color = "#000000";
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
-	dir = 8;
-	color = "#000000"
+	color = "#000000";
+	dir = 8
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /obj/machinery/scanner_gate{
 	scangate_mode = "Guns"
 	},
 /turf/open/floor/mineral/titanium/tiled/white,
 /area/city/fixers)
-"uU" = (
-/mob/living/simple_animal/hostile/ordeal/indigo_dawn{
-	name = "sweeper scout"
-	},
-/turf/open/floor/carpet/black,
-/area/city/backstreets_room)
-"uV" = (
-/obj/effect/turf_decal/siding/purple{
-	dir = 7
-	},
-/obj/structure/table/wood/fancy/purple,
-/turf/open/floor/carpet/purple,
-/area/city/backstreets_room)
 "uW" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -8338,8 +5355,8 @@
 "uX" = (
 /obj/structure/closet/secure_closet/armory1,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /turf/open/floor/facility/dark,
 /area/city/backstreets_checkpoint)
@@ -8347,11 +5364,11 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /turf/open/floor/sepia,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "uZ" = (
 /obj/structure/sink/kitchen{
 	dir = 4;
@@ -8363,20 +5380,6 @@
 /obj/structure/chair/office/light,
 /turf/open/floor/mineral/titanium/tiled/white,
 /area/city/shop)
-"vb" = (
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/stone,
-/area/city/backstreets_room)
-"vc" = (
-/mob/living/simple_animal/hostile/ordeal/amber_bug{
-	name = "carnivorous worm"
-	},
-/obj/structure/chair/comfy/black,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
 "vd" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -8385,24 +5388,17 @@
 	dir = 1
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /turf/open/floor/plating/grass,
-/area/facility_hallway/command)
-"ve" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/kirbyplants/dead{
-	desc = "A sad, dead plant";
-	name = "dead potted plant";
-	pixel_y = 10
+/area/facility_hallway/manager)
+"vf" = (
+/obj/machinery/computer/abnormality_archive{
+	dir = 8
 	},
-/turf/open/floor/wood,
-/area/city/backstreets_room)
-"vg" = (
-/obj/structure/window,
-/turf/open/floor/holofloor/white,
-/area/city/backstreets_room)
+/turf/open/floor/facility/dark,
+/area/facility_hallway/manager)
 "vh" = (
 /obj/structure/window/reinforced/spawner/west{
 	max_integrity = 25
@@ -8428,7 +5424,7 @@
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "vj" = (
 /obj/structure/chair/wood{
 	pixel_y = -2
@@ -8451,13 +5447,6 @@
 	},
 /turf/open/floor/plasteel/sepia,
 /area/city/shop)
-"vl" = (
-/obj/structure/table/greyscale,
-/obj/structure/curtain/bounty{
-	pixel_y = -30
-	},
-/turf/open/floor/plasteel/sepia,
-/area/city/backstreets_room)
 "vm" = (
 /obj/structure/chair/wood/wings{
 	dir = 8
@@ -8476,23 +5465,6 @@
 "vo" = (
 /turf/open/floor/plasteel/checker,
 /area/city/house)
-"vp" = (
-/obj/structure/table/reinforced,
-/obj/machinery/microwave{
-	pixel_y = 7
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/facility_hallway/command)
 "vq" = (
 /obj/structure/window/reinforced/spawner/north{
 	max_integrity = 25;
@@ -8507,9 +5479,6 @@
 /obj/machinery/door/window/westleft,
 /turf/open/floor/facility/white,
 /area/city/shop)
-"vs" = (
-/turf/open/floor/plating/asteroid/basalt,
-/area/city/backstreets_checkpoint)
 "vt" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#3234B9";
@@ -8530,12 +5499,6 @@
 	},
 /turf/open/floor/facility/halls,
 /area/city/house)
-"vv" = (
-/obj/structure/fence{
-	dir = 4
-	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_alley)
 "vw" = (
 /obj/structure/railing{
 	dir = 8
@@ -8548,13 +5511,7 @@
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
-"vx" = (
-/obj/effect/turf_decal/siding/yellow{
-	dir = 10
-	},
-/turf/open/floor/carpet/green,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "vy" = (
 /obj/structure/riser/dark,
 /obj/structure/bed/maint,
@@ -8571,66 +5528,23 @@
 /obj/machinery/light/floor,
 /turf/open/floor/mineral/titanium/blue,
 /area/city/fixers)
-"vB" = (
-/obj/effect/turf_decal/siding/yellow{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/green,
-/area/city/backstreets_room)
 "vC" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /turf/open/floor/wood,
 /area/city/shop)
-"vD" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/obj/structure/barricade/sandbags,
-/turf/open/floor/plating/asteroid/basalt,
-/area/city/backstreets_alley)
-"vE" = (
-/obj/structure/sign/plaques/kiddie/perfect_drone{
-	desc = "The image has been warn down from the weathering of time.";
-	pixel_y = 17
-	},
-/turf/closed/indestructible/reinforced,
-/area/city/backstreets_room)
-"vF" = (
-/obj/structure/table/wood,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/item/toy/plush/carpplushie,
-/obj/structure/sign/poster/lobotomycorp/random{
-	pixel_x = -32
-	},
-/obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
-	},
-/turf/open/floor/sepia,
-/area/facility_hallway/command)
 "vG" = (
 /obj/structure/chair/sofa/corp/right{
 	dir = 4
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /turf/open/floor/mineral/titanium/tiled/white,
 /area/city/shop)
@@ -8647,19 +5561,6 @@
 	},
 /turf/open/floor/eighties,
 /area/city/shop)
-"vJ" = (
-/obj/structure/chair/pew{
-	dir = 1
-	},
-/turf/open/indestructible/cult,
-/area/city/backstreets_room)
-"vK" = (
-/obj/effect/turf_decal/siding/wideplating/corner{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
 "vL" = (
 /obj/effect/light_emitter{
 	light_power = 4;
@@ -8677,81 +5578,37 @@
 /obj/structure/window/reinforced/spawner/north,
 /turf/open/floor/plasteel,
 /area/city/shop)
-"vN" = (
-/turf/closed/indestructible/fakedoor{
-	desc = "Too bad the door is broken.";
-	name = "Arcade Plush Storage"
-	},
-/area/city/backstreets_room)
-"vO" = (
-/obj/effect/turf_decal/siding/wideplating/end{
-	dir = 4
-	},
-/obj/effect/turf_decal/starfury/three,
-/obj/structure/flora/rock/jungle,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"vP" = (
-/obj/effect/turf_decal/trimline/neutral/corner{
-	pixel_x = 7;
-	pixel_y = -5
-	},
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/plating/dirt/jungle,
-/area/city/backstreets_room)
-"vQ" = (
-/obj/structure/fluff/broken_flooring,
-/obj/machinery/smartfridge/drinks{
-	pixel_y = 30
-	},
-/obj/machinery/door/window/northleft,
-/turf/open/floor/plasteel/shuttle{
-	name = "floor"
-	},
-/area/city/backstreets_room)
-"vR" = (
-/obj/structure/table/greyscale,
-/obj/machinery/microwave{
-	pixel_x = -3;
-	pixel_y = 6
-	},
-/obj/machinery/light/broken,
-/turf/open/floor/plasteel/sepia,
-/area/city/backstreets_room)
 "vS" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "vT" = (
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /turf/open/floor/mineral/titanium/tiled/white,
 /area/city/shop)
-"vU" = (
-/obj/structure/window/reinforced/tinted/frosted{
-	dir = 4
-	},
-/obj/machinery/door/poddoor,
+"vV" = (
+/obj/structure/lattice/catwalk,
 /turf/open/floor/plating,
-/area/city/backstreets_room)
+/area/space)
 "vW" = (
 /obj/structure/railing,
 /obj/item/grown/sunflower,
 /obj/structure/flora/ausbushes/brflowers,
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "vX" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -8771,30 +5628,16 @@
 	brightness = 16
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /turf/open/floor/plasteel/sepia,
 /area/city/shop)
-"vY" = (
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 4
-	},
-/obj/item/chair,
-/turf/open/floor/carpet/black,
-/area/city/backstreets_room)
 "vZ" = (
 /obj/structure/bed,
 /obj/item/bedsheet/wiz,
 /turf/open/floor/carpet/royalblue,
-/area/facility_hallway/command)
-"wa" = (
-/obj/effect/decal/cleanable/blood/drip{
-	pixel_x = 24;
-	pixel_y = 16
-	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "wb" = (
 /obj/effect/turf_decal/siding/wood/end{
 	dir = 4
@@ -8811,26 +5654,13 @@
 	dir = 4
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
-"wd" = (
-/obj/machinery/door/window/brigdoor/westleft,
-/obj/effect/turf_decal/siding/yellow{
-	dir = 10
-	},
-/turf/open/floor/carpet/green,
-/area/city/backstreets_room)
-"we" = (
-/obj/effect/decal/cleanable/blood/footprints{
-	dir = 3
-	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "wf" = (
 /obj/effect/turf_decal/siding/thinplating/dark/corner{
 	dir = 1
@@ -8840,37 +5670,9 @@
 "wg" = (
 /obj/item/bedsheet/mime,
 /obj/structure/bed,
+/obj/effect/landmark/latejoin,
 /turf/open/floor/carpet/purple,
 /area/city/house)
-"wh" = (
-/obj/structure/lootcrate/r_corp,
-/obj/structure/lootcrate/r_corp{
-	pixel_x = -5;
-	pixel_y = 15
-	},
-/obj/structure/lootcrate/r_corp{
-	pixel_x = 13;
-	pixel_y = 30
-	},
-/obj/structure/lootcrate/r_corp{
-	pixel_x = 10;
-	pixel_y = 10
-	},
-/turf/open/floor/engine,
-/area/city/backstreets_room)
-"wi" = (
-/obj/machinery/vending/medical,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/city/backstreets_room)
-"wj" = (
-/obj/machinery/door/airlock/silver/glass,
-/turf/open/floor/plasteel/rockvault/alien{
-	name = "floor"
-	},
-/area/city/backstreets_room)
 "wl" = (
 /obj/effect/turf_decal/arrows/red{
 	dir = 8
@@ -8886,22 +5688,22 @@
 /area/city/shop)
 "wn" = (
 /turf/closed/wall/mineral/silver{
+	desc = "A wall with unmistable white coloring. Iconic sight in N Corp's Nest!";
 	explosion_block = 50;
-	name = "N Corporation Nest Wall";
-	desc = "A wall with unmistable white coloring. Iconic sight in N Corp's Nest!"
+	name = "N Corporation Nest Wall"
 	},
 /area/city/backstreets_checkpoint)
 "wo" = (
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /obj/effect/turf_decal/caution/red{
 	dir = 1
 	},
 /obj/effect/turf_decal{
-	dir = 3;
-	color = "#FF0000"
+	color = "#FF0000";
+	dir = 3
 	},
 /obj/structure/window/reinforced/spawner{
 	max_integrity = 25
@@ -8917,13 +5719,6 @@
 	},
 /turf/open/floor/facility/white,
 /area/city/shop)
-"wq" = (
-/turf/open/floor/carpet/black,
-/area/city/backstreets_room)
-"wr" = (
-/obj/effect/turf_decal/weather/dirt,
-/turf/open/floor/plating/asteroid/basalt,
-/area/city/backstreets_room)
 "ws" = (
 /obj/structure/railing,
 /obj/item/grown/sunflower,
@@ -8932,7 +5727,7 @@
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "wt" = (
 /obj/machinery/door/airlock/wood{
 	icon = 'icons/obj/doors/airlocks/station/command.dmi';
@@ -8945,8 +5740,8 @@
 	color = "#000000"
 	},
 /obj/effect/turf_decal/tile/neutral{
-	dir = 4;
-	color = "#000000"
+	color = "#000000";
+	dir = 4
 	},
 /turf/open/floor/mineral/titanium/tiled/white,
 /area/city/fixers)
@@ -8956,65 +5751,43 @@
 	},
 /obj/structure/chair/stool/bar,
 /turf/open/floor/carpet/stellar,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "ww" = (
 /obj/machinery/vending/hydronutrients,
 /obj/structure/window/reinforced/spawner/north{
 	max_integrity = 25
 	},
 /obj/effect/turf_decal/tile/green{
-	dir = 1;
-	color = "#006400"
+	color = "#006400";
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/green{
 	color = "#006400"
 	},
 /obj/effect/turf_decal/tile/green{
-	dir = 4;
-	color = "#006400"
+	color = "#006400";
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/green{
-	dir = 8;
-	color = "#006400"
+	color = "#006400";
+	dir = 8
 	},
 /turf/open/floor/plasteel/sepia,
 /area/city/shop)
-"wx" = (
-/obj/structure/flora/rock/jungle,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"wy" = (
-/obj/machinery/door/airlock/hatch,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
 "wz" = (
 /obj/effect/turf_decal/siding/yellow{
 	dir = 9
 	},
 /turf/open/floor/carpet/stellar,
-/area/facility_hallway/command)
-"wA" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/glowstick{
-	pixel_x = -2
-	},
-/obj/effect/spawner/lootdrop/glowstick{
-	pixel_x = 4;
-	pixel_y = 6
-	},
-/obj/structure/window/reinforced/spawner,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "wB" = (
 /obj/effect/turf_decal/tile/neutral{
-	dir = 1;
-	color = "#000000"
+	color = "#000000";
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
-	dir = 8;
-	color = "#000000"
+	color = "#000000";
+	dir = 8
 	},
 /turf/open/floor/mineral/titanium/tiled/white,
 /area/city/fixers)
@@ -9022,39 +5795,32 @@
 /obj/structure/riser/dark,
 /turf/open/floor/facility/dark,
 /area/city/shop)
-"wD" = (
-/obj/structure/table/reinforced,
-/obj/structure/fireaxecabinet{
-	pixel_y = 28
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/city/backstreets_room)
 "wF" = (
 /obj/machinery/vending/hydroseeds,
 /obj/structure/window/reinforced/spawner/north{
 	max_integrity = 25
 	},
 /obj/effect/turf_decal/tile/green{
-	dir = 1;
-	color = "#006400"
+	color = "#006400";
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/green{
 	color = "#006400"
 	},
 /obj/effect/turf_decal/tile/green{
-	dir = 4;
-	color = "#006400"
+	color = "#006400";
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/green{
-	dir = 8;
-	color = "#006400"
+	color = "#006400";
+	dir = 8
 	},
 /turf/open/floor/plasteel/sepia,
 /area/city/shop)
 "wG" = (
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /turf/open/floor/carpet/black,
 /area/city/house)
@@ -9068,13 +5834,13 @@
 "wI" = (
 /obj/structure/closet/crate,
 /obj/structure/window/reinforced/spawner/east{
-	pixel_x = 3;
-	max_integrity = 25
+	max_integrity = 25;
+	pixel_x = 3
 	},
 /obj/effect/turf_decal/delivery/red,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /turf/open/floor/facility/white,
 /area/city/fixers)
@@ -9090,7 +5856,7 @@
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "wK" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/light/cold/no_nightlight,
@@ -9104,39 +5870,21 @@
 	opacity = 1
 	},
 /turf/open/floor/carpet/royalblack,
-/area/facility_hallway/command)
-"wM" = (
-/obj/effect/turf_decal/siding/thinplating/dark/corner{
-	dir = 1
-	},
-/turf/open/indestructible/cult,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "wN" = (
 /obj/machinery/conveyor_switch/oneway{
 	id = "Ncorp2"
 	},
 /turf/open/floor/plasteel/dark,
 /area/city/shop)
-"wO" = (
-/obj/machinery/door/window,
-/turf/open/floor/holofloor/white,
-/area/city/backstreets_room)
-"wP" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/food_packaging,
-/obj/effect/spawner/lootdrop/food_packaging,
-/turf/open/floor/plasteel/shuttle{
-	name = "floor"
-	},
-/area/city/backstreets_room)
 "wQ" = (
 /obj/structure/table/glass,
 /obj/structure/window/reinforced/spawner/east{
 	max_integrity = 25
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /obj/item/storage/firstaid/regular,
 /obj/item/storage/firstaid/regular,
@@ -9146,94 +5894,40 @@
 /obj/structure/table/wood,
 /obj/item/toy/plush/chesed,
 /turf/open/floor/wood,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "wT" = (
 /obj/machinery/computer/slot_machine,
 /obj/effect/turf_decal/siding/blue,
 /turf/open/floor/carpet/cyan,
 /area/city/shop)
-"wU" = (
-/obj/structure/flora/rock/pile{
-	pixel_x = 6;
-	pixel_y = -13
-	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"wW" = (
-/obj/machinery/door/poddoor/shutters/indestructible{
-	name = "Malfunctioning Backstreets Shutters"
-	},
-/turf/closed/indestructible/rock,
-/area/city/backstreets_alley)
 "wX" = (
 /obj/structure/toilet{
 	dir = 1
 	},
 /obj/machinery/light/cold/no_nightlight,
 /obj/machinery/door/window/northleft{
-	opacity = 1;
-	name = "Bathroom Door"
+	name = "Bathroom Door";
+	opacity = 1
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/city/fixers)
-"wZ" = (
+"wY" = (
+/obj/structure/closet/crate,
 /obj/structure/lattice/catwalk,
-/obj/structure/rack,
-/obj/item/stack/sheet/plasteel/fifty,
-/turf/open/floor/holofloor/dark,
-/area/city/backstreets_room)
+/turf/open/floor/plating,
+/area/space)
 "xa" = (
 /obj/structure/railing{
 	dir = 1
 	},
 /obj/effect/turf_decal,
 /turf/open/floor/plasteel/dark,
-/area/facility_hallway/command)
-"xb" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/rack,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/effect/spawner/lootdrop/food_packaging,
-/obj/effect/spawner/lootdrop/food_packaging,
-/turf/open/floor/plasteel/shuttle{
-	name = "floor"
-	},
-/area/city/backstreets_room)
-"xc" = (
-/obj/structure/destructible/cult/forge,
-/obj/machinery/light/red{
-	dir = 5
-	},
-/turf/open/indestructible/cult,
-/area/city/backstreets_room)
-"xd" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 3
-	},
-/turf/open/floor/plating/asteroid/basalt,
-/area/city/backstreets_checkpoint)
-"xe" = (
-/mob/living/simple_animal/hostile/ordeal/indigo_noon,
-/obj/structure/chair/pew{
-	dir = 1
-	},
-/turf/open/indestructible/cult,
-/area/city/backstreets_room)
-"xf" = (
-/obj/structure/table/reinforced,
-/obj/item/gun/energy/e_gun/hos,
-/turf/open/floor/engine,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "xg" = (
 /obj/structure/window/reinforced/spawner/east{
 	max_integrity = 25;
-	opacity = 1;
-	name = "Surgery Room Divider"
+	name = "Surgery Room Divider";
+	opacity = 1
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/city/shop)
@@ -9258,7 +5952,7 @@
 "xj" = (
 /obj/structure/table/wood,
 /turf/open/floor/facility/white,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "xk" = (
 /obj/structure/chair/sofa/right,
 /obj/effect/turf_decal/siding/wood{
@@ -9276,12 +5970,7 @@
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/plating/grass,
-/area/facility_hallway/command)
-"xn" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal,
-/turf/open/floor/engine,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "xo" = (
 /obj/structure/chair/sofa/corp/left{
 	dir = 4;
@@ -9289,26 +5978,11 @@
 	pixel_y = 1
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /turf/open/floor/carpet/purple,
 /area/city/house)
-"xp" = (
-/obj/structure/table/wood/fancy/black,
-/obj/item/kirbyplants/dead{
-	desc = "A sad, dead plant";
-	name = "dead potted plant";
-	pixel_y = 10
-	},
-/turf/open/indestructible/cult,
-/area/city/backstreets_room)
-"xq" = (
-/mob/living/simple_animal/hostile/ordeal/amber_bug{
-	name = "carnivorous worm"
-	},
-/turf/open/indestructible/hoteltile,
-/area/city/backstreets_room)
 "xr" = (
 /obj/effect/turf_decal{
 	dir = 1
@@ -9334,51 +6008,12 @@
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
-"xt" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 10
-	},
-/obj/item/kirbyplants{
-	pixel_x = -2;
-	pixel_y = 2
-	},
-/turf/open/floor/sepia,
-/area/city/backstreets_room)
-"xv" = (
-/obj/structure/closet/crate/large,
-/obj/effect/turf_decal{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/city/backstreets_room)
-"xw" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/city/backstreets_checkpoint)
-"xx" = (
-/obj/item/kirbyplants/dead{
-	desc = "A sad, dead plant";
-	name = "dead potted plant";
-	pixel_y = 10
-	},
-/turf/open/floor/wood,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "xy" = (
 /obj/effect/turf_decal/caution/stand_clear/red,
 /obj/effect/turf_decal,
 /turf/open/floor/plasteel/dark,
-/area/facility_hallway/command)
-"xz" = (
-/obj/structure/table/reinforced,
-/obj/structure/table/reinforced,
-/obj/effect/spawner/lootdrop/armory_contraband/cybersun,
-/obj/effect/spawner/lootdrop/armory_contraband/cybersun,
-/obj/effect/spawner/lootdrop/armory_contraband/cybersun,
-/turf/open/floor/engine,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "xA" = (
 /turf/open/floor/wood,
 /area/city/shop)
@@ -9386,16 +6021,6 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/facility/white,
 /area/city/shop)
-"xC" = (
-/obj/machinery/door/airlock/survival_pod,
-/turf/open/floor/plasteel/dark,
-/area/city/backstreets_room)
-"xD" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 3
-	},
-/turf/open/floor/wood,
-/area/city/backstreets_room)
 "xE" = (
 /obj/structure/table/reinforced{
 	color = "#00a86b"
@@ -9405,57 +6030,25 @@
 	},
 /turf/open/floor/mineral/silver,
 /area/city/shop)
-"xF" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/food/drinks/mug{
-	desc = "You would think that robots can't drink anything."
-	},
-/turf/open/floor/engine,
-/area/city/backstreets_room)
-"xG" = (
-/obj/structure/fence/cut,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_checkpoint)
-"xH" = (
-/obj/structure/chair/pew/right{
-	dir = 1
-	},
-/turf/open/indestructible/cult,
-/area/city/backstreets_room)
 "xI" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
 /obj/item/pen/fourcolor,
 /turf/open/floor/carpet/red,
-/area/facility_hallway/command)
-"xJ" = (
-/obj/structure/table/reinforced,
-/obj/item/dnainjector/thermal,
-/obj/item/dnainjector/thermal,
-/obj/item/dnainjector/thermal,
-/turf/open/floor/engine,
-/area/city/backstreets_room)
-"xK" = (
-/obj/structure/table/wood,
-/obj/machinery/light/broken{
-	dir = 8
-	},
-/obj/effect/spawner/lootdrop/space/fancytech,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "xL" = (
 /obj/structure/railing,
 /obj/item/grown/novaflower,
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "xM" = (
 /obj/structure/railing{
 	dir = 1
@@ -9471,35 +6064,26 @@
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
-"xN" = (
-/obj/structure/table/reinforced,
-/obj/item/gun/ballistic/automatic/sniper_rifle/syndicate,
-/turf/open/floor/engine,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "xO" = (
 /obj/structure/chair/comfy{
 	dir = 8
 	},
 /obj/machinery/light/cold/no_nightlight,
+/obj/effect/landmark/latejoin,
 /turf/open/floor/carpet/purple,
 /area/city/house)
-"xP" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 5
-	},
-/turf/open/floor/plating/asteroid/basalt,
-/area/city/backstreets_alley)
 "xQ" = (
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /turf/open/floor/carpet/royalblack,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "xR" = (
 /obj/structure/chair/pew/right,
 /obj/item/trash/candle,
+/obj/effect/landmark/latejoin,
 /turf/open/floor/plasteel/chapel{
 	dir = 4
 	},
@@ -9516,84 +6100,32 @@
 /area/city/shop)
 "xU" = (
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
-	},
-/turf/open/floor/facility/dark,
-/area/facility_hallway/command)
-"xV" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal{
+	brightness = 16;
 	dir = 8
 	},
-/turf/open/floor/engine,
-/area/city/backstreets_room)
-"xX" = (
-/obj/effect/turf_decal/raven{
-	dir = 4
-	},
-/turf/open/floor/holofloor/dark,
-/area/city/backstreets_room)
-"xY" = (
-/obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+/obj/machinery/vending/lobotomyarmband,
+/turf/open/floor/facility/dark,
+/area/facility_hallway/manager)
+"xW" = (
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood,
+/area/space)
+"yf" = (
+/obj/machinery/computer/abnormality_auxiliary{
+	dir = 8
 	},
 /turf/open/floor/facility/dark,
-/area/facility_hallway/command)
-"xZ" = (
-/obj/structure/table/reinforced,
-/obj/item/binoculars,
-/turf/open/floor/plasteel/dark,
-/area/city/backstreets_room)
-"ya" = (
-/obj/structure/table/greyscale,
-/obj/effect/turf_decal/siding/thinplating/light{
-	dir = 4
-	},
-/obj/structure/curtain/bounty{
-	pixel_y = -30
-	},
-/obj/item/kirbyplants/dead{
-	desc = "A sad, dead plant";
-	name = "dead potted plant";
-	pixel_y = 10
-	},
-/turf/open/floor/wood,
-/area/city/backstreets_room)
-"yb" = (
-/obj/machinery/door/poddoor,
-/turf/closed/indestructible/fakeglass,
-/area/city/backstreets_room)
-"yc" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/rack,
-/obj/item/stack/sheet/metal/fifty,
-/turf/open/floor/holofloor/dark,
-/area/city/backstreets_room)
-"yd" = (
-/obj/structure/table/greyscale,
-/obj/effect/spawner/lootdrop/three_course_meal,
-/turf/open/floor/plasteel/sepia,
-/area/city/backstreets_room)
-"ye" = (
-/obj/structure/chair/comfy/shuttle{
-	desc = "A comfortable throne fit for a king like yourself.";
-	name = "throne";
-	pixel_x = 17
-	},
-/turf/open/indestructible/necropolis,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "yg" = (
 /obj/structure/chair/comfy/brown{
 	dir = 1
 	},
 /turf/open/floor/carpet/red,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "yh" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -9606,18 +6138,7 @@
 	dir = 1
 	},
 /turf/open/floor/sepia,
-/area/facility_hallway/command)
-"yi" = (
-/obj/structure/table/reinforced,
-/obj/effect/spawner/lootdrop/techstorage/security{
-	pixel_x = 3;
-	pixel_y = 5
-	},
-/obj/effect/spawner/lootdrop/snowdin/dungeonmisc{
-	pixel_x = -3
-	},
-/turf/open/floor/stone,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "yj" = (
 /obj/structure/closet/secure_closet/freezer/fridge{
 	pixel_x = -8
@@ -9630,21 +6151,22 @@
 	pixel_x = 10
 	},
 /obj/item/storage/box/drinkingglasses{
-	pixel_y = 15;
-	pixel_x = 10
+	pixel_x = 10;
+	pixel_y = 15
 	},
 /turf/open/floor/material,
 /area/city/house)
+"yk" = (
+/obj/structure/closet/secure_closet/personal/cabinet,
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/turf/open/floor/wood,
+/area/space)
 "yl" = (
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/plating/grass,
 /area/city)
-"yn" = (
-/obj/structure/fluff/broken_flooring{
-	dir = 4
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/city/backstreets_room)
 "yo" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/chair/office{
@@ -9673,17 +6195,11 @@
 /obj/machinery/light/floor,
 /turf/open/floor/plasteel/sepia,
 /area/city/shop)
-"yq" = (
-/obj/structure/chair/sofa/corp{
-	dir = 8
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/city/backstreets_room)
 "yr" = (
 /obj/structure/bed,
 /obj/item/bedsheet/hos,
 /turf/open/floor/carpet/red,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "ys" = (
 /obj/machinery/grill,
 /obj/effect/turf_decal/tile{
@@ -9695,39 +6211,11 @@
 	},
 /obj/item/stack/sheet/mineral/wood/fifty,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /turf/open/floor/mineral/titanium/tiled/white,
 /area/city/shop)
-"yt" = (
-/obj/structure/table/reinforced,
-/obj/effect/spawner/lootdrop/space/cashmoney,
-/obj/effect/spawner/lootdrop/space/cashmoney,
-/obj/effect/spawner/lootdrop/space/cashmoney,
-/obj/effect/spawner/lootdrop/space/cashmoney,
-/obj/effect/spawner/lootdrop/space/cashmoney,
-/obj/effect/spawner/lootdrop/space/cashmoney,
-/obj/effect/spawner/lootdrop/space/cashmoney,
-/obj/effect/spawner/lootdrop/space/cashmoney,
-/obj/effect/spawner/lootdrop/space/cashmoney,
-/obj/effect/spawner/lootdrop/space/cashmoney,
-/obj/effect/spawner/lootdrop/space/cashmoney,
-/obj/effect/spawner/lootdrop/space/cashmoney,
-/obj/effect/spawner/lootdrop/space/cashmoney,
-/obj/effect/spawner/lootdrop/space/cashmoney,
-/obj/effect/spawner/lootdrop/space/cashmoney,
-/turf/open/floor/engine,
-/area/city/backstreets_room)
-"yu" = (
-/obj/effect/turf_decal/siding/purple{
-	dir = 8
-	},
-/obj/structure/chair/plastic{
-	dir = 4
-	},
-/turf/open/floor/carpet/purple,
-/area/city/backstreets_room)
 "yv" = (
 /obj/structure/table/wood/fancy/blue,
 /obj/item/instrument/trombone,
@@ -9740,11 +6228,16 @@
 	brightness = 16
 	},
 /turf/open/floor/carpet/stellar,
-/area/facility_hallway/command)
-"yw" = (
-/obj/structure/mineral_door/wood,
-/turf/open/floor/plasteel/airless/dark,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
+"yx" = (
+/obj/structure/chair/comfy/black{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/yellow{
+	dir = 1
+	},
+/turf/open/floor/carpet/royalblack,
+/area/facility_hallway/manager)
 "yy" = (
 /obj/structure/table/reinforced{
 	max_integrity = 25
@@ -9754,6 +6247,14 @@
 	},
 /turf/open/floor/facility/dark,
 /area/city/fixers)
+"yz" = (
+/obj/structure/bed,
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/obj/item/bedsheet/red,
+/turf/open/floor/wood,
+/area/space)
 "yA" = (
 /obj/machinery/vending/cola/blue{
 	name = "\improper Crane Game Machine"
@@ -9761,94 +6262,30 @@
 /obj/machinery/light/cold/no_nightlight,
 /turf/open/floor/eighties,
 /area/city/shop)
-"yB" = (
-/obj/effect/decal/cleanable/blood/footprints{
-	dir = 4;
-	pixel_x = 14;
-	pixel_y = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/mob/living/simple_animal/hostile/ordeal/green_bot{
-	name = "spear bot"
-	},
-/turf/open/floor/holofloor/dark,
-/area/city/backstreets_room)
-"yC" = (
-/obj/structure/table/reinforced,
-/obj/effect/spawner/lootdrop/techstorage/security{
-	pixel_x = -2;
-	pixel_y = 6
-	},
-/obj/effect/spawner/lootdrop/snowdin/dungeonmisc{
-	pixel_x = 3
-	},
-/turf/open/floor/stone,
-/area/city/backstreets_room)
-"yD" = (
-/turf/open/floor/plasteel/sepia,
-/area/city/backstreets_room)
-"yE" = (
-/obj/structure/dresser{
-	dir = 6
-	},
-/obj/item/kirbyplants/dead{
-	desc = "A sad, dead plant";
-	name = "dead potted plant";
-	pixel_y = 20
-	},
-/turf/open/floor/plasteel/dark,
-/area/city/backstreets_room)
 "yF" = (
 /obj/structure/railing/corner,
 /obj/structure/flora/ausbushes/brflowers,
 /obj/item/food/grown/moonflower,
 /obj/effect/turf_decal/siding/wood/corner,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
-"yG" = (
-/obj/structure/fence{
-	dir = 4;
-	pixel_x = -9;
-	pixel_y = 6
-	},
-/obj/structure/fence/cut/large{
-	dir = 8;
-	pixel_x = -9;
-	pixel_y = 6
-	},
-/turf/closed/indestructible/reinforced,
-/area/city/backstreets_room)
-"yH" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/obj/structure/barricade/sandbags,
-/turf/open/floor/plating/asteroid/basalt,
-/area/city/backstreets_alley)
-"yI" = (
-/obj/effect/turf_decal{
-	dir = 4
-	},
-/obj/structure/lootcrate/seven,
-/turf/open/floor/engine,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "yJ" = (
 /obj/item/reagent_containers/food/drinks/bottle/wine{
-	pixel_y = 13;
-	pixel_x = -70
+	pixel_x = -70;
+	pixel_y = 13
 	},
 /obj/structure/table/greyscale{
 	pixel_y = 6
 	},
 /obj/item/book/random{
-	pixel_y = 11;
-	pixel_x = -2
+	pixel_x = -2;
+	pixel_y = 11
 	},
 /turf/open/floor/carpet/royalblack,
 /area/city/house)
@@ -9871,23 +6308,19 @@
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
-"yM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "yN" = (
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
+/obj/machinery/vending/lobotomyheadset,
 /turf/open/floor/facility/dark,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "yO" = (
 /obj/structure/table/reinforced{
 	color = "#00a86b"
@@ -9897,21 +6330,9 @@
 	},
 /turf/open/floor/mineral/silver,
 /area/city/shop)
-"yP" = (
-/obj/structure/table/reinforced,
-/obj/item/gun/energy/sniper,
-/turf/open/floor/engine,
-/area/city/backstreets_room)
 "yQ" = (
 /turf/open/floor/plasteel/cafeteria,
 /area/city/house)
-"yR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/plastic{
-	dir = 8
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/city/backstreets_room)
 "yS" = (
 /obj/structure/toilet{
 	dir = 8
@@ -9925,7 +6346,7 @@
 	opacity = 1
 	},
 /turf/open/floor/plasteel/white,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "yU" = (
 /obj/structure/rack{
 	pixel_x = -1
@@ -9953,64 +6374,47 @@
 /obj/item/clothing/suit/apron,
 /obj/item/clothing/gloves/botanic_leather,
 /obj/effect/turf_decal/tile/green{
-	dir = 1;
+	color = "#006400";
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	color = "#006400";
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
 	color = "#006400"
 	},
 /obj/effect/turf_decal/tile/green{
-	dir = 8;
-	color = "#006400"
-	},
-/obj/effect/turf_decal/tile/green{
-	color = "#006400"
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4;
-	color = "#006400"
+	color = "#006400";
+	dir = 4
 	},
 /obj/machinery/light,
 /turf/open/floor/plasteel/sepia,
 /area/city/shop)
-"yV" = (
-/turf/open/floor/plasteel/dark,
-/area/city/backstreets_room)
-"yW" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/bed/dogbed/ian,
-/mob/living/simple_animal/pet/dog/corgi/puppy/ian{
-	desc = "It's everybodies favorite puppy. He looks a bit too thin though."
+"yY" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
 	},
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/obj/item/pen/blue,
 /turf/open/floor/wood,
-/area/city/backstreets_room)
-"yX" = (
-/obj/machinery/light/broken,
-/turf/open/indestructible/cult,
-/area/city/backstreets_room)
-"yZ" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 5
-	},
-/turf/open/indestructible/cult,
-/area/city/backstreets_room)
-"za" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/randomcolavend,
-/turf/open/floor/plasteel/shuttle,
-/area/city/backstreets_room)
+/area/space)
 "zb" = (
 /obj/machinery/griddle{
 	pixel_y = 1
 	},
 /turf/open/floor/plasteel/checker,
 /area/city/house)
-"zd" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 7
+"zc" = (
+/obj/effect/turf_decal/siding/blue{
+	dir = 4
 	},
-/turf/open/floor/plating/asteroid/basalt,
-/area/city/backstreets_alley)
-"ze" = (
-/turf/open/floor/eighties,
-/area/city/backstreets_room)
+/obj/effect/turf_decal/siding/blue{
+	dir = 8
+	},
+/turf/open/floor/carpet/cyan,
+/area/space)
 "zf" = (
 /obj/effect/turf_decal/siding/thinplating/dark,
 /obj/machinery/newscaster{
@@ -10018,59 +6422,45 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/city/house)
-"zg" = (
-/obj/structure/table/rolling,
-/obj/item/spear,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
 "zh" = (
 /obj/machinery/door/airlock/wood{
-	name = "Female Clerk Quarters"
+	name = "Control Head Office"
 	},
-/turf/open/floor/facility/halls,
-/area/facility_hallway/command)
+/turf/open/floor/facility/dark,
+/area/facility_hallway/manager)
 "zi" = (
 /obj/structure/fence/door,
 /turf/open/floor/plating/grass,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "zj" = (
 /obj/machinery/griddle{
 	pixel_y = 1
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /turf/open/floor/plasteel/checker,
 /area/city/house)
-"zk" = (
-/obj/effect/decal/cleanable/blood/gibs/core,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
 "zl" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/sepia,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "zm" = (
 /obj/structure/bed,
 /obj/item/bedsheet/red,
+/obj/effect/landmark/latejoin,
 /turf/open/floor/carpet,
 /area/city/house)
-"zn" = (
-/obj/machinery/computer/scan_consolenew{
-	dir = 1
+"zp" = (
+/obj/structure/closet/secure_closet/personal/cabinet{
+	anchored = 1
 	},
-/turf/open/floor/holofloor/white,
-/area/city/backstreets_room)
-"zo" = (
-/obj/effect/turf_decal/siding/wideplating/corner{
-	dir = 8
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
+/turf/open/floor/wood,
+/area/facility_hallway/manager)
 "zq" = (
 /obj/structure/chair/sofa/right{
 	dir = 4
@@ -10086,7 +6476,7 @@
 	icon_state = "LC26"
 	},
 /turf/open/floor/facility/dark,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "zs" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
@@ -10096,42 +6486,22 @@
 	pixel_y = 6
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /turf/open/floor/wood,
 /area/city/shop)
 "zt" = (
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /turf/open/floor/sepia,
-/area/facility_hallway/command)
-"zu" = (
-/obj/item/rack_parts,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/plasteel/shuttle{
-	name = "floor"
-	},
-/area/city/backstreets_room)
-"zv" = (
-/obj/structure/flora/ausbushes/sparsegrass{
-	pixel_x = 5;
-	pixel_y = 13
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/blood/gibs/old{
-	pixel_x = -12
-	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "zw" = (
 /obj/structure/chair/wood{
 	dir = 1;
@@ -10149,20 +6519,6 @@
 	},
 /turf/open/floor/facility/white,
 /area/city/shop)
-"zy" = (
-/obj/machinery/door/poddoor{
-	id = "armoryouterinterest";
-	name = "Outer Armory Door"
-	},
-/obj/machinery/door/airlock/hatch,
-/turf/open/floor/engine,
-/area/city/backstreets_room)
-"zz" = (
-/obj/structure/chair/office{
-	dir = 1
-	},
-/turf/open/indestructible/cult,
-/area/city/backstreets_room)
 "zA" = (
 /obj/machinery/door/airlock/silver{
 	name = "white-washed airlock"
@@ -10171,8 +6527,8 @@
 /area/city/house)
 "zB" = (
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /obj/structure/closet,
 /obj/structure/window/reinforced/spawner/east{
@@ -10192,26 +6548,13 @@
 	icon_state = "LC27"
 	},
 /turf/open/floor/facility/dark,
-/area/facility_hallway/command)
-"zE" = (
-/obj/machinery/door/airlock/grunge,
-/turf/open/floor/plasteel/dark,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "zF" = (
 /obj/structure/musician/piano{
 	icon_state = "piano"
 	},
 /turf/open/floor/wood,
 /area/city/shop)
-"zG" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 7
-	},
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 7
-	},
-/turf/open/floor/carpet/black,
-/area/city/backstreets_room)
 "zH" = (
 /obj/item/pushbroom,
 /obj/item/pushbroom,
@@ -10238,8 +6581,8 @@
 	},
 /obj/effect/turf_decal/delivery,
 /obj/structure/closet/crate{
-	storage_capacity = 100;
-	anchored = 1
+	anchored = 1;
+	storage_capacity = 100
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -10263,62 +6606,6 @@
 	},
 /turf/open/floor/wood,
 /area/city/shop)
-"zK" = (
-/obj/effect/decal/cleanable/blood{
-	pixel_x = 11
-	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"zL" = (
-/obj/effect/turf_decal/trimline/neutral/line{
-	pixel_y = -6
-	},
-/obj/effect/turf_decal/trimline/neutral/corner{
-	pixel_x = 7;
-	pixel_y = -5
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 4;
-	pixel_x = 7
-	},
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/railing{
-	dir = 6
-	},
-/obj/structure/sign/warning/biohazard{
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/obj/structure/fence/post{
-	layer = 2;
-	pixel_x = 7;
-	pixel_y = 1
-	},
-/turf/open/floor/plating/dirt/dark,
-/area/city/backstreets_room)
-"zM" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/bodypart/l_arm{
-	dir = 4;
-	pixel_x = -12;
-	pixel_y = -7
-	},
-/obj/effect/decal/cleanable/blood/drip{
-	pixel_x = 7;
-	pixel_y = -6
-	},
-/obj/effect/decal/cleanable/blood/drip{
-	pixel_x = -10;
-	pixel_y = 10
-	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"zO" = (
-/obj/structure/table/wood/fancy/black,
-/obj/item/reagent_containers/glass/beaker/unholywater,
-/turf/open/floor/carpet/black,
-/area/city/backstreets_room)
 "zP" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/effect/turf_decal/siding/thinplating/dark/corner{
@@ -10326,13 +6613,6 @@
 	},
 /turf/open/floor/plating/grass,
 /area/city)
-"zQ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/effect/turf_decal{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/city/backstreets_room)
 "zR" = (
 /obj/structure/easel,
 /obj/item/canvas/nineteen_nineteen,
@@ -10348,7 +6628,7 @@
 	dir = 8
 	},
 /turf/open/floor/carpet/stellar,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "zS" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/disposalpipe/segment{
@@ -10365,7 +6645,7 @@
 	},
 /obj/machinery/door/window/westleft,
 /turf/open/floor/plasteel/dark,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "zU" = (
 /obj/structure/table/reinforced,
 /obj/structure/railing{
@@ -10374,25 +6654,6 @@
 	},
 /turf/open/space/basic,
 /area/city/shop)
-"zV" = (
-/obj/structure/closet/crate/secure/gear,
-/obj/effect/turf_decal/siding/thinplating/dark/corner,
-/turf/open/indestructible/cult,
-/area/city/backstreets_room)
-"zW" = (
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 10
-	},
-/obj/effect/turf_decal/starfury/seven,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"zX" = (
-/mob/living/simple_animal/hostile/ordeal/green_bot_big{
-	name = "gunbot"
-	},
-/turf/open/floor/engine,
-/area/city/backstreets_room)
 "zY" = (
 /obj/structure/table/reinforced{
 	color = "#00a86b"
@@ -10405,30 +6666,15 @@
 	pixel_x = -7
 	},
 /obj/item/reagent_containers/glass/rag{
-	pixel_y = 2;
-	pixel_x = 5
+	pixel_x = 5;
+	pixel_y = 2
 	},
 /turf/open/floor/mineral/silver,
 /area/city/shop)
-"zZ" = (
-/obj/structure/fluff/broken_flooring{
-	dir = 4
-	},
-/turf/open/floor/plasteel/shuttle{
-	name = "floor"
-	},
-/area/city/backstreets_room)
 "Aa" = (
 /obj/machinery/door/airlock/grunge,
 /turf/open/floor/facility/halls,
 /area/city/shop)
-"Ab" = (
-/obj/machinery/smartfridge/drying_rack,
-/obj/machinery/light/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/sepia,
-/area/city/backstreets_room)
 "Ac" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -10451,27 +6697,17 @@
 	dir = 4
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /turf/open/floor/carpet/stellar,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "Ae" = (
 /obj/effect/spawner/randomarcade{
 	dir = 4
 	},
 /turf/open/floor/eighties,
 /area/city/shop)
-"Af" = (
-/obj/machinery/modular_computer/console{
-	desc = "For all your warehousing needs.";
-	name = "warehouse console"
-	},
-/obj/machinery/light/dim{
-	dir = 1
-	},
-/turf/open/floor/facility/dark,
-/area/city/backstreets_room)
 "Ag" = (
 /obj/structure/chair/office{
 	dir = 1;
@@ -10490,7 +6726,7 @@
 	name = "Captain Agent Bedroom"
 	},
 /turf/open/floor/facility/halls,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "Ai" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -10502,76 +6738,19 @@
 /obj/structure/sign/poster/lobotomycorp/wellcheers,
 /turf/closed/wall/mineral/silver,
 /area/city/house)
-"Ak" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/facility_hallway/command)
-"Al" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/city/backstreets_room)
-"Am" = (
-/mob/living/simple_animal/hostile/ordeal/green_bot_big{
-	name = "gun bot"
-	},
-/turf/open/floor/plasteel/dark,
-/area/city/backstreets_room)
 "An" = (
 /obj/structure/railing/corner{
 	dir = 4
 	},
 /obj/effect/turf_decal,
 /turf/open/floor/plasteel/dark,
-/area/facility_hallway/command)
-"Ao" = (
-/obj/effect/decal/cleanable/blood/drip,
-/obj/effect/spawner/lootdrop/garbage_spawner,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"Ap" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/kirbyplants/potty{
-	desc = "How a plant wearing a cakehat somehow got here is beyond me."
-	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"Aq" = (
-/obj/structure/chair/sofa/corp/right{
-	dir = 8
-	},
-/turf/open/floor/holofloor/white,
-/area/city/backstreets_room)
-"Ar" = (
-/obj/effect/turf_decal/trimline/neutral/line{
-	pixel_y = -6
-	},
-/obj/structure/railing,
-/obj/structure/sign/warning/biohazard{
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/obj/structure/fence/post{
-	pixel_x = 7
-	},
-/turf/open/floor/holofloor/dark,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "As" = (
 /obj/structure/sign/departments/restroom{
 	pixel_y = -32
 	},
 /turf/open/floor/facility/dark,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "At" = (
 /obj/effect/turf_decal/siding/blue{
 	dir = 4
@@ -10587,23 +6766,7 @@
 	},
 /obj/machinery/vending/cigarette,
 /turf/open/floor/carpet/stellar,
-/area/facility_hallway/command)
-"Av" = (
-/obj/structure/plaque/static_plaque/golden{
-	desc = "A certificate indicating the legal standing of the establishment.";
-	name = "Corporation Certificate of Approval";
-	pixel_x = -32;
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/siding/yellow{
-	dir = 1
-	},
-/turf/open/floor/carpet/green,
-/area/city/backstreets_room)
-"Aw" = (
-/obj/effect/landmark/latejoin,
-/turf/open/floor/carpet/red,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "Ax" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/plating/grass,
@@ -10645,11 +6808,15 @@
 	pixel_x = -32
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /turf/open/floor/sepia,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
+"AD" = (
+/obj/machinery/door/airlock/glass_large,
+/turf/open/floor/facility/halls,
+/area/city)
 "AE" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -10671,10 +6838,10 @@
 	brightness = 16
 	},
 /turf/open/floor/carpet/cyan,
-/area/facility_hallway/command)
-"AH" = (
-/turf/open/indestructible/hoteltile,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
+"AG" = (
+/turf/open/floor/facility/halls,
+/area/city)
 "AI" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -10682,14 +6849,30 @@
 	},
 /turf/open/floor/plating/grass,
 /area/city)
+"AJ" = (
+/obj/structure/bed,
+/obj/item/bedsheet/red,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/item/toy/plush/lisa,
+/turf/open/floor/sepia,
+/area/facility_hallway/manager)
 "AK" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /turf/open/floor/wood,
 /area/city/shop)
@@ -10709,24 +6892,29 @@
 	},
 /turf/open/floor/plasteel/checker,
 /area/city/house)
-"AO" = (
-/obj/machinery/vending/cigarette/beach,
-/obj/machinery/light/dim{
-	dir = 4
+"AN" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
 	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
+/obj/machinery/light/cold/no_nightlight{
+	brightness = 16;
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/space)
 "AP" = (
 /obj/structure/table/wood/fancy/orange,
 /turf/open/floor/oldshuttle,
 /area/city/fixers)
-"AR" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/turf_decal/siding/yellow{
-	dir = 6
+"AQ" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
-/turf/open/floor/carpet/green,
-/area/city/backstreets_room)
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/facility_hallway/manager)
 "AS" = (
 /obj/structure/chair/sofa/corner{
 	dir = 4
@@ -10735,12 +6923,12 @@
 	dir = 9
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /turf/open/floor/wood,
 /area/city/shop)
@@ -10750,35 +6938,16 @@
 	},
 /turf/open/floor/stone,
 /area/city)
-"AU" = (
-/obj/effect/decal/cleanable/blood/gibs/up,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
 "AV" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/tree/jungle,
 /turf/open/floor/plating/grass{
 	color = "#00A36C";
-	opacity = 1;
-	name = "Dense Forest Undergrowth"
+	name = "Dense Forest Undergrowth";
+	opacity = 1
 	},
 /area/city)
-"AW" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/obj/structure/barricade/wooden,
-/obj/structure/barricade/wooden/crude,
-/turf/open/floor/plating/asteroid/basalt,
-/area/city/backstreets_alley)
-"AX" = (
-/obj/structure/tutorialbox,
-/obj/effect/turf_decal{
-	dir = 6
-	},
-/turf/open/floor/engine,
-/area/city/backstreets_room)
 "AY" = (
 /obj/structure/window/reinforced/spawner/west{
 	max_integrity = 25
@@ -10786,26 +6955,6 @@
 /obj/machinery/vending/medical,
 /turf/open/floor/mineral/titanium/white,
 /area/city/shop)
-"AZ" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/turf/open/floor/plating/asteroid/basalt,
-/area/city/backstreets_alley)
-"Ba" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/gibs/down,
-/turf/open/floor/plasteel/shuttle,
-/area/city/backstreets_room)
-"Bb" = (
-/obj/machinery/light/cold/no_nightlight{
-	brightness = 16
-	},
-/turf/open/floor/plasteel/white,
-/area/facility_hallway/command)
 "Bc" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#3234B9";
@@ -10816,34 +6965,6 @@
 	},
 /turf/open/floor/mineral/silver,
 /area/city/shop)
-"Bd" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/blood{
-	pixel_x = -3;
-	pixel_y = -8
-	},
-/mob/living/simple_animal/hostile/ordeal/indigo_dawn{
-	dir = 1;
-	name = "sweeper scout"
-	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"Be" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/obj/effect/spawner/lootdrop/space/cashmoney,
-/obj/effect/spawner/lootdrop/space/cashmoney,
-/obj/effect/spawner/lootdrop/space/cashmoney,
-/turf/open/floor/grass,
-/area/city/backstreets_room)
-"Bf" = (
-/obj/effect/turf_decal{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/city/backstreets_room)
 "Bg" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#3234B9";
@@ -10858,66 +6979,16 @@
 	},
 /turf/open/floor/mineral/titanium/tiled/white,
 /area/city/fixers)
-"Bh" = (
-/obj/structure/table/greyscale,
-/obj/item/kitchen/knife/butcher,
-/obj/item/ego_weapon/city/rats/knife,
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/sepia,
-/area/city/backstreets_room)
-"Bi" = (
-/obj/effect/turf_decal/siding/purple{
-	dir = 9
-	},
-/turf/open/floor/carpet/purple,
-/area/city/backstreets_room)
-"Bk" = (
-/obj/structure/curtain,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/sepia,
-/area/city/backstreets_room)
 "Bl" = (
 /obj/effect/turf_decal/siding/yellow,
 /turf/open/floor/carpet/black,
 /area/city/house)
-"Bm" = (
-/obj/structure/chair/wood,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
 "Bn" = (
 /obj/structure/chair/sofa/corp/right{
 	dir = 1
 	},
 /turf/open/floor/carpet,
 /area/city/house)
-"Bo" = (
-/obj/structure/chair/plastic{
-	dir = 4
-	},
-/obj/machinery/light/dim{
-	dir = 8;
-	pixel_x = null;
-	pixel_y = null
-	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"Bp" = (
-/obj/effect/light_emitter{
-	light_power = 4;
-	light_range = 25;
-	set_cap = 3;
-	set_luminosity = 24
-	},
-/mob/living/simple_animal/hostile/ordeal/indigo_noon,
-/turf/open/indestructible/necropolis,
-/area/city/backstreets_room)
 "Bq" = (
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks/fullupgrade{
@@ -10943,14 +7014,10 @@
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "Bt" = (
 /turf/open/floor/sepia,
-/area/facility_hallway/command)
-"Bu" = (
-/obj/structure/table/glass,
-/turf/open/floor/plasteel/dark,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "Bv" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -10970,28 +7037,7 @@
 	brightness = 16
 	},
 /turf/open/floor/plating/grass,
-/area/facility_hallway/command)
-"Bx" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 3
-	},
-/obj/effect/spawner/lootdrop/space/cashmoney,
-/obj/effect/spawner/lootdrop/space/cashmoney,
-/obj/effect/spawner/lootdrop/space/cashmoney,
-/turf/open/floor/grass,
-/area/city/backstreets_room)
-"By" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/table/wood,
-/obj/item/paper_bin,
-/obj/item/paper_bin/carbon{
-	pixel_x = -14
-	},
-/obj/item/paper_bin/construction{
-	pixel_x = 14
-	},
-/turf/open/floor/wood,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "Bz" = (
 /obj/machinery/light/cold/no_nightlight,
 /turf/open/floor/mineral/titanium/tiled/white,
@@ -11001,61 +7047,18 @@
 	dir = 5
 	},
 /turf/open/floor/wood,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "BB" = (
 /turf/open/floor/plating/grass,
 /area/city)
-"BC" = (
-/obj/structure/window/reinforced/tinted/frosted,
-/obj/machinery/door/poddoor,
-/turf/open/floor/plating,
-/area/city/backstreets_room)
 "BD" = (
 /obj/machinery/door/airlock/highsecurity,
 /turf/open/floor/facility/halls,
-/area/facility_hallway/command)
-"BE" = (
-/obj/structure/chair/pew/right{
-	dir = 8;
-	name = "bench"
-	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"BF" = (
-/obj/structure/chair/pew,
-/turf/open/floor/carpet/black,
-/area/city/backstreets_room)
-"BG" = (
-/mob/living/simple_animal/hostile/ordeal/indigo_noon{
-	desc = "Its hanging out... and quite content with itself.";
-	name = "Leo"
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/city/backstreets_room)
-"BH" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/structure/table/greyscale,
-/turf/open/floor/plasteel/sepia,
-/area/city/backstreets_room)
-"BI" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
-"BJ" = (
-/obj/structure/table/reinforced,
-/obj/item/toy/redbutton{
-	anchored = 1;
-	desc = "A button meant for bolting the door shut. This one doesn't seem to work as intended, or at all.";
-	name = "door bolts button"
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "BK" = (
 /obj/effect/turf_decal{
-	dir = 3;
-	color = "#FF0000"
+	color = "#FF0000";
+	dir = 3
 	},
 /obj/structure/window/reinforced/spawner{
 	max_integrity = 25
@@ -11065,16 +7068,6 @@
 	},
 /turf/open/floor/plasteel/airless/white,
 /area/city/backstreets_checkpoint)
-"BL" = (
-/obj/item/coin/gold/debug,
-/obj/effect/light_emitter{
-	light_power = 4;
-	light_range = 25;
-	set_cap = 3;
-	set_luminosity = 24
-	},
-/turf/open/floor/carpet/lone,
-/area/city/backstreets_room)
 "BM" = (
 /obj/structure/railing{
 	dir = 5
@@ -11087,96 +7080,26 @@
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "BN" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/computer/extraction_cargo,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/city/shop)
-"BO" = (
-/obj/item/target/clown,
-/turf/open/floor/engine,
-/area/city/backstreets_room)
-"BP" = (
-/obj/structure/fence{
-	dir = 4
-	},
-/obj/structure/fence{
-	dir = 4
-	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_checkpoint)
-"BQ" = (
-/obj/effect/decal/cleanable/blood/gibs{
-	pixel_x = 9;
-	pixel_y = -6
-	},
-/obj/effect/decal/cleanable/blood/splatter{
-	pixel_x = -2;
-	pixel_y = 3
-	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"BR" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 6
-	},
-/turf/open/floor/plating/asteroid/basalt,
-/area/city/backstreets_alley)
-"BS" = (
-/obj/effect/decal/cleanable/blood/gibs{
-	pixel_x = 25
-	},
-/obj/structure/table/reinforced,
-/obj/structure/railing{
-	dir = 6;
-	pixel_x = 9;
-	pixel_y = -7
-	},
-/obj/item/bodypart/l_leg/alien{
-	pixel_x = 8;
-	pixel_y = -5
-	},
-/obj/item/bodypart/l_leg/robot/surplus{
-	pixel_x = -1;
-	pixel_y = 10
-	},
-/obj/item/bodypart/l_leg/grown_strong{
-	pixel_x = -8;
-	pixel_y = 17
-	},
-/obj/item/bodypart/l_leg/monkey{
-	dir = 4;
-	pixel_x = 4;
-	pixel_y = 7
-	},
-/obj/item/bodypart/l_leg/robot{
-	pixel_x = -6;
-	pixel_y = -4
-	},
-/turf/open/floor/stone,
-/area/city/backstreets_room)
-"BT" = (
-/obj/structure/table/greyscale,
-/obj/machinery/microwave{
-	pixel_y = 7
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/sepia,
-/area/city/backstreets_room)
 "BU" = (
 /obj/structure/chair/pew/left{
 	desc = "Sit here and relax";
-	name = "Bench";
-	dir = 8
+	dir = 8;
+	name = "Bench"
 	},
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 8
 	},
+/obj/effect/landmark/latejoin,
 /turf/open/floor/plating/grass,
 /area/city)
 "BV" = (
@@ -11228,86 +7151,43 @@
 /obj/machinery/light/cold/no_nightlight,
 /turf/open/floor/carpet/purple,
 /area/city/house)
-"BX" = (
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 4
+"BY" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
 	},
-/obj/structure/flora/ausbushes/sparsegrass,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"BZ" = (
-/obj/effect/turf_decal/siding/yellow/corner{
-	dir = 8
-	},
-/turf/open/floor/carpet/green,
-/area/city/backstreets_room)
-"Ca" = (
-/obj/structure/chair/sofa/corp/right{
+/obj/structure/showcase/machinery/tv,
+/turf/open/floor/wood,
+/area/space)
+"Cc" = (
+/obj/machinery/light/floor,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/blood/gibs,
-/mob/living/simple_animal/hostile/ordeal/indigo_noon{
-	dir = 1;
-	name = "Lex"
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
-/turf/open/floor/wood,
-/area/city/backstreets_room)
-"Cb" = (
-/obj/effect/decal/cleanable/blood/splatter,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"Cd" = (
-/obj/effect/decal/cleanable/blood,
-/obj/item/kirbyplants/dead{
-	desc = "A sad, dead plant";
-	name = "dead potted plant"
-	},
-/turf/open/floor/wood,
-/area/city/backstreets_room)
-"Ce" = (
-/obj/effect/turf_decal/weather/dirt{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/mob/living/simple_animal/hostile/ordeal/indigo_noon,
-/turf/open/floor/plating/asteroid/basalt,
-/area/city/backstreets_alley)
+/obj/structure/displaycase/trophy{
+	alert = 0
+	},
+/turf/open/floor/plasteel/dark,
+/area/facility_hallway/manager)
 "Cf" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/plating/grass,
-/area/facility_hallway/command)
-"Cg" = (
-/obj/item/storage/bag/money,
-/turf/open/floor/carpet/orange,
-/area/city/backstreets_room)
-"Ch" = (
-/obj/structure/grille/broken,
-/obj/item/shard,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/tracks,
-/turf/open/floor/plasteel/shuttle,
-/area/city/backstreets_room)
-"Ci" = (
-/obj/effect/turf_decal/trimline/neutral/corner{
-	pixel_x = 7;
-	pixel_y = -5
-	},
-/obj/effect/turf_decal/starfury/one{
-	pixel_x = 3
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/lootcrate/seven,
-/turf/open/floor/holofloor/dark,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "Cj" = (
 /obj/machinery/blackbox_recorder,
 /turf/open/floor/carpet/black,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "Ck" = (
 /turf/open/floor/plating/grass,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "Cl" = (
 /obj/structure/displaycase/forsale/kitchen{
 	pixel_y = 10
@@ -11372,8 +7252,8 @@
 /area/city/fixers)
 "Cn" = (
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /turf/open/floor/plasteel/chapel,
 /area/city/shop)
@@ -11390,81 +7270,32 @@
 	},
 /turf/open/floor/mineral/titanium/tiled/white,
 /area/city/fixers)
-"Cq" = (
-/obj/structure/table/glass,
-/obj/item/trait_injector/shrimp_injector,
-/obj/item/grenade/spawnergrenade/shrimp/super{
-	pixel_y = -15
-	},
-/turf/open/floor/plasteel/vaporwave,
-/area/city/backstreets_room)
-"Cr" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/blood/splatter{
-	pixel_x = 7;
-	pixel_y = 17
-	},
-/obj/effect/decal/cleanable/blood/drip{
-	pixel_x = -4;
-	pixel_y = -4
-	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
+"Cp" = (
+/obj/machinery/vending/lobotomyuniform,
+/turf/open/floor/facility/dark,
+/area/facility_hallway/manager)
 "Cs" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/tree/jungle/small,
 /turf/open/floor/plating/grass,
 /area/city)
-"Ct" = (
-/obj/structure/table/wood,
-/obj/structure/showcase/machinery/tv{
-	desc = "Guess robots can't fix their lesser machinery.";
-	name = "\improper Broken TV";
-	pixel_x = 2;
-	pixel_y = 5
-	},
-/turf/open/floor/wood,
-/area/city/backstreets_room)
-"Cu" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/turf/open/indestructible/hoteltile,
-/area/city/backstreets_room)
 "Cv" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/brown,
 /obj/machinery/chem_dispenser/fullupgrade{
-	dispensable_reagents = list(/datum/reagent/consumable/enzyme,/datum/reagent/consumable/eggyolk,/datum/reagent/consumable/flour,/datum/reagent/consumable/rice,/datum/reagent/consumable/sugar,/datum/reagent/consumable/caramel,/datum/reagent/consumable/honey,/datum/reagent/consumable/salt,/datum/reagent/consumable/blackpepper,/datum/reagent/consumable/soysauce,/datum/reagent/consumable/bbqsauce,/datum/reagent/consumable/ketchup,/datum/reagent/consumable/capsaicin,/datum/reagent/consumable/frostoil,/datum/reagent/consumable/garlic,/datum/reagent/consumable/cherryjelly,/datum/reagent/consumable/bluecherryjelly,/datum/reagent/consumable/vanilla,/datum/reagent/consumable/coco,/datum/reagent/consumable/cornoil,/datum/reagent/consumable/corn_syrup,/datum/reagent/consumable/corn_starch,/datum/reagent/consumable/dry_ramen,/datum/reagent/consumable/clownstears,/datum/reagent/consumable/astrotame,/datum/reagent/consumable/secretsauce,/datum/reagent/consumable/laughsyrup,/datum/reagent/consumable/pancakebatter,/datum/reagent/water/holywater,/datum/reagent/fuel);
-	name = "Industrial Foodstuff Dispenser";
 	desc = "Creates and dispenses a variety of kitchen ingredients.";
-	emagged_reagents = null
+	dispensable_reagents = list(/datum/reagent/consumable/enzyme,/datum/reagent/consumable/eggyolk,/datum/reagent/consumable/flour,/datum/reagent/consumable/rice,/datum/reagent/consumable/sugar,/datum/reagent/consumable/caramel,/datum/reagent/consumable/honey,/datum/reagent/consumable/salt,/datum/reagent/consumable/blackpepper,/datum/reagent/consumable/soysauce,/datum/reagent/consumable/bbqsauce,/datum/reagent/consumable/ketchup,/datum/reagent/consumable/capsaicin,/datum/reagent/consumable/frostoil,/datum/reagent/consumable/garlic,/datum/reagent/consumable/cherryjelly,/datum/reagent/consumable/bluecherryjelly,/datum/reagent/consumable/vanilla,/datum/reagent/consumable/coco,/datum/reagent/consumable/cornoil,/datum/reagent/consumable/corn_syrup,/datum/reagent/consumable/corn_starch,/datum/reagent/consumable/dry_ramen,/datum/reagent/consumable/clownstears,/datum/reagent/consumable/astrotame,/datum/reagent/consumable/secretsauce,/datum/reagent/consumable/laughsyrup,/datum/reagent/consumable/pancakebatter,/datum/reagent/water/holywater,/datum/reagent/fuel);
+	emagged_reagents = null;
+	name = "Industrial Foodstuff Dispenser"
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /turf/open/floor/mineral/titanium/tiled/yellow/airless,
 /area/city/shop)
-"Cw" = (
-/obj/structure/chair/office/light{
-	dir = 1
-	},
-/obj/structure/curtain/bounty{
-	pixel_y = -30
-	},
-/turf/open/floor/wood,
-/area/city/backstreets_room)
-"Cx" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 7
-	},
-/turf/open/floor/carpet/black,
-/area/city/backstreets_room)
 "Cy" = (
 /obj/effect/turf_decal/siding/blue{
 	dir = 8
@@ -11472,26 +7303,21 @@
 /obj/effect/turf_decal/siding/blue/corner,
 /turf/open/floor/carpet/cyan,
 /area/city/shop)
-"Cz" = (
-/obj/structure/chair/pew/left,
-/obj/item/instrument/violin/golden,
-/turf/open/floor/carpet/black,
-/area/city/backstreets_room)
 "CA" = (
 /obj/structure/window/reinforced/spawner/east{
 	max_integrity = 25;
-	opacity = 1;
-	name = "Glass"
+	name = "Glass";
+	opacity = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
-	dir = 4;
-	color = "#000000"
+	color = "#000000";
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral{
 	color = "#000000"
 	},
 /turf/open/floor/plasteel/white,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "CB" = (
 /obj/structure/filingcabinet{
 	pixel_x = -10
@@ -11506,20 +7332,6 @@
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/city/fixers)
-"CC" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/mob/living/simple_animal/hostile/ordeal/amber_bug{
-	name = "carnivorous worm"
-	},
-/turf/open/floor/wood,
-/area/city/backstreets_room)
-"CD" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
 "CE" = (
 /obj/structure/railing/corner,
 /obj/structure/flora/ausbushes/brflowers,
@@ -11528,13 +7340,13 @@
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "CF" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
 	},
 /turf/open/floor/wood,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "CG" = (
 /obj/effect/turf_decal/siding/thinplating/dark/corner{
 	dir = 1
@@ -11546,42 +7358,11 @@
 /area/city)
 "CH" = (
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /turf/open/floor/mineral/titanium/tiled/white,
 /area/city/fixers)
-"CI" = (
-/obj/structure/displaycase/trophy{
-	alert = 0
-	},
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/city/backstreets_room)
-"CJ" = (
-/obj/structure/fluff/divine/convertaltar,
-/obj/effect/light_emitter{
-	light_power = 4;
-	light_range = 25;
-	set_cap = 3;
-	set_luminosity = 24
-	},
-/turf/open/indestructible/necropolis,
-/area/city/backstreets_room)
-"CK" = (
-/obj/effect/decal/cleanable/cobweb{
-	layer = 5
-	},
-/turf/closed/indestructible/reinforced,
-/area/city/backstreets_room)
-"CL" = (
-/obj/structure/fence/corner{
-	dir = 10
-	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_alley)
 "CM" = (
 /obj/machinery/computer/slot_machine,
 /obj/effect/turf_decal/siding/blue,
@@ -11590,69 +7371,32 @@
 	},
 /turf/open/floor/carpet/cyan,
 /area/city/shop)
-"CN" = (
-/obj/structure/closet/crate/bin,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/sepia,
-/area/city/backstreets_room)
-"CO" = (
-/obj/effect/spawner/randomsnackvend,
-/obj/machinery/light/dim{
-	dir = 4
-	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"CP" = (
-/obj/effect/turf_decal/siding/purple{
-	dir = 8
-	},
-/obj/structure/chair/sofa/left{
-	dir = 4
-	},
-/turf/open/floor/carpet/purple,
-/area/city/backstreets_room)
 "CQ" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/effect/turf_decal/siding/thinplating/dark,
 /turf/open/floor/plating/grass,
 /area/city)
-"CR" = (
-/obj/structure/bed/maint,
-/obj/effect/decal/cleanable/blood,
-/obj/effect/mob_spawn/human/clown/corpse{
-	name = "Crinkles the Clown"
+"CS" = (
+/obj/effect/turf_decal/siding/yellow,
+/obj/machinery/door/airlock/wood/glass{
+	name = "Manager's Office"
 	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"CT" = (
-/obj/structure/destructible/cult/talisman,
-/obj/item/clothing/head/helmet/chaplain/clock,
-/turf/open/indestructible/cult,
-/area/city/backstreets_room)
-"CU" = (
-/obj/effect/decal/cleanable/blood/gibs,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"CV" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/city/backstreets_room)
+/turf/open/floor/carpet/royalblack,
+/area/facility_hallway/manager)
 "CW" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 8
 	},
 /turf/open/floor/plating/grass,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "CX" = (
 /obj/effect/turf_decal/plaque{
 	alpha = 230;
 	icon_state = "LC31"
 	},
 /turf/open/floor/facility/dark,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "CY" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -11672,29 +7416,26 @@
 "CZ" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/city/shop)
-"Da" = (
-/obj/effect/decal/cleanable/blood/footprints{
-	dir = 3
+"Db" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
 	},
-/obj/effect/decal/cleanable/blood{
-	pixel_x = -3;
-	pixel_y = -8
-	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
+/obj/structure/closet/secure_closet/personal/cabinet,
+/turf/open/floor/wood,
+/area/space)
 "Dc" = (
 /obj/effect/turf_decal/tile/green{
-	dir = 8;
-	color = "#006400"
+	color = "#006400";
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/green{
-	dir = 1;
-	color = "#006400"
+	color = "#006400";
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/green{
 	dir = 4
@@ -11705,22 +7446,22 @@
 "Dd" = (
 /obj/structure/window/reinforced/spawner/east{
 	max_integrity = 25;
-	opacity = 1;
-	name = "Glass"
+	name = "Glass";
+	opacity = 1
 	},
 /obj/effect/turf_decal/tile/bar{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/bar,
 /turf/open/floor/plasteel/white,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "De" = (
 /obj/machinery/computer/operating{
 	dir = 4
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /obj/machinery/light/cold/no_nightlight,
 /turf/open/floor/mineral/titanium/blue,
@@ -11747,8 +7488,8 @@
 "Dg" = (
 /obj/machinery/door/window/northleft,
 /obj/effect/turf_decal{
-	dir = 1;
-	color = "#FF0000"
+	color = "#FF0000";
+	dir = 1
 	},
 /obj/machinery/scanner_gate{
 	scangate_mode = "Guns"
@@ -11762,13 +7503,20 @@
 	icon_state = "LC25"
 	},
 /turf/open/floor/facility/dark,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
+"Di" = (
+/obj/machinery/door/airlock/wood{
+	icon = 'icons/obj/doors/airlocks/station/command.dmi';
+	name = "Association Airlock"
+	},
+/turf/open/floor/facility/halls,
+/area/city/fixers)
 "Dj" = (
 /obj/structure/chair/wood/wings{
 	dir = 1
 	},
 /turf/open/floor/facility/white,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "Dk" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#3234B9"
@@ -11778,7 +7526,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "Dl" = (
 /turf/open/floor/carpet/purple,
 /area/city/house)
@@ -11787,8 +7535,8 @@
 /area/city/fixers)
 "Dn" = (
 /obj/structure/chair/pew/right{
-	name = "Bench";
-	desc = "Sit here and relax"
+	desc = "Sit here and relax";
+	name = "Bench"
 	},
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 6
@@ -11805,16 +7553,6 @@
 	},
 /turf/open/floor/oldshuttle,
 /area/city/fixers)
-"Dp" = (
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 4
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/city/backstreets_room)
-"Dr" = (
-/obj/item/chair/plastic,
-/turf/open/floor/engine,
-/area/city/backstreets_room)
 "Ds" = (
 /obj/effect/turf_decal/siding/blue{
 	dir = 10
@@ -11827,29 +7565,6 @@
 	},
 /turf/open/floor/carpet/cyan,
 /area/city/shop)
-"Dt" = (
-/obj/effect/turf_decal/trimline/neutral/corner{
-	pixel_x = 7;
-	pixel_y = -5
-	},
-/obj/structure/fence/post{
-	layer = 2;
-	pixel_x = 15;
-	pixel_y = 2
-	},
-/obj/structure/railing/corner,
-/mob/living/simple_animal/hostile/ordeal/green_bot{
-	name = "spear bot"
-	},
-/turf/open/floor/holofloor/dark,
-/area/city/backstreets_room)
-"Dv" = (
-/obj/structure/chair/pew/right{
-	desc = "For resting your legs.";
-	name = "bench"
-	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
 "Dw" = (
 /obj/structure/chair/sofa/corp/left{
 	dir = 1
@@ -11863,35 +7578,6 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/city/house)
-"Dy" = (
-/obj/machinery/smartfridge/drying_rack,
-/turf/open/floor/plasteel/sepia,
-/area/city/backstreets_room)
-"Dz" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/rack,
-/obj/item/organ/lungs/cybernetic,
-/obj/item/organ/lungs/cybernetic/tier2,
-/obj/item/organ/lungs/cybernetic/tier3,
-/obj/item/organ/lungs/cybernetic/tier4,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/holofloor/dark,
-/area/city/backstreets_room)
-"DA" = (
-/obj/effect/turf_decal/siding/wideplating/corner{
-	dir = 4
-	},
-/obj/structure/flora/grass/jungle{
-	pixel_x = 7;
-	pixel_y = 6
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"DB" = (
-/obj/machinery/door/airlock/grunge,
-/turf/open/floor/plasteel/sepia,
-/area/city/backstreets_room)
 "DC" = (
 /obj/effect/decal/cleanable/glitter,
 /turf/open/floor/eighties,
@@ -11906,11 +7592,11 @@
 "DE" = (
 /obj/structure/closet/secure_closet/record,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /turf/open/floor/carpet/black,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "DG" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -11924,15 +7610,6 @@
 	},
 /turf/open/floor/plasteel/sepia,
 /area/city/shop)
-"DH" = (
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 6
-	},
-/turf/open/floor/plating/asteroid/basalt,
-/area/city/backstreets_room)
 "DI" = (
 /obj/structure/riser/dark,
 /obj/structure/closet/chefcloset,
@@ -11948,13 +7625,17 @@
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
-"DL" = (
-/obj/effect/turf_decal{
-	dir = 9
+/area/facility_hallway/manager)
+"DK" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
 	},
-/turf/open/floor/engine,
-/area/city/backstreets_room)
+/obj/machinery/light/cold/no_nightlight{
+	brightness = 16;
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/facility_hallway/manager)
 "DM" = (
 /obj/structure/sink{
 	dir = 8;
@@ -11968,7 +7649,7 @@
 	brightness = 16
 	},
 /turf/open/floor/holofloor/white,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "DN" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -11999,33 +7680,10 @@
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "DQ" = (
 /turf/closed/indestructible/fakeglass,
-/area/facility_hallway/command)
-"DR" = (
-/obj/structure/table/reinforced,
-/turf/open/floor/engine,
-/area/city/backstreets_room)
-"DS" = (
-/obj/effect/decal/cleanable/blood/footprints{
-	dir = 4;
-	pixel_x = 10;
-	pixel_y = -8
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/holofloor/dark,
-/area/city/backstreets_room)
-"DT" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/obj/effect/spawner/lootdrop/space/cashmoney,
-/obj/effect/spawner/lootdrop/space/cashmoney,
-/obj/effect/spawner/lootdrop/space/cashmoney,
-/obj/effect/spawner/lootdrop/space/cashmoney,
-/turf/open/floor/grass,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "DU" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#3234B9";
@@ -12042,8 +7700,8 @@
 	dir = 5
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /turf/open/floor/wood,
 /area/city/shop)
@@ -12063,23 +7721,13 @@
 	},
 /turf/open/floor/wood,
 /area/city/shop)
-"DY" = (
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 5
-	},
-/obj/effect/turf_decal/starfury/three{
-	dir = 1
-	},
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
 "DZ" = (
 /obj/structure/toilet{
 	dir = 8
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /turf/open/floor/sepia,
 /area/city/house)
@@ -12088,13 +7736,7 @@
 	name = "Extraction Officer Bedroom"
 	},
 /turf/open/floor/facility/halls,
-/area/facility_hallway/command)
-"Eb" = (
-/obj/structure/sign/poster/lobotomycorp/cleancorpses{
-	desc = "It's far too late for this, isn't it?"
-	},
-/turf/closed/indestructible/reinforced,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "Ec" = (
 /obj/structure/chair/office{
 	desc = "A rather boring gaming chair.";
@@ -12103,34 +7745,30 @@
 	},
 /turf/open/floor/mineral/titanium/tiled/white,
 /area/city/shop)
-"Ef" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/lootcrate,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
-"Eg" = (
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 5
+"Ee" = (
+/obj/effect/turf_decal/siding/blue{
+	dir = 9
 	},
-/obj/machinery/light/floor,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
+/turf/open/floor/carpet/cyan,
+/area/space)
 "Eh" = (
-/obj/machinery/vending/lobotomyheadset,
+/obj/machinery/computer/abnormality_archive{
+	dir = 4
+	},
 /turf/open/floor/facility/dark,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "Ei" = (
 /obj/effect/turf_decal/tile/neutral{
-	dir = 1;
-	color = "#000000"
+	color = "#000000";
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
-	dir = 8;
-	color = "#000000"
+	color = "#000000";
+	dir = 8
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /turf/open/floor/mineral/titanium/tiled/white,
 /area/city/fixers)
@@ -12150,42 +7788,17 @@
 	},
 /turf/open/floor/plating/grass,
 /area/city)
-"Em" = (
-/obj/structure/barricade/sandbags,
-/obj/effect/turf_decal{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/city/backstreets_room)
-"En" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/mob/living/simple_animal/hostile/ordeal/amber_bug{
-	name = "carnivorous worm"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/sepia,
-/area/city/backstreets_room)
-"Eo" = (
-/turf/open/floor/holofloor/dark,
-/area/city/backstreets_room)
 "Eq" = (
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/city/house)
-"Er" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/dresser,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
 "Es" = (
 /obj/structure/bodycontainer/crematorium{
-	id = "Ncorp1";
-	dir = 8
+	dir = 8;
+	id = "Ncorp1"
 	},
 /obj/machinery/button/crematorium/indestructible{
 	id = "Ncorp1";
@@ -12193,10 +7806,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/city/shop)
-"Et" = (
-/obj/machinery/door/airlock/public/glass,
-/turf/open/floor/holofloor/white,
-/area/city/backstreets_room)
 "Eu" = (
 /obj/structure/railing,
 /obj/item/grown/novaflower,
@@ -12205,17 +7814,14 @@
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
-"Ev" = (
-/obj/effect/decal/cleanable/blood/gibs/core,
-/turf/closed/indestructible/reinforced,
-/area/city/backstreets_room)
-"Ex" = (
-/obj/machinery/light/dim{
-	dir = 1
+/area/facility_hallway/manager)
+"Ew" = (
+/obj/structure/chair/comfy/brown,
+/obj/effect/turf_decal/siding/blue{
+	dir = 6
 	},
-/turf/open/floor/facility/dark,
-/area/city/backstreets_room)
+/turf/open/floor/carpet/cyan,
+/area/space)
 "Ey" = (
 /obj/structure/chair/wood/wings,
 /obj/effect/turf_decal/siding/wood{
@@ -12225,78 +7831,35 @@
 /area/city/shop)
 "Ez" = (
 /turf/open/floor/plasteel/elevatorshaft,
-/area/facility_hallway/command)
-"EA" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 9
-	},
-/obj/structure/table/greyscale,
-/turf/open/floor/plasteel/sepia,
-/area/city/backstreets_room)
-"EB" = (
-/obj/machinery/porta_turret/syndicate/energy,
-/turf/open/floor/engine,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "EC" = (
 /obj/item/candle,
 /turf/open/floor/plasteel/chapel,
 /area/city/shop)
-"EE" = (
-/obj/structure/flora/rock/jungle,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
 "EF" = (
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /turf/open/floor/plating/grass,
-/area/facility_hallway/command)
-"EG" = (
-/obj/structure/closet/cabinet,
-/obj/item/ego_weapon/city/streetlight_bat,
-/obj/item/ego_weapon/ranged/clerk{
-	desc = "A pistol that looks to be loaded with 9mm rounds. Fit and comforms to the Heads regulations.";
-	name = "9mm Pistol"
-	},
-/turf/open/floor/plasteel/dark,
-/area/city/backstreets_room)
-"EH" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 6
-	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"EI" = (
-/obj/structure/bookcase/random,
+/area/facility_hallway/manager)
+"EJ" = (
+/obj/structure/table/wood,
+/obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood,
-/area/city/backstreets_room)
+/area/space)
 "EK" = (
 /obj/effect/turf_decal/delivery/red,
 /obj/structure/table,
 /turf/open/floor/plasteel/airless/white,
 /area/city/backstreets_checkpoint)
-"EL" = (
-/obj/effect/turf_decal/siding/purple{
-	dir = 1
-	},
-/obj/structure/table/wood/fancy/purple,
-/obj/item/reagent_containers/food/drinks/colocup/lean,
-/turf/open/floor/carpet/purple,
-/area/city/backstreets_room)
-"EN" = (
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 9
-	},
-/obj/machinery/light/floor,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
+"EO" = (
+/turf/open/space/basic,
+/area/space)
 "EP" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -12305,32 +7868,10 @@
 /obj/machinery/chem_master/condimaster,
 /turf/open/floor/mineral/titanium/tiled/yellow/airless,
 /area/city/shop)
-"EQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate/wooden/toy,
-/obj/machinery/light/dim{
-	dir = 1
-	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
 "ER" = (
 /obj/structure/chair/office,
 /turf/open/floor/plasteel/dark,
-/area/facility_hallway/command)
-"ES" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/structure/window/reinforced/spawner{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/sepia,
-/area/city/backstreets_room)
-"ET" = (
-/turf/open/floor/plasteel/airless/dark,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "EU" = (
 /obj/structure/table/reinforced,
 /obj/machinery/button/door/indestructible{
@@ -12339,7 +7880,7 @@
 	pixel_y = 4
 	},
 /turf/open/space/basic,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "EV" = (
 /obj/structure/railing/corner,
 /obj/item/grown/novaflower,
@@ -12348,23 +7889,20 @@
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
-"EW" = (
-/obj/machinery/computer/operating{
-	dir = 4
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "EX" = (
 /obj/effect/turf_decal{
 	dir = 1
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /turf/open/floor/facility/dark,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
+"EY" = (
+/turf/open/floor/wood,
+/area/space)
 "EZ" = (
 /obj/structure/railing{
 	dir = 4
@@ -12377,7 +7915,7 @@
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "Fa" = (
 /obj/structure/window/reinforced/spawner/east{
 	max_integrity = 25
@@ -12392,21 +7930,6 @@
 	},
 /turf/open/floor/mineral/titanium/tiled/white,
 /area/city/fixers)
-"Fb" = (
-/obj/effect/decal/cleanable/blood/splatter,
-/obj/structure/chair/comfy/black{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/blood,
-/obj/effect/decal/cleanable/blood{
-	dir = 5;
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/turf/open/floor/plasteel/shuttle{
-	name = "floor"
-	},
-/area/city/backstreets_room)
 "Fc" = (
 /obj/structure/railing{
 	dir = 4
@@ -12417,13 +7940,13 @@
 	dir = 4
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "Fd" = (
 /obj/structure/chair/sofa/left{
 	dir = 4
@@ -12437,8 +7960,8 @@
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/machinery/light/cold/no_nightlight,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/city/shop)
@@ -12448,62 +7971,43 @@
 	},
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/plating/grass,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "Fg" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /turf/open/floor/wood,
 /area/city/shop)
+"Fh" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/obj/machinery/light/cold/no_nightlight{
+	brightness = 16;
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/space)
 "Fi" = (
 /obj/effect/landmark/salesspawn,
 /turf/closed/wall/mineral/silver{
+	desc = "A wall with unmistable white coloring. Iconic sight in N Corp's Nest!";
 	explosion_block = 50;
-	name = "N Corporation Nest Wall";
-	desc = "A wall with unmistable white coloring. Iconic sight in N Corp's Nest!"
+	name = "N Corporation Nest Wall"
 	},
 /area/city/shop)
-"Fk" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/landmark/latejoin,
-/turf/open/floor/sepia,
-/area/facility_hallway/command)
-"Fl" = (
-/obj/structure/table/wood/fancy/black,
-/obj/item/instrument/guitar,
-/turf/open/floor/carpet/black,
-/area/city/backstreets_room)
 "Fm" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/floor/plating/grass{
 	color = "#00A36C";
-	opacity = 1;
-	name = "Dense Forest Undergrowth"
+	name = "Dense Forest Undergrowth";
+	opacity = 1
 	},
 /area/city)
-"Fn" = (
-/obj/effect/turf_decal/siding/wideplating/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wideplating/corner{
-	dir = 1
-	},
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
 "Fo" = (
 /obj/machinery/door/poddoor{
 	id = "facilitylockdown";
@@ -12511,7 +8015,7 @@
 	resistance_flags = 64
 	},
 /turf/open/floor/facility/halls,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "Fp" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/effect/light_emitter{
@@ -12535,58 +8039,6 @@
 	},
 /turf/open/floor/mineral/titanium/tiled/white,
 /area/city/shop)
-"Fr" = (
-/obj/effect/spawner/randomsnackvend,
-/obj/machinery/light/dim{
-	dir = 1
-	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"Fs" = (
-/obj/machinery/shower{
-	dir = 1
-	},
-/obj/structure/curtain/cloth,
-/obj/item/soap/deluxe,
-/turf/open/floor/noslip,
-/area/facility_hallway/command)
-"Ft" = (
-/obj/structure/table/reinforced,
-/obj/item/ego_weapon/city/rats{
-	desc = "A somewhat durable hammer for equipment creation.";
-	name = "repurposed hammer"
-	},
-/obj/effect/turf_decal/raven{
-	dir = 8
-	},
-/obj/item/bodypart/l_arm/robot/surplus{
-	desc = "A thin, skeleton arm. Guess that belonged to the robotic meister.";
-	name = "broken prosthetic arm"
-	},
-/turf/open/floor/holofloor/dark,
-/area/city/backstreets_room)
-"Fu" = (
-/obj/structure/table/wood,
-/obj/item/kirbyplants/dead{
-	desc = "A sad, dead plant";
-	name = "dead potted plant";
-	pixel_y = 10
-	},
-/turf/open/floor/wood,
-/area/city/backstreets_room)
-"Fv" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/mob/living/simple_animal/hostile/ordeal/green_bot{
-	name = "spear bot"
-	},
-/turf/open/floor/plating/asteroid/basalt,
-/area/city/backstreets_alley)
-"Fw" = (
-/obj/item/chair/wood/wings,
-/turf/open/floor/carpet/black,
-/area/city/backstreets_room)
 "Fx" = (
 /obj/item/soap/ncorporation,
 /obj/machinery/shower{
@@ -12595,65 +8047,7 @@
 /obj/structure/window/reinforced/spawner/west,
 /obj/machinery/light/small,
 /turf/open/floor/noslip,
-/area/facility_hallway/command)
-"Fy" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/turf/open/floor/plasteel/sepia,
-/area/city/backstreets_room)
-"Fz" = (
-/obj/item/paperslip{
-	pixel_x = -41;
-	pixel_y = -8
-	},
-/obj/item/paper{
-	pixel_x = -17;
-	pixel_y = -6
-	},
-/obj/item/paperslip{
-	pixel_x = 7;
-	pixel_y = -5
-	},
-/obj/item/paperslip{
-	pixel_x = -8;
-	pixel_y = 5
-	},
-/obj/item/paper{
-	pixel_x = -12;
-	pixel_y = 13
-	},
-/obj/item/paper{
-	pixel_x = -1;
-	pixel_y = 7
-	},
-/obj/item/folder/documents{
-	desc = "A folder once belonged to a certain ambitious clown.";
-	name = "folder- '8 o'clock Circus Application'"
-	},
-/obj/machinery/light/dim{
-	dir = 4
-	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"FA" = (
-/obj/structure/lootcrate/r_corp,
-/obj/structure/lootcrate/r_corp{
-	pixel_y = 15
-	},
-/turf/open/floor/engine,
-/area/city/backstreets_room)
-"FB" = (
-/obj/effect/turf_decal/siding/wideplating/corner{
-	dir = 4
-	},
-/obj/structure/flora/rock/jungle{
-	pixel_x = 10
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "FC" = (
 /obj/structure/table/reinforced,
 /obj/structure/railing{
@@ -12662,30 +8056,22 @@
 	},
 /turf/open/floor/eighties,
 /area/city/shop)
-"FD" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/curtain/bounty{
-	pixel_y = -30
-	},
-/turf/open/floor/wood,
-/area/city/backstreets_room)
 "FE" = (
 /obj/structure/window/reinforced/spawner{
 	max_integrity = 25;
-	opacity = 1;
-	name = "Shower Glass"
+	name = "Shower Glass";
+	opacity = 1
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /turf/open/floor/carpet/red,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "FF" = (
 /obj/structure/closet/secure_closet/freezer/fridge{
-	pixel_y = -1;
-	pixel_x = -8
+	pixel_x = -8;
+	pixel_y = -1
 	},
 /obj/item/food/meat/slab{
 	pixel_x = -8;
@@ -12709,7 +8095,7 @@
 	brightness = 16
 	},
 /turf/open/floor/sepia,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "FH" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/effect/light_emitter{
@@ -12723,55 +8109,12 @@
 	},
 /turf/open/floor/plating/grass,
 /area/city)
-"FI" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/rack,
-/obj/item/stack/sheet/plastitaniumglass,
-/obj/item/stack/sheet/plastitaniumglass,
-/obj/item/stack/sheet/plastitaniumglass,
-/obj/item/stack/sheet/plastitaniumglass,
-/obj/item/stack/sheet/plastitaniumglass{
-	pixel_x = -4
-	},
-/turf/open/floor/holofloor/dark,
-/area/city/backstreets_room)
-"FJ" = (
-/obj/item/food/deadmouse{
-	desc = "Looks like roadkill."
-	},
-/obj/item/stack/sheet/cotton/cloth{
-	pixel_x = 5;
-	pixel_y = 10
-	},
-/obj/item/stack/sheet/silk,
-/obj/item/weaponcrafting/silkstring,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
 "FK" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Male Restroom"
+/obj/machinery/door/airlock/silver{
+	name = "Female Restroom"
 	},
 /turf/open/floor/facility/halls,
-/area/facility_hallway/command)
-"FL" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 9
-	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"FM" = (
-/obj/effect/turf_decal{
-	dir = 1
-	},
-/obj/structure/closet/crate/large,
-/obj/item/clothing/suit/armor/ego_gear/limbus/durante,
-/obj/item/clothing/neck/limbus_tie,
-/obj/item/clothing/accessory/limbusvest,
-/turf/open/floor/engine,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "FN" = (
 /obj/structure/chair/office{
 	desc = "A rather boring gaming chair.";
@@ -12780,12 +8123,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/city/fixers)
-"FP" = (
-/obj/machinery/light/broken{
-	dir = 1
+"FO" = (
+/obj/structure/table/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
 	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
+/turf/open/floor/wood,
+/area/space)
 "FQ" = (
 /obj/effect/light_emitter{
 	light_power = 4;
@@ -12803,30 +8147,29 @@
 	max_integrity = 25
 	},
 /obj/effect/turf_decal/tile/neutral{
-	dir = 8;
-	color = "#000000"
+	color = "#000000";
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral{
 	color = "#000000"
 	},
 /obj/effect/turf_decal/tile/neutral{
-	dir = 4;
-	color = "#000000"
+	color = "#000000";
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral{
-	dir = 1;
-	color = "#000000"
+	color = "#000000";
+	dir = 1
 	},
 /obj/machinery/light/floor,
 /turf/open/floor/mineral/titanium/white,
 /area/city/fixers)
-"FU" = (
-/obj/structure/chair/stool/bar{
-	desc = "It has some questionable stains on it...";
-	name = "arcade stool"
+"FT" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
 	},
-/turf/open/floor/eighties,
-/area/city/backstreets_room)
+/turf/open/floor/wood,
+/area/space)
 "FV" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
@@ -12835,8 +8178,8 @@
 	brightness = 16
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /obj/structure/closet/crate/bin,
 /turf/open/floor/wood,
@@ -12846,22 +8189,22 @@
 	dir = 4
 	},
 /turf/open/floor/plating/grass,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "FX" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /turf/open/floor/plating/grass,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "FY" = (
 /obj/effect/turf_decal/caution/red{
 	dir = 1
 	},
 /obj/effect/turf_decal{
-	dir = 3;
-	color = "#FF0000"
+	color = "#FF0000";
+	dir = 3
 	},
 /obj/machinery/door/window/southleft,
 /obj/machinery/scanner_gate{
@@ -12874,25 +8217,6 @@
 /obj/item/flashlight/lamp,
 /turf/open/floor/plasteel/dark,
 /area/city/shop)
-"Gb" = (
-/obj/effect/turf_decal/siding/yellow{
-	dir = 1
-	},
-/turf/open/floor/carpet/green,
-/area/city/backstreets_room)
-"Gc" = (
-/obj/effect/decal/cleanable/blood/gibs/up,
-/obj/effect/decal/cleanable/blood,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
-"Gd" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/city/backstreets_room)
 "Ge" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
@@ -12902,25 +8226,10 @@
 /obj/item/pen/blue,
 /turf/open/floor/wood,
 /area/city/shop)
-"Gf" = (
-/obj/structure/table/wood,
-/obj/item/book/manual/chef_recipes,
-/obj/item/toy/figure/chef,
-/turf/open/floor/plasteel/sepia,
-/area/city/backstreets_room)
-"Gg" = (
-/obj/structure/table/reinforced,
-/obj/item/gun/energy/e_gun/nuclear,
-/turf/open/floor/engine,
-/area/city/backstreets_room)
-"Gh" = (
-/obj/effect/decal/cleanable/blood/footprints,
-/turf/open/floor/sepia,
-/area/city/backstreets_room)
 "Gi" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/floor/plating/grass,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "Gj" = (
 /obj/effect/turf_decal/siding/blue{
 	dir = 1
@@ -12938,31 +8247,6 @@
 	},
 /turf/open/floor/mineral/titanium/tiled/white,
 /area/city/shop)
-"Gl" = (
-/obj/effect/decal/cleanable/blood{
-	pixel_x = 8;
-	pixel_y = 11
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/stone,
-/area/city/backstreets_room)
-"Gm" = (
-/obj/effect/decal/cleanable/blood/gibs,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
-"Gn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/gibs/torso,
-/obj/structure/chair/plastic{
-	dir = 4
-	},
-/obj/machinery/light/dim{
-	dir = 8;
-	pixel_x = null;
-	pixel_y = null
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/city/backstreets_room)
 "Go" = (
 /obj/structure/chair/comfy{
 	dir = 4
@@ -12970,26 +8254,13 @@
 /obj/item/toy/plush/gebura,
 /turf/open/floor/facility/dark,
 /area/city/backstreets_checkpoint)
-"Gq" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/mob/living/simple_animal/hostile/ordeal/green_bot{
-	name = "spear bot"
-	},
-/turf/open/floor/plating/asteroid/basalt,
-/area/city/backstreets_alley)
 "Gr" = (
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /turf/open/floor/carpet/black,
 /area/city/house)
-"Gs" = (
-/obj/structure/mineral_door/wood,
-/turf/open/indestructible/hoteltile,
-/area/city/backstreets_room)
 "Gt" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
@@ -13004,16 +8275,7 @@
 	},
 /obj/item/toy/plush/hokma,
 /turf/open/floor/carpet/black,
-/area/facility_hallway/command)
-"Gv" = (
-/obj/effect/decal/cleanable/blood/footprints{
-	dir = 4;
-	pixel_x = -9;
-	pixel_y = -8
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/holofloor/dark,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "Gw" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/effect/turf_decal/siding/thinplating/dark/corner{
@@ -13034,20 +8296,6 @@
 	},
 /turf/open/indestructible/white,
 /area/city/shop)
-"Gz" = (
-/obj/structure/fence/corner{
-	dir = 8;
-	pixel_x = -9;
-	pixel_y = 6
-	},
-/turf/closed/indestructible/reinforced,
-/area/city/backstreets_room)
-"GA" = (
-/obj/structure/chair/sofa/right{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/city/backstreets_room)
 "GB" = (
 /obj/structure/closet/secure_closet/freezer/fridge/open{
 	anchored = 1;
@@ -13090,13 +8338,6 @@
 	},
 /turf/open/floor/mineral/titanium/tiled/white,
 /area/city/shop)
-"GC" = (
-/obj/effect/decal/cleanable/blood/footprints{
-	pixel_x = 8
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/sepia,
-/area/city/backstreets_room)
 "GD" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#3234B9";
@@ -13127,19 +8368,10 @@
 	},
 /turf/open/floor/plasteel/checker,
 /area/city/shop)
-"GH" = (
-/obj/structure/chair/sofa/right{
-	dir = 4
-	},
-/mob/living/simple_animal/hostile/ordeal/green_bot{
-	name = "clerk bot"
-	},
-/turf/open/floor/plasteel/checker,
-/area/city/backstreets_room)
 "GI" = (
 /obj/effect/turf_decal{
-	dir = 3;
-	color = "#FF0000"
+	color = "#FF0000";
+	dir = 3
 	},
 /turf/open/floor/stone,
 /area/city/backstreets_alley)
@@ -13147,22 +8379,27 @@
 /obj/machinery/door/window/northleft,
 /turf/open/floor/mineral/titanium/tiled/blue,
 /area/city/shop)
+"GL" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/obj/structure/closet/secure_closet/personal/cabinet{
+	anchored = 1
+	},
+/turf/open/floor/wood,
+/area/facility_hallway/manager)
 "GM" = (
 /turf/open/floor/plasteel/white,
 /area/city/fixers)
 "GN" = (
 /turf/open/floor/circuit/telecomms,
 /area/city/fixers)
-"GO" = (
-/mob/living/simple_animal/hostile/butcher,
-/turf/open/floor/plasteel/sepia,
-/area/city/backstreets_room)
 "GP" = (
 /obj/effect/mermaid_water{
-	name = "Coastal Waters";
 	color = "#bbbbbb";
+	density = 1;
 	desc = "Not a drop of drinkable water, just a body of salty brine";
-	density = 1
+	name = "Coastal Waters"
 	},
 /turf/open/floor/plating/grass,
 /area/city)
@@ -13188,11 +8425,6 @@
 /obj/item/kitchen/knife,
 /turf/open/floor/mineral/titanium/tiled/yellow/airless,
 /area/city/shop)
-"GS" = (
-/obj/structure/table/glass,
-/obj/item/dnainjector/gigantism,
-/turf/open/floor/plasteel/freezer,
-/area/city/backstreets_room)
 "GT" = (
 /obj/machinery/door/window/northright,
 /turf/open/floor/mineral/titanium/tiled/white,
@@ -13204,25 +8436,6 @@
 	},
 /turf/open/floor/facility/white,
 /area/city/shop)
-"GV" = (
-/obj/effect/spawner/lootdrop/garbage_spawner,
-/turf/open/floor/plasteel/shuttle{
-	name = "floor"
-	},
-/area/city/backstreets_room)
-"GW" = (
-/obj/machinery/modular_computer/console/preset/civilian{
-	desc = "A stationary computer. This one comes preloaded with generic programs, for personal use, of course.";
-	dir = 8;
-	name = "personal console"
-	},
-/obj/structure/table/greyscale,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/dim{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/city/backstreets_room)
 "GX" = (
 /obj/structure/railing,
 /obj/item/grown/novaflower,
@@ -13231,16 +8444,11 @@
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
-"GY" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/closet/crate/bin,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "GZ" = (
 /obj/structure/bodycontainer/extraction,
 /turf/open/floor/carpet/royalblack,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "Ha" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "centralX";
@@ -13285,16 +8493,16 @@
 /area/city/shop)
 "Hf" = (
 /obj/docking_port/stationary{
+	dir = 4;
 	dwidth = 3;
 	height = 5;
 	id = "epsilon_command";
 	name = "1F - Command";
 	roundstart_template = /datum/map_template/shuttle/epsilon/elevator;
-	width = 6;
-	dir = 4
+	width = 6
 	},
 /turf/open/floor/plasteel/elevatorshaft,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "Hg" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -13320,8 +8528,8 @@
 /area/city/shop)
 "Hi" = (
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /obj/structure/window/reinforced/spawner/north{
 	max_integrity = 25;
@@ -13339,9 +8547,9 @@
 /area/city)
 "Hk" = (
 /turf/closed/wall/mineral/silver{
+	desc = "A wall with unmistable white coloring. Iconic sight in N Corp's Nest!";
 	explosion_block = 50;
-	name = "N Corporation Nest Wall";
-	desc = "A wall with unmistable white coloring. Iconic sight in N Corp's Nest!"
+	name = "N Corporation Nest Wall"
 	},
 /area/space)
 "Hl" = (
@@ -13352,8 +8560,8 @@
 	pixel_y = 16
 	},
 /obj/structure/window/reinforced/spawner/east{
-	opacity = 1;
-	name = "shower room glass"
+	name = "shower room glass";
+	opacity = 1
 	},
 /turf/open/floor/mineral/titanium/yellow,
 /area/city/fixers)
@@ -13363,8 +8571,8 @@
 "Hn" = (
 /obj/structure/chair/comfy,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /turf/open/floor/carpet/purple,
 /area/city/house)
@@ -13373,8 +8581,8 @@
 	dir = 8
 	},
 /obj/effect/turf_decal{
-	dir = 3;
-	color = "#FF0000"
+	color = "#FF0000";
+	dir = 3
 	},
 /obj/structure/window/reinforced/spawner{
 	max_integrity = 25
@@ -13384,37 +8592,9 @@
 	},
 /turf/open/floor/plasteel/airless/white,
 /area/city/backstreets_checkpoint)
-"Hp" = (
-/obj/structure/table/rolling,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/documents{
-	desc = "What was once considered important documents, now stained with the words \"HELP ME\" on the front, among other gibberish.";
-	name = "useless documents"
-	},
-/turf/open/floor/wood,
-/area/city/backstreets_room)
-"Hq" = (
-/obj/effect/spawner/randomcolavend,
-/turf/open/floor/plasteel/sepia,
-/area/city/backstreets_room)
-"Hr" = (
-/obj/structure/chair/sofa/corp{
-	dir = 1
-	},
-/mob/living/simple_animal/hostile/ordeal/indigo_dawn{
-	dir = 1;
-	name = "Willy"
-	},
-/turf/open/floor/wood,
-/area/city/backstreets_room)
 "Hs" = (
 /turf/closed/indestructible/fakeglass,
 /area/city/backstreets_checkpoint)
-"Ht" = (
-/obj/structure/table/glass,
-/obj/item/ego_weapon/ranged/sodarifle,
-/turf/open/floor/plasteel/vaporwave,
-/area/city/backstreets_room)
 "Hu" = (
 /obj/item/candle,
 /turf/open/floor/plasteel/chapel{
@@ -13424,30 +8604,30 @@
 "Hv" = (
 /obj/effect/turf_decal,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /turf/open/floor/facility/dark,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "Hw" = (
 /obj/effect/turf_decal/plaque{
 	alpha = 230;
 	icon_state = "LC15"
 	},
 /turf/open/floor/facility/dark,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "Hx" = (
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /obj/structure/window/reinforced/spawner/north{
 	max_integrity = 25;
 	opacity = 1
 	},
 /obj/effect/turf_decal{
-	dir = 1;
-	color = "#FF0000"
+	color = "#FF0000";
+	dir = 1
 	},
 /obj/effect/turf_decal/caution/red,
 /turf/open/floor/plasteel/airless/white,
@@ -13462,32 +8642,19 @@
 	},
 /turf/open/floor/eighties,
 /area/city/shop)
-"HA" = (
-/obj/effect/turf_decal/raven{
-	dir = 8
-	},
-/obj/structure/table/reinforced,
-/obj/item/stack/sheet/plasteel{
-	pixel_x = -10
-	},
-/obj/item/stack/sheet/plastitaniumglass{
-	pixel_x = 5
-	},
-/turf/open/floor/holofloor/dark,
-/area/city/backstreets_room)
 "HB" = (
 /obj/structure/railing,
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/item/grown/sunflower,
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "HC" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -13496,20 +8663,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/facility_hallway/command)
-"HD" = (
-/obj/effect/turf_decal/trimline/neutral/corner{
-	dir = 1;
-	pixel_x = -6;
-	pixel_y = 6
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/holofloor/dark,
-/area/city/backstreets_room)
-"HE" = (
-/obj/structure/fluff/broken_flooring,
-/turf/open/floor/plasteel/shuttle,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "HF" = (
 /obj/structure/table/wood/fancy/blue,
 /obj/item/instrument/guitar,
@@ -13519,129 +8673,32 @@
 	dir = 9
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
-	},
-/turf/open/floor/carpet/stellar,
-/area/facility_hallway/command)
-"HG" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
+	brightness = 16;
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
+/turf/open/floor/carpet/stellar,
+/area/facility_hallway/manager)
+"HG" = (
+/obj/effect/turf_decal/siding/yellow{
+	dir = 9
 	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/landmark/latejoin,
-/turf/open/floor/sepia,
-/area/facility_hallway/command)
-"HH" = (
-/obj/effect/turf_decal/trimline/neutral/line{
-	pixel_y = -6
-	},
-/obj/structure/railing,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/holofloor/dark,
-/area/city/backstreets_room)
-"HI" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/closet/cabinet,
-/obj/effect/spawner/lootdrop/costume,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
-"HJ" = (
-/obj/effect/spawner/lootdrop/space/cashmoney,
-/obj/effect/spawner/lootdrop/space/cashmoney,
-/obj/effect/spawner/lootdrop/space/cashmoney,
-/obj/effect/spawner/lootdrop/armory_contraband,
-/obj/structure/closet/cabinet,
-/obj/item/clothing/shoes/swagshoes,
-/obj/item/clothing/under/costume/swagoutfit,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
-"HK" = (
-/obj/structure/railing/corner{
-	dir = 1;
-	pixel_y = -34
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/blood/old{
-	pixel_x = -13;
-	pixel_y = -7
-	},
-/turf/open/floor/stone,
-/area/city/backstreets_room)
-"HL" = (
-/obj/structure/table/wood,
-/obj/machinery/light/red{
-	dir = 5
-	},
-/obj/item/clothing/suit/apron/chef,
-/obj/item/clothing/head/chefhat/i_am_assuming_direct_control,
-/turf/open/floor/plasteel/sepia,
-/area/city/backstreets_room)
+/turf/open/floor/carpet/royalblack,
+/area/facility_hallway/manager)
 "HM" = (
 /turf/open/floor/plasteel/dark,
 /area/city/shop)
-"HN" = (
-/obj/machinery/light/dim{
-	dir = 4
-	},
-/turf/open/floor/plasteel/shuttle{
-	name = "floor"
-	},
-/area/city/backstreets_room)
-"HO" = (
-/obj/structure/flora/tree/jungle/small,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"HP" = (
-/obj/structure/table/glass,
-/obj/item/clipboard,
-/turf/open/floor/holofloor/white,
-/area/city/backstreets_room)
-"HQ" = (
-/obj/structure/table/glass,
-/obj/item/dnainjector/activator,
-/turf/open/floor/holofloor/white,
-/area/city/backstreets_room)
 "HR" = (
 /turf/closed/wall/mineral/silver{
+	desc = "A wall with unmistable white coloring. Iconic sight in N Corp's Nest!";
 	explosion_block = 50;
-	name = "N Corporation Nest Wall";
-	desc = "A wall with unmistable white coloring. Iconic sight in N Corp's Nest!"
+	name = "N Corporation Nest Wall"
 	},
 /area/city)
-"HS" = (
-/obj/effect/turf_decal/trimline/neutral/corner{
-	dir = 4;
-	pixel_x = 7;
-	pixel_y = 6
-	},
-/obj/effect/decal/cleanable/blood/footprints{
-	dir = 4;
-	pixel_x = -6;
-	pixel_y = 8
-	},
-/turf/open/floor/holofloor/dark,
-/area/city/backstreets_room)
 "HT" = (
 /turf/open/floor/plasteel/chapel{
 	dir = 4
 	},
 /area/city/shop)
-"HU" = (
-/obj/effect/turf_decal/siding/wideplating/corner,
-/obj/structure/flora/rock/pile{
-	pixel_x = 20;
-	pixel_y = -1
-	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
 "HV" = (
 /obj/structure/railing{
 	dir = 9
@@ -13654,21 +8711,16 @@
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
-"HW" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/closet/secure_closet/mechanicus/implants,
-/turf/open/floor/holofloor/dark,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "HX" = (
 /obj/effect/turf_decal/siding/thinplating/dark/corner,
 /turf/open/floor/plating/grass,
 /area/city)
 "HY" = (
 /obj/structure/showcase/machinery/tv{
-	pixel_x = 1;
+	desc = "A slightly battered looking TV. Various Nest News infomercials play on a loop, accompanied by a jaunty tune.";
 	name = "\improper Zwei Association Newsfeed";
-	desc = "A slightly battered looking TV. Various Nest News infomercials play on a loop, accompanied by a jaunty tune."
+	pixel_x = 1
 	},
 /obj/structure/window/reinforced/spawner/north{
 	max_integrity = 25;
@@ -13691,38 +8743,12 @@
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/floor/plating/grass,
 /area/city)
-"Ib" = (
-/obj/item/chair/plastic,
-/mob/living/simple_animal/hostile/ordeal/green_bot{
-	name = "clerk bot"
-	},
-/turf/open/floor/engine,
-/area/city/backstreets_room)
-"Ic" = (
-/obj/structure/table/reinforced,
-/obj/structure/showcase/machinery/tv{
-	desc = "Guess robots can't fix their lesser machinery.";
-	name = "\improper Broken TV"
-	},
-/turf/open/floor/engine,
-/area/city/backstreets_room)
 "Id" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = 12;
-	pixel_y = -6
+/obj/structure/chair/comfy/black{
+	dir = 1
 	},
-/obj/structure/mirror{
-	pixel_x = 27
-	},
-/turf/open/floor/plasteel/white,
-/area/facility_hallway/command)
-"Ie" = (
-/obj/structure/fence/corner{
-	dir = 10
-	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_checkpoint)
+/turf/open/floor/facility/dark,
+/area/facility_hallway/manager)
 "If" = (
 /obj/structure/window/reinforced/spawner/east{
 	max_integrity = 25
@@ -13730,18 +8756,6 @@
 /obj/machinery/vending/wardrobe/medi_wardrobe,
 /turf/open/floor/mineral/titanium/white,
 /area/city/shop)
-"Ig" = (
-/obj/effect/turf_decal/starfury/seven,
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 8;
-	pixel_x = -6
-	},
-/obj/structure/flora/grass/jungle/b,
-/obj/effect/decal/cleanable/blood/gibs{
-	pixel_x = 25
-	},
-/turf/open/floor/plating/dirt,
-/area/city/backstreets_room)
 "Ih" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/closet/crate,
@@ -13755,17 +8769,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/city/shop)
-"Ii" = (
-/obj/structure/curtain/cloth{
-	pixel_x = 32
-	},
-/turf/open/floor/wood,
-/area/city/backstreets_room)
-"Ij" = (
-/obj/structure/barricade/wooden,
-/obj/structure/barricade/wooden/crude,
-/turf/closed/indestructible/fakeglass,
-/area/city/backstreets_checkpoint)
 "Ik" = (
 /obj/structure/sink/kitchen{
 	dir = 1;
@@ -13773,12 +8776,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/city/house)
-"Il" = (
-/obj/effect/turf_decal/siding/purple{
-	dir = 10
-	},
-/turf/open/floor/carpet/purple,
-/area/city/backstreets_room)
 "Im" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -13791,57 +8788,53 @@
 "In" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/sepia,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "Io" = (
 /turf/closed/indestructible/rock,
 /area/city)
+"Ip" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = 12;
+	pixel_y = -6
+	},
+/obj/structure/mirror{
+	pixel_x = 27
+	},
+/turf/open/floor/plasteel/white,
+/area/facility_hallway/manager)
 "Iq" = (
 /obj/structure/sign/departments/security,
 /turf/closed/wall/mineral/silver{
+	desc = "A wall with unmistable white coloring. Iconic sight in N Corp's Nest!";
 	explosion_block = 50;
-	name = "N Corporation Nest Wall";
-	desc = "A wall with unmistable white coloring. Iconic sight in N Corp's Nest!"
+	name = "N Corporation Nest Wall"
 	},
 /area/city/backstreets_checkpoint)
 "Ir" = (
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/plating/grass,
-/area/facility_hallway/command)
-"Is" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 6
-	},
-/turf/open/floor/plating/asteroid/basalt,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "It" = (
-/obj/machinery/vending/lobotomyuniform,
+/obj/machinery/computer/crew{
+	dir = 4
+	},
 /turf/open/floor/facility/dark,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "Iu" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
 /turf/open/floor/wood,
 /area/city/shop)
-"Iv" = (
-/obj/item/stack/sheet/mineral/wood,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_alley)
 "Iw" = (
 /obj/machinery/light/cold/no_nightlight,
 /turf/open/floor/carpet/black,
 /area/city/house)
-"Ix" = (
-/obj/structure/chair/sofa/right{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/green,
-/area/city/backstreets_room)
 "Iy" = (
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -13854,7 +8847,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "Iz" = (
 /obj/structure/table/reinforced,
 /obj/machinery/button/door/indestructible{
@@ -13863,14 +8856,7 @@
 	pixel_y = 4
 	},
 /turf/open/floor/facility/dark,
-/area/facility_hallway/command)
-"IA" = (
-/obj/effect/decal/cleanable/blood/gibs/up,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"IB" = (
-/turf/open/indestructible/necropolis,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "IC" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/effect/turf_decal/siding/thinplating/dark/corner{
@@ -13878,66 +8864,35 @@
 	},
 /turf/open/floor/plating/grass,
 /area/city)
-"ID" = (
-/obj/structure/lattice/catwalk,
-/turf/open/lava/smooth,
-/area/city/backstreets_room)
-"IE" = (
-/obj/structure/table/rolling,
-/obj/item/ego_weapon/city/rats/knife,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
-"IF" = (
-/obj/effect/turf_decal/siding{
-	dir = 10
-	},
-/turf/open/floor/carpet/black,
-/area/city/backstreets_room)
 "IG" = (
 /obj/structure/fence{
 	dir = 4
 	},
 /turf/open/floor/plating/grass,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "IH" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/tree/jungle/small,
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
-"II" = (
-/obj/effect/spawner/randomarcade,
-/turf/open/floor/eighties,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "IJ" = (
 /obj/structure/fence,
 /turf/open/floor/plating/grass,
-/area/facility_hallway/command)
-"IM" = (
-/obj/effect/turf_decal/siding/wideplating{
+/area/facility_hallway/manager)
+"IK" = (
+/obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/obj/structure/flora/rock/pile{
-	pixel_x = -2;
-	pixel_y = 14
-	},
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
+/turf/open/floor/wood,
+/area/space)
 "IN" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
 /turf/open/floor/plating/grass,
-/area/facility_hallway/command)
-"IO" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/blood/splatter,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "IP" = (
 /obj/effect/turf_decal/tile{
 	color = "#333333"
@@ -13954,17 +8909,11 @@
 	dir = 8
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /turf/open/floor/plating/grass,
-/area/facility_hallway/command)
-"IR" = (
-/obj/machinery/computer/med_data/laptop{
-	desc = "Guess this cat is a bit of a medical professional."
-	},
-/turf/open/floor/wood,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "IS" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -13984,15 +8933,15 @@
 	dir = 4
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/city/shop)
 "IU" = (
 /obj/effect/turf_decal/tile/green{
-	dir = 4;
-	color = "#006400"
+	color = "#006400";
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/green{
 	color = "#006400"
@@ -14005,85 +8954,53 @@
 	},
 /turf/open/indestructible/white,
 /area/city/shop)
+"IV" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Male Restroom"
+	},
+/turf/open/floor/facility/halls,
+/area/facility_hallway/manager)
+"IW" = (
+/obj/effect/turf_decal/siding/blue{
+	dir = 10
+	},
+/turf/open/floor/carpet/cyan,
+/area/space)
 "IX" = (
 /obj/structure/table/reinforced{
 	max_integrity = 25
 	},
 /obj/effect/turf_decal/tile/neutral{
-	dir = 1;
-	color = "#000000"
+	color = "#000000";
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
 	color = "#000000"
 	},
 /obj/effect/turf_decal/tile/neutral{
-	dir = 4;
-	color = "#000000"
+	color = "#000000";
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral{
-	dir = 8;
-	color = "#000000"
+	color = "#000000";
+	dir = 8
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/city/fixers)
 "IY" = (
 /turf/open/floor/carpet/black,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "IZ" = (
 /obj/machinery/door/window/eastright{
-	opacity = 1;
-	name = "Bathroom Door"
+	name = "Bathroom Door";
+	opacity = 1
 	},
 /turf/open/floor/plasteel/white,
-/area/facility_hallway/command)
-"Ja" = (
-/obj/effect/decal/cleanable/blood/splatter{
-	pixel_x = -18
-	},
-/obj/structure/table/reinforced,
-/obj/effect/spawner/lootdrop/organ_spawner{
-	pixel_x = -4;
-	pixel_y = 6
-	},
-/obj/effect/spawner/lootdrop/organ_spawner{
-	pixel_x = 5;
-	pixel_y = -1
-	},
-/turf/open/floor/stone,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "Jc" = (
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood,
 /area/city/shop)
-"Jd" = (
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"Je" = (
-/turf/open/floor/plasteel/showroomfloor,
-/area/city/backstreets_room)
-"Jf" = (
-/obj/effect/decal/cleanable/blood,
-/obj/structure/curtain/cloth{
-	pixel_y = 32
-	},
-/turf/open/floor/wood,
-/area/city/backstreets_room)
-"Jg" = (
-/obj/structure/chair/plastic{
-	dir = 4
-	},
-/obj/machinery/light/dim{
-	dir = 8;
-	pixel_x = null;
-	pixel_y = null
-	},
-/turf/open/floor/plasteel/sepia,
-/area/city/backstreets_room)
 "Jh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/light_emitter{
@@ -14093,62 +9010,30 @@
 	set_luminosity = 24
 	},
 /turf/open/floor/sepia,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "Ji" = (
 /obj/structure/curtain/cloth/fancy,
 /turf/closed/indestructible/fakeglass,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "Jj" = (
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/city/fixers)
+"Jk" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
+/turf/open/floor/wood,
+/area/space)
 "Jl" = (
 /obj/machinery/vending/cola/blue{
 	name = "\improper Crane Game Machine"
 	},
 /turf/open/floor/eighties,
 /area/city/shop)
-"Jm" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/rack,
-/obj/item/organ/liver/cybernetic,
-/obj/item/organ/liver/cybernetic/tier2,
-/obj/item/organ/liver/cybernetic/tier3,
-/obj/item/organ/stomach/cybernetic,
-/obj/item/organ/stomach/cybernetic/tier2,
-/obj/item/organ/stomach/cybernetic/tier3,
-/turf/open/floor/holofloor/dark,
-/area/city/backstreets_room)
-"Jn" = (
-/obj/structure/rack,
-/obj/item/clothing/shoes/sandal,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
-"Jo" = (
-/obj/structure/destructible/cult/forge{
-	desc = "A forge used in crafting various fixer equipment.";
-	name = "workshop forge"
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/effect/turf_decal/raven{
-	dir = 1
-	},
-/turf/open/floor/holofloor/dark,
-/area/city/backstreets_room)
-"Jp" = (
-/obj/structure/table/wood/fancy/purple,
-/turf/open/floor/carpet/purple,
-/area/city/backstreets_room)
-"Jq" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/firingpins,
-/turf/open/floor/engine,
-/area/city/backstreets_room)
 "Jr" = (
 /turf/open/floor/carpet/black,
 /area/city/house)
@@ -14176,75 +9061,22 @@
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
-"Jv" = (
-/obj/structure/chair/office,
-/obj/machinery/light,
-/turf/open/floor/eighties,
-/area/city/backstreets_room)
-"Jw" = (
-/obj/structure/closet/secure_closet/personal,
-/obj/effect/spawner/lootdrop/space/cashmoney,
-/obj/effect/spawner/lootdrop/space/cashmoney,
-/obj/effect/spawner/lootdrop/space/cashmoney,
-/obj/effect/spawner/lootdrop/space/cashmoney,
-/obj/effect/spawner/lootdrop/space/cashmoney,
-/obj/effect/spawner/lootdrop/space/cashmoney,
-/obj/effect/spawner/lootdrop/space/cashmoney,
-/obj/effect/spawner/lootdrop/space/cashmoney,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/holofloor/dark,
-/area/city/backstreets_room)
-"Jx" = (
-/obj/effect/turf_decal/siding/wideplating/corner{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/blood/footprints{
-	dir = 8;
-	pixel_x = -20
-	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"Jy" = (
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 10
-	},
-/turf/open/floor/plating/asteroid/basalt,
-/area/city/backstreets_room)
-"Jz" = (
-/obj/structure/closet/crate/large,
-/obj/effect/turf_decal{
-	dir = 3
-	},
-/turf/open/floor/engine,
-/area/city/backstreets_room)
-"JA" = (
-/mob/living/simple_animal/hostile/ordeal/green_bot_big{
-	name = "gun bot"
-	},
-/turf/open/floor/plating/asteroid/basalt,
-/area/city/backstreets_alley)
+/area/facility_hallway/manager)
+"Ju" = (
+/obj/structure/table/wood,
+/turf/open/floor/wood,
+/area/space)
 "JB" = (
 /obj/structure/toilet{
 	dir = 4;
 	pixel_y = 5
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /turf/open/floor/sepia,
 /area/city/house)
-"JC" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Medical Kiosk"
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/city/backstreets_room)
 "JD" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
@@ -14254,30 +9086,14 @@
 /area/city/fixers)
 "JE" = (
 /turf/closed/indestructible/reinforced,
-/area/facility_hallway/command)
-"JF" = (
-/obj/item/gun/ballistic/revolver/golden,
-/turf/open/floor/carpet/orange,
-/area/city/backstreets_room)
-"JG" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 8
-	},
-/obj/structure/dresser,
-/obj/item/kirbyplants/dead{
-	desc = "A sad, dead plant";
-	name = "dead potted plant";
-	pixel_y = 20
-	},
-/turf/open/floor/carpet/black,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "JH" = (
 /obj/effect/turf_decal/plaque{
 	alpha = 230;
 	icon_state = "LC13"
 	},
 /turf/open/floor/facility/dark,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "JI" = (
 /obj/structure/bed,
 /obj/item/bedsheet/hop,
@@ -14285,19 +9101,11 @@
 	dir = 5
 	},
 /turf/open/floor/wood,
-/area/facility_hallway/command)
-"JJ" = (
-/mob/living/simple_animal/pet/cat/breadcat,
-/obj/structure/bed/dogbed{
-	desc = "A comfy-looking cat bed. You can even strap your pet in, in case the gravity turns off.";
-	name = "cat bed"
-	},
-/turf/open/floor/wood,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "JK" = (
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /turf/open/floor/facility/dark,
 /area/city/backstreets_checkpoint)
@@ -14318,17 +9126,13 @@
 /obj/structure/bed,
 /obj/item/bedsheet/mime,
 /turf/open/floor/carpet/black,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "JO" = (
 /obj/structure/bed,
 /obj/item/bedsheet/rainbow,
+/obj/effect/landmark/latejoin,
 /turf/open/floor/carpet,
 /area/city/house)
-"JP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
 "JQ" = (
 /obj/structure/chair/plastic{
 	dir = 4
@@ -14338,11 +9142,11 @@
 /area/city/backstreets_checkpoint)
 "JR" = (
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /turf/open/floor/plating/grass,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "JS" = (
 /obj/effect/turf_decal/siding/thinplating/dark/corner,
 /obj/effect/turf_decal/siding/thinplating/dark/corner{
@@ -14359,12 +9163,6 @@
 	},
 /turf/open/floor/wood,
 /area/city/shop)
-"JU" = (
-/obj/structure/table/wood,
-/obj/item/food/meat/slab/human,
-/obj/item/food/meat/slab/human,
-/turf/open/floor/plasteel/sepia,
-/area/city/backstreets_room)
 "JV" = (
 /obj/structure/railing{
 	dir = 5
@@ -14377,16 +9175,7 @@
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
-"JW" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/blood/gibs/limb{
-	dir = 4;
-	pixel_x = 21;
-	pixel_y = 16
-	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "JX" = (
 /turf/open/floor/stone,
 /area/city/backstreets_alley)
@@ -14401,34 +9190,27 @@
 	color = "#000000"
 	},
 /obj/effect/turf_decal/tile/neutral{
-	dir = 4;
-	color = "#000000"
+	color = "#000000";
+	dir = 4
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /turf/open/floor/mineral/titanium/tiled/white,
 /area/city/fixers)
 "Kb" = (
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /obj/structure/window/reinforced/spawner/east{
 	max_integrity = 25;
-	opacity = 1;
-	name = "Surgery Room Divider"
+	name = "Surgery Room Divider";
+	opacity = 1
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/city/shop)
-"Kc" = (
-/obj/structure/chair/plastic{
-	dir = 1
-	},
-/obj/machinery/light/dim,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
 "Kd" = (
 /obj/structure/railing{
 	dir = 1
@@ -14441,38 +9223,38 @@
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
-"Ke" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/randomsnackvend,
-/turf/open/floor/plasteel/shuttle,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "Kf" = (
 /obj/effect/mermaid_water{
-	name = "Coastal Waters";
 	color = "#dddddd";
+	density = 1;
 	desc = "Not a drop of drinkable water, just a body of salty brine";
-	density = 1
+	name = "Coastal Waters"
 	},
 /obj/effect/mermaid_water{
-	name = "Coastal Waters";
 	color = "#bbbbbb";
+	density = 1;
 	desc = "Not a drop of drinkable water, just a body of salty brine";
-	density = 1
+	name = "Coastal Waters"
 	},
 /turf/open/floor/plating/grass,
 /area/city)
-"Kg" = (
-/obj/effect/turf_decal/siding/yellow{
-	dir = 6
-	},
-/turf/open/floor/carpet/green,
-/area/city/backstreets_room)
 "Kh" = (
 /obj/structure/flora/ausbushes/reedbush,
 /obj/effect/turf_decal/siding/thinplating/dark/corner,
 /turf/open/floor/plating/grass,
 /area/city)
+"Ki" = (
+/obj/structure/table/wood,
+/obj/machinery/photocopier{
+	pixel_y = 4
+	},
+/turf/open/floor/facility/white,
+/area/space)
+"Kj" = (
+/obj/machinery/vending/lobotomyarmband,
+/turf/open/floor/facility/dark,
+/area/facility_hallway/manager)
 "Kk" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#3234B9";
@@ -14483,16 +9265,13 @@
 	},
 /turf/open/floor/mineral/titanium/tiled/white,
 /area/city/fixers)
-"Kl" = (
-/turf/open/floor/plasteel/checker,
-/area/city/backstreets_room)
 "Km" = (
 /turf/closed/indestructible/paper,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "Kn" = (
 /obj/item/toy/plush/binah,
 /turf/open/floor/carpet/royalblack,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "Ko" = (
 /obj/structure/closet/secure_closet/personal/cabinet{
 	anchored = 1
@@ -14501,7 +9280,7 @@
 	dir = 10
 	},
 /turf/open/floor/wood,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "Kp" = (
 /obj/item/soap/ncorporation,
 /obj/machinery/shower{
@@ -14509,50 +9288,22 @@
 	},
 /obj/structure/window/reinforced/spawner/east{
 	max_integrity = 25;
-	opacity = 1;
-	name = "Glass"
+	name = "Glass";
+	opacity = 1
 	},
 /turf/open/floor/noslip,
-/area/facility_hallway/command)
-"Kq" = (
-/obj/structure/barricade/wooden,
-/obj/structure/barricade/wooden/crude,
-/turf/closed/indestructible/fakeglass,
-/area/city/backstreets_alley)
-"Kr" = (
-/obj/structure/bed/maint,
-/obj/item/bedsheet/brown,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "Ks" = (
 /obj/structure/flora/ausbushes/reedbush,
 /turf/open/floor/plating/grass,
 /area/city)
-"Kt" = (
-/obj/structure/bed/maint,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
 "Ku" = (
 /obj/effect/turf_decal/siding/yellow{
 	dir = 9
 	},
 /obj/effect/spawner/randomcolavend,
 /turf/open/floor/carpet/stellar,
-/area/facility_hallway/command)
-"Kv" = (
-/obj/structure/fence/corner{
-	dir = 1
-	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"Kw" = (
-/obj/structure/barricade/wooden,
-/obj/structure/barricade/wooden/crude,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "Kx" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
@@ -14560,86 +9311,42 @@
 /obj/machinery/light/cold/no_nightlight,
 /turf/open/floor/wood,
 /area/city/shop)
-"Ky" = (
-/obj/structure/chair/pew/left,
-/turf/open/floor/carpet/black,
-/area/city/backstreets_room)
 "Kz" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 1
 	},
 /turf/open/floor/plating/grass,
 /area/city)
-"KA" = (
-/obj/structure/flora/grass/jungle,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"KB" = (
-/obj/effect/decal/cleanable/blood/footprints,
-/obj/effect/turf_decal/siding/wood{
-	dir = 7
-	},
-/turf/open/floor/carpet/black,
-/area/city/backstreets_room)
-"KC" = (
-/obj/machinery/griddle,
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
+"KD" = (
+/obj/effect/turf_decal/siding/blue/end{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
-/area/facility_hallway/command)
-"KE" = (
-/obj/structure/fence/corner{
-	dir = 7
-	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"KF" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
+/turf/open/floor/carpet/cyan,
+/area/space)
+"KG" = (
+/obj/machinery/computer/camera_advanced/manager,
+/obj/machinery/light/cold/no_nightlight{
 	dir = 1
 	},
-/turf/open/indestructible/cult,
-/area/city/backstreets_room)
-"KH" = (
-/obj/structure/table/wood,
-/obj/item/kitchen/knife/butcher/deadly,
-/obj/item/clothing/gloves/butchering,
-/turf/open/floor/plasteel/sepia,
-/area/city/backstreets_room)
+/obj/machinery/camera/autoname{
+	dir = 6
+	},
+/turf/open/floor/facility/dark,
+/area/facility_hallway/manager)
 "KI" = (
 /obj/structure/closet/secure_closet/personal/cabinet{
 	anchored = 1
 	},
 /turf/open/floor/wood,
-/area/facility_hallway/command)
-"KJ" = (
-/obj/structure/flora/rock/pile{
-	pixel_x = -11
-	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"KK" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 1
-	},
-/mob/living/simple_animal/hostile/ordeal/indigo_noon,
-/turf/open/indestructible/cult,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "KL" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#3234B9";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral{
-	dir = 8;
-	color = "#000000"
+	color = "#000000";
+	dir = 8
 	},
 /obj/machinery/regenerator,
 /obj/structure/window/reinforced/spawner{
@@ -14650,16 +9357,6 @@
 	},
 /turf/open/floor/mineral/titanium/tiled/white,
 /area/city/fixers)
-"KM" = (
-/obj/effect/turf_decal{
-	dir = 5
-	},
-/obj/structure/lootcrate/seven,
-/turf/open/floor/engine,
-/area/city/backstreets_room)
-"KN" = (
-/turf/closed/indestructible/reinforced,
-/area/city/backstreets_alley)
 "KO" = (
 /obj/effect/turf_decal/tile/bar{
 	dir = 4
@@ -14668,23 +9365,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/facility_hallway/command)
-"KP" = (
-/obj/item/stack/sheet/mineral/wood,
-/obj/item/hatchet/wooden{
-	pixel_x = -10;
-	pixel_y = -4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
-"KQ" = (
-/obj/machinery/light/broken{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "KR" = (
 /obj/structure/table/bronze,
 /obj/item/reagent_containers/food/condiment/peppermill{
@@ -14693,34 +9374,18 @@
 	},
 /turf/open/floor/wood,
 /area/city/shop)
-"KS" = (
-/obj/structure/fluff/broken_flooring{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/shuttle{
-	name = "floor"
-	},
-/area/city/backstreets_room)
 "KT" = (
 /obj/structure/chair/wood/wings,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /turf/open/floor/facility/white,
-/area/facility_hallway/command)
-"KU" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/rack,
-/obj/item/organ/ears/cybernetic,
-/obj/item/organ/ears/cybernetic/upgraded,
-/turf/open/floor/holofloor/dark,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "KV" = (
 /obj/structure/bodycontainer/crematorium{
-	id = "Ncorp3";
-	dir = 8
+	dir = 8;
+	id = "Ncorp3"
 	},
 /obj/machinery/button/crematorium/indestructible{
 	id = "Ncorp3";
@@ -14728,13 +9393,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/city/shop)
-"KW" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/barricade/wooden/crude{
-	layer = 3
-	},
-/turf/open/floor/plating/dirt/dark,
-/area/city/backstreets_room)
 "KX" = (
 /obj/structure/table/bronze,
 /obj/item/statuebust{
@@ -14742,17 +9400,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/city/shop)
-"KY" = (
-/obj/effect/turf_decal/siding/wideplating/corner{
-	dir = 8
-	},
-/obj/structure/flora/grass/jungle{
-	pixel_x = -8;
-	pixel_y = -10
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
 "KZ" = (
 /obj/structure/chair/sofa/corp/left{
 	dir = 4;
@@ -14761,13 +9408,14 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/city/house)
-"La" = (
-/mob/living/simple_animal/hostile/ordeal/green_bot_big{
-	desc = "A big robot tasked to oversee the range.";
-	name = "Robotic Range Master"
+"Lb" = (
+/obj/structure/bed,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
 	},
-/turf/open/floor/engine,
-/area/city/backstreets_room)
+/obj/item/bedsheet/red,
+/turf/open/floor/wood,
+/area/space)
 "Lc" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#3234B9"
@@ -14778,12 +9426,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/city/fixers)
-"Ld" = (
-/obj/structure/chair/plastic{
-	dir = 4
-	},
-/turf/open/floor/plasteel/sepia,
-/area/city/backstreets_room)
+"Le" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/light/cold/no_nightlight,
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green,
+/turf/open/floor/wood,
+/area/space)
 "Lf" = (
 /obj/structure/closet/crate/trashcart,
 /obj/item/storage/bag/trash/bluespace,
@@ -14803,14 +9452,14 @@
 	pixel_y = 11
 	},
 /obj/item/reagent_containers/glass/rag{
-	pixel_y = 2;
-	pixel_x = 5
+	pixel_x = 5;
+	pixel_y = 2
 	},
 /obj/machinery/light/cold/no_nightlight{
 	brightness = 16
 	},
 /turf/open/floor/carpet/royalblack,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "Lh" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/closet/crate,
@@ -14823,71 +9472,12 @@
 /obj/effect/turf_decal/delivery/white,
 /turf/open/floor/plating,
 /area/city/shop)
-"Li" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/window/reinforced/survival_pod{
-	desc = "Shrimply too strong.";
-	dir = 1;
-	max_integrity = 10000;
-	name = "shrimp display window"
-	},
-/obj/structure/lootcrate/s_corp,
-/turf/open/floor/plasteel/vaporwave,
-/area/city/backstreets_room)
-"Lj" = (
-/obj/structure/closet/secure_closet/freezer/fridge/open{
-	anchored = 1;
-	storage_capacity = 1000
-	},
-/obj/item/reagent_containers/food/condiment/flour,
-/obj/item/storage/fancy/egg_box,
-/obj/item/reagent_containers/food/condiment/rice,
-/obj/item/food/meat/slab,
-/obj/item/food/meat/slab,
-/obj/item/food/meat/slab,
-/obj/item/food/meat/slab,
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/facility_hallway/command)
 "Lk" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 4
 	},
 /turf/open/floor/stone,
 /area/city)
-"Ll" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/turf/open/floor/plating/asteroid/basalt,
-/area/city/backstreets_alley)
-"Lm" = (
-/obj/structure/chair/sofa/corp/corner{
-	dir = 1
-	},
-/turf/open/floor/carpet/black,
-/area/city/backstreets_room)
-"Ln" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/mob/living/simple_animal/hostile/ordeal/green_bot_big{
-	name = "gun bot"
-	},
-/turf/open/floor/stone,
-/area/city/backstreets_room)
 "Lo" = (
 /obj/structure/chair/comfy{
 	dir = 8
@@ -14895,78 +9485,33 @@
 /obj/item/toy/plush/gebura,
 /turf/open/floor/facility/dark,
 /area/city/backstreets_checkpoint)
-"Lp" = (
-/obj/effect/decal/cleanable/blood{
-	pixel_x = -3;
-	pixel_y = -8
-	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
 "Lq" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "Lr" = (
 /obj/structure/table/greyscale{
 	pixel_y = 6
 	},
 /obj/item/reagent_containers/food/drinks/bottle/wine{
-	pixel_y = 13;
-	pixel_x = -70
+	pixel_x = -70;
+	pixel_y = 13
 	},
 /obj/item/book/random{
-	pixel_y = 11;
-	pixel_x = -2
+	pixel_x = -2;
+	pixel_y = 11
 	},
 /turf/open/floor/carpet/royalblack,
 /area/city/house)
-"Ls" = (
-/obj/structure/table/greyscale,
-/obj/item/folder/documents{
-	desc = "A folder with a K-Corp labelled stamped on the front.";
-	name = "K-Corp Folder"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
-"Lt" = (
-/obj/effect/light_emitter{
-	light_power = 4;
-	light_range = 25;
-	set_cap = 3;
-	set_luminosity = 24
-	},
-/turf/open/floor/plating/asteroid/basalt,
-/area/city/backstreets_alley)
-"Lu" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 7
-	},
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 7
-	},
-/obj/structure/table/wood/fancy/black,
-/obj/item/folder/yellow{
-	desc = "A folder containing sheet music. The contents are gibberish to you, however.";
-	name = "sheet music"
-	},
-/turf/open/floor/carpet/black,
-/area/city/backstreets_room)
 "Lv" = (
 /obj/structure/chair/sofa/corp/left{
 	dir = 8
 	},
 /turf/open/floor/mineral/titanium/tiled/white,
 /area/city/shop)
-"Lw" = (
-/mob/living/simple_animal/hostile/ordeal/green_bot_big{
-	name = "gun bot"
-	},
-/turf/open/floor/facility/dark,
-/area/city/backstreets_room)
 "Lx" = (
 /turf/closed/indestructible/reinforced{
 	color = "#ADD8E6"
@@ -14997,36 +9542,25 @@
 	dir = 8
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /turf/open/floor/carpet/stellar,
-/area/facility_hallway/command)
-"LA" = (
-/obj/structure/flora/grass/jungle{
-	pixel_x = -8;
-	pixel_y = -10
-	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "LB" = (
 /obj/structure/table/anvil,
 /turf/open/floor/mineral/titanium/tiled/blue,
 /area/city/shop)
-"LC" = (
-/obj/effect/decal/cleanable/blood/gibs/limb{
-	dir = 1
+"LE" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
 	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"LD" = (
-/obj/structure/table/wood,
-/obj/item/trash/candle,
-/obj/structure/curtain/cloth{
-	pixel_y = 32
+/obj/machinery/light/cold/no_nightlight{
+	brightness = 16;
+	dir = 4
 	},
 /turf/open/floor/wood,
-/area/city/backstreets_room)
+/area/space)
 "LF" = (
 /obj/effect/turf_decal/siding/wood/corner,
 /obj/effect/turf_decal/siding/wood/corner{
@@ -15034,14 +9568,9 @@
 	},
 /turf/open/floor/wood,
 /area/city/fixers)
-"LH" = (
-/obj/structure/lootcrate/k_corp,
-/obj/structure/lootcrate/k_corp{
-	pixel_x = -5;
-	pixel_y = 10
-	},
-/turf/open/floor/engine,
-/area/city/backstreets_room)
+"LG" = (
+/turf/open/floor/facility/halls,
+/area/space)
 "LI" = (
 /obj/structure/chair/sofa/left{
 	dir = 8
@@ -15052,11 +9581,11 @@
 /obj/structure/bed,
 /obj/item/bedsheet/ncorporation,
 /turf/open/floor/carpet/cyan,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "LK" = (
 /obj/structure/closet,
 /turf/open/floor/carpet/royalblue,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "LL" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -15065,11 +9594,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/facility_hallway/command)
-"LM" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/showroomfloor,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "LN" = (
 /obj/item/candle,
 /turf/open/floor/plasteel/chapel{
@@ -15090,7 +9615,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating/grass,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "LQ" = (
 /obj/structure/bed,
 /obj/effect/turf_decal/siding/wood{
@@ -15107,7 +9632,7 @@
 	brightness = 16
 	},
 /turf/open/floor/plating/grass,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "LS" = (
 /obj/machinery/newscaster{
 	pixel_x = 27
@@ -15125,17 +9650,21 @@
 /turf/open/floor/plasteel/sepia,
 /area/city/shop)
 "LT" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = -12;
-	pixel_y = -6
+/obj/structure/curtain/cloth,
+/obj/machinery/shower{
+	pixel_y = 15
 	},
-/obj/structure/mirror{
-	pixel_x = -27
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/sepia,
-/area/facility_hallway/command)
+/obj/item/soap/deluxe,
+/turf/open/floor/noslip,
+/area/facility_hallway/manager)
+"LU" = (
+/obj/machinery/computer/abnormality_queue,
+/turf/open/floor/facility/dark,
+/area/facility_hallway/manager)
+"LV" = (
+/obj/structure/sign/departments/control,
+/turf/closed/indestructible/reinforced,
+/area/facility_hallway/manager)
 "LW" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
@@ -15144,46 +9673,10 @@
 	brightness = 16
 	},
 /turf/open/floor/plating/grass,
-/area/facility_hallway/command)
-"LX" = (
-/turf/open/floor/engine,
-/area/city/backstreets_room)
-"LY" = (
-/turf/open/floor/plasteel/stairs/right,
-/area/city/backstreets_room)
-"LZ" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/turf/open/floor/plating/asteroid/basalt,
-/area/city/backstreets_alley)
-"Ma" = (
-/obj/structure/closet/crate/wooden,
-/obj/item/stack/sheet/bone{
-	desc = "Looks to be for dog usage.";
-	name = "chewed bones"
-	},
-/obj/item/food/meat/slab/human/mutant/skeleton{
-	desc = "Chewy.";
-	name = "chewbone"
-	},
-/turf/open/floor/wood,
-/area/city/backstreets_room)
-"Mb" = (
-/obj/structure/chair/sofa/left{
-	dir = 4
-	},
-/obj/structure/curtain/cloth{
-	pixel_x = -32
-	},
-/turf/open/floor/wood,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "Mc" = (
 /turf/open/floor/facility/dark,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "Md" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 6
@@ -15191,11 +9684,11 @@
 /turf/open/floor/stone,
 /area/city)
 "Me" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 6
+/obj/effect/turf_decal/siding/yellow{
+	dir = 4
 	},
-/turf/open/floor/wood,
-/area/facility_hallway/command)
+/turf/open/floor/carpet/royalblack,
+/area/facility_hallway/manager)
 "Mf" = (
 /obj/structure/fence/door/opened,
 /turf/open/floor/stone,
@@ -15222,102 +9715,52 @@
 	},
 /obj/item/reagent_containers/food/drinks/bottle/champagne,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /turf/open/floor/wood,
 /area/city/fixers)
-"Mi" = (
-/obj/structure/table/wood/fancy/black,
-/obj/item/book/granter/language_book/narsian,
-/turf/open/floor/carpet/black,
-/area/city/backstreets_room)
 "Mj" = (
 /obj/machinery/door/airlock/wood,
 /turf/open/floor/plasteel/checker,
 /area/city/house)
+"Mk" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/turf/open/floor/wood,
+/area/space)
 "Ml" = (
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/eighties,
 /area/city/shop)
-"Mn" = (
+"Mm" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet/black,
-/area/city/backstreets_room)
-"Mo" = (
-/obj/effect/decal/cleanable/blood/tracks,
-/turf/open/floor/carpet/black,
-/area/city/backstreets_room)
+/obj/machinery/light/cold/no_nightlight{
+	brightness = 16;
+	dir = 4
+	},
+/obj/structure/table/wood,
+/obj/item/modular_computer/laptop{
+	desc = "Appears to be a fixers laptop.";
+	name = "Fixer Laptop"
+	},
+/turf/open/floor/wood,
+/area/space)
 "Mp" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
-"Mq" = (
-/obj/effect/turf_decal/starfury/seven,
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 4;
-	pixel_x = 7
-	},
-/obj/structure/flora/rock/pile,
-/obj/structure/fence/post{
-	pixel_x = -11
-	},
-/turf/open/floor/plating/dirt,
-/area/city/backstreets_room)
-"Mr" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 5
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 10
-	},
-/mob/living/simple_animal/hostile/ordeal/amber_bug{
-	name = "carnivorous worm"
-	},
-/obj/item/food/meat/slab/human/mutant/skeleton,
-/turf/open/floor/fakepit,
-/area/city/backstreets_room)
-"Ms" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/turf/open/floor/carpet/black,
-/area/city/backstreets_room)
-"Mt" = (
-/obj/structure/table/reinforced,
-/obj/item/clipboard,
-/turf/open/floor/engine,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "Mu" = (
 /obj/structure/fence/corner{
 	dir = 4
 	},
 /turf/open/floor/plating/grass,
-/area/facility_hallway/command)
-"Mv" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/mob/living/simple_animal/hostile/ordeal/indigo_noon,
-/turf/open/floor/plating/asteroid/basalt,
-/area/city/backstreets_alley)
-"Mw" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/effect/turf_decal/raven{
-	dir = 9
-	},
-/obj/structure/fluff/big_chain{
-	pixel_y = 10
-	},
-/turf/open/floor/holofloor/dark,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "Mx" = (
 /obj/structure/railing{
 	dir = 1
@@ -15329,7 +9772,7 @@
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "My" = (
 /obj/structure/railing,
 /obj/structure/flora/ausbushes/brflowers,
@@ -15338,22 +9781,19 @@
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "Mz" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/city/shop)
-"MA" = (
-/turf/open/indestructible/cult,
-/area/city/backstreets_room)
 "MC" = (
 /obj/structure/toilet{
 	dir = 4;
 	pixel_y = 5
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /turf/open/floor/sepia,
 /area/city/house)
@@ -15362,17 +9802,7 @@
 	brightness = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/facility_hallway/command)
-"ME" = (
-/obj/structure/filingcabinet,
-/obj/structure/filingcabinet{
-	pixel_x = 10
-	},
-/obj/structure/filingcabinet{
-	pixel_x = -9
-	},
-/turf/open/floor/engine,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "MF" = (
 /obj/structure/chair/office,
 /turf/open/floor/mineral/titanium/blue,
@@ -15398,18 +9828,16 @@
 /obj/effect/turf_decal/siding/yellow/corner,
 /turf/open/floor/carpet/black,
 /area/city/house)
-"MJ" = (
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 10
-	},
-/mob/living/simple_animal/hostile/ordeal/green_bot{
-	name = "spear bot"
-	},
-/obj/effect/turf_decal/trimline/white/filled/line{
+"MK" = (
+/obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
+/obj/structure/fireplace{
+	pixel_x = 0;
+	pixel_y = 3
+	},
+/turf/open/floor/wood,
+/area/space)
 "ML" = (
 /obj/machinery/door/airlock/silver{
 	name = "white-washed airlock"
@@ -15420,18 +9848,6 @@
 /obj/machinery/door/airlock/sandstone,
 /turf/open/floor/facility/halls,
 /area/city/shop)
-"MN" = (
-/obj/structure/flora/tree/jungle,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"MP" = (
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 8;
-	pixel_x = -6
-	},
-/obj/structure/flora/rock/jungle,
-/turf/open/floor/plating/dirt/dark,
-/area/city/backstreets_room)
 "MQ" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 5
@@ -15439,22 +9855,9 @@
 /turf/open/floor/plating/grass,
 /area/city)
 "MR" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
-	},
-/turf/open/floor/wood,
-/area/facility_hallway/command)
-"MS" = (
-/obj/effect/turf_decal{
-	dir = 10
-	},
-/obj/structure/lootcrate/n_corp,
-/turf/open/floor/engine,
-/area/city/backstreets_room)
+/obj/structure/chair/comfy/black,
+/turf/open/floor/facility/dark,
+/area/facility_hallway/manager)
 "MT" = (
 /obj/machinery/door/airlock/wood,
 /turf/open/floor/plasteel/cafeteria,
@@ -15463,87 +9866,24 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/facility/dark,
 /area/city/backstreets_checkpoint)
-"MV" = (
-/obj/structure/fence{
-	dir = 4
-	},
-/obj/effect/turf_decal/weather/dirt,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_alley)
-"MW" = (
-/turf/open/floor/mineral/gold,
-/area/city/backstreets_room)
-"MX" = (
-/obj/effect/mob_spawn/human/corpse/damaged,
-/obj/effect/decal/cleanable/blood,
-/obj/effect/decal/cleanable/blood{
-	pixel_x = -17;
-	pixel_y = -6
-	},
-/obj/effect/decal/cleanable/blood/gibs/torso{
-	pixel_x = 7;
-	pixel_y = -5
-	},
-/turf/open/floor/stone,
-/area/city/backstreets_room)
-"MY" = (
-/obj/machinery/vending/cigarette/beach,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"MZ" = (
-/obj/structure/table/glass,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
 "Na" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /turf/open/floor/wood,
 /area/city/shop)
-"Nb" = (
-/obj/structure/closet/secure_closet/freezer/fridge,
-/obj/item/food/meat/slab/xeno{
-	desc = "You wouldn't.";
-	name = "disgusting looking meat"
-	},
-/obj/item/food/meat/slab/xeno{
-	desc = "You wouldn't.";
-	name = "disgusting looking meat"
-	},
-/obj/item/food/meat/slab/xeno{
-	desc = "You wouldn't.";
-	name = "disgusting looking meat"
-	},
-/obj/item/food/meat/slab/xeno{
-	desc = "You wouldn't.";
-	name = "disgusting looking meat"
-	},
-/obj/item/food/meat/slab/xeno{
-	desc = "You wouldn't.";
-	name = "disgusting looking meat"
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 5
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/sepia,
-/area/city/backstreets_room)
 "Nc" = (
 /obj/structure/chair/sofa/corp/left{
 	dir = 4
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /turf/open/floor/mineral/titanium/tiled/white,
 /area/city/shop)
@@ -15552,36 +9892,11 @@
 	dir = 8
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
-	},
-/turf/open/floor/plasteel/dark,
-/area/facility_hallway/command)
-"Ne" = (
-/obj/structure/fence/door{
+	brightness = 16;
 	dir = 4
 	},
-/obj/effect/decal/cleanable/blood/footprints{
-	dir = 8;
-	pixel_x = -20
-	},
-/obj/effect/decal/cleanable/blood/footprints{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/blood/footprints{
-	dir = 8;
-	pixel_x = -9
-	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"Nf" = (
-/obj/machinery/door/airlock/hatch,
 /turf/open/floor/plasteel/dark,
-/area/city/backstreets_room)
-"Ng" = (
-/obj/effect/landmark/latejoin,
-/turf/open/floor/carpet/royalblack,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "Nh" = (
 /obj/machinery/door/airlock/wood,
 /turf/open/floor/material,
@@ -15613,17 +9928,7 @@
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
-"Nl" = (
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 5
-	},
-/obj/effect/decal/cleanable/blood{
-	pixel_x = -3;
-	pixel_y = -8
-	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "Nm" = (
 /obj/structure/chair/sofa,
 /obj/effect/turf_decal/siding/wood{
@@ -15631,46 +9936,19 @@
 	},
 /turf/open/floor/wood,
 /area/city/shop)
-"Nn" = (
-/obj/structure/flora/rock/pile{
-	pixel_x = -7;
-	pixel_y = -8
-	},
-/obj/structure/flora/ausbushes/sparsegrass,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"No" = (
-/obj/structure/filingcabinet,
-/obj/structure/filingcabinet{
-	pixel_x = -10
-	},
-/obj/structure/filingcabinet{
-	pixel_x = 10
-	},
-/obj/item/ego_weapon/ranged/clerk{
-	desc = "A pistol that looks to be loaded with 9mm rounds. Fit and comforms to the Heads regulations.";
-	name = "9mm Pistol";
-	pixel_y = 10
-	},
-/turf/open/floor/wood,
-/area/city/backstreets_room)
 "Np" = (
 /turf/open/floor/holofloor/white,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "Nq" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 5
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /turf/open/floor/plating/grass,
-/area/facility_hallway/command)
-"Nr" = (
-/obj/structure/destructible/cult/tome,
-/turf/open/indestructible/cult,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "Ns" = (
 /obj/structure/railing{
 	dir = 8
@@ -15681,43 +9959,13 @@
 	dir = 8
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
-"Nt" = (
-/mob/living/simple_animal/hostile/ordeal/green_bot{
-	name = "spear bot"
-	},
-/obj/effect/turf_decal/trimline/white/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"Nu" = (
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 1;
-	pixel_y = 6
-	},
-/obj/structure/railing/corner{
-	dir = 4;
-	pixel_x = -23;
-	pixel_y = 2
-	},
-/turf/open/floor/holofloor/dark,
-/area/city/backstreets_room)
-"Nv" = (
-/obj/structure/table/greyscale,
-/obj/structure/showcase/machinery/microwave{
-	desc = "These robots really gotta be careful.";
-	name = "\improper Broken Microwave";
-	pixel_y = 10
-	},
-/turf/open/floor/plasteel/checker,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "Nw" = (
 /obj/structure/fluff/paper/stack{
 	dir = 8
@@ -15734,32 +9982,19 @@
 	},
 /turf/open/floor/wood,
 /area/city/shop)
-"Nz" = (
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 8
-	},
-/mob/living/simple_animal/hostile/ordeal/indigo_dawn{
-	name = "sweeper scout"
-	},
-/obj/item/paper/crumpled{
-	pixel_x = 5;
-	pixel_y = -5
-	},
-/obj/item/paper/crumpled{
-	pixel_x = 10
-	},
-/obj/item/paper/crumpled{
-	pixel_x = -10
-	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"NA" = (
-/obj/structure/chair/sofa/corp/right{
+"Ny" = (
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/turf/open/floor/sepia,
+/area/facility_hallway/manager)
 "NB" = (
 /obj/structure/chair/wood/wings{
 	dir = 4
@@ -15768,8 +10003,8 @@
 	dir = 8
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /turf/open/floor/wood,
 /area/city/shop)
@@ -15781,81 +10016,16 @@
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
-"ND" = (
-/obj/structure/fence{
-	dir = 4
+/area/facility_hallway/manager)
+"NE" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
 	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_checkpoint)
-"NF" = (
-/obj/item/stack/sheet/mineral/wood,
-/obj/item/stack/sheet/mineral/wood{
-	pixel_x = -5
-	},
-/obj/item/stack/sheet/mineral/wood{
-	pixel_x = 7
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
-/area/city/backstreets_room)
-"NG" = (
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 5
-	},
-/obj/effect/turf_decal/starfury/ten{
-	dir = 8
-	},
-/obj/structure/flora/rock/pile,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"NH" = (
-/obj/structure/table/reinforced,
-/obj/structure/table/reinforced,
-/obj/item/living_heart,
-/obj/item/living_heart{
-	pixel_x = 6;
-	pixel_y = 6
-	},
-/obj/item/organ/heart{
-	pixel_x = 11;
-	pixel_y = -5
-	},
-/obj/item/organ/heart/demon{
-	pixel_x = -5;
-	pixel_y = -11
-	},
-/obj/item/organ/heart/fly{
-	pixel_x = -7;
-	pixel_y = 8
-	},
-/obj/item/organ/heart/cursed{
-	pixel_x = 5;
-	pixel_y = -1
-	},
-/turf/open/floor/stone,
-/area/city/backstreets_room)
-"NI" = (
-/obj/structure/chair/pew/right,
-/turf/open/floor/carpet/black,
-/area/city/backstreets_room)
-"NJ" = (
-/obj/item/emptysandbag,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_alley)
+/area/facility_hallway/manager)
 "NK" = (
 /turf/open/floor/stone,
 /area/city)
-"NL" = (
-/obj/effect/mob_spawn/human/skeleton/alive,
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/decal/cleanable/blood/old{
-	pixel_y = -20
-	},
-/turf/open/floor/wood,
-/area/city/backstreets_room)
 "NM" = (
 /obj/effect/light_emitter{
 	light_power = 4;
@@ -15868,24 +10038,11 @@
 	density = 1
 	},
 /area/city)
-"NO" = (
-/obj/item/stack/sheet/mineral/wood,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
 "NP" = (
 /obj/structure/flora/tree/jungle/small,
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/floor/plating/grass,
-/area/facility_hallway/command)
-"NR" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light/broken{
-	dir = 4
-	},
-/turf/open/floor/plasteel/shuttle{
-	name = "floor"
-	},
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "NS" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -15904,30 +10061,20 @@
 /area/city/fixers)
 "NT" = (
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /turf/open/floor/circuit/telecomms,
 /area/city/fixers)
 "NU" = (
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /turf/open/floor/plasteel/chapel{
 	dir = 4
 	},
 /area/city/shop)
-"NV" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 10
-	},
-/turf/open/floor/plating/asteroid/basalt,
-/area/city/backstreets_checkpoint)
-"NW" = (
-/obj/structure/table/greyscale,
-/turf/open/floor/eighties,
-/area/city/backstreets_room)
 "NX" = (
 /obj/structure/rack{
 	pixel_x = -1
@@ -15935,52 +10082,45 @@
 /obj/item/melee/classic_baton,
 /turf/open/floor/mineral/titanium/blue/airless,
 /area/city/shop)
-"NY" = (
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/blood/gibs,
-/turf/open/floor/stone,
-/area/city/backstreets_room)
 "NZ" = (
 /obj/machinery/door/window/southleft{
-	opacity = 1;
-	name = "Bathroom Door"
+	name = "Bathroom Door";
+	opacity = 1
 	},
 /turf/open/floor/carpet/red,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "Oa" = (
 /obj/machinery/computer/security,
 /turf/open/floor/facility/dark,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
+"Oc" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/obj/structure/bed,
+/obj/item/bedsheet/wiz,
+/turf/open/floor/wood,
+/area/space)
+"Od" = (
+/obj/machinery/door/airlock/silver{
+	name = "white-washed airlock"
+	},
+/turf/open/floor/facility/halls,
+/area/city)
 "Of" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/obj/effect/landmark/latejoin,
 /turf/open/floor/wood,
-/area/facility_hallway/command)
-"Og" = (
-/obj/effect/decal/cleanable/blood/gibs/body,
-/obj/effect/decal/cleanable/blood/gibs/bubblegum{
-	pixel_x = -12
-	},
-/turf/open/floor/wood,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "Oh" = (
 /obj/structure/table/wood,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /turf/open/floor/carpet/purple,
 /area/city/house)
-"Oi" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 6
-	},
-/turf/open/floor/carpet/black,
-/area/city/backstreets_room)
 "Oj" = (
 /obj/structure/railing{
 	dir = 1
@@ -15993,124 +10133,67 @@
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
-"Ok" = (
-/obj/structure/sign/warning{
-	desc = "A warning sign, something about killer robots.";
-	pixel_y = 30
+/area/facility_hallway/manager)
+"Ol" = (
+/obj/structure/closet/secure_closet/personal/cabinet,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
 	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 9
-	},
-/turf/open/floor/plating/asteroid/basalt,
-/area/city/backstreets_alley)
+/turf/open/floor/wood,
+/area/space)
 "Om" = (
-/obj/structure/toilet{
-	dir = 4
+/obj/machinery/shower{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/sepia,
-/area/facility_hallway/command)
+/obj/structure/curtain/cloth,
+/obj/item/soap/deluxe,
+/turf/open/floor/noslip,
+/area/facility_hallway/manager)
 "On" = (
 /obj/structure/bed,
 /obj/item/bedsheet/hop,
 /turf/open/floor/mineral/titanium/blue,
 /area/city/fixers)
-"Oo" = (
-/obj/effect/spawner/randomcolavend,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/eighties,
-/area/city/backstreets_room)
-"Op" = (
-/obj/structure/mineral_door/wood,
-/turf/open/floor/plasteel/shuttle{
-	name = "floor"
-	},
-/area/city/backstreets_room)
-"Oq" = (
-/obj/structure/table/reinforced,
-/turf/open/floor/facility/dark,
-/area/city/backstreets_room)
 "Or" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
 	},
 /turf/open/floor/plating/grass,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "Ot" = (
 /obj/structure/window/reinforced/spawner{
 	max_integrity = 25;
-	opacity = 1;
-	name = "Shower Glass"
+	name = "Shower Glass";
+	opacity = 1
 	},
 /obj/structure/closet/secure_closet/personal/cabinet{
 	anchored = 1
 	},
 /obj/item/toy/plush/binah,
 /turf/open/floor/carpet/royalblack,
-/area/facility_hallway/command)
-"Ou" = (
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "Ov" = (
 /obj/structure/bed/maint,
 /obj/item/bedsheet/blue,
 /turf/open/floor/plasteel/white,
 /area/city/fixers)
-"Ow" = (
-/obj/machinery/light/broken{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
-"Ox" = (
-/obj/machinery/door/airlock/titanium{
-	name = "airlock"
-	},
-/turf/open/floor/holofloor/white,
-/area/city/backstreets_room)
-"Oy" = (
-/obj/structure/closet/crate/large,
-/obj/item/clothing/suit/armor/ego_gear/limbus/ego/minos,
-/turf/open/floor/engine,
-/area/city/backstreets_room)
-"Oz" = (
-/obj/machinery/light/broken{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/city/backstreets_room)
-"OA" = (
-/obj/machinery/medipen_refiller,
-/turf/open/floor/plasteel/showroomfloor,
-/area/city/backstreets_room)
 "OB" = (
 /turf/open/floor/facility/halls,
 /area/city/fixers)
 "OC" = (
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /turf/open/floor/carpet/cyan,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "OD" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 6
+/obj/machinery/computer/abnormality_archive{
+	dir = 1
 	},
-/obj/structure/closet/secure_closet/personal/cabinet{
-	anchored = 1
-	},
-/turf/open/floor/wood,
-/area/facility_hallway/command)
-"OF" = (
-/obj/effect/decal/cleanable/blood/tracks,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
+/turf/open/floor/facility/dark,
+/area/facility_hallway/manager)
 "OG" = (
 /obj/structure/flora/ausbushes/reedbush,
 /obj/effect/turf_decal/siding/thinplating/dark/corner{
@@ -16127,24 +10210,11 @@
 	opacity = 1
 	},
 /obj/machinery/door/window/eastright{
-	opacity = 1;
-	name = "Bathroom Door"
+	name = "Bathroom Door";
+	opacity = 1
 	},
 /turf/open/floor/plasteel/white,
-/area/facility_hallway/command)
-"OI" = (
-/obj/effect/turf_decal/starfury/three{
-	dir = 4
-	},
-/obj/structure/flora/grass/jungle/b,
-/obj/effect/decal/cleanable/blood/gibs,
-/obj/machinery/light/dim{
-	dir = 4;
-	pixel_y = -7
-	},
-/obj/structure/lootcrate/w_corp,
-/turf/open/floor/plating/dirt/dark,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "OJ" = (
 /obj/structure/railing{
 	dir = 8
@@ -16157,56 +10227,13 @@
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
-"OK" = (
-/obj/structure/fence/corner{
-	dir = 8;
-	pixel_x = -9;
-	pixel_y = -3
-	},
-/turf/closed/indestructible/reinforced,
-/area/city/backstreets_room)
-"OL" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/turf/open/floor/plating/asteroid/basalt,
-/area/city/backstreets_alley)
-"OM" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/chair/plastic{
-	dir = 8
-	},
-/turf/open/floor/plasteel/sepia,
-/area/city/backstreets_room)
-"ON" = (
-/obj/effect/decal/cleanable/blood/splatter{
-	pixel_x = -18
-	},
-/obj/effect/decal/cleanable/blood,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/blood/old{
-	pixel_x = 17;
-	pixel_y = -7
-	},
-/turf/open/floor/stone,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "OO" = (
 /obj/structure/chair/comfy/brown{
 	dir = 8
 	},
 /turf/open/floor/wood,
 /area/city/shop)
-"OP" = (
-/obj/machinery/griddle,
-/obj/machinery/light/broken{
-	dir = 8
-	},
-/turf/open/floor/plasteel/sepia,
-/area/city/backstreets_room)
 "OQ" = (
 /obj/structure/lattice/catwalk,
 /obj/effect/turf_decal/loading_area/white,
@@ -16215,19 +10242,6 @@
 	},
 /turf/open/floor/plating,
 /area/city/shop)
-"OR" = (
-/obj/effect/turf_decal/trimline/neutral/line{
-	pixel_y = -6
-	},
-/obj/structure/fence/post{
-	pixel_x = 15
-	},
-/turf/open/floor/holofloor/dark,
-/area/city/backstreets_room)
-"OS" = (
-/obj/effect/decal/fakelattice,
-/turf/open/lava/smooth,
-/area/city/backstreets_room)
 "OT" = (
 /turf/open/floor/plasteel/airless/white,
 /area/city/backstreets_checkpoint)
@@ -16255,7 +10269,7 @@
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "OX" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
@@ -16265,18 +10279,9 @@
 	desc = "Appears to be a fixers laptop.";
 	name = "Fixer Laptop"
 	},
+/obj/item/choice_beacon/association,
 /turf/open/floor/wood,
 /area/city/fixers)
-"OY" = (
-/obj/structure/stone_tile/slab/cracked,
-/obj/effect/light_emitter{
-	light_power = 4;
-	light_range = 25;
-	set_cap = 3;
-	set_luminosity = 24
-	},
-/turf/open/floor/plating/dirt/jungle/wasteland,
-/area/city/backstreets_room)
 "OZ" = (
 /obj/effect/turf_decal/siding/blue,
 /obj/effect/turf_decal/siding/blue/corner{
@@ -16288,83 +10293,22 @@
 /obj/structure/lattice/catwalk,
 /turf/open/floor/plating,
 /area/city/fixers)
-"Pb" = (
-/turf/closed/indestructible/fakedoor{
-	desc = "Too bad the door is broken.";
-	name = "Arcade Plush Storage"
-	},
-/area/city/backstreets_alley)
 "Pc" = (
 /obj/effect/turf_decal/plaque{
 	alpha = 230;
 	icon_state = "LC1"
 	},
 /turf/open/floor/facility/dark,
-/area/facility_hallway/command)
-"Pd" = (
-/mob/living/simple_animal/hostile/ordeal/amber_bug{
-	name = "carnivorous worm"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/sepia,
-/area/city/backstreets_room)
-"Pe" = (
-/obj/structure/table/wood,
-/obj/item/documents/ncorporation,
-/obj/item/book_of_babel,
-/turf/open/indestructible/cult,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "Pg" = (
 /obj/effect/turf_decal/siding/yellow{
 	dir = 10
 	},
 /turf/open/floor/carpet/stellar,
-/area/facility_hallway/command)
-"Ph" = (
-/obj/structure/closet/crate/large,
-/obj/effect/turf_decal/siding/thinplating/dark/corner{
-	dir = 8
-	},
-/turf/open/indestructible/cult,
-/area/city/backstreets_room)
-"Pi" = (
-/obj/machinery/door/airlock/freezer{
-	name = "airlock"
-	},
-/turf/open/floor/holofloor/white,
-/area/city/backstreets_room)
-"Pj" = (
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 9
-	},
-/obj/effect/turf_decal/starfury/ten,
-/obj/structure/flora/rock/jungle{
-	pixel_x = 6;
-	pixel_y = 1
-	},
-/obj/structure/flora/rock/pile{
-	pixel_x = -1;
-	pixel_y = -15
-	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "Pk" = (
 /turf/open/floor/holofloor/white,
 /area/city/shop)
-"Pl" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/landmark/latejoin,
-/turf/open/floor/sepia,
-/area/facility_hallway/command)
 "Pm" = (
 /obj/effect/turf_decal/siding/blue{
 	dir = 8
@@ -16373,14 +10317,11 @@
 	dir = 4
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /turf/open/floor/carpet/cyan,
 /area/city/shop)
-"Pn" = (
-/turf/open/floor/facility/dark,
-/area/city/backstreets_room)
 "Po" = (
 /obj/structure/railing{
 	dir = 1
@@ -16396,13 +10337,7 @@
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
-"Pq" = (
-/obj/structure/chair/wood{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "Pr" = (
 /obj/item/assembly/control{
 	id = "centralX"
@@ -16417,30 +10352,11 @@
 /obj/structure/table/wood/fancy/blue,
 /obj/item/modular_computer/laptop,
 /turf/open/floor/carpet/royalblue,
-/area/facility_hallway/command)
-"Pt" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/kirbyplants/dead{
-	desc = "A sad, dead plant";
-	name = "dead potted plant";
-	pixel_y = 10
-	},
-/turf/open/floor/wood,
-/area/city/backstreets_room)
-"Pu" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/turf/open/floor/plating/dirt/dark,
-/area/city/backstreets_room)
-"Pv" = (
-/turf/open/floor/holofloor/white,
-/area/city/backstreets_room)
-"Pw" = (
-/obj/structure/sign/warning/firingrange{
-	pixel_x = -30
-	},
-/turf/open/floor/plasteel/dark,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
+"Px" = (
+/obj/effect/turf_decal/siding/blue/end,
+/turf/open/floor/carpet/cyan,
+/area/space)
 "Py" = (
 /obj/machinery/door/window/westright,
 /turf/open/floor/facility/white,
@@ -16467,12 +10383,12 @@
 	pixel_y = 6
 	},
 /obj/item/book/random{
-	pixel_y = 11;
-	pixel_x = -2
+	pixel_x = -2;
+	pixel_y = 11
 	},
 /obj/item/reagent_containers/food/drinks/bottle/wine{
-	pixel_y = 13;
-	pixel_x = -70
+	pixel_x = -70;
+	pixel_y = 13
 	},
 /turf/open/floor/carpet/royalblack,
 /area/city/house)
@@ -16500,21 +10416,14 @@
 /area/city/shop)
 "PC" = (
 /obj/effect/mermaid_water{
-	name = "Coastal Waters";
-	desc = "Not a drop of drinkable water, just a body of salty brine"
+	desc = "Not a drop of drinkable water, just a body of salty brine";
+	name = "Coastal Waters"
 	},
 /obj/machinery/modular_computer/console/preset/civilian{
 	dir = 8
 	},
 /turf/open/floor/plating/grass,
 /area/city)
-"PD" = (
-/obj/effect/decal/cleanable/blood/old{
-	pixel_x = 17;
-	pixel_y = -7
-	},
-/turf/open/floor/wood,
-/area/city/backstreets_room)
 "PE" = (
 /obj/structure/window/reinforced/spawner/east{
 	max_integrity = 25
@@ -16537,52 +10446,27 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/city/shop)
-"PG" = (
-/obj/structure/flora/grass/jungle{
-	pixel_x = 7;
-	pixel_y = 6
-	},
-/obj/structure/flora/tree/jungle,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"PH" = (
-/obj/effect/decal/cleanable/blood/gibs/core,
-/turf/closed/indestructible/rock,
-/area/space)
 "PI" = (
 /obj/structure/sign/barsign,
 /turf/closed/wall/mineral/silver{
+	desc = "A wall with unmistable white coloring. Iconic sight in N Corp's Nest!";
 	explosion_block = 50;
-	name = "N Corporation Nest Wall";
-	desc = "A wall with unmistable white coloring. Iconic sight in N Corp's Nest!"
+	name = "N Corporation Nest Wall"
 	},
 /area/city/shop)
-"PJ" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/table/glass,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
 "PK" = (
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /turf/open/floor/mineral/titanium/tiled/white,
 /area/city/shop)
-"PM" = (
-/obj/effect/turf_decal/siding/wideplating/corner{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
 "PN" = (
 /obj/effect/turf_decal/siding{
 	dir = 10
 	},
 /turf/open/floor/carpet/black,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "PO" = (
 /turf/open/floor/wood,
 /area/city/house)
@@ -16593,38 +10477,20 @@
 	},
 /turf/open/floor/plating/grass,
 /area/city)
-"PQ" = (
-/mob/living/simple_animal/hostile/ordeal/green_bot{
-	name = "guard bot"
+"PS" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
 	},
-/turf/open/floor/holofloor/dark,
-/area/city/backstreets_room)
-"PR" = (
-/obj/structure/altar_of_gods,
-/obj/item/clothing/suit/armor/riot/chaplain/clock,
-/turf/open/indestructible/cult,
-/area/city/backstreets_room)
-"PT" = (
-/obj/structure/table/greyscale,
-/obj/item/documents/syndicate/blue{
-	desc = "Appears to be documents and certifications signed by corporations to legalize something.";
-	name = "Warehouse Documents"
+/obj/structure/table/wood/fancy/cyan,
+/obj/structure/closet/mini_fridge{
+	desc = "A small contraption designed to imbue a few drinks with a pleasant chill.";
+	name = "Mini-fridge";
+	pixel_y = 6
 	},
-/obj/machinery/light/dim{
-	dir = 1
-	},
-/turf/open/floor/facility/dark,
-/area/city/backstreets_room)
-"PU" = (
-/mob/living/simple_animal/hostile/ordeal/green_bot{
-	name = "clerk bot"
-	},
-/turf/open/floor/facility/dark,
-/area/city/backstreets_room)
-"PV" = (
-/obj/structure/lootcrate/workshopleaf,
-/turf/open/indestructible/cult,
-/area/city/backstreets_room)
+/obj/item/food/meat/steak/crimson,
+/obj/item/reagent_containers/food/drinks/bottle/champagne,
+/turf/open/floor/wood,
+/area/space)
 "PW" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 8
@@ -16641,7 +10507,7 @@
 	pixel_x = -27
 	},
 /turf/open/floor/sepia,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "PY" = (
 /obj/structure/sign/barsign,
 /turf/closed/indestructible/iron,
@@ -16655,11 +10521,7 @@
 	brightness = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/facility_hallway/command)
-"Qa" = (
-/obj/structure/chair/sofa/corp,
-/turf/open/floor/plasteel/showroomfloor,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "Qb" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
@@ -16690,28 +10552,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/facility_hallway/command)
-"Qf" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/mask/surgical,
-/obj/item/clothing/suit/apron/surgical{
-	pixel_y = 5
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#e8eaff"
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/city/backstreets_room)
-"Qg" = (
-/obj/effect/decal/cleanable/blood/splatter{
-	pixel_y = 9
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "Qh" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -16730,23 +10571,6 @@
 	},
 /turf/open/floor/plasteel/sepia,
 /area/city/shop)
-"Qi" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/mob/living/simple_animal/hostile/ordeal/indigo_noon,
-/turf/open/floor/plating/asteroid/basalt,
-/area/city/backstreets_alley)
-"Qj" = (
-/obj/structure/table/wood,
-/obj/machinery/computer/libraryconsole{
-	pixel_x = -1;
-	pixel_y = 6
-	},
-/turf/open/floor/plasteel/shuttle{
-	name = "floor"
-	},
-/area/city/backstreets_room)
 "Qk" = (
 /obj/machinery/computer/slot_machine,
 /obj/effect/turf_decal/siding/blue{
@@ -16754,23 +10578,6 @@
 	},
 /turf/open/floor/carpet/cyan,
 /area/city/shop)
-"Ql" = (
-/obj/effect/turf_decal/raven{
-	dir = 10
-	},
-/obj/structure/fluff/big_chain{
-	pixel_y = 10
-	},
-/turf/open/floor/holofloor/dark,
-/area/city/backstreets_room)
-"Qm" = (
-/obj/machinery/light/small,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"Qn" = (
-/mob/living/simple_animal/hostile/ordeal/indigo_dawn,
-/turf/open/floor/plating/asteroid/basalt,
-/area/city/backstreets_alley)
 "Qo" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
@@ -16787,46 +10594,24 @@
 "Qp" = (
 /obj/structure/window/reinforced/spawner/east{
 	max_integrity = 25;
-	opacity = 1;
-	name = "Glass"
+	name = "Glass";
+	opacity = 1
 	},
 /turf/open/floor/plasteel/white,
-/area/facility_hallway/command)
-"Qq" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 9
-	},
-/turf/open/indestructible/cult,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "Qr" = (
 /turf/open/floor/plasteel/checker,
 /area/city/shop)
-"Qs" = (
-/obj/structure/chair/stool/bar{
-	desc = "It has some questionable stains on it...";
-	name = "arcade stool"
-	},
-/obj/structure/chair/stool/bar{
-	desc = "It has some questionable stains on it...";
-	name = "arcade stool"
-	},
-/turf/open/floor/eighties,
-/area/city/backstreets_room)
-"Qt" = (
-/turf/closed/indestructible/fakeglass,
-/area/city/backstreets_room)
-"Qu" = (
-/mob/living/simple_animal/hostile/ordeal/green_bot_big{
-	name = "gun bot"
-	},
-/obj/effect/turf_decal/trimline/white/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
 "Qv" = (
 /turf/open/floor/mineral/titanium/white,
 /area/city/shop)
+"Qw" = (
+/obj/effect/turf_decal/siding/wood/corner,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/space)
 "Qx" = (
 /obj/structure/table/wood,
 /obj/machinery/photocopier{
@@ -16845,23 +10630,19 @@
 	},
 /turf/open/floor/wood,
 /area/city/shop)
-"Qz" = (
-/obj/structure/fence/corner{
-	dir = 3
+"QB" = (
+/obj/structure/chair/wood/wings,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
 	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_checkpoint)
-"QA" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 9
-	},
-/turf/open/floor/plating/asteroid/basalt,
-/area/city/backstreets_alley)
-"QD" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/costume,
 /turf/open/floor/wood,
-/area/city/backstreets_room)
+/area/space)
+"QC" = (
+/obj/effect/turf_decal/siding/yellow{
+	dir = 5
+	},
+/turf/open/floor/carpet/royalblack,
+/area/facility_hallway/manager)
 "QE" = (
 /obj/effect/turf_decal/siding/thinplating/dark,
 /turf/open/floor/mineral/plastitanium,
@@ -16875,109 +10656,40 @@
 	dir = 5
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /turf/open/floor/carpet/stellar,
-/area/facility_hallway/command)
-"QG" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 10
-	},
-/turf/open/indestructible/cult,
-/area/city/backstreets_room)
-"QH" = (
-/obj/machinery/shower{
-	pixel_y = 15
-	},
-/obj/structure/curtain/cloth,
-/obj/item/soap/deluxe,
-/turf/open/floor/noslip,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "QI" = (
 /obj/effect/turf_decal/siding{
 	dir = 9
 	},
 /turf/open/floor/carpet/black,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "QK" = (
 /obj/effect/turf_decal/siding/wood/corner,
 /turf/open/floor/wood,
 /area/city/shop)
-"QL" = (
-/obj/structure/chair/pew/left{
-	desc = "For resting your legs.";
-	name = "bench"
-	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"QM" = (
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 8;
-	pixel_x = -6
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 1;
-	pixel_y = 6
-	},
-/obj/structure/fence/post{
-	layer = 3;
-	pixel_x = -13;
-	pixel_y = 24
-	},
-/obj/item/bodypart/chest,
-/obj/effect/decal/cleanable/blood/old{
-	pixel_x = 17;
-	pixel_y = -7
-	},
-/turf/open/floor/holofloor/dark,
-/area/city/backstreets_room)
-"QN" = (
-/obj/machinery/hydroponics/soil,
-/turf/open/floor/plating/grass,
-/area/facility_hallway/command)
 "QO" = (
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /turf/open/floor/carpet/black,
 /area/city/house)
-"QP" = (
-/turf/closed/indestructible/rock,
-/area/city/backstreets_alley)
 "QQ" = (
-/obj/structure/bed,
-/obj/item/bedsheet/red,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/computer/abnormality_logs{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/item/toy/plush/lisa,
-/turf/open/floor/sepia,
-/area/facility_hallway/command)
+/turf/open/floor/facility/dark,
+/area/facility_hallway/manager)
 "QR" = (
 /obj/effect/turf_decal/siding/yellow{
 	dir = 5
 	},
 /turf/open/floor/carpet/stellar,
-/area/facility_hallway/command)
-"QS" = (
-/obj/structure/bed/maint,
-/obj/item/bedsheet/dorms,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/mob/living/simple_animal/mouse,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "QT" = (
 /obj/effect/turf_decal/tile{
 	color = "#333333";
@@ -16998,53 +10710,16 @@
 /obj/structure/kitchenspike,
 /turf/open/floor/plasteel/kitchen_coldroom,
 /area/city/shop)
-"QU" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/obj/structure/table/greyscale,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/kitchen/knife,
-/obj/item/kitchen/rollingpin,
-/obj/structure/curtain/bounty{
-	pixel_y = -30
-	},
-/turf/open/floor/plasteel/sepia,
-/area/city/backstreets_room)
 "QV" = (
 /obj/structure/bed,
 /obj/item/bedsheet/hop,
 /turf/open/floor/wood,
-/area/facility_hallway/command)
-"QW" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 7
-	},
-/turf/open/floor/plating/ashplanet/rocky,
-/area/city/backstreets_room)
-"QX" = (
-/obj/machinery/door/airlock/cult/unruned/friendly{
-	name = "cult airlock"
-	},
-/turf/open/indestructible/cult,
-/area/city/backstreets_room)
-"QY" = (
-/mob/living/simple_animal/hostile/ordeal/green_bot_big{
-	name = "gun bot"
-	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_checkpoint)
+/area/facility_hallway/manager)
 "QZ" = (
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "Ra" = (
 /obj/effect/turf_decal/siding/blue/end,
 /turf/open/floor/carpet/cyan,
@@ -17056,32 +10731,6 @@
 	},
 /turf/open/floor/facility/white,
 /area/city/shop)
-"Rc" = (
-/obj/structure/sacrificealtar,
-/turf/open/indestructible/cult,
-/area/city/backstreets_room)
-"Rd" = (
-/obj/effect/decal/cleanable/blood/old,
-/obj/structure/window/reinforced/tinted/frosted,
-/obj/machinery/door/poddoor,
-/turf/open/floor/plating,
-/area/city/backstreets_room)
-"Re" = (
-/obj/effect/turf_decal/trimline/neutral/corner{
-	dir = 8;
-	pixel_x = -7;
-	pixel_y = -6
-	},
-/obj/structure/railing/corner{
-	dir = 8;
-	pixel_x = -1;
-	pixel_y = 2
-	},
-/obj/structure/fence/post{
-	pixel_x = -12
-	},
-/turf/open/floor/holofloor/dark,
-/area/city/backstreets_room)
 "Rf" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -17094,8 +10743,8 @@
 	dir = 1
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /turf/open/floor/mineral/gold,
 /area/city/shop)
@@ -17109,60 +10758,34 @@
 	},
 /turf/open/floor/wood,
 /area/city/shop)
-"Rh" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/lava/smooth,
-/area/city/backstreets_room)
-"Ri" = (
-/obj/structure/table/reinforced,
-/obj/item/screwdriver/nuke{
-	pixel_y = 10
-	},
-/turf/open/floor/engine,
-/area/city/backstreets_room)
-"Rj" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
 "Rk" = (
 /obj/effect/turf_decal/plaque{
 	alpha = 230;
 	icon_state = "LC22"
 	},
 /turf/open/floor/facility/dark,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "Rl" = (
 /obj/effect/turf_decal/plaque{
 	alpha = 230;
 	icon_state = "LC8"
 	},
 /turf/open/floor/facility/dark,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "Rm" = (
 /obj/item/candle,
 /turf/open/floor/plasteel/dark,
 /area/city/shop)
-"Rn" = (
-/obj/effect/decal/cleanable/blood,
-/obj/effect/decal/cleanable/blood/old{
-	pixel_x = -13;
-	pixel_y = -7
-	},
-/turf/open/floor/stone,
-/area/city/backstreets_room)
 "Ro" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /turf/open/floor/plating/grass,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "Rp" = (
 /obj/structure/chair/office{
 	desc = "A rather boring gaming chair.";
@@ -17171,23 +10794,6 @@
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/city/fixers)
-"Rq" = (
-/obj/structure/fluff/big_chain{
-	pixel_y = 10
-	},
-/obj/effect/turf_decal/raven{
-	dir = 6
-	},
-/turf/open/floor/holofloor/dark,
-/area/city/backstreets_room)
-"Rr" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/blood/footprints{
-	dir = 8;
-	pixel_x = -9
-	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
 "Rs" = (
 /obj/structure/sink/kitchen{
 	dir = 8;
@@ -17216,30 +10822,13 @@
 	},
 /turf/open/floor/plasteel/sepia,
 /area/city/shop)
-"Ru" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 6
-	},
-/turf/open/floor/carpet/black,
-/area/city/backstreets_room)
 "Rv" = (
 /obj/effect/turf_decal/plaque{
 	alpha = 230;
 	icon_state = "LC10"
 	},
 /turf/open/floor/facility/dark,
-/area/facility_hallway/command)
-"Rw" = (
-/obj/effect/turf_decal/trimline/neutral/corner{
-	pixel_x = 7;
-	pixel_y = -5
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/blood/gibs/old{
-	pixel_x = 11
-	},
-/turf/open/floor/holofloor/dark,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "Rx" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#3234B9";
@@ -17251,10 +10840,6 @@
 	},
 /turf/open/floor/mineral/titanium/tiled/white,
 /area/city/fixers)
-"Ry" = (
-/obj/item/toy/beach_ball/holoball/dodgeball,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
 "Rz" = (
 /obj/machinery/scanner_gate{
 	scangate_mode = "Guns"
@@ -17263,7 +10848,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "RA" = (
 /obj/structure/table/reinforced{
 	color = "#00a86b"
@@ -17288,91 +10873,66 @@
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "RC" = (
 /obj/effect/turf_decal/siding/blue/end{
 	dir = 8
 	},
 /turf/open/floor/carpet/cyan,
 /area/city/shop)
-"RD" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/closet/cabinet,
-/obj/item/clothing/suit/armor/ego_gear/city/seven,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
-"RE" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 7
-	},
-/turf/open/indestructible/cult,
-/area/city/backstreets_room)
 "RF" = (
-/obj/structure/sign/departments/restroom{
-	pixel_y = 32
+/obj/machinery/door/airlock/wood{
+	name = "Disciplinary Head Office"
 	},
 /turf/open/floor/facility/dark,
-/area/facility_hallway/command)
-"RI" = (
-/obj/structure/filingcabinet{
-	pixel_x = 11
+/area/facility_hallway/manager)
+"RG" = (
+/obj/effect/turf_decal/siding/wood/corner,
+/turf/open/floor/wood,
+/area/space)
+"RH" = (
+/obj/structure/table/wood,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
-/obj/structure/filingcabinet,
-/obj/structure/filingcabinet{
-	pixel_x = -11
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
-/turf/open/floor/plasteel/shuttle,
-/area/city/backstreets_room)
-"RJ" = (
-/obj/structure/closet/secure_closet/freezer/fridge,
-/obj/item/food/meat/slab/human,
-/obj/item/food/meat/slab/human,
-/obj/item/food/meat/slab/human,
-/obj/item/food/meat/slab/human,
-/turf/open/floor/plasteel/sepia,
-/area/city/backstreets_room)
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/item/toy/plush/pkplush,
+/obj/structure/sign/poster/lobotomycorp/random{
+	pixel_x = 32
+	},
+/obj/machinery/light/cold/no_nightlight{
+	brightness = 16;
+	dir = 4
+	},
+/turf/open/floor/sepia,
+/area/facility_hallway/manager)
 "RK" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 1
 	},
 /turf/open/floor/stone,
 /area/city)
-"RL" = (
-/obj/structure/filingcabinet{
-	pixel_x = -11
-	},
-/obj/structure/filingcabinet,
-/obj/structure/filingcabinet{
-	pixel_x = 11
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/city/backstreets_room)
-"RM" = (
-/obj/effect/turf_decal/siding/yellow{
-	dir = 5
-	},
-/obj/structure/filingcabinet,
-/obj/structure/filingcabinet{
-	pixel_x = -9
-	},
-/obj/structure/filingcabinet{
-	pixel_x = 10
-	},
-/turf/open/floor/carpet/green,
-/area/city/backstreets_room)
 "RN" = (
 /obj/item/bedsheet/black,
 /obj/structure/bed,
 /turf/open/floor/wood,
 /area/city/house)
-"RP" = (
-/obj/machinery/light/small{
-	dir = 8
+"RO" = (
+/obj/effect/spawner/room/backstreet_template,
+/turf/closed/indestructible/rock,
+/area/space)
+"RQ" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
 	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
+/turf/open/floor/wood,
+/area/space)
 "RR" = (
 /obj/structure/table/reinforced{
 	max_integrity = 25
@@ -17392,26 +10952,15 @@
 	density = 1
 	},
 /area/city)
-"RV" = (
-/obj/effect/decal/cleanable/blood/tracks,
-/turf/open/floor/plasteel/shuttle,
-/area/city/backstreets_room)
-"RW" = (
-/obj/effect/turf_decal/trimline/white/filled/line,
-/obj/effect/turf_decal/trimline/white/filled/line{
+"RU" = (
+/obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
 	},
-/obj/item/toy/beach_ball/holoball/dodgeball,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"RX" = (
-/obj/machinery/light/red{
-	dir = 8;
-	pixel_x = 4;
-	pixel_y = -6
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
 	},
-/turf/open/floor/stone,
-/area/city/backstreets_room)
+/turf/open/floor/wood,
+/area/space)
 "RY" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -17419,46 +10968,16 @@
 	},
 /turf/open/floor/plating/grass,
 /area/city)
-"RZ" = (
-/obj/effect/decal/cleanable/blood/splatter{
-	pixel_x = -18
-	},
-/obj/effect/decal/cleanable/blood/gibs/limb{
-	dir = 4;
-	layer = 4;
-	pixel_x = 12;
-	pixel_y = 10
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/stone,
-/area/city/backstreets_room)
-"Sa" = (
-/obj/structure/curtain/bounty{
-	pixel_y = -30
-	},
-/turf/open/floor/wood,
-/area/city/backstreets_room)
-"Sb" = (
-/obj/structure/chair/pew/left{
-	desc = "For resting your legs.";
-	dir = 8;
-	name = "bench"
-	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
 "Sc" = (
 /obj/effect/turf_decal/plaque{
 	alpha = 230;
 	icon_state = "LC7"
 	},
 /turf/open/floor/facility/dark,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "Sd" = (
 /turf/open/floor/mineral/titanium/tiled/white,
 /area/city/shop)
-"Se" = (
-/turf/open/floor/plating/ashplanet/rocky,
-/area/city/backstreets_alley)
 "Sf" = (
 /obj/item/storage/backpack/duffelbag/med/upgradedsurgery,
 /obj/structure/window/reinforced/spawner/north{
@@ -17495,7 +11014,7 @@
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "Si" = (
 /obj/structure/chair/stool/bar,
 /obj/effect/turf_decal/siding/blue{
@@ -17503,24 +11022,6 @@
 	},
 /turf/open/floor/carpet/cyan,
 /area/city/shop)
-"Sj" = (
-/obj/structure/showcase/machinery/tv{
-	desc = "A TV that fails to work as intended.";
-	name = "\improper Malfunctioning TV"
-	},
-/turf/open/floor/eighties,
-/area/city/backstreets_room)
-"Sk" = (
-/obj/structure/lootcrate/k_corp,
-/obj/structure/lootcrate/k_corp{
-	pixel_x = 5;
-	pixel_y = 10
-	},
-/obj/structure/lootcrate/k_corp{
-	pixel_x = 10
-	},
-/turf/open/floor/engine,
-/area/city/backstreets_room)
 "Sl" = (
 /obj/effect/turf_decal/tile/bar{
 	dir = 4
@@ -17533,38 +11034,12 @@
 	dir = 1
 	},
 /turf/open/floor/sepia,
-/area/facility_hallway/command)
-"Sm" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/turf/open/floor/plating/asteroid/basalt,
-/area/city/backstreets_room)
-"Sn" = (
-/obj/structure/chair/sofa/corp/left{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/holofloor/dark,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "So" = (
 /obj/effect/turf_decal/delivery/red,
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/dark,
 /area/city/shop)
-"Sp" = (
-/obj/structure/table/reinforced,
-/obj/effect/spawner/lootdrop/space/fancytech,
-/obj/effect/spawner/lootdrop/space/fancytech,
-/turf/open/floor/engine,
-/area/city/backstreets_room)
-"Sq" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/item/kirbyplants/random,
-/turf/open/floor/plasteel/sepia,
-/area/city/backstreets_room)
 "Sr" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -17586,7 +11061,7 @@
 	dir = 4
 	},
 /turf/open/floor/carpet/stellar,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "St" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -17597,7 +11072,7 @@
 	set_luminosity = 24
 	},
 /turf/open/floor/sepia,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "Su" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/tile/green{
@@ -17615,6 +11090,10 @@
 	},
 /turf/open/floor/plasteel/sepia,
 /area/city/shop)
+"Sv" = (
+/obj/structure/curtain/bounty,
+/turf/closed/indestructible/fakeglass,
+/area/facility_hallway/manager)
 "Sw" = (
 /obj/structure/table/reinforced{
 	max_integrity = 25
@@ -17624,73 +11103,12 @@
 	},
 /turf/open/floor/stone,
 /area/city/house)
-"Sx" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/obj/effect/light_emitter{
-	light_power = 4;
-	light_range = 25;
-	set_cap = 3;
-	set_luminosity = 24
-	},
-/turf/open/floor/plating/asteroid/basalt,
-/area/city/backstreets_checkpoint)
 "Sy" = (
 /obj/structure/chair/office/light{
 	dir = 1
 	},
 /turf/open/floor/mineral/titanium/tiled/blue,
 /area/city/fixers)
-"Sz" = (
-/obj/effect/turf_decal/trimline/neutral/corner{
-	dir = 4;
-	pixel_x = 7;
-	pixel_y = 6
-	},
-/obj/structure/fence/post{
-	layer = 3;
-	pixel_x = 16;
-	pixel_y = 24
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/holofloor/dark,
-/area/city/backstreets_room)
-"SB" = (
-/obj/machinery/door/airlock/grunge,
-/turf/open/floor/plasteel/shuttle,
-/area/city/backstreets_room)
-"SC" = (
-/obj/effect/turf_decal/siding/yellow{
-	dir = 5
-	},
-/turf/open/floor/carpet/green,
-/area/city/backstreets_room)
-"SD" = (
-/obj/effect/decal/cleanable/blood/gibs/old,
-/obj/effect/decal/cleanable/blood/gibs/core{
-	pixel_x = -8;
-	pixel_y = 2
-	},
-/obj/effect/decal/cleanable/blood/gibs/body{
-	pixel_x = -7
-	},
-/obj/effect/decal/cleanable/blood/footprints{
-	dir = 8;
-	pixel_y = 19
-	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"SE" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 5
-	},
-/turf/open/floor/plating/asteroid/basalt,
-/area/city/backstreets_room)
-"SF" = (
-/obj/structure/closet/crate/trashcart/filled,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
 "SG" = (
 /obj/machinery/modular_computer/console{
 	dir = 8
@@ -17701,27 +11119,15 @@
 /obj/structure/chair/comfy/black{
 	pixel_y = 14
 	},
+/obj/effect/landmark/latejoin,
 /turf/open/floor/carpet/royalblack,
 /area/city/house)
-"SI" = (
-/obj/machinery/vending/medical,
-/obj/item/storage/backpack/duffelbag/med/upgradedsurgery{
-	pixel_y = 18
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/city/backstreets_room)
 "SJ" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 8
 	},
 /turf/open/floor/wood,
 /area/city/shop)
-"SK" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/turf/open/floor/plating/asteroid/basalt,
-/area/city/backstreets_room)
 "SL" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -17735,49 +11141,12 @@
 	},
 /turf/open/indestructible/white,
 /area/city/shop)
-"SM" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/cobweb,
-/obj/item/kirbyplants/dead{
-	desc = "A sad, dead plant";
-	name = "dead potted plant";
-	pixel_y = 10
-	},
-/turf/open/floor/wood,
-/area/city/backstreets_room)
 "SN" = (
 /obj/structure/chair/wood/wings{
 	dir = 8
 	},
 /turf/open/floor/facility/white,
-/area/facility_hallway/command)
-"SO" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal{
-	dir = 8
-	},
-/obj/item/clipboard,
-/turf/open/floor/engine,
-/area/city/backstreets_room)
-"SP" = (
-/obj/structure/chair/sofa/corp/corner{
-	dir = 8
-	},
-/turf/open/floor/carpet/black,
-/area/city/backstreets_room)
-"SQ" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/effect/turf_decal/raven{
-	dir = 5
-	},
-/obj/structure/fluff/big_chain{
-	pixel_y = 10
-	},
-/turf/open/floor/holofloor/dark,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "SR" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#3234B9";
@@ -17798,46 +11167,27 @@
 /obj/item/bedsheet/red,
 /turf/open/floor/wood,
 /area/city/shop)
-"ST" = (
-/obj/effect/turf_decal/siding/wideplating{
+"SU" = (
+/obj/machinery/light/cold/no_nightlight{
+	brightness = 16;
+	dir = 8
+	},
+/obj/machinery/computer/camera_advanced/manager/sephirah{
 	dir = 1
 	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"SU" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 10
-	},
-/obj/structure/closet/secure_closet/personal/cabinet{
-	anchored = 1
-	},
-/turf/open/floor/wood,
-/area/facility_hallway/command)
+/turf/open/floor/facility/dark,
+/area/facility_hallway/manager)
 "SV" = (
 /obj/structure/chair/pew/right,
 /obj/effect/turf_decal/siding/thinplating/dark,
 /turf/open/floor/plating/grass,
 /area/city)
-"SW" = (
-/obj/effect/turf_decal/siding/purple{
-	dir = 7
-	},
-/turf/open/floor/carpet/purple,
-/area/city/backstreets_room)
 "SX" = (
 /obj/machinery/door/airlock/glass_large{
 	name = "Long-Term Sleep Centre"
 	},
 /turf/open/floor/facility/halls,
 /area/city/shop)
-"SY" = (
-/obj/structure/chair/pew/left{
-	desc = "For resting your legs.";
-	dir = 1;
-	name = "bench"
-	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
 "SZ" = (
 /obj/structure/bed,
 /obj/item/bedsheet/hop,
@@ -17845,31 +11195,11 @@
 	dir = 6
 	},
 /turf/open/floor/wood,
-/area/facility_hallway/command)
-"Ta" = (
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 5
-	},
-/turf/open/floor/carpet/black,
-/area/city/backstreets_room)
-"Tb" = (
-/obj/effect/turf_decal/siding/wood/corner,
-/obj/effect/turf_decal/weather/dirt{
-	dir = 9
-	},
-/turf/open/floor/plating/asteroid/basalt,
-/area/city/backstreets_room)
-"Tc" = (
-/obj/structure/bed/maint,
-/obj/item/ego_weapon/city/rats/scalpel,
-/obj/effect/spawner/lootdrop/maint_drugs,
-/obj/effect/spawner/lootdrop/maint_drugs,
-/turf/open/floor/plating,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "Td" = (
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /turf/open/floor/plasteel/chapel{
 	dir = 4
@@ -17886,8 +11216,8 @@
 /area/city/shop)
 "Tf" = (
 /obj/structure/closet/secure_closet/freezer/fridge{
-	pixel_y = -1;
-	pixel_x = -8
+	pixel_x = -8;
+	pixel_y = -1
 	},
 /obj/item/reagent_containers/food/condiment/milk{
 	pixel_x = -8
@@ -17917,23 +11247,7 @@
 "Th" = (
 /obj/structure/window/reinforced/spawner/west,
 /turf/open/floor/plasteel/white,
-/area/facility_hallway/command)
-"Ti" = (
-/mob/living/simple_animal/hostile/ordeal/indigo_dawn,
-/obj/effect/decal/cleanable/blood/footprints,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"Tj" = (
-/obj/structure/curtain,
-/turf/open/floor/plasteel/sepia,
-/area/city/backstreets_room)
-"Tk" = (
-/obj/structure/chair/sofa/left,
-/obj/effect/turf_decal/siding/yellow/corner{
-	dir = 4
-	},
-/turf/open/floor/carpet/green,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "Tl" = (
 /obj/structure/easel,
 /obj/item/canvas/nineteen_nineteen,
@@ -17949,11 +11263,11 @@
 	dir = 8
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /turf/open/floor/carpet/stellar,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "Tm" = (
 /obj/machinery/light/cold/no_nightlight{
 	brightness = 16
@@ -17967,75 +11281,46 @@
 	dir = 6
 	},
 /turf/open/floor/plating/grass,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "To" = (
 /obj/effect/turf_decal/plaque{
 	alpha = 230;
 	icon_state = "LC14"
 	},
 /turf/open/floor/facility/dark,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "Tp" = (
 /obj/structure/chair/pew/left{
 	desc = "Sit here and relax";
 	name = "Bench"
 	},
 /obj/effect/turf_decal/siding/thinplating/dark,
+/obj/effect/landmark/latejoin,
 /turf/open/floor/plating/grass,
 /area/city)
+"Tq" = (
+/obj/machinery/door/airlock/wood{
+	name = "Safety Head Office"
+	},
+/turf/open/floor/facility/dark,
+/area/facility_hallway/manager)
 "Tr" = (
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
-	},
-/obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
-	},
-/turf/open/floor/plating/grass,
-/area/facility_hallway/command)
-"Ts" = (
-/obj/effect/decal/cleanable/blood/drip,
-/obj/effect/decal/cleanable/blood/tracks{
+	brightness = 16;
 	dir = 4
 	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
+/obj/machinery/light/cold/no_nightlight{
+	brightness = 16;
+	dir = 8
+	},
+/turf/open/floor/plating/grass,
+/area/facility_hallway/manager)
 "Tt" = (
 /turf/open/floor/stone{
 	color = "#989898";
 	density = 1
 	},
 /area/city)
-"Tu" = (
-/obj/structure/barricade/wooden,
-/obj/structure/barricade/wooden,
-/obj/structure/barricade/wooden/crude,
-/turf/closed/indestructible/fakeglass,
-/area/city/backstreets_room)
-"Tv" = (
-/obj/structure/flora/rock/jungle,
-/obj/structure/flora/ausbushes/sparsegrass{
-	pixel_x = 20;
-	pixel_y = -2
-	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"Tw" = (
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/blood/splatter,
-/turf/open/floor/plasteel/shuttle{
-	name = "floor"
-	},
-/area/city/backstreets_room)
-"Tx" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/city/backstreets_room)
 "Ty" = (
 /obj/structure/chair/sofa/right,
 /obj/effect/turf_decal/siding/wood{
@@ -18043,13 +11328,6 @@
 	},
 /turf/open/floor/wood,
 /area/city/shop)
-"Tz" = (
-/obj/effect/landmark/latejoin,
-/turf/open/floor/carpet/black,
-/area/facility_hallway/command)
-"TA" = (
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_checkpoint)
 "TB" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -18064,12 +11342,6 @@
 /obj/machinery/light,
 /turf/open/indestructible/white,
 /area/city/shop)
-"TC" = (
-/mob/living/simple_animal/hostile/ordeal/green_bot_big{
-	name = "gun bot"
-	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_alley)
 "TD" = (
 /obj/structure/railing{
 	dir = 4
@@ -18078,46 +11350,17 @@
 	color = "#808080"
 	},
 /area/city/shop)
-"TE" = (
-/obj/structure/chair/sofa/corp/right,
-/turf/open/floor/plasteel/showroomfloor,
-/area/city/backstreets_room)
-"TF" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal{
-	dir = 1
-	},
-/obj/structure/showcase/machinery/tv{
-	desc = "Guess robots can't fix their lesser machinery.";
-	name = "\improper Broken TV"
-	},
-/turf/open/floor/engine,
-/area/city/backstreets_room)
-"TG" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/turf/open/floor/plasteel/sepia,
-/area/city/backstreets_room)
-"TH" = (
-/turf/open/floor/plasteel/rockvault/alien{
-	name = "floor"
-	},
-/area/city/backstreets_room)
 "TI" = (
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /turf/open/floor/eighties,
 /area/city/shop)
-"TJ" = (
-/turf/closed/indestructible/reinforced,
-/area/city/backstreets_checkpoint)
 "TK" = (
 /obj/item/reagent_containers/food/drinks/mug/tea,
 /turf/open/floor/carpet/royalblack,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "TL" = (
 /obj/structure/fluff/paper{
 	dir = 4
@@ -18134,16 +11377,18 @@
 	pixel_x = -20
 	},
 /turf/open/floor/carpet/black,
-/area/facility_hallway/command)
-"TM" = (
-/obj/structure/table/greyscale,
-/obj/machinery/microwave{
-	pixel_y = 7
+/area/facility_hallway/manager)
+"TN" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/sepia,
-/area/city/backstreets_room)
+/obj/machinery/light/cold/no_nightlight{
+	brightness = 16;
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/space)
 "TO" = (
 /obj/structure/railing{
 	dir = 1
@@ -18159,7 +11404,7 @@
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "TQ" = (
 /obj/structure/table,
 /obj/structure/fluff/paper/stack{
@@ -18176,7 +11421,7 @@
 	icon_state = "LC21"
 	},
 /turf/open/floor/facility/dark,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "TS" = (
 /obj/structure/closet/secure_closet/personal/patient,
 /turf/open/floor/mineral/titanium/blue,
@@ -18186,16 +11431,16 @@
 	max_integrity = 25
 	},
 /obj/effect/turf_decal/tile/neutral{
-	dir = 1;
-	color = "#000000"
+	color = "#000000";
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
-	dir = 8;
-	color = "#000000"
+	color = "#000000";
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral{
-	dir = 4;
-	color = "#000000"
+	color = "#000000";
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral{
 	color = "#000000"
@@ -18204,8 +11449,8 @@
 /area/city/fixers)
 "TU" = (
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /turf/open/floor/sepia,
 /area/city/house)
@@ -18214,27 +11459,7 @@
 	dir = 6
 	},
 /turf/open/floor/carpet/stellar,
-/area/facility_hallway/command)
-"TX" = (
-/obj/machinery/shower{
-	pixel_y = 15
-	},
-/obj/structure/curtain/cloth,
-/obj/item/soap/homemade,
-/turf/open/indestructible/hoteltile,
-/area/city/backstreets_room)
-"TY" = (
-/obj/structure/dresser{
-	pixel_x = -2;
-	pixel_y = -3
-	},
-/obj/item/flashlight/lamp/green{
-	pixel_x = -6;
-	pixel_y = 13
-	},
-/obj/effect/decal/cleanable/blood,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "TZ" = (
 /obj/structure/closet/secure_closet/personal/cabinet{
 	anchored = 1
@@ -18243,14 +11468,14 @@
 	dir = 9
 	},
 /turf/open/floor/wood,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "Ua" = (
 /obj/machinery/shower{
 	dir = 1
 	},
 /obj/structure/window/reinforced/spawner/east{
-	opacity = 1;
-	name = "shower room glass"
+	name = "shower room glass";
+	opacity = 1
 	},
 /turf/open/floor/noslip,
 /area/city/fixers)
@@ -18273,40 +11498,22 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plasteel/kitchen_coldroom,
 /area/city/shop)
-"Uc" = (
-/turf/closed/indestructible/reinforced,
-/area/city/backstreets_room)
-"Ud" = (
-/obj/structure/table/glass,
-/obj/item/dnainjector/acidflesh,
-/turf/open/floor/plasteel/freezer,
-/area/city/backstreets_room)
 "Ue" = (
 /turf/open/floor/carpet,
 /area/city/house)
 "Uf" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
+/obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
 	},
 /turf/open/floor/sepia,
-/area/facility_hallway/command)
-"Ug" = (
-/obj/effect/turf_decal/siding/thinplating/dark/corner{
-	dir = 4
-	},
-/turf/open/indestructible/cult,
-/area/city/backstreets_room)
-"Uh" = (
-/obj/machinery/biogenerator,
-/turf/open/floor/holofloor/white,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "Ui" = (
 /obj/effect/turf_decal/tile/bar{
 	dir = 4
@@ -18319,52 +11526,11 @@
 	dir = 1
 	},
 /turf/open/floor/sepia,
-/area/facility_hallway/command)
-"Uj" = (
-/obj/structure/statue/sandstone/venus{
-	desc = "To know and manipulate all the secrets of the world; that is the privilege of the Head, the Eye, and the Claws. It is their honor and absolute power.";
-	icon = 'ModularTegustation/Teguicons/tegumobs.dmi';
-	icon_state = "fixer_p";
-	name = "statue of a tax collector";
-	pixel_y = null
-	},
-/turf/open/floor/wood,
-/area/city/backstreets_room)
-"Uk" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
-"Ul" = (
-/obj/item/kirbyplants{
-	pixel_x = 6;
-	pixel_y = -2
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
-"Um" = (
-/obj/structure/fence/corner,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_checkpoint)
+/area/facility_hallway/manager)
 "Un" = (
 /obj/machinery/vending/cola/shamblers,
 /turf/open/floor/mineral/titanium/blue,
 /area/city/fixers)
-"Uo" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/obj/effect/light_emitter{
-	light_power = 4;
-	light_range = 25;
-	set_cap = 3;
-	set_luminosity = 24
-	},
-/turf/open/floor/plating/asteroid/basalt,
-/area/city/backstreets_checkpoint)
 "Up" = (
 /obj/structure/chair/pew/right,
 /turf/open/floor/plasteel/chapel,
@@ -18384,34 +11550,17 @@
 	},
 /obj/effect/turf_decal,
 /turf/open/floor/plasteel/dark,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "Us" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
 /turf/open/floor/wood,
 /area/city/shop)
-"Ut" = (
-/obj/structure/table/greyscale,
-/obj/effect/turf_decal/siding/thinplating/light{
-	dir = 4
-	},
-/obj/item/flashlight/lamp{
-	pixel_x = -5;
-	pixel_y = 10
-	},
-/turf/open/floor/wood,
-/area/city/backstreets_room)
-"Uu" = (
-/obj/effect/turf_decal/siding/yellow{
-	dir = 8
-	},
-/turf/open/floor/carpet/green,
-/area/city/backstreets_room)
 "Uv" = (
 /obj/effect/turf_decal{
-	dir = 1;
-	color = "#FF0000"
+	color = "#FF0000";
+	dir = 1
 	},
 /turf/open/floor/plasteel/airless/white,
 /area/city/backstreets_checkpoint)
@@ -18420,17 +11569,20 @@
 	pixel_y = 1
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/city/house)
-"Uy" = (
-/obj/item/kirbyplants/random{
-	pixel_y = 10
+"Ux" = (
+/obj/structure/chair/wood/wings{
+	dir = 8
 	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/city/backstreets_room)
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/space)
 "Uz" = (
 /obj/machinery/light/cold/no_nightlight,
 /turf/open/floor/mineral/titanium/tiled/white,
@@ -18444,11 +11596,21 @@
 	},
 /obj/machinery/door/window/eastright,
 /turf/open/floor/plasteel/dark,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
+"UB" = (
+/obj/machinery/computer/crew{
+	dir = 1
+	},
+/obj/machinery/light/cold/no_nightlight{
+	brightness = 16;
+	dir = 4
+	},
+/turf/open/floor/facility/dark,
+/area/facility_hallway/manager)
 "UC" = (
 /obj/structure/bodycontainer/crematorium{
-	id = "Ncorp2";
-	dir = 8
+	dir = 8;
+	id = "Ncorp2"
 	},
 /obj/machinery/button/crematorium/indestructible{
 	id = "Ncorp2";
@@ -18456,13 +11618,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/city/shop)
-"UD" = (
-/obj/structure/barricade/sandbags,
-/obj/effect/turf_decal{
-	dir = 5
-	},
-/turf/open/floor/engine,
-/area/city/backstreets_room)
 "UE" = (
 /obj/structure/closet/crate,
 /obj/structure/lattice/catwalk,
@@ -18471,29 +11626,20 @@
 /area/city/shop)
 "UF" = (
 /obj/structure/sink/kitchen{
-	pixel_y = 7;
 	dir = 4;
-	pixel_x = -11
+	pixel_x = -11;
+	pixel_y = 7
 	},
 /turf/open/floor/plasteel/checker,
 /area/city/house)
 "UG" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/window/reinforced/spawner/east{
-	pixel_x = 3;
-	max_integrity = 25
+	max_integrity = 25;
+	pixel_x = 3
 	},
 /turf/open/floor/plating,
 /area/city/fixers)
-"UH" = (
-/obj/effect/turf_decal{
-	dir = 3
-	},
-/obj/structure/closet/crate/large,
-/obj/item/ego_weapon/ranged/pistol/kcorp/nade,
-/obj/item/ego_weapon/shield/kcorp,
-/turf/open/floor/engine,
-/area/city/backstreets_room)
 "UI" = (
 /obj/structure/bookcase/random{
 	pixel_y = -5
@@ -18505,39 +11651,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/floor/plating,
 /area/city/shop)
-"UK" = (
-/mob/living/simple_animal/hostile/ordeal/green_bot/price{
-	desc = "A slim robot that appears to have lost itself and its arm.";
-	name = "Corrupted Meister Emett"
-	},
-/turf/open/floor/holofloor/dark,
-/area/city/backstreets_room)
-"UL" = (
-/obj/machinery/implantchair/genepurge,
-/turf/open/floor/holofloor/white,
-/area/city/backstreets_room)
-"UM" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/table/wood,
-/obj/item/kirbyplants/dead{
-	desc = "A sad, dead plant";
-	name = "dead potted plant";
-	pixel_y = 10
-	},
-/obj/machinery/light/broken{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/city/backstreets_room)
-"UN" = (
-/obj/structure/chair/sofa/right{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding{
-	dir = 4
-	},
-/turf/open/floor/plasteel/checker,
-/area/city/backstreets_room)
 "UO" = (
 /obj/structure/railing{
 	dir = 8
@@ -18550,36 +11663,11 @@
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
-"UP" = (
-/obj/structure/filingcabinet,
-/obj/structure/filingcabinet{
-	pixel_x = -9
-	},
-/obj/structure/filingcabinet{
-	pixel_x = 10
-	},
-/turf/open/floor/holofloor/white,
-/area/city/backstreets_room)
-"UQ" = (
-/obj/structure/fence/corner{
-	pixel_x = 22;
-	pixel_y = -3
-	},
+/area/facility_hallway/manager)
+"UT" = (
+/obj/structure/sign/departments/info,
 /turf/closed/indestructible/reinforced,
-/area/city/backstreets_room)
-"UR" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/city/backstreets_checkpoint)
-"US" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 4
-	},
-/turf/open/floor/carpet/black,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "UU" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -18588,36 +11676,15 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "UW" = (
 /turf/closed/indestructible/fakedoor{
-	name = "Locked White-Washed Airlock";
 	icon = 'icons/obj/doors/airlocks/station/silver.dmi';
 	icon_state = "closed";
+	name = "Locked White-Washed Airlock";
 	opacity = 0
 	},
 /area/city)
-"UX" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/paperslip{
-	pixel_x = -8;
-	pixel_y = 5
-	},
-/turf/open/floor/wood,
-/area/city/backstreets_room)
-"UY" = (
-/obj/effect/decal/cleanable/blood/drip,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"UZ" = (
-/obj/effect/turf_decal/starfury/one,
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 4;
-	pixel_x = 7
-	},
-/obj/structure/flora/rock/jungle,
-/turf/open/floor/plating/dirt/dark,
-/area/city/backstreets_room)
 "Va" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -18627,11 +11694,7 @@
 	brightness = 16
 	},
 /turf/open/floor/plating/grass,
-/area/facility_hallway/command)
-"Vb" = (
-/obj/structure/lootcrate/s_corp,
-/turf/open/floor/plasteel/vaporwave,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "Vc" = (
 /obj/effect/turf_decal/siding/blue,
 /obj/effect/turf_decal/siding/blue{
@@ -18645,17 +11708,7 @@
 	icon_state = "LC5"
 	},
 /turf/open/floor/facility/dark,
-/area/facility_hallway/command)
-"Ve" = (
-/obj/structure/filingcabinet,
-/obj/structure/filingcabinet{
-	pixel_x = -9
-	},
-/obj/structure/filingcabinet{
-	pixel_x = 10
-	},
-/turf/open/floor/facility/dark,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "Vf" = (
 /obj/effect/turf_decal/tile{
 	color = "#333333"
@@ -18670,15 +11723,12 @@
 /obj/item/book/granter/crafting_recipe/cooking_sweets_101,
 /turf/open/floor/mineral/titanium/tiled/white,
 /area/city/shop)
-"Vg" = (
-/turf/closed/indestructible/rock,
-/area/city/backstreets_room)
 "Vh" = (
 /obj/structure/sign/poster/lobotomycorp/hhpp,
 /turf/closed/wall/mineral/silver{
+	desc = "A wall with unmistable white coloring. Iconic sight in N Corp's Nest!";
 	explosion_block = 50;
-	name = "N Corporation Nest Wall";
-	desc = "A wall with unmistable white coloring. Iconic sight in N Corp's Nest!"
+	name = "N Corporation Nest Wall"
 	},
 /area/city/shop)
 "Vi" = (
@@ -18687,7 +11737,7 @@
 	icon_state = "LC11"
 	},
 /turf/open/floor/facility/dark,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "Vj" = (
 /obj/effect/spawner/randomarcade{
 	dir = 1
@@ -18697,44 +11747,20 @@
 	},
 /turf/open/floor/eighties,
 /area/city/shop)
-"Vk" = (
-/obj/structure/table/reinforced,
-/obj/effect/spawner/lootdrop/armory_contraband,
-/obj/effect/spawner/lootdrop/armory_contraband,
-/turf/open/floor/engine,
-/area/city/backstreets_room)
 "Vl" = (
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /obj/structure/railing{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "Vm" = (
 /obj/machinery/door/window/eastleft,
 /turf/open/floor/mineral/titanium/white,
 /area/city/shop)
-"Vo" = (
-/obj/structure/closet/crate/trashcart/laundry,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/cobweb,
-/mob/living/simple_animal/mouse/brown,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
-"Vp" = (
-/obj/effect/turf_decal/siding/thinplating/dark/corner{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/city/backstreets_room)
-"Vq" = (
-/obj/structure/table/wood,
-/obj/item/ego_weapon/city/streetlight_greatsword,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
 "Vr" = (
 /turf/open/floor/oldshuttle,
 /area/city/fixers)
@@ -18743,7 +11769,7 @@
 	dir = 4
 	},
 /turf/open/floor/sepia,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "Vt" = (
 /obj/structure/table/wood,
 /obj/machinery/light/cold/no_nightlight,
@@ -18751,22 +11777,13 @@
 /area/city/house)
 "Vu" = (
 /obj/effect/mermaid_water{
-	name = "Coastal Waters";
 	color = "#dddddd";
+	density = 1;
 	desc = "Not a drop of drinkable water, just a body of salty brine";
-	density = 1
+	name = "Coastal Waters"
 	},
 /turf/open/floor/plating/grass,
 /area/city)
-"Vv" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 7
-	},
-/turf/open/floor/carpet/black,
-/area/city/backstreets_room)
 "Vw" = (
 /obj/item/modular_computer/laptop{
 	desc = "Appears to be a fixers laptop.";
@@ -18805,7 +11822,7 @@
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "Vz" = (
 /obj/effect/turf_decal/siding/wood/end{
 	dir = 8
@@ -18815,43 +11832,12 @@
 "VA" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/waterbottle{
-	pixel_y = 13;
-	pixel_x = -4
+	pixel_x = -4;
+	pixel_y = 13
 	},
 /obj/item/trash/plate,
 /turf/open/floor/carpet,
 /area/city/house)
-"VB" = (
-/obj/effect/turf_decal{
-	dir = 6
-	},
-/obj/structure/closet/crate/large,
-/obj/item/ego_weapon/city/seven,
-/obj/item/ego_weapon/city/seven/vet,
-/turf/open/floor/engine,
-/area/city/backstreets_room)
-"VC" = (
-/obj/structure/table/glass,
-/turf/open/floor/carpet/black,
-/area/city/backstreets_room)
-"VD" = (
-/obj/effect/turf_decal/siding/wideplating/corner{
-	dir = 8
-	},
-/obj/structure/flora/rock/jungle{
-	pixel_y = -24
-	},
-/obj/structure/flora/rock/pile{
-	pixel_x = -11
-	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"VE" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/turf/open/floor/plating/asteroid/basalt,
-/area/city/backstreets_room)
 "VF" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/tile/green{
@@ -18872,12 +11858,6 @@
 	},
 /turf/open/floor/plasteel/sepia,
 /area/city/shop)
-"VG" = (
-/obj/structure/bed/maint,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
 "VH" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
@@ -18887,76 +11867,27 @@
 	},
 /turf/open/floor/wood,
 /area/city/shop)
-"VI" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/landmark/latejoin,
-/turf/open/floor/sepia,
-/area/facility_hallway/command)
-"VJ" = (
-/obj/effect/decal/cleanable/blood/gibs/limb,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
 "VK" = (
 /obj/effect/spawner/randomarcade{
 	dir = 8
 	},
 /turf/open/floor/eighties,
 /area/city/shop)
-"VL" = (
-/obj/effect/decal/cleanable/blood/footprints{
-	dir = 4
+"VP" = (
+/obj/structure/table/wood,
+/obj/machinery/computer/libraryconsole{
+	pixel_y = 10
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/holofloor/dark,
-/area/city/backstreets_room)
-"VM" = (
-/obj/effect/turf_decal/starfury/one,
-/obj/effect/turf_decal/trimline/neutral/line{
-	pixel_y = -6
-	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 4;
-	pixel_x = 7
-	},
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/fence/post{
-	layer = 3;
-	pixel_x = 11;
-	pixel_y = 2
-	},
-/obj/item/bodypart/chest,
-/obj/effect/decal/cleanable/blood,
-/obj/effect/decal/cleanable/blood/gibs/limb{
-	dir = 8;
-	pixel_x = -15;
-	pixel_y = 4
-	},
-/turf/open/floor/plating/dirt/dark,
-/area/city/backstreets_room)
-"VN" = (
-/obj/structure/chair/pew/left{
+/obj/effect/turf_decal/siding/blue/end{
 	dir = 1
 	},
-/turf/open/indestructible/cult,
-/area/city/backstreets_room)
-"VQ" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/closed/indestructible/reinforced,
-/area/city/backstreets_room)
+/turf/open/floor/carpet/cyan,
+/area/space)
 "VR" = (
 /obj/structure/sink/kitchen{
-	pixel_y = 14;
 	dir = 4;
-	pixel_x = -11
+	pixel_x = -11;
+	pixel_y = 14
 	},
 /turf/open/floor/sepia,
 /area/city/house)
@@ -18981,34 +11912,34 @@
 	color = "#000000"
 	},
 /obj/effect/turf_decal/tile/neutral{
-	dir = 8;
-	color = "#000000"
+	color = "#000000";
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral{
-	dir = 1;
-	color = "#000000"
+	color = "#000000";
+	dir = 1
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /obj/machinery/scanner_gate{
 	scangate_mode = "Guns"
 	},
 /turf/open/floor/mineral/titanium/tiled/white,
 /area/city/fixers)
-"VU" = (
-/obj/structure/chair/sofa/corp/left{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/blood/gibs/down,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
 "VV" = (
 /obj/effect/turf_decal/siding/thinplating/dark,
 /obj/structure/chair/comfy/black,
 /turf/open/floor/mineral/plastitanium,
 /area/city/house)
+"VW" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/obj/machinery/light/cold/no_nightlight,
+/turf/open/floor/wood,
+/area/space)
 "VX" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
@@ -19020,38 +11951,13 @@
 	dir = 10
 	},
 /turf/open/floor/plating/grass,
-/area/facility_hallway/command)
-"VZ" = (
-/obj/structure/stone_tile/slab/cracked,
-/obj/item/bodypart/l_arm{
-	dir = 4;
-	pixel_x = -12;
-	pixel_y = -7
-	},
-/obj/item/ego_weapon/city/rats/knife,
-/turf/open/floor/plating/dirt/jungle/wasteland,
-/area/city/backstreets_room)
-"Wa" = (
-/obj/structure/table/reinforced,
-/obj/item/gun/energy/e_gun/rabbit{
-	desc = "An energy gun found within the ranks of the R-Corporation's Rabbit Team. How it got here is a mystery.";
-	name = "Smuggled R-Corp Lawnmower"
-	},
-/turf/open/floor/engine,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "Wb" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
 	},
 /turf/open/floor/plating/grass,
-/area/facility_hallway/command)
-"Wc" = (
-/obj/machinery/light/broken{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "Wd" = (
 /obj/structure/window/reinforced/spawner/west{
 	max_integrity = 25
@@ -19063,25 +11969,11 @@
 /area/city/shop)
 "We" = (
 /turf/closed/wall/mineral/silver{
+	desc = "A wall with unmistable white coloring. Iconic sight in N Corp's Nest!";
 	explosion_block = 50;
-	name = "N Corporation Nest Wall";
-	desc = "A wall with unmistable white coloring. Iconic sight in N Corp's Nest!"
+	name = "N Corporation Nest Wall"
 	},
 /area/city/house)
-"Wf" = (
-/mob/living/simple_animal/hostile/ordeal/green_bot_big{
-	name = "gun bot"
-	},
-/turf/open/floor/holofloor/dark,
-/area/city/backstreets_room)
-"Wg" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/blood/splatter{
-	pixel_x = 10;
-	pixel_y = 18
-	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
 "Wh" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 7
@@ -19094,22 +11986,10 @@
 	},
 /turf/open/floor/wood,
 /area/city/fixers)
-"Wi" = (
-/obj/structure/table/reinforced,
-/obj/item/organ_storage,
-/obj/item/storage/organbox,
-/turf/open/floor/plasteel/showroomfloor,
-/area/city/backstreets_room)
 "Wj" = (
 /obj/structure/curtain/cloth,
 /turf/closed/indestructible/fakeglass,
-/area/facility_hallway/command)
-"Wk" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 4
-	},
-/turf/open/floor/plating/asteroid/basalt,
-/area/city/backstreets_alley)
+/area/facility_hallway/manager)
 "Wl" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/effect/turf_decal/siding/thinplating/dark/corner{
@@ -19127,52 +12007,16 @@
 	},
 /turf/open/floor/eighties,
 /area/city/shop)
-"Wo" = (
-/obj/effect/decal/cleanable/blood/splatter,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/structure/closet/crate/bin,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
-"Wp" = (
-/mob/living/simple_animal/hostile/ordeal/indigo_spawn,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"Wq" = (
-/obj/machinery/light,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
-"Wr" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 5
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet/black,
-/area/city/backstreets_room)
-"Ws" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plasteel/shuttle{
-	name = "floor"
-	},
-/area/city/backstreets_room)
 "Wt" = (
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /obj/machinery/light/cold/no_nightlight{
 	brightness = 16
 	},
 /turf/open/floor/facility/dark,
-/area/facility_hallway/command)
-"Wu" = (
-/obj/structure/table/wood,
-/obj/item/paperslip,
-/obj/structure/fluff/paper/stack,
-/obj/effect/spawner/lootdrop/armory_contraband,
-/turf/open/floor/plasteel/shuttle{
-	name = "floor"
-	},
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "Wv" = (
 /obj/structure/chair/office{
 	dir = 1;
@@ -19187,11 +12031,11 @@
 	name = "gaming chair"
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "Wx" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#3234B9";
@@ -19209,18 +12053,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/city/fixers)
-"Wy" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal{
-	dir = 1
-	},
-/obj/machinery/computer/libraryconsole{
-	desc = "For a store in the backstreets, quite progressive.";
-	name = "ecash register";
-	pixel_y = 10
-	},
-/turf/open/floor/engine,
-/area/city/backstreets_room)
 "WA" = (
 /obj/structure/table/bronze,
 /obj/item/reagent_containers/food/condiment/saltshaker{
@@ -19246,15 +12078,7 @@
 	name = "white-washed airlock"
 	},
 /turf/open/floor/facility/halls,
-/area/facility_hallway/command)
-"WE" = (
-/obj/structure/table/wood/fancy/royalblack,
-/obj/item/key/displaycase,
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "WF" = (
 /obj/item/instrument/piano_synth,
 /obj/item/instrument/glockenspiel,
@@ -19262,10 +12086,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/plasteel/checker,
 /area/city/shop)
-"WG" = (
-/mob/living/simple_animal/hostile/ordeal/indigo_noon,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_alley)
 "WH" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -19275,6 +12095,12 @@
 	},
 /turf/open/floor/wood,
 /area/city/shop)
+"WI" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/turf/open/floor/wood,
+/area/facility_hallway/manager)
 "WJ" = (
 /obj/item/instrument/guitar,
 /obj/item/instrument/trumpet,
@@ -19295,26 +12121,26 @@
 	},
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/glass/beaker/bluespace{
-	pixel_y = 1;
-	pixel_x = 4
+	pixel_x = 4;
+	pixel_y = 1
 	},
 /obj/item/reagent_containers/glass/beaker/bluespace{
-	pixel_y = 1;
-	pixel_x = 4
-	},
-/obj/item/reagent_containers/glass/beaker/bluespace{
-	pixel_y = 12
+	pixel_x = 4;
+	pixel_y = 1
 	},
 /obj/item/reagent_containers/glass/beaker/bluespace{
 	pixel_y = 12
 	},
 /obj/item/reagent_containers/glass/beaker/bluespace{
-	pixel_y = 7;
-	pixel_x = -6
+	pixel_y = 12
 	},
 /obj/item/reagent_containers/glass/beaker/bluespace{
-	pixel_y = 7;
-	pixel_x = -6
+	pixel_x = -6;
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/glass/beaker/bluespace{
+	pixel_x = -6;
+	pixel_y = 7
 	},
 /obj/item/reagent_containers/food/condiment/enzyme{
 	pixel_x = -5;
@@ -19327,8 +12153,8 @@
 	dir = 8
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /turf/open/floor/mineral/titanium/tiled/white,
 /area/city/shop)
@@ -19340,8 +12166,8 @@
 /area/city)
 "WN" = (
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /obj/item/candle,
 /turf/open/floor/plasteel/chapel{
@@ -19350,52 +12176,21 @@
 /area/city/shop)
 "WO" = (
 /turf/open/floor/carpet/red,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "WP" = (
 /turf/closed/indestructible/fakedoor{
-	name = "Locked Casino Door";
 	icon = 'icons/obj/doors/airlocks/station/gold.dmi';
 	icon_state = "closed";
+	name = "Locked Casino Door";
 	opacity = 0
 	},
 /area/city/shop)
-"WR" = (
-/obj/structure/closet/crate/wooden,
-/obj/effect/turf_decal{
-	dir = 3
+"WQ" = (
+/obj/machinery/door/airlock/wood{
+	name = "Female Clerk Quarters"
 	},
-/turf/open/floor/engine,
-/area/city/backstreets_room)
-"WS" = (
-/obj/structure/table/wood,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/item/toy/plush/moth,
-/obj/structure/sign/poster/lobotomycorp/random{
-	pixel_x = 32
-	},
-/obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
-	},
-/turf/open/floor/sepia,
-/area/facility_hallway/command)
-"WT" = (
-/obj/structure/fence{
-	dir = 4;
-	pixel_x = 23;
-	pixel_y = -3
-	},
-/turf/closed/indestructible/reinforced,
-/area/city/backstreets_room)
+/turf/open/floor/facility/halls,
+/area/facility_hallway/manager)
 "WU" = (
 /obj/effect/turf_decal/siding/blue{
 	dir = 5
@@ -19411,7 +12206,7 @@
 	pixel_y = 10
 	},
 /turf/open/floor/carpet/cyan,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "WW" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#3234B9";
@@ -19443,36 +12238,26 @@
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
-"WY" = (
-/obj/effect/turf_decal/siding/purple{
-	dir = 10
-	},
-/obj/structure/table/glass,
-/obj/item/kirbyplants/random{
-	pixel_y = 10
-	},
-/turf/open/floor/carpet/purple,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "WZ" = (
 /obj/machinery/biogenerator,
 /obj/structure/window/reinforced/spawner/north{
 	max_integrity = 25
 	},
 /obj/effect/turf_decal/tile/green{
-	dir = 1;
-	color = "#006400"
+	color = "#006400";
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/green{
 	color = "#006400"
 	},
 /obj/effect/turf_decal/tile/green{
-	dir = 4;
-	color = "#006400"
+	color = "#006400";
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/green{
-	dir = 8;
-	color = "#006400"
+	color = "#006400";
+	dir = 8
 	},
 /turf/open/floor/plasteel/sepia,
 /area/city/shop)
@@ -19486,11 +12271,11 @@
 	pixel_y = -6
 	},
 /obj/machinery/door/window/southleft{
-	opacity = 1;
-	name = "Shower Door"
+	name = "Shower Door";
+	opacity = 1
 	},
 /turf/open/floor/plasteel/white,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "Xb" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 6
@@ -19502,70 +12287,27 @@
 	icon_state = "LC32"
 	},
 /turf/open/floor/facility/dark,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "Xe" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood,
 /area/city/shop)
-"Xf" = (
-/obj/structure/flora/rock/pile/largejungle{
-	pixel_x = -2;
-	pixel_y = -10
-	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"Xg" = (
-/obj/machinery/door/airlock/survival_pod,
-/obj/effect/turf_decal{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/city/backstreets_room)
 "Xh" = (
 /obj/structure/closet/crate,
 /obj/structure/lattice/catwalk,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/city/shop)
-"Xi" = (
-/obj/structure/grille/broken,
-/obj/item/stack/sheet/mineral/wood,
-/obj/item/shard,
-/obj/item/stack/sheet/silk,
-/obj/item/weaponcrafting/silkstring,
-/turf/open/floor/plating,
-/area/city/backstreets_room)
 "Xj" = (
 /obj/structure/toilet{
 	pixel_y = 15
 	},
 /turf/open/floor/holofloor/white,
-/area/facility_hallway/command)
-"Xk" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/obj/effect/spawner/lootdrop/space/cashmoney,
-/obj/effect/spawner/lootdrop/space/cashmoney,
-/turf/open/floor/grass,
-/area/city/backstreets_room)
-"Xl" = (
-/obj/effect/turf_decal/trimline/neutral/line{
-	pixel_y = -6
-	},
-/obj/structure/railing,
-/obj/machinery/light/dim{
-	dir = 8;
-	pixel_x = -8;
-	pixel_y = 2
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/holofloor/dark,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "Xm" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -19574,7 +12316,7 @@
 	dir = 5
 	},
 /turf/open/floor/carpet/black,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "Xn" = (
 /obj/effect/turf_decal/tile/blue{
 	color = "#3234B9";
@@ -19592,34 +12334,17 @@
 	dir = 4
 	},
 /turf/open/floor/sepia,
-/area/facility_hallway/command)
-"Xo" = (
-/obj/machinery/door/airlock/public,
-/turf/open/floor/eighties,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "Xp" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/facility/dark,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "Xq" = (
 /obj/machinery/door/airlock/wood{
 	name = "Male Clerk Quarters"
 	},
 /turf/open/floor/facility/halls,
-/area/facility_hallway/command)
-"Xr" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 10
-	},
-/turf/open/floor/plating/asteroid/basalt,
-/area/city/backstreets_room)
-"Xs" = (
-/obj/machinery/modular_computer/console{
-	desc = "A corporate computer for private communications between persons of interest. This one appears to have its memory reset, however.";
-	name = "communications console"
-	},
-/turf/open/floor/holofloor/white,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "Xt" = (
 /obj/structure/sink{
 	dir = 8;
@@ -19634,7 +12359,7 @@
 	opacity = 1
 	},
 /turf/open/floor/plasteel/white,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "Xu" = (
 /obj/structure/rack{
 	pixel_x = -1
@@ -19649,15 +12374,13 @@
 /obj/item/flashlight/seclite,
 /obj/item/flashlight/seclite,
 /turf/open/floor/plasteel/dark,
-/area/facility_hallway/command)
-"Xv" = (
-/obj/effect/turf_decal/siding/wideplating,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "Xw" = (
-/obj/machinery/light/small,
-/turf/open/floor/sepia,
-/area/facility_hallway/command)
+/obj/machinery/light/cold/no_nightlight{
+	brightness = 16
+	},
+/turf/open/floor/plasteel/white,
+/area/facility_hallway/manager)
 "Xx" = (
 /obj/structure/table/reinforced,
 /obj/machinery/microwave{
@@ -19670,8 +12393,8 @@
 /area/city/shop)
 "Xz" = (
 /obj/effect/turf_decal{
-	dir = 3;
-	color = "#FF0000"
+	color = "#FF0000";
+	dir = 3
 	},
 /turf/open/floor/plasteel/airless/white,
 /area/city/backstreets_checkpoint)
@@ -19693,26 +12416,14 @@
 	shuttleId = "epsilon"
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /obj/structure/railing{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/facility_hallway/command)
-"XD" = (
-/obj/structure/chair/sofa{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/city/backstreets_room)
-"XE" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/table/greyscale,
-/obj/effect/spawner/lootdrop/space/languagebook,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "XF" = (
 /obj/structure/railing{
 	dir = 1
@@ -19728,15 +12439,15 @@
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "XG" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /turf/open/floor/plating/grass,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "XH" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -19744,45 +12455,6 @@
 	},
 /turf/open/floor/plating/grass,
 /area/city)
-"XI" = (
-/obj/structure/table/reinforced,
-/obj/effect/spawner/lootdrop/organ_spawner{
-	pixel_x = 4;
-	pixel_y = 9
-	},
-/obj/effect/spawner/lootdrop/armory_contraband,
-/turf/open/floor/stone,
-/area/city/backstreets_room)
-"XJ" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet/black,
-/area/city/backstreets_room)
-"XK" = (
-/turf/open/floor/plating/asteroid/basalt,
-/area/city/backstreets_room)
-"XL" = (
-/obj/structure/window/reinforced/survival_pod{
-	desc = "Shrimply too strong.";
-	dir = 4;
-	max_integrity = 10000;
-	name = "shrimp display window"
-	},
-/turf/open/floor/plasteel/rockvault/alien{
-	name = "floor"
-	},
-/area/city/backstreets_room)
-"XM" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 9
-	},
-/turf/open/floor/plating/asteroid/basalt,
-/area/city/backstreets_room)
-"XN" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/turf/open/floor/plating/asteroid/basalt,
-/area/city/backstreets_room)
 "XO" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/mineral/titanium/tiled/white,
@@ -19791,21 +12463,14 @@
 /obj/structure/table/wood,
 /obj/item/trash/plate,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /turf/open/floor/carpet/purple,
 /area/city/house)
 "XQ" = (
-/obj/effect/landmark/latejoin,
 /turf/open/floor/wood,
-/area/facility_hallway/command)
-"XR" = (
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 4
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "XS" = (
 /obj/effect/turf_decal/plaque{
 	alpha = 230;
@@ -19815,19 +12480,19 @@
 	brightness = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "XT" = (
 /obj/structure/plaque/static_plaque/golden{
 	pixel_y = 32
 	},
 /turf/open/floor/carpet/cyan,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "XU" = (
 /obj/structure/closet/secure_closet/personal/cabinet{
 	anchored = 1
 	},
 /turf/open/floor/carpet/cyan,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "XV" = (
 /obj/machinery/door/airlock/glass_large,
 /turf/open/floor/facility/halls,
@@ -19849,52 +12514,42 @@
 	dir = 4
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "XY" = (
 /obj/effect/turf_decal/tile/neutral{
-	dir = 4;
-	color = "#000000"
+	color = "#000000";
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral{
-	dir = 1;
-	color = "#000000"
+	color = "#000000";
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
 	color = "#000000"
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /obj/machinery/scanner_gate{
 	scangate_mode = "Guns"
 	},
 /turf/open/floor/mineral/titanium/tiled/white,
 /area/city/fixers)
-"Ya" = (
-/obj/machinery/vending/medical,
-/obj/machinery/light,
-/turf/open/floor/plasteel/showroomfloor,
-/area/city/backstreets_room)
-"Yb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/folder/blue{
-	desc = "Appears to be permits and documents of an unspecified workshop.";
-	name = "Workshop Folder"
+"XZ" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/light/cold/no_nightlight{
+	brightness = 16;
+	dir = 4
 	},
-/turf/open/floor/holofloor/dark,
-/area/city/backstreets_room)
-"Yc" = (
-/obj/machinery/light,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
+/turf/open/floor/plating,
+/area/space)
 "Yd" = (
 /obj/effect/turf_decal/siding/blue{
 	dir = 4
@@ -19904,52 +12559,22 @@
 	},
 /turf/open/floor/carpet/cyan,
 /area/city/shop)
-"Ye" = (
-/obj/structure/mineral_door/wood,
-/obj/effect/decal/cleanable/blood/tracks,
-/turf/open/floor/plasteel/sepia,
-/area/city/backstreets_room)
-"Yf" = (
-/obj/structure/table/glass,
-/obj/item/dnainjector/epimut,
-/turf/open/floor/plasteel/freezer,
-/area/city/backstreets_room)
 "Yg" = (
 /obj/machinery/shower{
 	dir = 1
 	},
 /turf/open/floor/noslip,
 /area/city/fixers)
-"Yh" = (
-/obj/structure/table/wood/fancy/green,
-/obj/effect/turf_decal/siding/yellow{
-	dir = 8
-	},
-/obj/item/modular_computer/laptop/preset/civilian{
-	desc = "A laptop belonging to a robotic director. It's contents appear to be insubstantial to you.";
-	name = "Stoff's Laptop"
-	},
-/turf/open/floor/carpet/green,
-/area/city/backstreets_room)
 "Yi" = (
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /obj/structure/chair/comfy{
 	dir = 4
 	},
 /turf/open/floor/facility/dark,
 /area/city/backstreets_checkpoint)
-"Yj" = (
-/obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/space/cashmoney,
-/obj/effect/spawner/lootdrop/space/cashmoney,
-/obj/effect/spawner/lootdrop/space/cashmoney,
-/obj/effect/spawner/lootdrop/space/cashmoney,
-/obj/effect/spawner/lootdrop/space/cashmoney,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
 "Yk" = (
 /obj/effect/turf_decal/plaque{
 	alpha = 230;
@@ -19957,23 +12582,7 @@
 	},
 /obj/effect/landmark/observer_start,
 /turf/open/floor/facility/dark,
-/area/facility_hallway/command)
-"Yl" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal{
-	dir = 8
-	},
-/obj/machinery/computer/libraryconsole{
-	desc = "For a store in the backstreets, quite progressive.";
-	name = "ecash register";
-	pixel_y = 10
-	},
-/turf/open/floor/engine,
-/area/city/backstreets_room)
-"Ym" = (
-/mob/living/simple_animal/hostile/shrimp_soldier,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "Yn" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -19986,49 +12595,15 @@
 	},
 /turf/open/floor/mineral/titanium/tiled/yellow/airless,
 /area/city/shop)
-"Yo" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/facility_hallway/command)
-"Yp" = (
-/obj/structure/fence/cut/large{
-	dir = 8;
-	pixel_x = -9;
-	pixel_y = -3
-	},
-/turf/closed/indestructible/reinforced,
-/area/city/backstreets_room)
-"Yq" = (
-/obj/effect/decal/cleanable/blood/splatter,
-/obj/effect/spawner/randomcolavend,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
 "Yr" = (
 /obj/effect/turf_decal/siding/thinplating/dark,
 /turf/open/floor/stone,
 /area/city)
-"Yt" = (
-/obj/structure/closet/cabinet,
-/obj/item/ego_weapon/ranged/pistol/kcorp,
-/obj/item/ego_weapon/city/kcorp,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
-"Yu" = (
-/obj/structure/table/wood/fancy/royalblack,
-/obj/item/folder/syndicate/blue{
-	desc = "You have a feeling that these series of documents within this folder are not for the average person to gaze at.";
-	name = "Highly Confidential Folder"
-	},
-/obj/effect/turf_decal/siding/wideplating/dark,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
 "Yv" = (
 /obj/structure/fluff/paper/corner,
 /obj/structure/chair/comfy,
 /turf/open/floor/carpet/black,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "Yw" = (
 /obj/structure/chair/stool/bar,
 /obj/effect/turf_decal/siding/blue{
@@ -20038,8 +12613,8 @@
 /area/city/shop)
 "Yx" = (
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /turf/open/floor/facility/dark,
 /area/city/backstreets_checkpoint)
@@ -20054,44 +12629,12 @@
 	},
 /turf/open/floor/mineral/titanium/tiled/yellow/airless,
 /area/city/shop)
-"Yz" = (
-/obj/machinery/door/airlock/silver/glass,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
-"YA" = (
-/obj/structure/toilet/secret,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/indestructible/hoteltile,
-/area/city/backstreets_room)
-"YB" = (
-/obj/structure/fence/corner{
-	pixel_x = -9;
-	pixel_y = 6
-	},
-/turf/closed/indestructible/reinforced,
-/area/city/backstreets_room)
-"YC" = (
-/obj/effect/decal/cleanable/blood/footprints,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
 "YD" = (
 /obj/effect/turf_decal/siding/blue{
 	dir = 8
 	},
 /turf/open/floor/carpet/cyan,
 /area/city/shop)
-"YE" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/carpet/black,
-/area/city/backstreets_room)
-"YF" = (
-/obj/effect/decal/cleanable/blood/gibs/limb,
-/turf/open/floor/plasteel/stairs/left,
-/area/city/backstreets_room)
 "YG" = (
 /obj/effect/decal/cleanable/oil,
 /obj/effect/decal/cleanable/glitter,
@@ -20109,7 +12652,11 @@
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
+"YI" = (
+/obj/structure/reagent_dispensers/water_cooler,
+/turf/open/floor/facility/white,
+/area/space)
 "YJ" = (
 /obj/structure/chair/comfy/brown,
 /obj/effect/turf_decal/siding/blue{
@@ -20123,55 +12670,18 @@
 	icon_state = "LC24"
 	},
 /turf/open/floor/facility/dark,
-/area/facility_hallway/command)
-"YL" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 7
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/turf/open/floor/carpet/black,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "YM" = (
 /obj/structure/table/reinforced{
 	pixel_y = 2
 	},
 /obj/item/storage/box/drinkingglasses{
-	pixel_y = 16;
-	pixel_x = -5
+	pixel_x = -5;
+	pixel_y = 16
 	},
 /obj/item/reagent_containers/food/drinks/waterbottle,
 /turf/open/floor/plasteel/cafeteria,
 /area/city/house)
-"YN" = (
-/obj/structure/barricade/wooden,
-/obj/structure/barricade/wooden/crude,
-/obj/structure/barricade/wooden,
-/obj/structure/barricade/wooden/crude,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
-"YO" = (
-/obj/effect/decal/cleanable/blood{
-	pixel_x = -5;
-	pixel_y = 17
-	},
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"YP" = (
-/obj/effect/turf_decal/siding{
-	dir = 5
-	},
-/obj/structure/bed/pod,
-/obj/item/bedsheet/rd/royal_cape,
-/obj/item/folder/syndicate/red{
-	desc = "A folder belonging to one of the City's corporations.";
-	name = "Corporation Folder";
-	pixel_x = -5;
-	pixel_y = -5
-	},
-/turf/open/floor/carpet/black,
-/area/city/backstreets_room)
 "YQ" = (
 /obj/structure/sink/kitchen{
 	dir = 1;
@@ -20180,46 +12690,19 @@
 /obj/machinery/light/cold/no_nightlight,
 /turf/open/floor/plasteel/cafeteria,
 /area/city/house)
-"YR" = (
-/obj/machinery/light,
-/turf/open/floor/eighties,
-/area/city/backstreets_room)
-"YS" = (
-/obj/effect/decal/cleanable/blood/tracks{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/paperslip{
-	pixel_x = -8;
-	pixel_y = 5
-	},
-/turf/open/floor/plasteel/shuttle{
-	name = "floor"
-	},
-/area/city/backstreets_room)
 "YT" = (
 /obj/structure/railing,
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/item/grown/novaflower,
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
-"YU" = (
-/mob/living/simple_animal/hostile/shrimp_soldier,
-/turf/open/floor/plasteel/vaporwave,
-/area/city/backstreets_room)
-"YV" = (
-/obj/effect/turf_decal/siding/purple{
-	dir = 4
-	},
-/turf/open/floor/carpet/purple,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "YW" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -20229,12 +12712,19 @@
 /area/city/shop)
 "YX" = (
 /obj/structure/sink/kitchen{
-	pixel_y = 7;
 	dir = 4;
-	pixel_x = -11
+	pixel_x = -11;
+	pixel_y = 7
 	},
 /turf/open/floor/material,
 /area/city/house)
+"YY" = (
+/obj/structure/chair/wood/wings{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood,
+/area/space)
 "YZ" = (
 /obj/effect/turf_decal/siding/blue{
 	dir = 6
@@ -20246,8 +12736,8 @@
 	pixel_y = 2
 	},
 /obj/item/storage/box/drinkingglasses{
-	pixel_y = 16;
-	pixel_x = -5
+	pixel_x = -5;
+	pixel_y = 16
 	},
 /obj/item/kitchen/knife{
 	pixel_x = 11;
@@ -20255,32 +12745,15 @@
 	},
 /turf/open/floor/plasteel/checker,
 /area/city/house)
-"Zb" = (
-/mob/living/simple_animal/hostile/ordeal/green_bot_big{
-	name = "gun bot"
-	},
-/obj/effect/turf_decal/weather/dirt{
-	dir = 8
-	},
-/turf/open/floor/plating/asteroid/basalt,
-/area/city/backstreets_alley)
 "Zc" = (
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /turf/open/floor/plasteel/chapel{
 	dir = 8
 	},
 /area/city/shop)
-"Zd" = (
-/obj/structure/fluff/broken_flooring,
-/obj/item/chair/plastic,
-/obj/machinery/light/dim{
-	dir = 4
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/city/backstreets_room)
 "Ze" = (
 /obj/structure/chair/sofa/left,
 /obj/effect/turf_decal/siding/wood{
@@ -20290,8 +12763,8 @@
 /area/city/shop)
 "Zf" = (
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /turf/open/floor/material,
 /area/city/house)
@@ -20307,59 +12780,22 @@
 	},
 /turf/open/floor/wood,
 /area/city/shop)
-"Zi" = (
-/obj/machinery/light/dim{
-	dir = 8;
-	pixel_x = null;
-	pixel_y = null
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
 "Zj" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/table/wood,
-/obj/item/paper/crumpled/muddy/fluff/elephant_graveyard/rnd_notes,
+/obj/item/choice_beacon/fixer,
 /turf/open/floor/wood,
 /area/city/shop)
-"Zk" = (
-/mob/living/simple_animal/hostile/ordeal/indigo_noon,
-/obj/effect/light_emitter{
-	light_power = 4;
-	light_range = 25;
-	set_cap = 3;
-	set_luminosity = 24
-	},
-/turf/open/indestructible/necropolis,
-/area/city/backstreets_room)
-"Zl" = (
-/obj/machinery/porta_turret/syndicate/energy,
-/turf/open/floor/plasteel/dark,
-/area/city/backstreets_room)
 "Zm" = (
 /obj/structure/chair/stool/bar,
 /turf/open/floor/wood,
 /area/city/shop)
-"Zn" = (
-/obj/structure/table/wood,
-/obj/machinery/microwave{
-	pixel_y = 5
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/city/backstreets_room)
 "Zo" = (
 /obj/structure/fluff/paper/corner{
 	dir = 8
 	},
 /turf/open/floor/carpet/black,
-/area/facility_hallway/command)
-"Zp" = (
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "Zq" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/closet/crate,
@@ -20375,44 +12811,18 @@
 	},
 /turf/open/floor/plating,
 /area/city/shop)
-"Zr" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/blood/gibs/old,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
 "Zs" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
 	},
 /turf/open/floor/plating/grass,
-/area/facility_hallway/command)
-"Zt" = (
-/obj/structure/table/glass,
-/obj/item/ego_weapon/ranged/shrimp/assault,
-/turf/open/floor/plasteel/vaporwave,
-/area/city/backstreets_room)
-"Zu" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/spawner/lootdrop/garbage_spawner,
-/turf/open/floor/plasteel/shuttle{
-	name = "floor"
-	},
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "Zv" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 10
 	},
 /turf/open/floor/stone,
 /area/city)
-"Zw" = (
-/obj/effect/light_emitter{
-	light_power = 4;
-	light_range = 25;
-	set_cap = 3;
-	set_luminosity = 24
-	},
-/turf/open/indestructible/cult,
-/area/city/backstreets_room)
 "Zx" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/effect/turf_decal/siding/thinplating/dark/corner{
@@ -20425,22 +12835,13 @@
 /obj/effect/turf_decal/siding/thinplating/dark,
 /turf/open/floor/plating/grass,
 /area/city)
-"Zz" = (
-/mob/living/simple_animal/hostile/ordeal/green_bot{
-	name = "clerk bot"
-	},
-/obj/effect/turf_decal{
-	dir = 3
-	},
-/turf/open/floor/engine,
-/area/city/backstreets_room)
 "ZA" = (
 /obj/structure/flora/tree/jungle,
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "ZB" = (
 /obj/structure/rack{
 	pixel_x = -1
@@ -20473,23 +12874,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/city/fixers)
-"ZC" = (
-/obj/structure/table/wood/fancy/black,
-/obj/effect/spawner/lootdrop/space/cashmoney,
-/obj/effect/spawner/lootdrop/space/cashmoney,
-/obj/effect/spawner/lootdrop/space/cashmoney,
-/obj/effect/spawner/lootdrop/space/cashmoney,
-/obj/effect/spawner/lootdrop/space/cashmoney,
-/obj/effect/spawner/lootdrop/space/cashmoney,
-/turf/open/indestructible/necropolis,
-/area/city/backstreets_room)
-"ZD" = (
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 6
-	},
-/obj/machinery/light/floor,
-/turf/open/floor/wood,
-/area/city/backstreets_room)
 "ZE" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -20502,7 +12886,7 @@
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "ZF" = (
 /obj/effect/turf_decal{
 	dir = 1
@@ -20525,7 +12909,7 @@
 	dir = 4
 	},
 /turf/open/floor/carpet/stellar,
-/area/facility_hallway/command)
+/area/facility_hallway/manager)
 "ZH" = (
 /obj/structure/chair/stool/bar,
 /obj/effect/turf_decal/siding/blue{
@@ -20544,8 +12928,8 @@
 /area/city/fixers)
 "ZK" = (
 /obj/effect/turf_decal/tile/neutral{
-	dir = 4;
-	color = "#000000"
+	color = "#000000";
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral{
 	color = "#000000"
@@ -20553,11 +12937,9 @@
 /turf/open/floor/mineral/titanium/tiled/white,
 /area/city/fixers)
 "ZL" = (
-/obj/structure/toilet{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/facility_hallway/command)
+/obj/machinery/computer/abnormality_archive,
+/turf/open/floor/facility/dark,
+/area/facility_hallway/manager)
 "ZM" = (
 /obj/structure/railing{
 	dir = 9
@@ -20570,11 +12952,7 @@
 /turf/open/floor/plating/grass/jungle{
 	name = "Grass"
 	},
-/area/facility_hallway/command)
-"ZN" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
+/area/facility_hallway/manager)
 "ZO" = (
 /obj/item/soap/ncorporation,
 /obj/machinery/shower{
@@ -20582,29 +12960,26 @@
 	},
 /obj/structure/window/reinforced/spawner/east{
 	max_integrity = 25;
-	opacity = 1;
-	name = "Glass"
+	name = "Glass";
+	opacity = 1
 	},
 /obj/machinery/light/small,
 /turf/open/floor/noslip,
-/area/facility_hallway/command)
-"ZR" = (
-/obj/machinery/door/airlock/wood/glass,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/sepia,
-/area/city/backstreets_room)
-"ZS" = (
-/obj/machinery/door/airlock/silver{
-	name = "Female Restroom"
+/area/facility_hallway/manager)
+"ZP" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
 	},
-/turf/open/floor/facility/halls,
-/area/facility_hallway/command)
-"ZT" = (
-/mob/living/simple_animal/hostile/ordeal/amber_bug{
-	name = "carnivorous worm"
+/obj/effect/turf_decal/siding/wood/corner,
+/turf/open/floor/wood,
+/area/space)
+"ZQ" = (
+/obj/effect/turf_decal/siding/wood/end{
+	dir = 8
 	},
-/turf/open/floor/plasteel/sepia,
-/area/city/backstreets_room)
+/obj/machinery/light/cold/no_nightlight,
+/turf/open/floor/wood,
+/area/space)
 "ZU" = (
 /obj/structure/chair/office{
 	desc = "A rather boring gaming chair.";
@@ -20620,31 +12995,6 @@
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/floor/plating/grass,
 /area/city)
-"ZW" = (
-/obj/item/folder/documents{
-	desc = "A folder with a K-Corp labelled stamped on the front.";
-	name = "K-Corp Folder"
-	},
-/obj/structure/lootcrate/k_corp{
-	pixel_x = 5;
-	pixel_y = -7
-	},
-/turf/open/floor/stone,
-/area/city/backstreets_room)
-"ZX" = (
-/obj/effect/decal/cleanable/blood/gibs/down,
-/turf/open/floor/plating/dirt/jungle/dark,
-/area/city/backstreets_room)
-"ZY" = (
-/turf/open/floor/carpet/green,
-/area/city/backstreets_room)
-"ZZ" = (
-/obj/effect/decal/cleanable/blood/splatter,
-/obj/structure/chair/plastic{
-	dir = 4
-	},
-/turf/open/floor/plasteel/shuttle,
-/area/city/backstreets_room)
 
 (1,1,1) = {"
 jq
@@ -20677,117 +13027,117 @@ jq
 jq
 jq
 jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+EO
+RO
 jq
 jq
 jq
@@ -21272,16 +13622,16 @@ jq
 jq
 jq
 jq
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -21529,16 +13879,16 @@ jq
 jq
 jq
 jq
-Uc
-EW
-lv
-dP
-Bk
-dD
-Ld
-Jg
-yD
-Uc
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -21786,16 +14136,16 @@ jq
 jq
 jq
 jq
-Uc
-LM
-Dp
-Je
-Tj
-yD
-dD
-dD
-hZ
-Uc
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -22043,16 +14393,16 @@ jq
 jq
 jq
 jq
-Uc
-lN
-Je
-lN
-Bk
-yD
-yD
-yD
-Hq
-Uc
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -22300,16 +14650,16 @@ jq
 jq
 jq
 jq
-Uc
-Wi
-Qf
-SI
-Tj
-yD
-OM
-tt
-CN
-Uc
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -22557,16 +14907,16 @@ jq
 jq
 jq
 jq
-Uc
-Uc
-Uc
-Uc
-Uc
-qA
-Uc
-Uc
-Uc
-Uc
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -22814,30 +15164,30 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-he
-he
-he
-he
-he
-he
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -23071,30 +15421,30 @@ jq
 jq
 jq
 jq
-Kq
-he
-he
-he
-he
-he
-he
-he
-he
-LZ
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-Fv
-uf
-gD
-gD
-gD
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -23328,30 +15678,30 @@ jq
 jq
 jq
 jq
-ah
-he
-he
-he
-he
-he
-he
-he
-he
-lR
-or
-or
-or
-or
-or
-or
-or
-JA
-or
-uf
-gD
-gD
-gD
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -23523,26 +15873,6 @@ jq
 jq
 jq
 jq
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
 jq
 jq
 jq
@@ -23585,30 +15915,50 @@ jq
 jq
 jq
 jq
-Kq
-he
-he
-he
-he
-he
-he
-he
-he
-Ll
-Wk
-Wk
-Wk
-eZ
-Wk
-Wk
-Wk
-eZ
-Gq
-uf
-gD
-gD
-gD
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -23780,26 +16130,6 @@ jq
 jq
 jq
 jq
-Uc
-Fl
-gT
-Lu
-MA
-MA
-MA
-MA
-MA
-MA
-MA
-MA
-MA
-MA
-MA
-xp
-Uc
-Nr
-Rc
-Uc
 jq
 jq
 jq
@@ -23842,30 +16172,50 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-he
-KN
-KN
-KN
-KN
-Uc
-Uc
-SB
-af
-Uc
-ac
-Uc
-Uc
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -24037,26 +16387,6 @@ jq
 jq
 jq
 jq
-Uc
-wq
-Fw
-pK
-MA
-cO
-kg
-Ug
-MA
-MA
-MA
-jC
-MA
-MA
-MA
-MA
-Uc
-MA
-MA
-Uc
 jq
 jq
 jq
@@ -24099,22 +16429,42 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-he
-KN
 jq
 jq
 jq
-OK
-nK
-DS
-jz
-vP
-Mq
-eF
-Gz
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -24294,26 +16644,6 @@ jq
 jq
 jq
 jq
-Uc
-Cz
-wq
-zG
-cO
-de
-Bp
-yZ
-Ug
-VN
-MA
-VN
-MA
-VN
-MA
-jC
-oJ
-MA
-xc
-Uc
 jq
 jq
 jq
@@ -24356,22 +16686,42 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-he
-KN
 jq
 jq
 jq
-eh
-Pu
-VL
-jz
-OR
-RZ
-sc
-ax
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -24551,26 +16901,6 @@ jq
 jq
 jq
 jq
-Uc
-fu
-uU
-pK
-RE
-IB
-IB
-IB
-KF
-xe
-MA
-vJ
-MA
-pz
-MA
-VN
-Uc
-MA
-MA
-Uc
 jq
 jq
 jq
@@ -24613,22 +16943,42 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-he
-KN
 jq
 jq
 jq
-WT
-Eo
-Gv
-yB
-Ar
-ju
-rH
-yG
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -24808,26 +17158,6 @@ jq
 jq
 jq
 jq
-Uc
-NI
-wq
-gW
-RE
-IB
-IB
-IB
-KF
-vJ
-MA
-vJ
-MA
-vJ
-MA
-vJ
-Uc
-CT
-PR
-Uc
 jq
 jq
 jq
@@ -24870,22 +17200,42 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-he
-KN
 jq
 jq
 jq
-WT
-OI
-Sz
-VL
-Xl
-NH
-ON
-kb
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -25065,48 +17415,6 @@ jq
 jq
 jq
 jq
-Uc
-mK
-US
-Ru
-RE
-IB
-IB
-IB
-KF
-vJ
-MA
-vJ
-MA
-vJ
-MA
-vJ
-Uc
-Uc
-Uc
-Uc
-TJ
-Ij
-Ij
-Ij
-TJ
-Ij
-Ij
-Ij
-TJ
-Ij
-Ij
-Ij
-TJ
-Ij
-Ij
-Ij
-TJ
-Ij
-Ij
-Ij
-TJ
-TJ
 jq
 jq
 jq
@@ -25127,22 +17435,64 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-he
-KN
 jq
 jq
 jq
-Uc
-ai
-jd
-HS
-dc
-gK
-bV
-ax
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -25322,48 +17672,6 @@ jq
 jq
 jq
 jq
-Uc
-PV
-zV
-kg
-de
-IB
-IB
-dX
-yZ
-hE
-kg
-hE
-kg
-hE
-kg
-hE
-Ug
-MA
-MA
-Uc
-hi
-hi
-hi
-hi
-hi
-hi
-hi
-hi
-hi
-hi
-hi
-hi
-hi
-hi
-hi
-hi
-hi
-hi
-hi
-hi
-gg
-TJ
 jq
 jq
 jq
@@ -25384,22 +17692,64 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-he
-KN
 jq
 jq
 jq
-eh
-HK
-bg
-px
-Eo
-Re
-Ig
-kb
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -25579,84 +17929,84 @@ jq
 jq
 jq
 jq
-Uc
-hh
-de
-ZC
-pN
-IB
-IB
-IB
-IB
-IB
-IB
-dX
-IB
-IB
-IB
-IB
-yZ
-Ug
-dk
-MA
-sG
-vs
-vs
-vs
-sG
-vs
-vs
-vs
-sG
-vs
-vs
-vs
-sG
-vs
-vs
-vs
-sG
-vs
-vs
-sG
-xd
-TJ
-TJ
-Ij
-Ij
-TJ
-Ij
-Ij
-TJ
-Ij
-Ij
-TJ
-Ij
-Ij
-TJ
-Ij
-Ij
-TJ
-Ij
-Ij
-TJ
-TJ
-TJ
-he
-he
-he
-KN
 jq
 jq
 jq
-WT
-bg
-BS
-Nu
-Wf
-jz
-ty
-ax
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -25836,84 +18186,84 @@ jq
 jq
 jq
 jq
-Uc
-iu
-ye
-IB
-IB
-dX
-CJ
-IB
-IB
-IB
-IB
-IB
-dX
-IB
-IB
-IB
-IB
-KK
-MA
-Zw
-vs
-vs
-vs
-vs
-vs
-vs
-vs
-vs
-vs
-vs
-vs
-vs
-vs
-vs
-vs
-vs
-vs
-vs
-vs
-vs
-vs
-Sx
-hi
-hi
-hi
-hi
-hi
-hi
-hi
-hi
-hi
-hi
-hi
-hi
-hi
-hi
-hi
-hi
-hi
-hi
-hi
-hi
-NV
-WG
-he
-he
-KN
 jq
 jq
 jq
-Uc
-RX
-QM
-sS
-jz
-jz
-iN
-ax
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -26093,84 +18443,84 @@ jq
 jq
 jq
 jq
-Uc
-iu
-IB
-IB
-IB
-jm
-CJ
-IB
-IB
-IB
-IB
-IB
-dX
-IB
-IB
-IB
-IB
-KK
-MA
-Zw
-vs
-vs
-vs
-vs
-vs
-vs
-vs
-vs
-vs
-vs
-vs
-vs
-vs
-vs
-vs
-vs
-vs
-vs
-vs
-vs
-vs
-Uo
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-gn
-he
-he
-he
-KN
 jq
 jq
 jq
-Yp
-MP
-HD
-Eo
-jz
-Rw
-UZ
-ax
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -26236,7 +18586,7 @@ Ck
 Ck
 JE
 JI
-Yo
+Of
 SZ
 JE
 Tn
@@ -26350,84 +18700,84 @@ jq
 jq
 jq
 jq
-Uc
-Ph
-QG
-ZC
-bj
-IB
-IB
-IB
-IB
-IB
-IB
-dX
-IB
-IB
-IB
-IB
-Qq
-wM
-dk
-MA
-sG
-vs
-vs
-vs
-sG
-vs
-vs
-vs
-sG
-vs
-vs
-vs
-sG
-vs
-vs
-vs
-sG
-vs
-vs
-sG
-xd
-TJ
-TJ
-TJ
-Ij
-Ij
-TJ
-Ij
-Ij
-TJ
-Ij
-Ij
-TJ
-Ij
-Ij
-TJ
-Ij
-Ij
-TJ
-Ij
-Ij
-TJ
-TJ
-he
-he
-he
-KN
 jq
 jq
 jq
-eh
-Pu
-jz
-Dt
-rs
-VM
-rH
-ax
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -26607,48 +18957,6 @@ jq
 jq
 jq
 jq
-Uc
-PV
-nq
-dF
-QG
-IB
-IB
-dX
-Qq
-gP
-dF
-gP
-dF
-gP
-dF
-gP
-wM
-MA
-MA
-Uc
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-ge
-kE
-TJ
 jq
 jq
 jq
@@ -26669,22 +18977,64 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-he
-KN
 jq
 jq
 jq
-WT
-jz
-ub
-zL
-Ja
-yi
-sc
-kb
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -26864,48 +19214,6 @@ jq
 jq
 jq
 jq
-Uc
-JG
-bM
-ce
-RE
-IB
-IB
-IB
-KF
-vJ
-MA
-vJ
-MA
-vJ
-dk
-vJ
-Uc
-Uc
-Uc
-Uc
-TJ
-Ij
-Ij
-Ij
-TJ
-Ij
-Ij
-Ij
-TJ
-Ij
-Ij
-Ij
-TJ
-Ij
-Ij
-Ij
-TJ
-Ij
-Ij
-Ij
-TJ
-TJ
 jq
 jq
 jq
@@ -26926,22 +19234,64 @@ jq
 jq
 jq
 jq
-KN
-WG
-he
-he
-KN
 jq
 jq
 jq
-WT
-jz
-HH
-yC
-Ln
-bg
-vb
-ax
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -27014,19 +19364,19 @@ xm
 bI
 Bt
 Mx
-jj
-QQ
+Sv
+Cc
 oy
 QQ
 JE
-xY
+Mc
 aq
 ss
 JE
-QQ
-vF
-QQ
-jj
+JE
+JE
+JE
+JE
 ws
 Bt
 In
@@ -27121,26 +19471,6 @@ jq
 jq
 jq
 jq
-Uc
-Ky
-wq
-gW
-RE
-IB
-IB
-IB
-KF
-vJ
-MA
-vJ
-MA
-vJ
-MA
-vJ
-Uc
-bn
-Pe
-Uc
 jq
 jq
 jq
@@ -27183,22 +19513,42 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-he
-KN
 jq
 jq
 jq
-WT
-Ci
-gw
-XI
-uo
-bg
-NY
-kb
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -27271,19 +19621,19 @@ fr
 bI
 Bt
 DP
-jj
-ix
+Sv
+LU
 HG
 ix
 JE
-Mc
-aq
-Mc
+UT
+zh
+Sv
 JE
-ix
-HG
-ix
-jj
+JE
+JE
+JE
+JE
 Eu
 Bt
 bI
@@ -27378,26 +19728,6 @@ jq
 jq
 jq
 jq
-Uc
-BF
-wq
-pK
-RE
-IB
-IB
-IB
-KF
-vJ
-MA
-vJ
-jC
-vJ
-MA
-xH
-Uc
-mV
-zz
-Uc
 jq
 jq
 jq
@@ -27440,22 +19770,42 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-he
-KN
 jq
 jq
 jq
-UQ
-gS
-aG
-Rn
-Gl
-ZW
-MX
-yG
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -27528,17 +19878,17 @@ Ir
 Jh
 Bt
 tZ
-JE
-TZ
-iI
+Sv
+KG
+yx
 qB
-JE
+CS
 Mc
 aq
 Mc
-JE
-CF
-iI
+LV
+Mc
+Mc
 SU
 JE
 NC
@@ -27635,26 +19985,6 @@ jq
 jq
 jq
 jq
-Uc
-NI
-uU
-pK
-qJ
-QG
-Zk
-Qq
-wM
-xH
-MA
-xH
-MA
-xH
-MA
-jC
-QX
-MA
-yX
-Uc
 jq
 jq
 jq
@@ -27697,22 +20027,42 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-he
-KN
 jq
 jq
 jq
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-YB
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -27785,19 +20135,19 @@ fr
 In
 Bt
 tZ
-JE
+Sv
 ho
-MR
+QC
 Me
-zh
-fV
+JE
+Mc
 aq
-pD
+aq
 zh
-BA
+Mc
 MR
 OD
-JE
+Sv
 lt
 bI
 bI
@@ -27892,26 +20242,6 @@ jq
 jq
 jq
 jq
-Uc
-bE
-wq
-pK
-MA
-qJ
-dF
-wM
-MA
-jC
-MA
-MA
-MA
-MA
-MA
-MA
-Uc
-jw
-MA
-Uc
 jq
 jq
 jq
@@ -27954,11 +20284,31 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-he
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -28042,19 +20392,19 @@ xm
 Bt
 Bt
 xs
+Sv
+nr
+vf
+yf
 JE
-JE
-JE
-JE
-JE
-xY
+Mc
 aq
 ss
-JE
-JE
-JE
-JE
-JE
+Sv
+rd
+tF
+UB
+Sv
 vW
 bI
 In
@@ -28149,26 +20499,6 @@ jq
 jq
 jq
 jq
-Uc
-zO
-Mi
-pK
-MA
-MA
-MA
-MA
-MA
-MA
-MA
-MA
-MA
-MA
-MA
-xp
-Uc
-jw
-MA
-Uc
 jq
 jq
 jq
@@ -28206,21 +20536,41 @@ jq
 jq
 jq
 jq
-Vg
-Vg
-Vg
-Vg
-Vg
-Uc
-jJ
-jJ
-Ou
-Uc
-Vg
-Vg
-Vg
-Vg
-Vg
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -28300,17 +20650,17 @@ Bt
 In
 rx
 JE
-QH
-Fs
 JE
-RF
-Mc
+JE
+JE
+JE
+qv
 aq
 Mc
-Mc
 JE
-kh
-Fs
+JE
+JE
+JE
 JE
 My
 bI
@@ -28406,26 +20756,6 @@ jq
 jq
 jq
 jq
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
 jq
 jq
 jq
@@ -28463,21 +20793,41 @@ jq
 jq
 jq
 jq
-Vg
-Uc
-kT
-kT
-tY
-Uc
-Ou
-Ou
-Ou
-Uc
-tY
-kT
-kT
-Uc
-Vg
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -28556,18 +20906,18 @@ Bt
 Bt
 bI
 rx
-JE
+Sv
 aZ
-ek
-ZS
+Mc
+Mc
 oB
+Mc
 aq
-aq
-aq
-pD
-ZS
-ek
-Bb
+Mc
+JE
+Mc
+Mc
+SU
 JE
 iq
 bI
@@ -28720,21 +21070,21 @@ jq
 jq
 jq
 jq
-Uc
-Uc
-Ou
-Ou
-Nl
-ZX
-Ou
-we
-dM
-Ou
-Da
-Wp
-Cb
-Uc
-Uc
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -28806,26 +21156,26 @@ Ck
 Ck
 JE
 QV
-jO
+XQ
 QV
 JE
 eW
 Bt
 bI
 cb
-JE
+Sv
 ZL
 Id
-JE
+Mc
 RF
-Mc
 aq
+aq
+aq
+aT
 Mc
-Mc
-JE
-Id
-ZL
-JE
+MR
+OD
+Sv
 pR
 In
 Bt
@@ -28977,21 +21327,21 @@ jq
 jq
 jq
 jq
-tY
-sh
-oT
-lT
-jJ
-Ou
-tc
-LC
-Ou
-UY
-jJ
-Ou
-Ou
-Ou
-tY
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -29070,19 +21420,19 @@ Ir
 Bt
 bI
 kO
-JE
-JE
-JE
-JE
-JE
-xY
+Sv
+my
+tF
+rd
+Sv
+Mc
 aq
-ss
-JE
-JE
-JE
-JE
-JE
+Mc
+Sv
+rd
+tF
+UB
+Sv
 iw
 In
 Bt
@@ -29223,48 +21573,48 @@ jq
 jq
 jq
 jq
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-kT
-Cb
-Ou
-jJ
-jJ
-Ou
-pv
-Ou
-Ou
-Ou
-VZ
-jJ
-CU
-Ou
-kT
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -29328,17 +21678,17 @@ Bt
 In
 tZ
 JE
-TZ
-sH
-qB
-zh
+JE
+JE
+JE
+JE
 fV
 aq
-pD
-zh
-CF
-sH
-SU
+ss
+JE
+JE
+JE
+JE
 JE
 My
 In
@@ -29480,48 +21830,48 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-kT
-Ou
-Ou
-Wp
-we
-Ou
-UY
-ZX
-oT
-IA
-Ou
-jJ
-Ou
-Ou
-kT
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -29584,18 +21934,18 @@ Tn
 Bt
 Bt
 DP
-JE
-ho
-Yo
-Me
-JE
+Sv
+aZ
+Mc
+Mc
+qC
 Mc
 aq
 Mc
-JE
-BA
-Yo
-OD
+kV
+Mc
+Mc
+SU
 JE
 go
 Bt
@@ -29737,48 +22087,48 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-Uc
-tS
-Ou
-tc
-Ou
-Ou
-Cb
-OY
-tQ
-Ou
-Ou
-jJ
-Ou
-Yq
-Uc
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -29841,19 +22191,19 @@ In
 Bt
 Bt
 yL
-jj
-cG
-Fk
-cG
-JE
+Sv
+ZL
+Id
 Mc
+ft
 aq
+aq
+aq
+Tq
 Mc
-JE
-oK
-Pl
-oK
-jj
+MR
+OD
+Sv
 Eu
 Bt
 Bt
@@ -29994,48 +22344,48 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-kT
-IA
-oT
-Ou
-Ou
-CU
-Ou
-Ou
-Ou
-Ou
-qq
-Ou
-Ou
-Ou
-kT
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -30098,19 +22448,19 @@ Bt
 Bt
 Bt
 Oj
-jj
-QQ
-fY
-QQ
-JE
-xY
+Sv
+my
+tF
+rd
+Sv
+jP
 mN
-ss
-JE
-QQ
-WS
-QQ
-jj
+jP
+Sv
+rd
+tF
+UB
+Sv
 pR
 In
 bI
@@ -30251,48 +22601,48 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-he
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-kT
-Ou
-jJ
-tR
-Ou
-Ou
-pv
-Ou
-qq
-Ou
-Wp
-Ou
-Ts
-IA
-kT
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-he
-he
-he
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -30361,7 +22711,7 @@ JE
 JE
 JE
 JE
-BD
+eC
 JE
 JE
 JE
@@ -30508,32 +22858,6 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-he
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-tY
-YO
-of
-jJ
-jJ
-Ou
-jJ
-Ou
-ZX
-oT
-oT
-lT
-oT
-Lp
-tY
 jq
 jq
 jq
@@ -30545,11 +22869,37 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-he
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -30765,32 +23115,6 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-he
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-Uc
-Uc
-pv
-Ou
-fo
-qq
-dM
-Ou
-Cb
-UY
-zK
-Ou
-Ou
-Uc
-Uc
 jq
 jq
 jq
@@ -30802,11 +23126,37 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-he
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -31022,32 +23372,6 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-he
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-Vg
-Uc
-kT
-Tu
-tY
-Uc
-Ou
-we
-jJ
-Uc
-tY
-kT
-kT
-Uc
-Vg
 jq
 jq
 jq
@@ -31059,11 +23383,37 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-he
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -31279,32 +23629,6 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-he
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-Vg
-Vg
-Vg
-Vg
-Vg
-Uc
-Ou
-jJ
-Ou
-Uc
-Vg
-Vg
-Vg
-Vg
-Vg
 jq
 jq
 jq
@@ -31316,11 +23640,37 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-he
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -31536,27 +23886,6 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-he
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-KN
-he
-he
-he
-KN
 jq
 jq
 jq
@@ -31573,11 +23902,32 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-he
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -31639,7 +23989,7 @@ tZ
 Ji
 kw
 yg
-Aw
+WO
 WO
 tG
 JE
@@ -31653,7 +24003,7 @@ Mc
 fN
 Cj
 IY
-Tz
+IY
 Yv
 TL
 Ji
@@ -31793,27 +24143,6 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-he
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-KN
-he
-he
-he
-KN
 jq
 jq
 jq
@@ -31830,11 +24159,32 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-he
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -32050,27 +24400,6 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-he
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-KN
-he
-he
-he
-KN
 jq
 jq
 jq
@@ -32087,11 +24416,32 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-he
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -32307,27 +24657,6 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-he
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-KN
-he
-he
-he
-KN
 jq
 jq
 jq
@@ -32344,11 +24673,32 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-he
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -32564,27 +24914,6 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-he
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-KN
-he
-he
-he
-KN
 jq
 jq
 jq
@@ -32601,11 +24930,32 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-he
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -32821,27 +25171,6 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-he
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-KN
-he
-he
-he
-KN
 jq
 jq
 jq
@@ -32858,11 +25187,32 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-he
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -33078,27 +25428,6 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-he
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-KN
-he
-he
-he
-KN
 jq
 jq
 jq
@@ -33115,11 +25444,32 @@ jq
 jq
 jq
 jq
-KN
-uf
-uf
-uf
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -33335,27 +25685,6 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-he
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-KN
-he
-he
-he
-KN
 jq
 jq
 jq
@@ -33372,16 +25701,37 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-he
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -33592,11 +25942,6 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-he
-KN
 jq
 jq
 jq
@@ -33608,37 +25953,42 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-he
-KN
-KN
-Kq
-Kq
-KN
-Kq
-Kq
-KN
-KN
-KN
-KN
-KN
-KN
-rI
-Kq
-Kq
-KN
-KN
-he
-he
-he
-Ou
-jr
-jr
-Bo
-jr
-Uc
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -33849,11 +26199,6 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-he
-KN
 jq
 jq
 jq
@@ -33865,37 +26210,42 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-he
-he
-he
-he
-he
-he
-nb
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-Ou
-Ou
-Ou
-Ou
-Ou
-Uc
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -34106,11 +26456,6 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-he
-KN
 jq
 jq
 jq
@@ -34122,37 +26467,42 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-WG
-he
-Ou
-Ou
-Ou
-Ou
-Ou
-Uc
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -34363,11 +26713,6 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-he
-KN
 jq
 jq
 jq
@@ -34379,37 +26724,42 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-he
-he
-he
-nb
-he
-he
-he
-he
-he
-he
-WG
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-Ou
-Ou
-Ou
-Ou
-Ou
-Uc
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -34480,7 +26830,7 @@ Mc
 JE
 JE
 cU
-rO
+gk
 Ps
 nR
 JE
@@ -34577,10 +26927,6 @@ jq
 jq
 jq
 jq
-KN
-KN
-KN
-KN
 jq
 jq
 jq
@@ -34620,11 +26966,6 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-he
-KN
 jq
 jq
 jq
@@ -34636,37 +26977,46 @@ jq
 jq
 jq
 jq
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-Kq
-Kq
-KN
-KN
-Kq
-Kq
-Kq
-Kq
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-he
-he
-he
-Ou
-rp
-bw
-CO
-MY
-Uc
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -34721,9 +27071,9 @@ In
 Bt
 Kd
 Ji
-Ng
+qB
 TK
-lU
+qB
 Kn
 Lg
 tH
@@ -34737,8 +27087,8 @@ Mc
 JE
 LK
 ri
-rO
-rO
+gk
+gk
 jg
 Ji
 GX
@@ -34834,10 +27184,6 @@ jq
 jq
 jq
 jq
-KN
-uf
-uf
-KN
 jq
 jq
 jq
@@ -34877,11 +27223,6 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-he
-KN
 jq
 jq
 jq
@@ -34914,16 +27255,25 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-he
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -34979,10 +27329,10 @@ Bt
 kH
 Ji
 TK
-lU
+qB
 TK
-lU
-lU
+qB
+qB
 Ea
 HC
 aq
@@ -34992,10 +27342,10 @@ aq
 aq
 Dk
 Ah
-rO
-rO
-rO
-rO
+gk
+gk
+gk
+gk
 gk
 Ji
 iM
@@ -35091,17 +27441,6 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-Uc
-Uc
-Uc
-kT
-kT
-Uc
-Uc
-Uc
 jq
 jq
 jq
@@ -35134,11 +27473,6 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-he
-KN
 jq
 jq
 jq
@@ -35171,11 +27505,27 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-he
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -35241,7 +27591,7 @@ ud
 dt
 dt
 JE
-xY
+fV
 Mc
 Mc
 aq
@@ -35348,17 +27698,6 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-kT
-bH
-Vv
-Mb
-aY
-eB
-Jn
-Uc
 jq
 jq
 jq
@@ -35391,11 +27730,6 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-he
-KN
 jq
 jq
 jq
@@ -35421,18 +27755,34 @@ jq
 jq
 jq
 jq
-Vg
-Vg
-Vg
-Uc
-Uc
-Uc
-Uc
-Uc
-he
-he
-WG
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -35465,7 +27815,7 @@ fD
 Lx
 Lx
 Lx
-wt
+Di
 Lx
 cC
 vt
@@ -35496,7 +27846,7 @@ JE
 Ot
 hN
 Xt
-ZL
+cK
 JE
 JE
 qV
@@ -35605,17 +27955,6 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-Ye
-Mo
-KB
-YC
-OF
-eB
-qb
-Uc
 jq
 jq
 jq
@@ -35648,11 +27987,6 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-he
-KN
 jq
 jq
 jq
@@ -35678,18 +28012,34 @@ jq
 jq
 jq
 jq
-Vg
-Uc
-Uc
-Uc
-pQ
-hc
-pQ
-Uc
-he
-he
-he
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -35862,17 +28212,6 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-kT
-as
-jQ
-Fu
-mi
-fw
-iF
-Uc
 jq
 jq
 jq
@@ -35905,11 +28244,6 @@ jq
 jq
 jq
 jq
-KN
-uf
-uf
-uf
-KN
 jq
 jq
 jq
@@ -35935,18 +28269,34 @@ jq
 jq
 jq
 jq
-Vg
-Uc
-RP
-sK
-pQ
-nc
-pQ
-Op
-he
-he
-he
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -36119,17 +28469,6 @@ jq
 jq
 jq
 jq
-Kq
-he
-he
-Uc
-Uc
-Uc
-Uc
-Uc
-oq
-Uc
-Uc
 jq
 jq
 jq
@@ -36151,32 +28490,6 @@ jq
 jq
 jq
 jq
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-lR
-or
-aI
-KN
-KN
-KN
-Kq
-Kq
-KN
-KN
-KN
-KN
-KN
-KN
 jq
 jq
 jq
@@ -36192,18 +28505,55 @@ jq
 jq
 jq
 jq
-Vg
-Uc
-Ou
-Uc
-pQ
-HN
-pQ
-Uc
-he
-he
-he
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -36266,19 +28616,19 @@ In
 Bt
 Bt
 lV
-jj
+Sv
 iV
 AC
 iV
 JE
-xY
+fV
 UU
 ss
 JE
 iV
 AC
 iV
-jj
+Sv
 lt
 In
 In
@@ -36376,17 +28726,6 @@ jq
 jq
 jq
 jq
-ah
-he
-he
-Uc
-Cd
-mF
-au
-eB
-fw
-eB
-Uc
 jq
 jq
 jq
@@ -36408,32 +28747,6 @@ jq
 jq
 jq
 jq
-KN
-AZ
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-or
-or
-or
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-ea
-KN
 jq
 jq
 jq
@@ -36449,18 +28762,55 @@ jq
 jq
 jq
 jq
-Vg
-Uc
-dZ
-Uc
-Uc
-Uc
-Uc
-Uc
-he
-he
-he
-Kq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -36492,17 +28842,17 @@ Yr
 fD
 Lx
 Lx
-wt
+Di
 Lx
 Lx
 Lx
-wt
+Di
 Lx
-wt
+Di
 Lx
 Lx
 Lx
-wt
+Di
 Lx
 Lx
 fD
@@ -36523,9 +28873,9 @@ In
 In
 In
 lV
-jj
+Sv
 yh
-VI
+yh
 yh
 JE
 Mc
@@ -36533,9 +28883,9 @@ aq
 Mc
 JE
 yh
-VI
 yh
-jj
+yh
+Sv
 My
 bI
 Bt
@@ -36633,17 +28983,6 @@ jq
 jq
 jq
 jq
-Kq
-he
-he
-kT
-iJ
-Gm
-Ca
-lO
-rK
-Bh
-Uc
 jq
 jq
 jq
@@ -36665,32 +29004,6 @@ jq
 jq
 jq
 jq
-KN
-lR
-or
-Qn
-or
-or
-or
-or
-or
-or
-or
-or
-or
-Qn
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-ea
-KN
 jq
 jq
 jq
@@ -36706,18 +29019,55 @@ jq
 jq
 jq
 jq
-Vg
-Uc
-MW
-qS
-gz
-rm
-MW
-Uc
-he
-he
-he
-Kq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -36783,7 +29133,7 @@ DP
 JE
 mt
 iI
-qB
+NE
 JE
 Mc
 aq
@@ -36791,7 +29141,7 @@ Mc
 JE
 CF
 iI
-SU
+GL
 JE
 go
 Bt
@@ -36890,17 +29240,6 @@ jq
 jq
 jq
 jq
-Kq
-he
-he
-kT
-fh
-eB
-Hr
-eB
-Fy
-vR
-Uc
 jq
 jq
 jq
@@ -36922,32 +29261,6 @@ jq
 jq
 jq
 jq
-KN
-lR
-or
-or
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-or
-or
-ea
-KN
 jq
 jq
 jq
@@ -36963,18 +29276,55 @@ jq
 jq
 jq
 jq
-Vg
-Uc
-MW
-JF
-BL
-tw
-MW
-Uc
-he
-he
-he
-Kq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -37039,16 +29389,16 @@ Bt
 yL
 JE
 ph
-MR
-Me
+DK
+WI
 Xq
 LL
 aq
 si
 Xq
 BA
-MR
-OD
+DK
+nd
 JE
 DJ
 bI
@@ -37147,17 +29497,6 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-kT
-LD
-zk
-gb
-eB
-Fy
-yd
-Uc
 jq
 jq
 jq
@@ -37175,36 +29514,6 @@ jq
 jq
 jq
 jq
-Uc
-Uc
-Uc
-Uc
-Uc
-lR
-or
-ea
-KN
-KN
-ah
-KN
-KN
-KN
-ah
-KN
-KN
-ah
-KN
-KN
-Uc
-Uc
-vU
-vU
-Uc
-Uc
-lR
-or
-ea
-KN
 jq
 jq
 jq
@@ -37220,18 +29529,59 @@ jq
 jq
 jq
 jq
-Vg
-Uc
-MW
-hb
-hb
-kY
-MW
-Uc
-he
-he
-he
-ah
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -37262,19 +29612,19 @@ NK
 Yr
 fD
 Lx
-wt
+Lx
+Di
+Lx
+Lx
+Lx
+Lx
+Di
 Lx
 Lx
 Lx
 Lx
 Lx
-wt
-Lx
-Lx
-Lx
-Lx
-Lx
-wt
+Di
 Lx
 fD
 RK
@@ -37299,7 +29649,7 @@ JE
 JE
 JE
 JE
-xY
+fV
 aq
 ss
 JE
@@ -37404,17 +29754,6 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-kT
-Jf
-AU
-eB
-Gm
-oA
-Nb
-Uc
 jq
 jq
 jq
@@ -37432,36 +29771,6 @@ jq
 jq
 jq
 jq
-Uc
-Ke
-Gn
-ZZ
-Uc
-lR
-or
-ea
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-Uc
-na
-YF
-Rj
-rb
-Uc
-lR
-or
-ea
-KN
 jq
 jq
 jq
@@ -37477,18 +29786,59 @@ jq
 jq
 jq
 jq
-Vg
-Uc
-MW
-uN
-Xk
-mJ
-MW
-Uc
-he
-he
-WG
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -37555,7 +29905,7 @@ JE
 Vs
 PX
 JE
-RF
+kp
 Mc
 aq
 Mc
@@ -37661,17 +30011,6 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-Uc
-Wo
-eB
-eB
-eB
-eB
-Rj
-Uc
 jq
 jq
 jq
@@ -37689,36 +30028,6 @@ jq
 jq
 jq
 jq
-Uc
-wD
-BG
-RV
-Ch
-lR
-or
-ea
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-Ev
-bN
-LY
-eB
-UX
-nj
-lR
-or
-ea
-KN
 jq
 jq
 jq
@@ -37734,18 +30043,59 @@ jq
 jq
 jq
 jq
-Vg
-Uc
-MW
-Be
-cZ
-Bx
-MW
-Uc
-he
-he
-he
-ah
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -37811,14 +30161,14 @@ rx
 JE
 hm
 In
-FK
+IV
 LL
 aq
 aq
 aq
 si
 FK
-In
+pn
 Xw
 JE
 iM
@@ -37918,17 +30268,6 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-Uc
-Uc
-ka
-Uc
-Uc
-Uc
-Uc
-Uc
 jq
 jq
 jq
@@ -37946,36 +30285,6 @@ jq
 jq
 jq
 jq
-Uc
-BJ
-XR
-kC
-kC
-lR
-or
-ea
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-Uc
-nN
-Uc
-Uc
-Vp
-Uc
-lR
-or
-ea
-ah
 jq
 jq
 jq
@@ -37991,18 +30300,59 @@ jq
 jq
 jq
 jq
-Vg
-Uc
-MW
-Be
-rC
-Bx
-MW
-Uc
-he
-he
-he
-Kq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -38056,8 +30406,8 @@ JE
 Gi
 JE
 JE
-cQ
-cQ
+JE
+JE
 mW
 AF
 JE
@@ -38066,16 +30416,16 @@ In
 bI
 hX
 JE
-cK
-cK
+pM
+pM
 JE
-RF
+kp
 Mc
 aq
 Mc
 As
 JE
-cK
+Ip
 cK
 JE
 go
@@ -38175,17 +30525,6 @@ jq
 jq
 jq
 jq
-Kq
-he
-he
-Uc
-hu
-eB
-ul
-QD
-el
-tD
-Uc
 jq
 jq
 jq
@@ -38203,36 +30542,6 @@ jq
 jq
 jq
 jq
-Uc
-md
-Ba
-gZ
-fX
-lR
-or
-ea
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-BC
-YS
-Ws
-Ws
-Al
-Uc
-lR
-Qn
-ea
-KN
 jq
 jq
 jq
@@ -38248,18 +30557,59 @@ jq
 jq
 jq
 jq
-Vg
-Uc
-MW
-hp
-DT
-tV
-MW
-Uc
-WG
-he
-he
-Kq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -38312,9 +30662,9 @@ sf
 JE
 Gi
 JE
-KC
 gF
-cQ
+gF
+JE
 mW
 mW
 JE
@@ -38327,7 +30677,7 @@ JE
 JE
 JE
 JE
-xY
+fV
 aq
 ss
 JE
@@ -38432,17 +30782,6 @@ jq
 jq
 jq
 jq
-Kq
-he
-he
-Uc
-QS
-eB
-eB
-eB
-jW
-Yc
-Uc
 jq
 jq
 jq
@@ -38460,36 +30799,6 @@ jq
 jq
 jq
 jq
-Uc
-za
-Zd
-yR
-Uc
-lR
-or
-ea
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-BC
-Tw
-eJ
-ez
-Al
-hy
-lR
-or
-ea
-KN
 jq
 jq
 jq
@@ -38505,18 +30814,59 @@ jq
 jq
 jq
 jq
-Vg
-Uc
-MW
-Cg
-Cg
-mU
-MW
-Uc
-he
-he
-he
-Kq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -38569,9 +30919,9 @@ sf
 JE
 Gi
 JE
-vp
 gF
-cQ
+gF
+JE
 mW
 mW
 JE
@@ -38582,15 +30932,15 @@ rx
 JE
 TZ
 sH
-qB
-Xq
-LL
+NE
+WQ
+AQ
 aq
-si
-Xq
+iA
+WQ
 CF
 sH
-SU
+GL
 JE
 lt
 In
@@ -38689,17 +31039,6 @@ jq
 jq
 jq
 jq
-Kq
-he
-he
-Uc
-HJ
-Rj
-Ii
-Ii
-db
-Ef
-Uc
 jq
 jq
 jq
@@ -38717,15 +31056,6 @@ jq
 jq
 jq
 jq
-Uc
-Uc
-Uc
-Uc
-Uc
-lR
-or
-ea
-KN
 jq
 jq
 jq
@@ -38737,43 +31067,63 @@ jq
 jq
 jq
 jq
-Rd
-Fb
-Wu
-KS
-Uk
-hy
-lR
-or
-ea
-KN
-KN
-Kq
-Kq
-Kq
-Kq
-Kq
-KN
-KN
-KN
-KN
-KN
-KN
 jq
 jq
 jq
-Vg
-Uc
-MW
-Cg
-aF
-Cg
-MW
-Uc
-he
-he
-he
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -38826,9 +31176,9 @@ sf
 JE
 Gi
 JE
-Lj
+gF
 Iy
-Ak
+JE
 mW
 mW
 JE
@@ -38837,17 +31187,17 @@ Bt
 Jh
 cb
 JE
-ho
-Yo
-Me
+zp
+Of
+WI
 JE
 Mc
 aq
 Mc
 JE
 BA
-Yo
-OD
+Of
+nd
 JE
 lt
 Bt
@@ -38941,22 +31291,6 @@ jq
 jq
 jq
 jq
-KN
-KN
-KN
-KN
-KN
-KN
-he
-he
-Uc
-Uc
-Uc
-kT
-kT
-Uc
-Uc
-Uc
 jq
 jq
 jq
@@ -38978,11 +31312,6 @@ jq
 jq
 jq
 jq
-KN
-lR
-Qn
-ea
-KN
 jq
 jq
 jq
@@ -38994,43 +31323,64 @@ jq
 jq
 jq
 jq
-BC
-Qj
-hj
-ez
-Uk
-hy
-lR
-or
-or
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-KN
 jq
 jq
 jq
-Vg
-Uc
-MW
-Cg
-Cg
-Cg
-MW
-Uc
-he
-he
-he
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -39093,19 +31443,19 @@ Ir
 Bt
 In
 Oj
-jj
-Uf
-pV
-Uf
+Sv
+Ny
+Ny
+Ny
 JE
 Mc
 aq
 Mc
 JE
 Uf
-pV
 Uf
-jj
+Uf
+Sv
 lt
 Bt
 bI
@@ -39198,21 +31548,6 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-KN
 jq
 jq
 jq
@@ -39235,11 +31570,6 @@ jq
 jq
 jq
 jq
-KN
-lR
-or
-ea
-KN
 jq
 jq
 jq
@@ -39251,43 +31581,63 @@ jq
 jq
 jq
 jq
-Uc
-RI
-nW
-RL
-rA
-Uc
-lR
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-KN
 jq
 jq
 jq
-Vg
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-he
-he
-he
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -39324,13 +31674,13 @@ Lx
 Lx
 Lx
 Lx
-wt
+Di
 Lx
 Lx
 Lx
 Lx
 Lx
-wt
+Di
 Lx
 fD
 RK
@@ -39350,19 +31700,19 @@ Ir
 Bt
 In
 tZ
-jj
-iV
-df
-iV
+Sv
+AJ
+RH
+AJ
 JE
-xY
-aq
+fV
+mN
 ss
 JE
-iV
+AJ
 df
-iV
-jj
+AJ
+Sv
 pR
 Bt
 In
@@ -39455,21 +31805,6 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-KN
 jq
 jq
 jq
@@ -39487,49 +31822,6 @@ jq
 jq
 jq
 jq
-Vg
-Vg
-Uc
-Uc
-Uc
-Uc
-ic
-ic
-dM
-Uc
-Uc
-Uc
-Vg
-Vg
-Vg
-jq
-jq
-jq
-jq
-jq
-jq
-Uc
-Uc
-Uc
-Uc
-pc
-Uc
-lR
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-or
-or
-or
-KN
 jq
 jq
 jq
@@ -39540,11 +31832,69 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-he
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -39612,9 +31962,9 @@ JE
 JE
 JE
 JE
-eg
-Eh
-It
+Kj
+dp
+Cp
 JE
 JE
 JE
@@ -39705,28 +32055,6 @@ jq
 jq
 jq
 jq
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-he
-he
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-he
-he
-KN
 jq
 jq
 jq
@@ -39744,21 +32072,6 @@ jq
 jq
 jq
 jq
-Vg
-Uc
-mM
-Cr
-CD
-ic
-ic
-iN
-qf
-EE
-Uc
-Uc
-Vg
-Vg
-Vg
 jq
 jq
 jq
@@ -39770,38 +32083,75 @@ jq
 jq
 jq
 jq
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-lR
-or
-ea
-Uc
-Uc
-Uc
-Uc
-Uc
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-he
-he
-he
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -39962,60 +32312,6 @@ jq
 jq
 jq
 jq
-Uc
-jl
-sb
-eB
-Yj
-xK
-HI
-Uc
-he
-he
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-KN
-he
-he
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-Uc
-Ou
-Ou
-HU
-Zp
-BX
-bu
-zM
-Ou
-ic
-Ou
-Nn
-Uc
-Vg
-Vg
 jq
 jq
 jq
@@ -40039,26 +32335,80 @@ jq
 jq
 jq
 jq
-KN
-lR
-or
-ea
-Ao
-RP
-dj
-ew
-Uc
-he
-he
-he
-he
-he
-he
-nb
-he
-he
-he
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -40090,7 +32440,7 @@ Yr
 fD
 Lx
 Lx
-wt
+Di
 Lx
 Lx
 Lx
@@ -40100,7 +32450,7 @@ fc
 Lx
 Lx
 Lx
-wt
+Di
 Lx
 Lx
 fD
@@ -40219,60 +32569,6 @@ jq
 jq
 jq
 jq
-Uc
-yW
-eB
-eB
-eB
-eB
-Sa
-kT
-he
-he
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-KN
-he
-he
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-Uc
-Ou
-tp
-rg
-Vg
-Vg
-lZ
-PM
-Bd
-JW
-ic
-Ou
-Tv
-Uc
-Vg
 jq
 jq
 jq
@@ -40296,26 +32592,80 @@ jq
 jq
 jq
 jq
-KN
-lR
-or
-ea
-Ou
-Ti
-oN
-SF
-Uc
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -40476,17 +32826,6 @@ jq
 jq
 jq
 jq
-Uc
-Ma
-eB
-eB
-eB
-bl
-FD
-kT
-he
-he
-KN
 jq
 jq
 jq
@@ -40494,85 +32833,96 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-Uc
-Ou
-Xv
-Vg
-jG
-Vg
-Vg
-DY
-DA
-IO
-ic
-Ou
-ic
-Uc
-Vg
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-lR
-or
-ea
-dj
-Ou
-Qm
-Uc
-Uc
-he
-he
-KN
-KN
-Kq
-Kq
-Kq
-Kq
-Kq
-KN
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -40628,8 +32978,8 @@ JE
 JE
 JE
 JE
-sZ
-jY
+Ck
+Ck
 IG
 qp
 LP
@@ -40733,17 +33083,6 @@ jq
 jq
 jq
 jq
-Uc
-Er
-eB
-eB
-Ls
-GW
-XE
-Uc
-he
-he
-KN
 jq
 jq
 jq
@@ -40751,77 +33090,88 @@ jq
 jq
 jq
 jq
-KN
-AZ
-mm
-rS
-uf
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-Uc
-Ou
-vK
-sO
-Fn
-at
-Vg
-Vg
-NG
-FB
-ic
-ic
-og
-Uc
-Vg
-KN
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-or
-or
-ea
-Ou
-IA
-pX
-SF
-Uc
-he
-he
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -40990,17 +33340,6 @@ jq
 jq
 jq
 jq
-Uc
-Uc
-ka
-Uc
-Uc
-Uc
-Uc
-Uc
-he
-he
-KN
 jq
 jq
 jq
@@ -41008,77 +33347,88 @@ jq
 jq
 jq
 jq
-KN
-lR
-or
-ea
-uf
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-Vg
-Uc
-ur
-ic
-ic
-fM
-Vg
-Vg
-Vg
-ST
-Ou
-ic
-Rr
-VQ
-Vg
-KN
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-Qn
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-ea
-qq
-pr
-dj
-tb
-Uc
-he
-nb
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -41128,7 +33478,7 @@ Do
 br
 Lx
 Lx
-wt
+Di
 Lx
 Lx
 fD
@@ -41139,11 +33489,11 @@ sf
 JE
 Gi
 IG
-QN
-QN
-QN
-QN
-QN
+Ck
+Ck
+Ck
+Ck
+Ck
 IG
 nw
 sl
@@ -41247,17 +33597,6 @@ jq
 jq
 jq
 jq
-Uc
-SM
-en
-eB
-eS
-OP
-BT
-Uc
-he
-he
-KN
 jq
 jq
 jq
@@ -41265,77 +33604,88 @@ jq
 jq
 jq
 jq
-KN
-lR
-or
-ea
-uf
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-Vg
-Uc
-ic
-BQ
-Ou
-VD
-zW
-Vg
-Vg
-ip
-oP
-IM
-Jx
-SD
-Uc
-KN
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-or
-or
-ea
-Uc
-Uc
-Uc
-Uc
-Uc
-he
-he
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -41504,17 +33854,6 @@ jq
 jq
 jq
 jq
-Uc
-Oz
-eB
-eB
-Fy
-yD
-vl
-kT
-he
-he
-KN
 jq
 jq
 jq
@@ -41522,77 +33861,88 @@ jq
 jq
 jq
 jq
-KN
-lR
-or
-ea
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-Vg
-Uc
-ic
-ov
-YO
-Ou
-vK
-cf
-Vg
-Vg
-vO
-Vg
-ST
-Zr
-VQ
-KN
-KN
-KN
-Kq
-Kq
-Kq
-ah
-KN
-KN
-KN
-KN
-KN
-he
-he
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
 jq
 jq
 jq
-KN
-he
-he
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -41761,29 +34111,6 @@ jq
 jq
 jq
 jq
-Uc
-Rj
-eB
-eB
-tN
-ok
-QU
-kT
-he
-he
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-Kq
-lR
-or
-ea
-KN
 jq
 jq
 jq
@@ -41800,36 +34127,6 @@ jq
 jq
 jq
 jq
-Vg
-Uc
-EE
-zv
-ir
-Ou
-Ou
-KY
-aa
-Vg
-Vg
-Pj
-ey
-kq
-Uc
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-KN
-he
-he
-KN
 jq
 jq
 jq
@@ -41846,10 +34143,63 @@ jq
 jq
 jq
 jq
-KN
-nb
-he
-ah
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -42018,29 +34368,6 @@ jq
 jq
 jq
 jq
-Uc
-kW
-mi
-Pq
-eB
-eB
-rh
-Uc
-he
-he
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-Kq
-lR
-or
-ea
-KN
 jq
 jq
 jq
@@ -42057,21 +34384,6 @@ jq
 jq
 jq
 jq
-Vg
-Vg
-Uc
-od
-ic
-kc
-wa
-ic
-zo
-Jd
-no
-ey
-am
-wx
-Uc
 jq
 jq
 jq
@@ -42083,30 +34395,68 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-he
-he
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -42275,29 +34625,6 @@ jq
 jq
 jq
 jq
-Uc
-Bm
-bs
-Pq
-eB
-eB
-eB
-ka
-he
-he
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-Kq
-lR
-or
-ea
-KN
 jq
 jq
 jq
@@ -42314,21 +34641,6 @@ jq
 jq
 jq
 jq
-Vg
-Vg
-Vg
-Uc
-ic
-wx
-ic
-FL
-eX
-Wg
-Ou
-Ou
-ma
-Uc
-Vg
 jq
 jq
 jq
@@ -42340,30 +34652,68 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-nb
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -42532,29 +34882,6 @@ jq
 jq
 jq
 jq
-Uc
-Uc
-Uc
-Uc
-rh
-en
-eB
-Uc
-he
-he
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-ah
-pY
-or
-ea
-KN
 jq
 jq
 jq
@@ -42571,21 +34898,6 @@ jq
 jq
 jq
 jq
-Vg
-Vg
-Vg
-Uc
-Uc
-VQ
-Lp
-EH
-CD
-Uc
-Uc
-Uc
-Uc
-Vg
-Vg
 jq
 jq
 jq
@@ -42597,30 +34909,68 @@ jq
 jq
 jq
 jq
-KN
-nb
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-nb
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -42789,29 +35139,6 @@ jq
 jq
 jq
 jq
-Uc
-YA
-Cu
-Uc
-Rj
-eB
-Sa
-kT
-he
-he
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-KN
-lR
-or
-ea
-KN
 jq
 jq
 jq
@@ -42833,11 +35160,6 @@ jq
 jq
 jq
 jq
-KN
-QA
-mm
-al
-KN
 jq
 jq
 jq
@@ -42854,30 +35176,58 @@ jq
 jq
 jq
 jq
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-he
-nb
-KN
-Kq
-Kq
-Kq
-KN
-ah
-KN
-KN
-KN
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -43046,55 +35396,6 @@ jq
 jq
 jq
 jq
-Uc
-qK
-xq
-Gs
-eB
-eB
-rt
-kT
-he
-he
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-KN
-lR
-or
-ea
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-KN
-lR
-or
-ea
-Kq
 jq
 jq
 jq
@@ -43122,10 +35423,59 @@ jq
 jq
 jq
 jq
-KN
-nb
-he
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -43303,55 +35653,6 @@ jq
 jq
 jq
 jq
-Uc
-TX
-AH
-Uc
-jy
-UM
-jy
-Uc
-he
-he
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-KN
-lR
-or
-ea
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-KN
-lR
-or
-ea
-Kq
 jq
 jq
 jq
@@ -43379,10 +35680,59 @@ jq
 jq
 jq
 jq
-ah
-he
-he
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -43560,55 +35910,6 @@ jq
 jq
 jq
 jq
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-he
-he
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-KN
-lR
-or
-ea
-Uc
-fK
-kN
-fK
-dC
-Ou
-Mr
-Uc
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-KN
-lR
-or
-ea
-Kq
 jq
 jq
 jq
@@ -43636,10 +35937,59 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -43824,48 +36174,6 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-KN
-lR
-or
-ea
-Uc
-YE
-Ms
-YL
-xD
-pe
-Ou
-Uc
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-KN
-lR
-or
-ea
-ah
 jq
 jq
 jq
@@ -43887,16 +36195,58 @@ jq
 jq
 jq
 jq
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-he
-he
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -44081,29 +36431,6 @@ jq
 jq
 jq
 jq
-KN
-uf
-uf
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-KN
-pY
-or
-ea
-NO
-wq
-XJ
-Cx
-eB
-CV
-CC
-Uc
 jq
 jq
 jq
@@ -44118,24 +36445,6 @@ jq
 jq
 jq
 jq
-KN
-lR
-or
-ea
-ah
-jq
-jq
-jq
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
 jq
 jq
 jq
@@ -44144,16 +36453,57 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-he
-he
-he
-he
-he
-he
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -44338,29 +36688,6 @@ jq
 jq
 jq
 jq
-KN
-KN
-KN
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-KN
-lR
-or
-ea
-Uc
-Wr
-Mn
-Oi
-eB
-eB
-eB
-Uc
 jq
 jq
 jq
@@ -44375,24 +36702,6 @@ jq
 jq
 jq
 jq
-KN
-lR
-or
-ea
-Kq
-jq
-jq
-jq
-Uc
-EW
-lv
-dP
-Bk
-dD
-Ld
-Jg
-yD
-Uc
 jq
 jq
 jq
@@ -44401,16 +36710,57 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-he
-he
-he
-he
-he
-he
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -44606,18 +36956,6 @@ jq
 jq
 jq
 jq
-KN
-lR
-or
-ea
-Uc
-GY
-en
-eB
-en
-eB
-eB
-Uc
 jq
 jq
 jq
@@ -44632,24 +36970,6 @@ jq
 jq
 jq
 jq
-KN
-lR
-or
-ea
-Kq
-jq
-jq
-jq
-Uc
-LM
-Dp
-Je
-Tj
-yD
-dD
-dD
-hZ
-Uc
 jq
 jq
 jq
@@ -44658,16 +36978,46 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-KN
-KN
-KN
-KN
-KN
-KN
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -44863,18 +37213,6 @@ jq
 jq
 jq
 jq
-ah
-lR
-or
-ea
-Xi
-eB
-eB
-Rj
-EA
-TG
-En
-Uc
 jq
 jq
 jq
@@ -44889,24 +37227,6 @@ jq
 jq
 jq
 jq
-KN
-lR
-or
-ea
-Kq
-jq
-jq
-jq
-Uc
-lN
-Je
-lN
-Bk
-yD
-yD
-yD
-Hq
-Uc
 jq
 jq
 jq
@@ -44915,10 +37235,40 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -45120,18 +37470,6 @@ jq
 jq
 jq
 jq
-Kq
-pY
-or
-ea
-Xi
-eB
-en
-eB
-BH
-ZT
-Pd
-Uc
 jq
 jq
 jq
@@ -45142,28 +37480,6 @@ jq
 jq
 jq
 jq
-Uc
-Uc
-Uc
-Uc
-Uc
-Qi
-or
-ea
-KN
-jq
-jq
-jq
-Uc
-Wi
-Qf
-SI
-Tj
-yD
-OM
-tt
-CN
-Uc
 jq
 jq
 jq
@@ -45172,10 +37488,44 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -45377,18 +37727,6 @@ jq
 jq
 jq
 jq
-Kq
-lR
-or
-ea
-Uc
-ve
-eB
-Rj
-BH
-TM
-kx
-Uc
 jq
 jq
 jq
@@ -45399,47 +37737,59 @@ jq
 jq
 jq
 jq
-Uc
-Je
-oU
-nC
-Uc
-lR
-or
-ea
-KN
-KN
-KN
-KN
-Uc
-Uc
-Uc
-Uc
-Uc
-qA
-Uc
-Uc
-Uc
-Uc
-KN
-KN
-Kq
-Kq
-Kq
-KN
-KN
-KN
-KN
-he
-he
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -45634,18 +37984,6 @@ jq
 jq
 jq
 jq
-Kq
-lR
-or
-ea
-Uc
-Uc
-ka
-Uc
-Uc
-Uc
-Uc
-Uc
 jq
 jq
 jq
@@ -45656,47 +37994,59 @@ jq
 jq
 jq
 jq
-Uc
-TE
-Je
-Je
-JC
-lR
-or
-or
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-Ce
-mm
-mm
-mm
-mm
-or
-or
-ea
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -45891,18 +38241,6 @@ jq
 jq
 jq
 jq
-Kq
-lR
-or
-ea
-Uc
-Pt
-eB
-Rj
-Rj
-NL
-ll
-Uc
 jq
 jq
 jq
@@ -45913,47 +38251,59 @@ jq
 jq
 jq
 jq
-Uc
-Qa
-Je
-bQ
-Uc
-lR
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-ea
-ah
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -45998,7 +38348,7 @@ RK
 NK
 Yr
 We
-aH
+ar
 Dl
 Nh
 Zf
@@ -46032,7 +38382,7 @@ Yr
 We
 iU
 XP
-zw
+sB
 fU
 MC
 fU
@@ -46148,18 +38498,6 @@ jq
 jq
 jq
 jq
-Kq
-lR
-or
-ea
-Xi
-eB
-en
-jb
-eB
-PD
-tL
-Uc
 jq
 jq
 jq
@@ -46170,47 +38508,59 @@ jq
 jq
 jq
 jq
-Uc
-iZ
-Je
-Je
-JC
-lR
-or
-or
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-or
-or
-ea
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -46405,18 +38755,6 @@ jq
 jq
 jq
 jq
-Kq
-pY
-or
-ea
-Xi
-Ct
-eB
-XD
-eB
-Vq
-mg
-Uc
 jq
 jq
 jq
@@ -46427,52 +38765,64 @@ jq
 jq
 jq
 jq
-Uc
-OA
-wi
-Uy
-Uc
-lR
-or
-ea
-KN
-Kq
-Kq
-Kq
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-he
-he
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-pY
-or
-ea
-Uc
-Uc
-mS
-mS
-Uc
-Uc
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -46662,52 +39012,6 @@ jq
 jq
 jq
 jq
-KN
-lR
-or
-ea
-Xi
-eB
-eB
-GA
-eB
-vc
-rE
-Uc
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-Uc
-Uc
-Uc
-Uc
-Uc
-lR
-or
-ea
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-KN
-WG
-he
-KN
 jq
 jq
 jq
@@ -46720,16 +39024,62 @@ jq
 jq
 jq
 jq
-KN
-lR
-or
-ea
-ZR
-bc
-ES
-mC
-xt
-Uc
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -46919,18 +39269,6 @@ jq
 jq
 jq
 jq
-KN
-lR
-or
-ea
-Uc
-RD
-eB
-Rj
-eB
-jK
-By
-Uc
 jq
 jq
 jq
@@ -46945,11 +39283,6 @@ jq
 jq
 jq
 jq
-KN
-lR
-or
-ea
-KN
 jq
 jq
 jq
@@ -46961,32 +39294,49 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
 jq
 jq
 jq
-KN
-lR
-or
-ea
-nJ
-Gh
-GC
-by
-da
-Uc
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -47176,18 +39526,6 @@ jq
 jq
 jq
 jq
-KN
-lR
-or
-ea
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
 jq
 jq
 jq
@@ -47202,11 +39540,6 @@ jq
 jq
 jq
 jq
-KN
-lR
-or
-ea
-KN
 jq
 jq
 jq
@@ -47218,32 +39551,49 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-Uc
-yE
-yV
-yV
-yV
-yV
-yV
-yV
-EG
-Uc
 jq
 jq
 jq
-KN
-lR
-or
-ea
-Uc
-CK
-Uc
-lJ
-on
-Uc
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -47433,11 +39783,6 @@ jq
 jq
 jq
 jq
-KN
-lR
-or
-ea
-KN
 jq
 jq
 jq
@@ -47459,11 +39804,6 @@ jq
 jq
 jq
 jq
-KN
-lR
-or
-ea
-KN
 jq
 jq
 jq
@@ -47475,32 +39815,42 @@ jq
 jq
 jq
 jq
-Kq
-he
-he
-kT
-Bu
-wq
-ux
-wq
-VC
-Lm
-wq
-yV
-kv
 jq
 jq
 jq
-KN
-lR
-or
-ea
-KW
-VU
-NA
-VJ
-Rj
-Uc
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -47574,7 +39924,7 @@ Yr
 We
 UI
 xo
-fG
+qT
 fU
 MC
 fU
@@ -47690,11 +40040,6 @@ jq
 jq
 jq
 jq
-KN
-lR
-or
-ea
-KN
 jq
 jq
 jq
@@ -47716,15 +40061,6 @@ jq
 jq
 jq
 jq
-Kq
-lR
-or
-ea
-KN
-KN
-ah
-KN
-KN
 jq
 jq
 jq
@@ -47732,32 +40068,46 @@ jq
 jq
 jq
 jq
-Kq
-he
-he
-kT
-Bu
-wq
-dR
-wq
-VC
-SP
-wq
-fH
-Uc
 jq
 jq
 jq
-KN
-lR
-or
-ea
-KW
-Rj
-Og
-Qg
-Rj
-VQ
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -47947,11 +40297,6 @@ jq
 jq
 jq
 jq
-KN
-pY
-or
-ea
-KN
 jq
 jq
 jq
@@ -47973,15 +40318,6 @@ jq
 jq
 jq
 jq
-Kq
-lR
-or
-or
-mm
-mm
-mm
-rc
-KN
 jq
 jq
 jq
@@ -47989,32 +40325,46 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-Uc
-yE
-yV
-yV
-yV
-yV
-yV
-yV
-ps
-Uc
 jq
 jq
 jq
-KN
-lR
-or
-ea
-KW
-Ul
-Rj
-Uc
-vE
-VQ
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -48204,11 +40554,6 @@ jq
 jq
 jq
 jq
-KN
-lR
-or
-ea
-KN
 jq
 jq
 jq
@@ -48230,15 +40575,6 @@ jq
 jq
 jq
 jq
-ah
-lR
-or
-or
-Wk
-or
-or
-zd
-KN
 jq
 jq
 jq
@@ -48246,32 +40582,46 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-Uc
-Uc
-bP
-Uc
-Uc
-kT
-kT
-kT
-Uc
-Uc
-KN
 jq
 jq
-KN
-lR
-or
-ea
-Uc
-EI
-eB
-TY
-wA
-mS
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -48461,11 +40811,6 @@ jq
 jq
 jq
 jq
-KN
-lR
-or
-ea
-KN
 jq
 jq
 jq
@@ -48487,15 +40832,6 @@ jq
 jq
 jq
 jq
-Kq
-lR
-or
-ea
-CL
-lR
-or
-zd
-KN
 jq
 jq
 jq
@@ -48503,32 +40839,46 @@ jq
 jq
 jq
 jq
-ah
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-KN
 jq
 jq
-KN
-lR
-or
-ea
-Uc
-py
-Rj
-Rj
-rL
-mS
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -48713,21 +41063,6 @@ jq
 jq
 jq
 jq
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-XN
-XK
-wr
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
 jq
 jq
 jq
@@ -48744,15 +41079,6 @@ jq
 jq
 jq
 jq
-Kq
-lR
-or
-ea
-vv
-lR
-or
-ea
-KN
 jq
 jq
 jq
@@ -48760,32 +41086,56 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-he
-WG
-he
-WG
-he
-he
-he
-he
-he
-he
-KN
 jq
 jq
-KN
-lR
-or
-ea
-Uc
-Uc
-Eb
-Uc
-Uc
-Uc
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -48970,21 +41320,6 @@ jq
 jq
 jq
 jq
-Uc
-fE
-Zi
-No
-Uc
-HO
-XN
-XK
-XK
-kT
-Vg
-Vg
-Vg
-Vg
-Uc
 jq
 jq
 jq
@@ -49001,15 +41336,6 @@ jq
 jq
 jq
 jq
-KN
-lR
-or
-ea
-vv
-lR
-or
-ea
-KN
 jq
 jq
 jq
@@ -49017,27 +41343,51 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-KN
-KN
-KN
-KN
-KN
-QA
-mm
-al
-KN
-KN
-KN
 jq
 jq
-KN
-lR
-or
-ea
-Kq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -49227,21 +41577,6 @@ jq
 jq
 jq
 jq
-Uc
-Rj
-Rj
-eB
-Uc
-Ou
-XN
-XK
-XK
-kT
-Vg
-Vg
-Vg
-Vg
-Uc
 jq
 jq
 jq
@@ -49258,15 +41593,6 @@ jq
 jq
 jq
 jq
-KN
-lR
-or
-ea
-vv
-lR
-or
-ea
-KN
 jq
 jq
 jq
@@ -49274,27 +41600,51 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-KN
-QP
-QP
-QP
-KN
-lR
-or
-ea
-KN
 jq
 jq
 jq
 jq
-KN
-lR
-or
-ea
-Kq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -49484,21 +41834,6 @@ jq
 jq
 jq
 jq
-Uc
-Rj
-lY
-Cw
-fi
-Ou
-XN
-XK
-XK
-kT
-Vg
-Vg
-Vg
-Vg
-Uc
 jq
 jq
 jq
@@ -49515,15 +41850,6 @@ jq
 jq
 jq
 jq
-KN
-lR
-or
-ea
-MV
-lR
-or
-ea
-KN
 jq
 jq
 jq
@@ -49531,27 +41857,51 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-KN
-QP
-QP
-QP
-KN
-lR
-or
-ea
-KN
 jq
 jq
 jq
 jq
-KN
-pY
-or
-ea
-Kq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -49741,74 +42091,74 @@ jq
 jq
 jq
 jq
-Uc
-qG
-Ut
-ya
-hy
-dj
-XN
-XK
-XK
-Uc
-kT
-kT
-mB
-Uc
-Uc
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-lR
-or
-ea
-MV
-lR
-or
-ea
-KN
-KN
-KN
-Kq
-Kq
-Kq
-KN
-QP
-KN
-he
-he
-KN
-KN
-KN
-KN
-KN
-lR
-or
-ea
-KN
 jq
 jq
 jq
 jq
-KN
-lR
-or
-ea
-ah
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -49998,74 +42348,74 @@ jq
 jq
 jq
 jq
-Uc
-Zu
-pQ
-Ws
-Uc
-FP
-XN
-XK
-XK
-XK
-XK
-XK
-XK
-XK
-XK
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-OL
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-or
-or
-ea
-vv
-lR
-or
-or
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-or
-or
-ea
-Kq
 jq
 jq
 jq
 jq
-KN
-lR
-or
-ea
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -50255,74 +42605,74 @@ jq
 jq
 jq
 jq
-Uc
-pQ
-pG
-pQ
-sm
-QW
-XN
-XK
-XK
-XK
-XK
-XK
-XK
-XK
-XK
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-ea
-vv
-lR
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-ea
-Kq
 jq
 jq
 jq
 jq
-Kq
-lR
-or
-ea
-ah
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -50512,74 +42862,74 @@ jq
 jq
 jq
 jq
-Uc
-xb
-wP
-zZ
-Uc
-FP
-XN
-XK
-XK
-XK
-jX
-jX
-jX
-jX
-jX
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-eZ
-Wk
-or
-or
-ea
-vv
-lR
-or
-or
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-or
-or
-ea
-Kq
 jq
 jq
 jq
 jq
-Kq
-lR
-or
-ea
-Kq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -50769,74 +43119,74 @@ jq
 jq
 jq
 jq
-Uc
-pk
-Ws
-Zu
-hy
-Ou
-XN
-XK
-XK
-Is
-Ou
-dj
-Ou
-HO
-Uc
-KN
-KN
-KN
-Kq
-Kq
-Kq
-KN
-KN
-KN
-he
-he
-KN
-KN
-KN
-KN
-Kq
-Kq
-Kq
-KN
-KN
-KN
-lR
-or
-ea
-KN
-KN
-KN
-Kq
-Kq
-Kq
-KN
-KN
-KN
-KN
-KN
-he
-he
-KN
-KN
-KN
-lR
-or
-ea
-Kq
 jq
 jq
 jq
 jq
-Kq
-lR
-or
-ea
-Kq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -51026,46 +43376,6 @@ jq
 jq
 jq
 jq
-Uc
-jD
-zu
-Ws
-hy
-Ou
-XN
-XK
-wr
-Ou
-Ou
-Ou
-Ou
-SY
-Uc
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-KN
-he
-he
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-KN
-lR
-or
-ea
-KN
 jq
 jq
 jq
@@ -51075,25 +43385,65 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-KN
-jq
-KN
-lR
-or
-ea
-Kq
 jq
 jq
 jq
 jq
-KN
-lR
-or
-ea
-Kq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -51283,46 +43633,6 @@ jq
 jq
 jq
 jq
-Uc
-vQ
-GV
-Ws
-Uc
-Ou
-XN
-XK
-wr
-Ou
-Ou
-Ou
-dj
-pd
-Uc
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-KN
-he
-he
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-KN
-lR
-or
-ea
-KN
 jq
 jq
 jq
@@ -51332,25 +43642,65 @@ jq
 jq
 jq
 jq
-Kq
-he
-he
-KN
-jq
-KN
-lR
-or
-ea
-KN
 jq
 jq
 jq
 jq
-Kq
-lR
-or
-ea
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -51540,46 +43890,6 @@ jq
 jq
 jq
 jq
-Uc
-uh
-NR
-Ws
-Uc
-od
-XN
-XK
-wr
-dj
-Sb
-BE
-CO
-Ou
-Uc
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-KN
-fq
-he
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-KN
-lR
-or
-ea
-KN
 jq
 jq
 jq
@@ -51589,25 +43899,65 @@ jq
 jq
 jq
 jq
-Kq
-he
-he
-KN
-jq
-KN
-lR
-or
-ea
-ah
 jq
 jq
 jq
 jq
-Kq
-lR
-or
-ea
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -51797,46 +44147,6 @@ jq
 jq
 jq
 jq
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-XK
-XK
-XK
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-Kq
-he
-he
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-KN
-lR
-or
-ea
-Kq
 jq
 jq
 jq
@@ -51846,25 +44156,65 @@ jq
 jq
 jq
 jq
-Kq
-he
-he
-KN
-jq
-KN
-lR
-or
-ea
-KN
 jq
 jq
 jq
 jq
-Kq
-pY
-or
-ea
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -52059,11 +44409,6 @@ jq
 jq
 jq
 jq
-KN
-lR
-or
-ea
-KN
 jq
 jq
 jq
@@ -52077,23 +44422,6 @@ jq
 jq
 jq
 jq
-Kq
-he
-he
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-KN
-lR
-or
-ea
-Kq
 jq
 jq
 jq
@@ -52103,25 +44431,47 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-KN
-jq
-KN
-lR
-or
-ea
-KN
 jq
 jq
 jq
 jq
-KN
-lR
-or
-ea
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -52316,11 +44666,6 @@ jq
 jq
 jq
 jq
-KN
-pY
-or
-ea
-KN
 jq
 jq
 jq
@@ -52334,23 +44679,6 @@ jq
 jq
 jq
 jq
-Kq
-he
-he
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-KN
-lR
-or
-ea
-ah
 jq
 jq
 jq
@@ -52360,25 +44688,47 @@ jq
 jq
 jq
 jq
-ah
-he
-he
-KN
-jq
-KN
-lR
-or
-ea
-KN
 jq
 jq
 jq
 jq
-KN
-lR
-or
-ea
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -52573,11 +44923,6 @@ jq
 jq
 jq
 jq
-KN
-lR
-or
-ea
-KN
 jq
 jq
 jq
@@ -52591,23 +44936,6 @@ jq
 jq
 jq
 jq
-ah
-he
-he
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-KN
-lR
-or
-ea
-Kq
 jq
 jq
 jq
@@ -52617,46 +44945,68 @@ jq
 jq
 jq
 jq
-KN
-he
-WG
-KN
 jq
-KN
-lR
-or
-ea
-KN
-KN
-Kq
-Kq
-KN
-KN
-lR
-or
-ea
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 eR
@@ -52830,11 +45180,6 @@ jq
 jq
 jq
 jq
-KN
-lR
-or
-ea
-KN
 jq
 jq
 jq
@@ -52848,23 +45193,6 @@ jq
 jq
 jq
 jq
-Kq
-he
-he
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-KN
-lR
-or
-ea
-Kq
 jq
 jq
 jq
@@ -52874,48 +45202,70 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-KN
 jq
-KN
-lR
-or
-or
-mm
-mm
-mm
-mm
-mm
-or
-or
-or
-or
-al
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-Se
-Se
-he
-he
-he
-he
-he
-he
-eR
-eR
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 eR
 eR
 eR
@@ -53080,18 +45430,6 @@ jq
 jq
 jq
 jq
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-lR
-or
-ea
-KN
 jq
 jq
 jq
@@ -53105,10 +45443,6 @@ jq
 jq
 jq
 jq
-Kq
-he
-he
-KN
 jq
 jq
 jq
@@ -53117,62 +45451,78 @@ jq
 jq
 jq
 jq
-KN
-lR
-or
-ea
-KN
 jq
 jq
-QP
-KN
-KN
-Kq
-Kq
-KN
-KN
-KN
-he
-he
-KN
 jq
-KN
-lR
-or
-or
-or
-or
-or
-or
-or
-or
-or
-Lt
-or
-aI
-he
-he
-he
-he
-he
-Se
-he
-he
-he
-he
-he
-he
-he
-he
-Se
-Se
-he
-he
-he
-he
-Se
-eR
-eR
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 eR
 eR
 eR
@@ -53337,18 +45687,6 @@ jq
 jq
 jq
 jq
-Uc
-Uh
-Pv
-vg
-UL
-Pv
-UL
-fB
-lR
-or
-ea
-KN
 jq
 jq
 jq
@@ -53362,74 +45700,86 @@ jq
 jq
 jq
 jq
-Kq
-he
-he
-KN
-jq
-jq
-jq
-PH
 jq
 jq
 jq
 jq
-KN
-lR
-or
-ea
-KN
 jq
 jq
-KN
-KN
-he
-he
-he
-WG
-he
-he
-he
-he
-KN
 jq
-KN
-lR
-or
-or
-Wk
-Wk
-Wk
-Wk
-Wk
-or
-or
-or
-or
-BR
-he
-he
-he
-he
-he
-Se
-Se
-Se
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-Se
-Se
-eR
-eR
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 eR
 eR
 eR
@@ -53594,18 +45944,6 @@ jq
 jq
 jq
 jq
-Uc
-ei
-Pv
-vg
-oG
-Pv
-oG
-fB
-lR
-or
-ea
-KN
 jq
 jq
 jq
@@ -53619,10 +45957,6 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-KN
 jq
 jq
 jq
@@ -53631,60 +45965,76 @@ jq
 jq
 jq
 jq
-Kq
-lR
-or
-ea
-KN
 jq
 jq
-KN
-he
-he
-he
-he
-he
-he
-he
-he
-KN
-KN
 jq
-KN
-KN
-KN
-Kq
-Kq
-Kq
-Kq
-KN
-KN
-KN
-lR
-or
-ea
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -53851,18 +46201,6 @@ jq
 jq
 jq
 jq
-Uc
-aj
-Pv
-wO
-Pv
-Pv
-Pv
-fB
-pY
-or
-ea
-KN
 jq
 jq
 jq
@@ -53876,36 +46214,6 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-Kq
-lR
-or
-ea
-KN
-jq
-jq
-KN
-he
-he
-KN
-KN
-KN
-ah
-KN
-KN
-KN
-QP
 jq
 jq
 jq
@@ -53916,11 +46224,53 @@ jq
 jq
 jq
 jq
-KN
-lR
-or
-ea
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -54108,54 +46458,6 @@ jq
 jq
 jq
 jq
-Uc
-ml
-Pv
-vg
-HQ
-js
-zn
-fB
-lR
-or
-ea
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-KN
-he
-he
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-ah
-lR
-or
-ea
-KN
-jq
-jq
-KN
-WG
-he
-KN
 jq
 jq
 jq
@@ -54173,11 +46475,59 @@ jq
 jq
 jq
 jq
-Kq
-lR
-or
-ea
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -54365,54 +46715,6 @@ jq
 jq
 jq
 jq
-Uc
-Uc
-Et
-Uc
-fB
-fB
-fB
-Uc
-lR
-or
-ea
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-KN
-he
-he
-ah
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-Kq
-lR
-or
-ea
-KN
-jq
-jq
-KN
-he
-he
-KN
 jq
 jq
 jq
@@ -54430,11 +46732,59 @@ jq
 jq
 jq
 jq
-Kq
-lR
-or
-ea
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -54516,8 +46866,8 @@ HR
 HR
 HR
 HR
+Od
 HR
-UW
 HR
 HR
 HR
@@ -54622,54 +46972,6 @@ jq
 jq
 jq
 jq
-Uc
-UP
-Pv
-Pv
-Pv
-Pv
-ml
-fB
-pY
-or
-ea
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-KN
-he
-fq
-Kq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-Kq
-lR
-or
-ea
-KN
-jq
-jq
-ah
-he
-he
-KN
 jq
 jq
 jq
@@ -54687,11 +46989,59 @@ jq
 jq
 jq
 jq
-Pb
-pY
-or
-ea
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -54768,17 +47118,17 @@ RK
 NK
 Yr
 HR
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
+yk
+AN
+QB
+FO
+Hk
+be
+Hk
+Mk
+cj
+kk
+FT
 HR
 RK
 NK
@@ -54879,54 +47229,6 @@ jq
 jq
 jq
 jq
-Uc
-kS
-Pv
-iB
-Pv
-Pv
-Pv
-Pi
-lR
-or
-ea
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-Kq
-Kq
-Kq
-KN
-KN
-KN
-he
-he
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-KN
-lR
-or
-ea
-KN
-jq
-jq
-KN
-he
-he
-KN
 jq
 jq
 jq
@@ -54944,11 +47246,59 @@ jq
 jq
 jq
 jq
-Kq
-lR
-or
-ea
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -55025,17 +47375,17 @@ RK
 NK
 Yr
 HR
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
+Ol
+EY
+aK
+EJ
+Hk
+TN
+Hk
+mn
+Ju
+Ju
+YY
 HR
 RK
 NK
@@ -55136,54 +47486,6 @@ jq
 jq
 jq
 jq
-Uc
-Xs
-js
-HP
-Pv
-Pv
-Pv
-Pi
-lR
-or
-ea
-he
-he
-he
-he
-he
-fq
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-KN
-lR
-or
-ea
-KN
-jq
-jq
-KN
-he
-he
-KN
 jq
 jq
 jq
@@ -55201,11 +47503,59 @@ jq
 jq
 jq
 jq
-Kq
-lR
-or
-ea
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -55282,17 +47632,17 @@ RK
 NK
 Yr
 HR
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
+dW
+EY
+EY
+Qw
+fs
+oh
+fs
+Jk
+Ux
+Ux
+VW
 HR
 RK
 NK
@@ -55393,54 +47743,6 @@ jq
 jq
 jq
 jq
-Uc
-UP
-Pv
-Pv
-Pv
-Aq
-mf
-fB
-lR
-or
-ea
-he
-he
-he
-he
-he
-he
-he
-he
-he
-fq
-he
-he
-he
-he
-he
-he
-he
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-KN
-lR
-or
-ea
-KN
-jq
-jq
-KN
-he
-he
-KN
 jq
 jq
 jq
@@ -55458,11 +47760,59 @@ jq
 jq
 jq
 jq
-KN
-lR
-or
-ea
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -55539,17 +47889,17 @@ RK
 NK
 Yr
 HR
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
+qH
+EY
+RG
+jt
+Hk
+rl
+Hk
+VP
+hF
+zc
+Px
 HR
 RK
 NK
@@ -55650,35 +48000,6 @@ jq
 jq
 jq
 jq
-Uc
-Uc
-Ox
-Uc
-Uc
-Uc
-Uc
-Uc
-lR
-or
-ea
-KN
-Kq
-Kq
-Kq
-KN
-KN
-he
-he
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
 jq
 jq
 jq
@@ -55687,39 +48008,68 @@ jq
 jq
 jq
 jq
-KN
-lR
-or
-ea
-KN
-KN
-KN
-KN
-he
-he
-KN
-KN
-KN
-KN
-Kq
-Kq
-Kq
-ah
-KN
-KN
-Kq
-Kq
-Kq
-Kq
-KN
-KN
-KN
-KN
-KN
-lR
-or
-ea
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -55796,17 +48146,17 @@ RT
 RT
 RT
 HR
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
+tz
+Lb
+yz
+Hk
+Hk
+fs
+Hk
+Hk
+ji
+YI
+Ki
 HR
 RT
 RT
@@ -55907,26 +48257,6 @@ jq
 jq
 jq
 jq
-Uc
-ra
-jn
-jn
-jn
-jn
-eO
-Uc
-lR
-or
-ea
-KN
-jq
-jq
-jq
-jq
-KN
-he
-he
-KN
 jq
 jq
 jq
@@ -55944,39 +48274,59 @@ jq
 jq
 jq
 jq
-KN
-lR
-or
-or
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-Ce
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-or
-or
-or
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -56053,17 +48403,17 @@ RT
 RT
 RT
 HR
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
+Hk
+Hk
+Hk
+Hk
+cX
+qg
+FT
+Hk
+Hk
+Hk
+Hk
 HR
 RT
 RT
@@ -56164,26 +48514,6 @@ jq
 jq
 jq
 jq
-Uc
-ny
-jn
-Ud
-nP
-jn
-kU
-Uc
-pY
-or
-ea
-KN
-jq
-jq
-jq
-jq
-ah
-he
-he
-KN
 jq
 jq
 jq
@@ -56201,39 +48531,59 @@ jq
 jq
 jq
 jq
-KN
-lR
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -56313,15 +48663,15 @@ HR
 jq
 jq
 jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-UW
+Hk
+RQ
+KD
+cS
+FT
+hK
+Mk
+Fh
+AD
 RT
 RT
 RT
@@ -56421,26 +48771,6 @@ jq
 jq
 jq
 jq
-Uc
-ny
-jn
-Yf
-GS
-jn
-kU
-Uc
-lR
-or
-ea
-KN
-jq
-jq
-jq
-jq
-KN
-he
-he
-KN
 jq
 jq
 jq
@@ -56458,39 +48788,59 @@ jq
 jq
 jq
 jq
-KN
-lR
-or
-or
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Mv
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-or
-or
-or
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -56570,15 +48920,15 @@ HR
 jq
 jq
 jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-HR
+Hk
+uM
+oV
+RG
+jt
+LG
+Jk
+LE
+AG
 RT
 FQ
 RT
@@ -56678,76 +49028,6 @@ jq
 jq
 jq
 jq
-Uc
-ny
-jn
-jn
-jn
-jn
-kU
-Uc
-lR
-or
-ea
-Kq
-jq
-jq
-jq
-jq
-KN
-he
-he
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-KN
-lR
-or
-ea
-KN
-KN
-Kq
-Pb
-Kq
-Uc
-yw
-Uc
-Uc
-Uc
-yw
-Uc
-Uc
-yw
-Uc
-KN
-KN
-KN
-KN
-Kq
-Kq
-Kq
-KN
-KN
-KN
-lR
-or
-ea
-KN
 jq
 jq
 jq
@@ -56776,6 +49056,76 @@ jq
 jq
 jq
 jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+eR
+eR
+eR
+eR
+eR
+eR
+eR
 eR
 eR
 eR
@@ -56824,17 +49174,17 @@ Tt
 NM
 Tt
 HR
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
+Hk
+Hk
+Hk
+Hk
+lA
+ZP
+VW
+Hk
+Hk
+Hk
+Hk
 HR
 RT
 RT
@@ -56935,26 +49285,10 @@ jq
 jq
 jq
 jq
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-pY
-or
-ea
-Kq
 jq
 jq
 jq
 jq
-KN
-he
-he
-KN
 jq
 jq
 jq
@@ -56972,25 +49306,10 @@ jq
 jq
 jq
 jq
-KN
-lR
-or
-ea
-KN
 jq
 jq
 jq
 jq
-kv
-ET
-ET
-rJ
-ET
-ET
-gO
-ET
-ET
-kv
 jq
 jq
 jq
@@ -57000,11 +49319,6 @@ jq
 jq
 jq
 jq
-KN
-xP
-Wk
-BR
-KN
 jq
 jq
 jq
@@ -57036,6 +49350,42 @@ jq
 jq
 jq
 jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+eR
+eR
+eR
+eR
+eR
+eR
+eR
+eR
+eR
+eR
 jq
 jq
 jq
@@ -57081,17 +49431,17 @@ Tt
 Tt
 Tt
 HR
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
+wY
+fl
+vV
+Hk
+Hk
+fs
+Hk
+Hk
+Oc
+PS
+Db
 HR
 Tt
 Tt
@@ -57199,19 +49549,10 @@ jq
 jq
 jq
 jq
-KN
-lR
-or
-ea
-KN
 jq
 jq
 jq
 jq
-KN
-he
-he
-KN
 jq
 jq
 jq
@@ -57229,25 +49570,10 @@ jq
 jq
 jq
 jq
-KN
-lR
-or
-ea
-KN
 jq
 jq
 jq
 jq
-Uc
-Uc
-cn
-Uc
-cn
-Uc
-Uc
-cn
-Uc
-Uc
 jq
 jq
 jq
@@ -57257,11 +49583,6 @@ jq
 jq
 jq
 jq
-Uc
-oZ
-Ou
-Ou
-Uc
 jq
 jq
 jq
@@ -57293,6 +49614,35 @@ jq
 jq
 jq
 jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+eR
+eR
+eR
+eR
+eR
+eR
+eR
+eR
+eR
+eR
 jq
 jq
 jq
@@ -57338,17 +49688,17 @@ Tt
 Tt
 Tt
 HR
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
+vV
+wY
+vV
+vV
+Hk
+ZQ
+Hk
+BY
+RQ
+EY
+xW
 HR
 Tt
 Tt
@@ -57456,19 +49806,10 @@ jq
 jq
 jq
 jq
-KN
-lR
-or
-ea
-ah
 jq
 jq
 jq
 jq
-KN
-he
-he
-KN
 jq
 jq
 jq
@@ -57486,25 +49827,10 @@ jq
 jq
 jq
 jq
-KN
-lR
-or
-ea
-KN
 jq
 jq
 jq
 jq
-Uc
-hW
-IF
-Uc
-HE
-yn
-Uc
-eB
-eB
-Uc
 jq
 jq
 jq
@@ -57514,11 +49840,6 @@ jq
 jq
 jq
 jq
-Uc
-ku
-Nz
-Ou
-Uc
 jq
 jq
 jq
@@ -57550,6 +49871,35 @@ jq
 jq
 jq
 jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+eR
+eR
+eR
 jq
 jq
 jq
@@ -57595,17 +49945,17 @@ Tt
 Tt
 Tt
 HR
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
+qm
+rX
+wY
+vV
+fs
+oh
+fs
+RU
+Ee
+IW
+Le
 HR
 Tt
 Tt
@@ -57713,19 +50063,6 @@ jq
 jq
 jq
 jq
-KN
-lR
-or
-ea
-ah
-jq
-jq
-jq
-jq
-KN
-he
-fq
-KN
 jq
 jq
 jq
@@ -57743,25 +50080,6 @@ jq
 jq
 jq
 jq
-KN
-lR
-or
-ea
-KN
-jq
-jq
-jq
-jq
-Uc
-YP
-cw
-Uc
-Tc
-Zn
-Uc
-IR
-JJ
-Uc
 jq
 jq
 jq
@@ -57771,11 +50089,43 @@ jq
 jq
 jq
 jq
-Uc
-ku
-tc
-Ou
-Uc
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -57852,17 +50202,17 @@ Tt
 Tt
 Tt
 HR
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
+wY
+wY
+vV
+vV
+Hk
+Hk
+Hk
+MK
+nX
+Ew
+qI
 HR
 Tt
 Tt
@@ -57970,19 +50320,6 @@ jq
 jq
 jq
 jq
-KN
-lR
-or
-ea
-KN
-jq
-jq
-jq
-jq
-KN
-he
-he
-KN
 jq
 jq
 jq
@@ -58000,25 +50337,6 @@ jq
 jq
 jq
 jq
-KN
-lR
-or
-ea
-KN
-jq
-jq
-jq
-jq
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
 jq
 jq
 jq
@@ -58028,11 +50346,43 @@ jq
 jq
 jq
 jq
-Uc
-CR
-Fz
-Ou
-Uc
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -58109,17 +50459,17 @@ HR
 HR
 HR
 HR
+vV
+XZ
+wY
+vV
+Hk
 jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
+Hk
+Jk
+IK
+Mm
+yY
 HR
 Tt
 Tt
@@ -58227,41 +50577,6 @@ jq
 jq
 jq
 jq
-KN
-lR
-or
-ea
-Kq
-jq
-jq
-jq
-jq
-KN
-he
-he
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-KN
-lR
-or
-ea
-KN
 jq
 jq
 jq
@@ -58285,11 +50600,46 @@ jq
 jq
 jq
 jq
-Uc
-Uc
-Uc
-kv
-Uc
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -58365,18 +50715,18 @@ jq
 jq
 jq
 jq
+Hk
+Hk
+Hk
+Hk
+Hk
+Hk
 jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
+Hk
+Hk
+Hk
+Hk
+Hk
 HR
 HR
 HR
@@ -58476,27 +50826,6 @@ jq
 jq
 jq
 jq
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-pY
-or
-ea
-Kq
-jq
-jq
-jq
-jq
-KN
-he
-he
-KN
 jq
 jq
 jq
@@ -58509,21 +50838,42 @@ jq
 jq
 jq
 jq
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-XN
-XK
-wr
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -58733,27 +51083,6 @@ jq
 jq
 jq
 jq
-KN
-ki
-he
-he
-he
-he
-fq
-he
-he
-lR
-or
-ea
-KN
-jq
-jq
-jq
-jq
-KN
-he
-he
-KN
 jq
 jq
 jq
@@ -58766,21 +51095,42 @@ jq
 jq
 jq
 jq
-Uc
-MN
-Ou
-Ou
-od
-MN
-XN
-XK
-wr
-od
-wU
-Ou
-Xf
-Xf
-Uc
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -58990,27 +51340,6 @@ jq
 jq
 jq
 jq
-KN
-ki
-he
-fq
-he
-he
-he
-he
-he
-lR
-or
-ea
-KN
-jq
-jq
-jq
-jq
-ah
-he
-he
-KN
 jq
 jq
 jq
@@ -59023,21 +51352,42 @@ jq
 jq
 jq
 jq
-Uc
-Ou
-LA
-Ou
-Ou
-Ou
-XN
-XK
-wr
-Ou
-Ou
-Ou
-Ou
-Xf
-Uc
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -59247,27 +51597,6 @@ jq
 jq
 jq
 jq
-KN
-KN
-he
-he
-KN
-KN
-KN
-KN
-KN
-lR
-or
-ea
-KN
-jq
-jq
-jq
-jq
-KN
-fq
-he
-KN
 jq
 jq
 jq
@@ -59280,21 +51609,42 @@ jq
 jq
 jq
 jq
-Uc
-od
-Ou
-Ou
-KA
-Tb
-VE
-VE
-VE
-Jy
-Ou
-KJ
-od
-Ou
-Uc
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -59505,97 +51855,97 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-KN
 jq
 jq
 jq
-KN
-lR
-or
-ea
-KN
-Kq
-Kq
-Kq
-KN
-KN
-he
-he
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-Uc
-Ou
-Ou
-MN
-Tb
-qj
-oX
-oX
-oX
-SE
-Jy
-Ou
-Ou
-KJ
-Uc
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -59762,97 +52112,97 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-KN
 jq
 jq
 jq
-KN
-lR
-or
-or
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-Sm
-Sm
-Sm
-Sm
-oE
-oX
-EN
-cN
-nk
-oX
-aS
-Sm
-Sm
-Sm
-Sm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-bo
-AW
-yH
-yH
-AW
-mm
-mm
-mm
-pC
-mm
-he
-he
-he
-he
-he
-TC
-he
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -60019,97 +52369,97 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-KN
 jq
 jq
 jq
-KN
-lR
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-XK
-XK
-XK
-XK
-oE
-oX
-WE
-Uj
-Yu
-oX
-aS
-XK
-XK
-XK
-XK
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-ls
-hU
-hU
-ls
-or
-or
-or
-or
-or
-he
-he
-he
-he
-he
-he
-he
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -60276,97 +52626,97 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-KN
 jq
 jq
 jq
-KN
-Ll
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-jX
-jX
-jX
-jX
-oE
-oX
-Eg
-CI
-ZD
-oX
-aS
-jX
-jX
-jX
-jX
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-nS
-aQ
-vD
-vD
-aQ
-Wk
-nQ
-Wk
-Wk
-Wk
-he
-he
-he
-TC
-he
-he
-he
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -60533,97 +52883,97 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-KN
 jq
 jq
 jq
-KN
-KN
-Uc
-Uc
-Uc
-qu
-qu
-qu
-Uc
-bP
-Uc
-Uc
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-Uc
-HO
-Ou
-od
-fA
-Xr
-oX
-oX
-oX
-XM
-DH
-od
-Ou
-PG
-Uc
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-he
-he
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-he
-TC
-he
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -60790,71 +53140,6 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-KN
-jq
-jq
-jq
-jq
-jq
-Uc
-dA
-Wc
-cV
-vB
-Uu
-iE
-BI
-xx
-Uc
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-Uc
-QL
-Ou
-Ou
-KA
-fA
-SK
-SK
-SK
-DH
-Ou
-Ou
-Ou
-Ou
-Uc
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-KN
-he
-he
-KN
 jq
 jq
 jq
@@ -60876,18 +53161,83 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-he
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -61047,71 +53397,6 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-KN
-jq
-jq
-jq
-jq
-jq
-Uc
-Yt
-cV
-ih
-to
-ii
-BZ
-vx
-MZ
-Uc
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-Uc
-Dv
-Ou
-Ou
-Ou
-Ou
-XK
-XK
-wr
-od
-Ou
-Ou
-Ou
-od
-Uc
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-KN
-he
-he
-KN
 jq
 jq
 jq
@@ -61133,18 +53418,83 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-he
-Uc
-Rh
-ID
-ID
-ID
-ID
-ID
-Uc
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -61304,71 +53654,6 @@ jq
 jq
 jq
 jq
-ah
-he
-he
-KN
-jq
-jq
-jq
-jq
-jq
-Uc
-ld
-SC
-Tk
-ha
-Ix
-il
-Kg
-PJ
-Uc
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-Uc
-rp
-bw
-AO
-lH
-od
-XK
-XK
-wr
-mb
-Ou
-Ou
-Ou
-MN
-Uc
-jq
-jq
-jq
-pT
-hP
-hP
-hP
-hP
-hP
-hP
-hP
-hP
-Kv
-Vg
-KN
-he
-he
-KN
 jq
 jq
 jq
@@ -61390,18 +53675,83 @@ jq
 jq
 jq
 jq
-Kq
-he
-he
-he
-Uc
-OS
-Mw
-HA
-Ft
-Ql
-ID
-Uc
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -61561,71 +53911,6 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-KN
-jq
-jq
-jq
-jq
-jq
-Uc
-hG
-KQ
-SC
-lE
-lE
-AR
-Ow
-ve
-Uc
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-XN
-XK
-wr
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-jq
-jq
-jq
-hJ
-nM
-Ry
-Ou
-rN
-Ou
-Ou
-Ry
-Nt
-hJ
-Vg
-KN
-he
-he
-KN
 jq
 jq
 jq
@@ -61647,18 +53932,83 @@ jq
 jq
 jq
 jq
-Kq
-he
-he
-he
-Uc
-OS
-Jo
-Eo
-UK
-kL
-ID
-Uc
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -61818,71 +54168,6 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-KN
-jq
-jq
-jq
-jq
-jq
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-KN
-lR
-or
-ea
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-hJ
-Ou
-lW
-Ou
-bi
-Ou
-Ou
-Qu
-Ou
-hJ
-Vg
-KN
-he
-he
-ah
 jq
 jq
 jq
@@ -61904,18 +54189,83 @@ jq
 jq
 jq
 jq
-Kq
-he
-he
-TC
-Uc
-OS
-SQ
-xX
-xX
-Rq
-ID
-Uc
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -62075,10 +54425,6 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-KN
 jq
 jq
 jq
@@ -62112,34 +54458,6 @@ jq
 jq
 jq
 jq
-KN
-pY
-or
-ea
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-hJ
-Ou
-lW
-Ou
-RW
-Ou
-Ou
-Qu
-Ou
-hJ
-Vg
-KN
-he
-he
-KN
 jq
 jq
 jq
@@ -62161,18 +54479,50 @@ jq
 jq
 jq
 jq
-Kq
-he
-he
-he
-Uc
-ID
-ID
-ID
-ID
-ID
-fd
-Uc
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -62332,10 +54682,6 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-KN
 jq
 jq
 jq
@@ -62369,34 +54715,6 @@ jq
 jq
 jq
 jq
-KN
-lR
-or
-ea
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-hJ
-jU
-Ry
-Ou
-rN
-Ou
-Ou
-qU
-MJ
-hJ
-Vg
-KN
-fq
-he
-KN
 jq
 jq
 jq
@@ -62418,18 +54736,50 @@ jq
 jq
 jq
 jq
-Pb
-he
-he
-he
-Uc
-Uc
-Uc
-Uc
-Uc
-ob
-Uc
-Uc
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -62589,10 +54939,6 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-KN
 jq
 jq
 jq
@@ -62626,34 +54972,6 @@ jq
 jq
 jq
 jq
-KN
-lR
-or
-ea
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-KN
-nu
-Ne
-hP
-hP
-hP
-hP
-hP
-hP
-nv
-KE
-Uc
-KN
-he
-he
-KN
 jq
 jq
 jq
@@ -62675,18 +54993,50 @@ jq
 jq
 jq
 jq
-Kq
-he
-he
-he
-Uc
-re
-yc
-wZ
-FI
-ry
-op
-Uc
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -62846,10 +55196,6 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-KN
 jq
 jq
 jq
@@ -62883,34 +55229,6 @@ jq
 jq
 jq
 jq
-KN
-pY
-or
-ea
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-KN
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-KN
 jq
 jq
 jq
@@ -62932,18 +55250,50 @@ jq
 jq
 jq
 jq
-Kq
-he
-he
-he
-Uc
-eH
-Eo
-Eo
-Eo
-Wf
-Yb
-Uc
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -63103,71 +55453,6 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-ah
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-KN
-lR
-or
-ea
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-KN
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-fq
-he
-KN
 jq
 jq
 jq
@@ -63189,18 +55474,83 @@ jq
 jq
 jq
 jq
-KN
-he
-TC
-he
-Uc
-Dz
-ry
-Jm
-KU
-rr
-HW
-Uc
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -63360,71 +55710,6 @@ jq
 jq
 jq
 jq
-KN
-fq
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-fq
-he
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-KN
-lR
-or
-ea
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-KN
-he
-he
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-he
-he
-KN
 jq
 jq
 jq
@@ -63446,18 +55731,83 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-he
-Uc
-Uc
-lm
-Uc
-Uc
-Uc
-Uc
-Uc
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -63617,25 +55967,6 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-fq
-he
-he
-he
-he
-he
-KN
 jq
 jq
 jq
@@ -63654,46 +55985,6 @@ jq
 jq
 jq
 jq
-KN
-lR
-or
-ea
-Kq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-KN
-he
-he
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-KN
-he
-he
-KN
-jq
-jq
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
 jq
 jq
 jq
@@ -63703,18 +55994,77 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-he
-Uc
-rv
-jz
-Eo
-dU
-jz
-Jw
-Uc
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -63874,25 +56224,6 @@ jq
 jq
 jq
 jq
-KN
-KN
-he
-he
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-he
-he
-ah
 jq
 jq
 jq
@@ -63911,46 +56242,6 @@ jq
 jq
 jq
 jq
-KN
-lR
-or
-ea
-Kq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-KN
-he
-he
-Kq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-Kq
-he
-he
-KN
-jq
-jq
-Uc
-JP
-FJ
-io
-JP
-Kr
-Uc
-Vo
-Kt
-Uc
 jq
 jq
 jq
@@ -63960,18 +56251,77 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-he
-yb
-Eo
-sF
-tU
-kZ
-eN
-iL
-Uc
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -64128,28 +56478,6 @@ jq
 jq
 jq
 jq
-Uc
-Uc
-Uc
-Uc
-Uc
-he
-he
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-KN
-he
-he
-KN
 jq
 jq
 jq
@@ -64168,46 +56496,6 @@ jq
 jq
 jq
 jq
-KN
-lR
-or
-ea
-Pb
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-ah
-he
-he
-Kq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-Kq
-he
-he
-KN
-jq
-jq
-Uc
-sp
-BI
-Uc
-ci
-BI
-Uc
-BI
-BI
-Uc
 jq
 jq
 jq
@@ -64217,18 +56505,80 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-he
-yb
-Eo
-Ta
-uc
-vY
-pf
-ba
-Uc
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -64385,28 +56735,6 @@ jq
 jq
 jq
 jq
-Uc
-Je
-oU
-nC
-Uc
-he
-he
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-KN
-he
-he
-Kq
 jq
 jq
 jq
@@ -64425,46 +56753,6 @@ jq
 jq
 jq
 jq
-KN
-pY
-or
-ea
-Kq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-KN
-he
-he
-Kq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-Kq
-he
-he
-KN
-jq
-jq
-Uc
-bk
-gQ
-Uc
-Gc
-tC
-fb
-ad
-gQ
-Uc
 jq
 jq
 jq
@@ -64474,18 +56762,80 @@ jq
 jq
 jq
 jq
-KN
-TC
-he
-TC
-Uc
-jz
-PQ
-Eo
-Eo
-PQ
-Sn
-Uc
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -64642,28 +56992,6 @@ jq
 jq
 jq
 jq
-Uc
-TE
-Je
-Je
-JC
-he
-fq
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-KN
-he
-he
-Kq
 jq
 jq
 jq
@@ -64682,46 +57010,6 @@ jq
 jq
 jq
 jq
-KN
-lR
-or
-ea
-Kq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-KN
-he
-he
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-KN
-he
-he
-KN
-jq
-jq
-Uc
-qk
-IE
-Uc
-KP
-Hp
-Uc
-JP
-zg
-Uc
 jq
 jq
 jq
@@ -64731,22 +57019,84 @@ jq
 jq
 jq
 jq
-KN
-he
-TC
-he
-Uc
-yb
-yb
-lm
-lm
-yb
-yb
-Uc
-KN
-KN
-KN
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -64899,28 +57249,6 @@ jq
 jq
 jq
 jq
-Uc
-Qa
-Je
-bQ
-Uc
-he
-he
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-KN
-he
-he
-Kq
 jq
 jq
 jq
@@ -64939,46 +57267,6 @@ jq
 jq
 jq
 jq
-KN
-lR
-or
-ea
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-KN
-he
-he
-KN
-KN
-KN
-Kq
-Kq
-Kq
-ah
-KN
-KN
-KN
-he
-he
-KN
-KN
-KN
-Uc
-NF
-Uc
-Uc
-YN
-Uc
-Uc
-ka
-Uc
-Uc
 jq
 jq
 jq
@@ -64988,22 +57276,84 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-wW
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -65156,28 +57506,6 @@ jq
 jq
 jq
 jq
-Uc
-iZ
-Je
-Je
-JC
-he
-he
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-ah
-he
-he
-KN
 jq
 jq
 jq
@@ -65196,46 +57524,6 @@ jq
 jq
 jq
 jq
-KN
-pY
-or
-ea
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-KN
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-KN
 jq
 jq
 jq
@@ -65245,22 +57533,84 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-wW
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -65413,28 +57763,6 @@ jq
 jq
 jq
 jq
-Uc
-OA
-wi
-Uy
-Uc
-he
-he
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-KN
-he
-he
-KN
 jq
 jq
 jq
@@ -65453,46 +57781,6 @@ jq
 jq
 jq
 jq
-KN
-lR
-or
-ea
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-KN
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-fq
-KN
 jq
 jq
 jq
@@ -65502,22 +57790,84 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-he
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -65670,28 +58020,6 @@ jq
 jq
 jq
 jq
-Uc
-Uc
-Uc
-Uc
-Uc
-he
-he
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-KN
-he
-he
-KN
 jq
 jq
 jq
@@ -65710,46 +58038,6 @@ jq
 jq
 jq
 jq
-KN
-lR
-or
-ea
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-KN
-he
-he
-KN
-KN
-KN
-Uc
-Uc
-JC
-Uc
-JC
-Uc
-Uc
-he
-he
-KN
-KN
-KN
-KN
-ah
-KN
-KN
-KN
-he
-he
-KN
-KN
-KN
 jq
 jq
 jq
@@ -65759,11 +58047,73 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-he
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -65931,80 +58281,6 @@ jq
 jq
 jq
 jq
-KN
-uf
-uf
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-KN
-he
-he
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-jq
-jq
-jq
-KN
-pY
-or
-ea
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-KN
-he
-he
-KN
-jq
-jq
-Uc
-nC
-Je
-bQ
-Je
-Uy
-Uc
-he
-he
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-KN
-he
-he
-KN
 jq
 jq
 jq
@@ -66016,11 +58292,85 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-he
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -66188,80 +58538,6 @@ jq
 jq
 jq
 jq
-KN
-KN
-KN
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-KN
-he
-he
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-Uc
-VG
-Ou
-yM
-Ou
-Ap
-Uc
-jq
-jq
-jq
-KN
-lR
-or
-ea
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-KN
-KN
-KN
-KN
-jq
-jq
-Uc
-aB
-Je
-Je
-Je
-Ya
-Uc
-KN
-KN
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-KN
-he
-TC
-KN
 jq
 jq
 jq
@@ -66273,11 +58549,85 @@ jq
 jq
 jq
 jq
-KN
-he
-TC
-he
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -66459,33 +58809,6 @@ jq
 jq
 jq
 jq
-KN
-he
-fq
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-Uc
-EQ
-tI
-Ou
-Ou
-Ou
-Uc
-jq
-jq
-jq
-KN
-lR
-or
-ea
-KN
 jq
 jq
 jq
@@ -66499,26 +58822,6 @@ jq
 jq
 jq
 jq
-Uc
-Je
-uv
-yq
-su
-OA
-Uc
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-KN
-he
-he
-KN
 jq
 jq
 jq
@@ -66530,11 +58833,58 @@ jq
 jq
 jq
 jq
-Kq
-he
-he
-he
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -66716,33 +59066,6 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-Uc
-ef
-yM
-Ou
-ZN
-Ou
-Uc
-jq
-jq
-jq
-KN
-lR
-or
-ea
-KN
 jq
 jq
 jq
@@ -66756,26 +59079,6 @@ jq
 jq
 jq
 jq
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-KN
-he
-he
-KN
 jq
 jq
 jq
@@ -66787,11 +59090,58 @@ jq
 jq
 jq
 jq
-Kq
-he
-he
-TC
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -66966,40 +59316,6 @@ jq
 jq
 jq
 jq
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-he
-he
-KN
-KN
-KN
-ah
-KN
-KN
-KN
-KN
-KN
-Uc
-Kw
-Kw
-Kw
-jI
-Uc
-Uc
-KN
-KN
-KN
-KN
-lR
-or
-ea
-KN
 jq
 jq
 jq
@@ -67029,10 +59345,6 @@ jq
 jq
 jq
 jq
-ah
-he
-he
-ah
 jq
 jq
 jq
@@ -67044,11 +59356,49 @@ jq
 jq
 jq
 jq
-Pb
-bY
-Iv
-Iv
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -67223,40 +59573,6 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-fq
-he
-he
-he
-he
-he
-he
-he
-he
-he
-fq
-he
-he
-lR
-or
-ea
-KN
 jq
 jq
 jq
@@ -67286,10 +59602,6 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-KN
 jq
 jq
 jq
@@ -67301,11 +59613,49 @@ jq
 jq
 jq
 jq
-Kq
-NJ
-NJ
-he
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -67480,40 +59830,6 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-he
-he
-he
-he
-fq
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-fq
-he
-he
-he
-he
-he
-he
-pY
-or
-ea
-KN
 jq
 jq
 jq
@@ -67543,10 +59859,6 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-KN
 jq
 jq
 jq
@@ -67558,11 +59870,49 @@ jq
 jq
 jq
 jq
-Kq
-he
-he
-NJ
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -67737,40 +60087,6 @@ jq
 jq
 jq
 jq
-Uc
-rp
-Ou
-Ou
-Ou
-cY
-Uc
-KN
-KN
-KN
-he
-he
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-ah
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-lR
-or
-ea
-KN
 jq
 jq
 jq
@@ -67800,10 +60116,6 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-KN
 jq
 jq
 jq
@@ -67815,11 +60127,49 @@ jq
 jq
 jq
 jq
-KN
-Iv
-Iv
-Iv
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -67994,40 +60344,6 @@ jq
 jq
 jq
 jq
-Uc
-bw
-Ou
-Ou
-Ou
-cY
-Uc
-jq
-jq
-KN
-he
-he
-KN
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-jq
-KN
-lR
-or
-ea
-KN
 jq
 jq
 jq
@@ -68057,10 +60373,6 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-KN
 jq
 jq
 jq
@@ -68072,11 +60384,49 @@ jq
 jq
 jq
 jq
-KN
-Ok
-mm
-gx
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -68251,19 +60601,6 @@ jq
 jq
 jq
 jq
-Uc
-Fr
-Ou
-Ou
-Ou
-Kc
-Uc
-jq
-jq
-KN
-he
-he
-KN
 jq
 jq
 jq
@@ -68280,62 +60617,75 @@ jq
 jq
 jq
 jq
-KN
-lR
-or
-ea
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-ah
-Kq
-Kq
-KN
-KN
-KN
-fq
-he
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-lR
-or
-aI
-KN
-KN
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -68508,19 +60858,6 @@ jq
 jq
 jq
 jq
-Uc
-MY
-Ou
-Ou
-Ou
-cY
-Uc
-jq
-jq
-KN
-he
-he
-Kq
 jq
 jq
 jq
@@ -68537,62 +60874,75 @@ jq
 jq
 jq
 jq
-KN
-lR
-or
-or
-mm
-mm
-Zb
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-or
-or
-aI
-he
-uf
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -68765,19 +61115,6 @@ jq
 jq
 jq
 jq
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-jq
-jq
-KN
-he
-he
-Kq
 jq
 jq
 jq
@@ -68794,62 +61131,75 @@ jq
 jq
 jq
 jq
-KN
-lR
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-aI
-he
-uf
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -69031,10 +61381,6 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-Kq
 jq
 jq
 jq
@@ -69051,62 +61397,66 @@ jq
 jq
 jq
 jq
-KN
-Ll
-mE
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-mE
-Wk
-Wk
-or
-or
-or
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-or
-or
-aI
-he
-uf
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -69288,10 +61638,6 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-KN
 jq
 jq
 jq
@@ -69308,62 +61654,66 @@ jq
 jq
 jq
 jq
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-Kq
-Kq
-Kq
-KN
-KN
-Kq
-Kq
-Kq
-KN
-KN
-lR
-or
-ea
-hQ
-xG
-xG
-xG
-xG
-xG
-xG
-xG
-xG
-xG
-xG
-xG
-xG
-xG
-xG
-xG
-xG
-xG
-xG
-xG
-xG
-xG
-xG
-xG
-xG
-xG
-xG
-xG
-xG
-Ie
-lR
-or
-aI
-KN
-KN
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -69545,10 +61895,6 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-KN
 jq
 jq
 jq
@@ -69581,44 +61927,48 @@ jq
 jq
 jq
 jq
-KN
-lR
-or
-ea
-ND
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-QY
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-QY
-TA
-ND
-lR
-or
-aI
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -69800,12 +62150,6 @@ jq
 jq
 jq
 jq
-KN
-KN
-KN
-he
-he
-KN
 jq
 jq
 jq
@@ -69838,44 +62182,50 @@ jq
 jq
 jq
 jq
-Kq
-lR
-or
-ea
-ND
-QY
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-aO
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-ND
-lR
-or
-aI
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -70053,16 +62403,6 @@ jq
 jq
 jq
 jq
-KN
-KN
-KN
-KN
-KN
-he
-he
-he
-he
-KN
 jq
 jq
 jq
@@ -70095,44 +62435,54 @@ jq
 jq
 jq
 jq
-Kq
-lR
-or
-ea
-ND
-TA
-TA
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-TA
-TA
-ND
-lR
-or
-aI
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -70303,23 +62653,6 @@ jq
 jq
 jq
 jq
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-he
-he
-he
-he
-he
-he
-he
-he
-KN
 jq
 jq
 jq
@@ -70352,44 +62685,61 @@ jq
 jq
 jq
 jq
-ah
-lR
-or
-ea
-ND
-TA
-TA
-Uc
-DR
-jh
-DR
-Uc
-Nv
-Kl
-iH
-GH
-Uc
-LX
-bZ
-yV
-Pw
-xZ
-Em
-LX
-LX
-LX
-LX
-LX
-LX
-BO
-Uc
-aO
-TA
-ND
-lR
-or
-aI
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -70560,23 +62910,6 @@ jq
 jq
 jq
 jq
-Uc
-ne
-CP
-lh
-lh
-rW
-WY
-Uc
-he
-he
-he
-he
-he
-he
-KN
-KN
-KN
 jq
 jq
 jq
@@ -70609,44 +62942,61 @@ jq
 jq
 jq
 jq
-Kq
-lR
-or
-ea
-ND
-TA
-TA
-Uc
-LX
-zX
-LX
-Uc
-gl
-Kl
-rT
-rT
-Uc
-LX
-xn
-yV
-yV
-Am
-Em
-LX
-LX
-LX
-LX
-LX
-LX
-BO
-Uc
-TA
-TA
-ND
-lR
-or
-aI
-ah
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -70817,21 +63167,6 @@ jq
 jq
 jq
 jq
-Uc
-ja
-cI
-cI
-cI
-cI
-SW
-up
-he
-he
-KN
-KN
-KN
-KN
-KN
 jq
 jq
 jq
@@ -70866,44 +63201,59 @@ jq
 jq
 jq
 jq
-Kq
-lR
-or
-ea
-ND
-TA
-aO
-Uc
-LX
-LX
-LX
-Uc
-uP
-uP
-UN
-rY
-Uc
-ks
-xn
-yV
-yV
-xZ
-Em
-LX
-LX
-LX
-LX
-LX
-LX
-BO
-Uc
-TA
-TA
-ND
-lR
-or
-aI
-Kq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -71074,17 +63424,6 @@ jq
 jq
 jq
 jq
-Uc
-ne
-YV
-YV
-YV
-YV
-qE
-Uc
-he
-he
-KN
 jq
 jq
 jq
@@ -71123,44 +63462,55 @@ jq
 jq
 jq
 jq
-KN
-lR
-or
-ea
-ND
-TA
-TA
-Uc
-LX
-LX
-LX
-pq
-yV
-yV
-yV
-yV
-Uc
-LX
-xn
-yV
-yV
-Am
-Em
-LX
-LX
-LX
-LX
-LX
-LX
-BO
-Uc
-TA
-TA
-ND
-lR
-or
-aI
-Kq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -71331,17 +63681,6 @@ jq
 jq
 jq
 jq
-Uc
-Uc
-Uc
-Yz
-Yz
-Uc
-Uc
-Uc
-he
-he
-KN
 jq
 jq
 jq
@@ -71380,44 +63719,55 @@ jq
 jq
 jq
 jq
-KN
-lR
-or
-ea
-ND
-TA
-TA
-fS
-aE
-aE
-aE
-Uc
-yV
-yV
-yV
-yV
-Uc
-tq
-dI
-yV
-yV
-xZ
-UD
-tq
-tq
-tq
-tq
-tq
-tq
-nm
-Uc
-TA
-TA
-ND
-lR
-or
-aI
-Kq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -71588,17 +63938,6 @@ jq
 jq
 jq
 jq
-Uc
-dQ
-eB
-eB
-eB
-eB
-dQ
-Uc
-he
-he
-Kq
 jq
 jq
 jq
@@ -71637,44 +63976,55 @@ jq
 jq
 jq
 jq
-KN
-lR
-or
-ea
-ND
-TA
-TA
-fS
-eB
-eB
-eB
-Uc
-yV
-yV
-yV
-yV
-Uc
-yV
-yV
-yV
-yV
-yV
-yV
-yV
-yV
-yV
-yV
-yV
-yV
-yV
-Uc
-TA
-TA
-ND
-lR
-or
-aI
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -71845,17 +64195,6 @@ jq
 jq
 jq
 jq
-Uc
-eB
-Bi
-yu
-yu
-Il
-eB
-Uc
-he
-he
-Kq
 jq
 jq
 jq
@@ -71894,44 +64233,55 @@ jq
 jq
 jq
 jq
-KN
-lR
-or
-ea
-BP
-QY
-TA
-Uc
-lB
-Yh
-wd
-Uc
-yV
-yV
-yV
-yV
-Uc
-yV
-yV
-yV
-yV
-Uc
-zQ
-zQ
-zQ
-Uc
-zQ
-zQ
-zQ
-Uc
-Uc
-TA
-TA
-ND
-lR
-or
-aI
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -72102,17 +64452,6 @@ jq
 jq
 jq
 jq
-Uc
-Gd
-EL
-Jp
-Jp
-uV
-Wq
-Uc
-he
-he
-Kq
 jq
 jq
 jq
@@ -72144,51 +64483,62 @@ jq
 jq
 jq
 jq
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-jA
-lR
-or
-ea
-ND
-TA
-TA
-fS
-Av
-ru
-ni
-Uc
-yV
-yV
-yV
-yV
-xC
-yV
-yV
-yV
-yV
-Uc
-Ic
-Dr
-xF
-Uc
-LX
-LX
-LX
-Zl
-Uc
-TA
-TA
-ND
-lR
-or
-aI
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -72359,17 +64709,6 @@ jq
 jq
 jq
 jq
-Uc
-eB
-qx
-hd
-hd
-aU
-eB
-Uc
-he
-he
-Kq
 jq
 jq
 jq
@@ -72401,51 +64740,62 @@ jq
 jq
 jq
 jq
-Uc
-Ve
-Pn
-Lw
-Pn
-bT
-Lw
-es
-lR
-or
-ea
-ND
-TA
-TA
-fS
-Gb
-ZY
-ni
-Uc
-yV
-yV
-yV
-yV
-Uc
-yV
-yV
-yV
-yV
-xC
-LX
-La
-LX
-pq
-LX
-LX
-LX
-pZ
-Uc
-TA
-TA
-ND
-lR
-or
-aI
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -72616,17 +64966,6 @@ jq
 jq
 jq
 jq
-Uc
-Ym
-Tx
-eB
-eB
-Tx
-Ym
-Uc
-he
-he
-Kq
 jq
 jq
 jq
@@ -72658,51 +64997,62 @@ jq
 jq
 jq
 jq
-Uc
-Af
-PU
-Oq
-Pn
-Pn
-Pn
-oF
-lR
-or
-ea
-ND
-TA
-TA
-Uc
-RM
-aP
-rq
-Uc
-xV
-SO
-xV
-aL
-Uc
-yV
-yV
-yV
-yV
-Uc
-rk
-LX
-Mt
-Uc
-LX
-LX
-LX
-Zl
-Uc
-TA
-TA
-ND
-lR
-or
-aI
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -72873,17 +65223,6 @@ jq
 jq
 jq
 jq
-Uc
-Uc
-Uc
-wj
-wj
-Uc
-Uc
-Uc
-he
-he
-Kq
 jq
 jq
 jq
@@ -72915,51 +65254,62 @@ jq
 jq
 jq
 jq
-Uc
-PT
-Pn
-Oq
-Pn
-Pn
-Pn
-oF
-lR
-or
-ea
-ND
-TA
-TA
-Uc
-Uc
-Uc
-Uc
-Uc
-rk
-tK
-LX
-LX
-Uc
-Uc
-Nf
-Nf
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-TA
-TA
-ND
-lR
-or
-aI
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -73130,17 +65480,6 @@ jq
 jq
 jq
 jq
-Uc
-Vb
-YU
-uA
-uA
-YU
-Vb
-Uc
-he
-he
-KN
 jq
 jq
 jq
@@ -73172,51 +65511,62 @@ jq
 jq
 jq
 jq
-Uc
-Ve
-Pn
-Lw
-Pn
-ak
-Lw
-OK
-lR
-or
-ea
-ND
-TA
-TA
-Uc
-Jq
-yP
-Ri
-Uc
-DR
-LX
-LX
-LX
-Uc
-eV
-yV
-yV
-Bf
-Uc
-oi
-WR
-yV
-yV
-yV
-yV
-yV
-Am
-Uc
-QY
-TA
-Um
-lR
-or
-aI
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -73387,17 +65737,6 @@ jq
 jq
 jq
 jq
-Uc
-Ht
-TH
-TH
-TH
-TH
-Zt
-Uc
-he
-he
-KN
 jq
 jq
 jq
@@ -73429,51 +65768,62 @@ jq
 jq
 jq
 jq
-Uc
-Uc
-nH
-Uc
-Uc
-Uc
-Uc
-eh
-lR
-or
-ea
-ND
-TA
-TA
-Uc
-LX
-LX
-LX
-Uc
-ME
-LX
-LX
-ME
-Uc
-Zz
-yV
-yV
-hO
-Uc
-sN
-Jz
-yV
-yV
-yV
-yV
-yV
-yV
-zE
-UR
-UR
-xw
-lR
-or
-aI
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -73644,26 +65994,6 @@ jq
 jq
 jq
 jq
-Uc
-et
-TH
-XL
-XL
-TH
-pj
-Uc
-he
-he
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
 jq
 jq
 jq
@@ -73686,51 +66016,71 @@ jq
 jq
 jq
 jq
-Uc
-Pn
-Pn
-Pn
-Pn
-Pn
-Pn
-WT
-lR
-or
-ea
-ND
-aO
-TA
-Uc
-Sk
-LX
-LX
-Uc
-Uc
-zy
-zy
-Uc
-Uc
-eV
-yV
-yV
-Bf
-Uc
-xv
-AX
-yV
-yV
-yV
-yV
-yV
-yV
-zE
-dq
-dq
-ns
-pY
-or
-aI
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -73901,27 +66251,6 @@ jq
 jq
 jq
 jq
-Uc
-Vb
-gC
-Cq
-cz
-Li
-Vb
-Uc
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-KN
-KN
 jq
 jq
 jq
@@ -73943,51 +66272,72 @@ jq
 jq
 jq
 jq
-Uc
-Ex
-aM
-mr
-mr
-MS
-lX
-WT
-lR
-or
-ea
-ND
-QY
-TA
-Uc
-LH
-LX
-LX
-Uc
-EB
-LX
-LX
-EB
-Uc
-eV
-yV
-yV
-Bf
-Uc
-yV
-yV
-yV
-yV
-yV
-yV
-yV
-Am
-Uc
-QY
-TA
-Ie
-lR
-or
-aI
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -74158,27 +66508,6 @@ jq
 jq
 jq
 jq
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-KN
 jq
 jq
 jq
@@ -74200,51 +66529,72 @@ jq
 jq
 jq
 jq
-Uc
-Pn
-Bf
-ks
-LX
-eV
-Pn
-Uc
-lR
-or
-ea
-ND
-TA
-TA
-Uc
-LX
-LX
-LX
-Uc
-EB
-LX
-LX
-EB
-Uc
-eV
-yV
-yV
-Bf
-Uc
-yV
-yV
-yV
-yV
-Uc
-Yl
-xV
-xV
-Uc
-TA
-TA
-ND
-lR
-or
-aI
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -74422,20 +66772,6 @@ jq
 jq
 jq
 jq
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-he
-he
-he
-KN
 jq
 jq
 jq
@@ -74457,51 +66793,65 @@ jq
 jq
 jq
 jq
-Uc
-Pn
-mO
-kt
-kt
-UH
-Pn
-eh
-lR
-or
-ea
-ND
-TA
-TA
-Uc
-xf
-LX
-LX
-Uc
-Uc
-lx
-lx
-Uc
-Uc
-eV
-yV
-yV
-Bf
-Uc
-yV
-yV
-yV
-yV
-TF
-LX
-qc
-LX
-Uc
-TA
-TA
-ND
-lR
-or
-aI
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -74688,11 +67038,6 @@ jq
 jq
 jq
 jq
-KN
-KN
-he
-he
-KN
 jq
 jq
 jq
@@ -74714,51 +67059,56 @@ jq
 jq
 jq
 jq
-Uc
-Pn
-Bf
-ks
-LX
-eV
-Pn
-WT
-lR
-or
-ea
-ND
-TA
-TA
-Uc
-Wa
-LX
-LX
-oe
-xJ
-LX
-LX
-xN
-Uc
-eV
-yV
-yV
-Bf
-Uc
-yV
-yV
-yV
-yV
-ta
-Ib
-LX
-LX
-Uc
-TA
-TA
-ND
-lR
-or
-aI
-Kq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -74946,10 +67296,6 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-ah
 jq
 jq
 jq
@@ -74971,51 +67317,55 @@ jq
 jq
 jq
 jq
-Uc
-Pn
-FM
-lz
-Oy
-uy
-Pn
-Uc
-lR
-or
-ea
-ND
-TA
-TA
-Uc
-Gg
-LX
-LX
-LX
-LX
-LX
-LX
-LX
-Uc
-eV
-yV
-yV
-cH
-Uc
-dV
-yV
-yV
-yV
-Wy
-LX
-LX
-LX
-Uc
-TA
-TA
-ND
-lR
-or
-aI
-Kq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -75203,10 +67553,6 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-KN
 jq
 jq
 jq
@@ -75228,51 +67574,55 @@ jq
 jq
 jq
 jq
-Uc
-Pn
-Bf
-ks
-LX
-eV
-Pn
-Yp
-lR
-or
-ea
-ND
-TA
-TA
-Uc
-yt
-LX
-LX
-LX
-LX
-LX
-LX
-LX
-Uc
-eV
-yV
-yV
-yV
-wy
-yV
-yV
-yV
-yV
-Uc
-LX
-LX
-LX
-Uc
-TA
-TA
-ND
-lR
-or
-aI
-Kq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -75460,10 +67810,6 @@ jq
 jq
 jq
 jq
-Kq
-he
-he
-KN
 jq
 jq
 jq
@@ -75485,51 +67831,55 @@ jq
 jq
 jq
 jq
-Uc
-Ex
-KM
-yI
-yI
-VB
-lX
-eh
-lR
-or
-ea
-ND
-TA
-TA
-Uc
-LX
-LX
-LX
-LX
-LX
-LX
-LX
-wh
-Uc
-eV
-yV
-yV
-yV
-wy
-yV
-yV
-yV
-yV
-Xg
-sr
-LX
-LX
-Uc
-TA
-TA
-ND
-lR
-or
-aI
-ah
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -75717,10 +68067,6 @@ jq
 jq
 jq
 jq
-Kq
-he
-he
-KN
 jq
 jq
 jq
@@ -75742,51 +68088,55 @@ jq
 jq
 jq
 jq
-Uc
-Pn
-ak
-Pn
-Pn
-ak
-Pn
-WT
-lR
-or
-ea
-ND
-TA
-TA
-Uc
-jf
-LX
-Sp
-xz
-tg
-Vk
-LX
-FA
-Uc
-eV
-yV
-yV
-DL
-Uc
-dV
-yV
-yV
-yV
-Uc
-ME
-DR
-ME
-Uc
-TA
-TA
-ND
-lR
-or
-aI
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -75974,10 +68324,6 @@ jq
 jq
 jq
 jq
-Kq
-he
-he
-KN
 jq
 jq
 jq
@@ -75999,51 +68345,55 @@ jq
 jq
 jq
 jq
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-UQ
-lR
-or
-ea
-ND
-TA
-TA
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-fS
-fS
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-TA
-TA
-ND
-lR
-or
-aI
-ah
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -76231,10 +68581,6 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-KN
 jq
 jq
 jq
@@ -76263,44 +68609,48 @@ jq
 jq
 jq
 jq
-KN
-lR
-or
-ea
-ND
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-ND
-lR
-or
-aI
-Kq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -76488,10 +68838,6 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-KN
 jq
 jq
 jq
@@ -76520,44 +68866,48 @@ jq
 jq
 jq
 jq
-KN
-lR
-or
-ea
-ND
-QY
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-aO
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-TA
-QY
-ND
-lR
-or
-aI
-Kq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -76743,14 +69093,6 @@ jq
 jq
 jq
 jq
-KN
-KN
-KN
-he
-he
-KN
-KN
-KN
 jq
 jq
 jq
@@ -76775,46 +69117,54 @@ jq
 jq
 jq
 jq
-KN
-KN
-KN
-lR
-or
-ea
-eq
-xG
-xG
-xG
-xG
-xG
-xG
-xG
-xG
-xG
-xG
-xG
-xG
-xG
-xG
-xG
-xG
-xG
-xG
-xG
-xG
-xG
-xG
-xG
-xG
-xG
-xG
-xG
-xG
-Qz
-lR
-or
-aI
-Kq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -77000,14 +69350,6 @@ jq
 jq
 jq
 jq
-KN
-uf
-he
-he
-he
-he
-uf
-KN
 jq
 jq
 jq
@@ -77032,46 +69374,54 @@ jq
 jq
 jq
 jq
-KN
-uf
-mm
-or
-or
-or
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-mm
-or
-or
-aI
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -77257,14 +69607,6 @@ jq
 jq
 jq
 jq
-KN
-uf
-he
-he
-he
-he
-uf
-KN
 jq
 jq
 jq
@@ -77289,46 +69631,54 @@ jq
 jq
 jq
 jq
-KN
-uf
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-or
-aI
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -77514,14 +69864,6 @@ jq
 jq
 jq
 jq
-KN
-uf
-he
-he
-he
-he
-uf
-KN
 jq
 jq
 jq
@@ -77546,46 +69888,54 @@ jq
 jq
 jq
 jq
-KN
-uf
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-Wk
-or
-or
-aI
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -77771,14 +70121,6 @@ jq
 jq
 jq
 jq
-KN
-KN
-KN
-he
-he
-KN
-KN
-KN
 jq
 jq
 jq
@@ -77803,46 +70145,54 @@ jq
 jq
 jq
 jq
-KN
-KN
-KN
-KN
-KN
-KN
-he
-he
-KN
-KN
-Kq
-Kq
-Kq
-Kq
-Kq
-ah
-KN
-KN
-KN
-KN
-KN
-Kq
-Kq
-Kq
-Kq
-ah
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-lR
-or
-aI
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -78030,10 +70380,6 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-KN
 jq
 jq
 jq
@@ -78065,10 +70411,6 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-KN
 jq
 jq
 jq
@@ -78095,11 +70437,19 @@ jq
 jq
 jq
 jq
-KN
-uf
-uf
-uf
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -78287,10 +70637,6 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-KN
 jq
 jq
 jq
@@ -78322,10 +70668,6 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-KN
 jq
 jq
 jq
@@ -78352,11 +70694,19 @@ jq
 jq
 jq
 jq
-KN
-KN
-KN
-KN
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -78544,10 +70894,6 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-KN
 jq
 jq
 jq
@@ -78579,10 +70925,14 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-gD
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -78801,10 +71151,6 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-KN
 jq
 jq
 jq
@@ -78819,27 +71165,31 @@ jq
 jq
 jq
 jq
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-he
-he
-gD
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -79058,45 +71408,45 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-KN
 jq
 jq
 jq
 jq
 jq
-Vg
-Vg
-Vg
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-gD
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -79315,45 +71665,45 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-Kq
 jq
 jq
 jq
 jq
 jq
-Vg
-Vg
-Vg
-Uc
-RJ
-JU
-bq
-ts
-oa
-Uc
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -79572,45 +71922,45 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-Kq
 jq
 jq
 jq
 jq
 jq
-Uc
-Uc
-kv
-Uc
-RJ
-yD
-yD
-GO
-KH
-Uc
-he
-he
-KN
-KN
-KN
-Uc
-Uc
-Xo
-Qt
-Qt
-Qt
-Uc
-Uc
-Uc
-Uc
-KN
-KN
-KN
-KN
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -79829,40 +72179,40 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-Kq
 jq
 jq
 jq
 jq
 jq
-kv
-yD
-yD
-DB
-yD
-yD
-yD
-yD
-HL
-Uc
-he
-he
-KN
 jq
 jq
-Uc
-mT
-ze
-II
-II
-II
-ze
-ze
-ze
-vN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -80086,40 +72436,40 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-KN
 jq
 jq
 jq
 jq
 jq
-Uc
-Sq
-yD
-Uc
-Gf
-Dy
-Ab
-Dy
-fZ
-Uc
-he
-he
-KN
 jq
 jq
-Uc
-Oo
-ze
-FU
-FU
-Qs
-ze
-ow
-YR
-Uc
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -80343,40 +72693,40 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-KN
-KN
-KN
-KN
-KN
-KN
-Uc
-Uc
-qA
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-Uc
-he
-he
-KN
 jq
 jq
-Uc
-kI
-ze
-FU
-FU
-FU
-ze
-NW
-Jv
-Uc
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -80600,40 +72950,40 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-KN
 jq
 jq
-Uc
-mT
-ze
-II
-II
-II
-ze
-ep
-Sj
-Uc
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -80857,40 +73207,40 @@ jq
 jq
 jq
 jq
-KN
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-he
-KN
 jq
 jq
-Uc
-Uc
-Uc
-nh
-nh
-nh
-Uc
-Uc
-Uc
-Uc
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq
@@ -81114,28 +73464,28 @@ jq
 jq
 jq
 jq
-KN
-KN
-KN
-Kq
-Kq
-ah
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-KN
-Kq
-ah
-Kq
-KN
-KN
-KN
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
+jq
 jq
 jq
 jq

--- a/_maps/map_files/Xi/xicorp.dmm
+++ b/_maps/map_files/Xi/xicorp.dmm
@@ -3471,6 +3471,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/facility_hallway/information)
+"zJ" = (
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/department_main/manager)
 "zO" = (
 /obj/effect/turf_decal/plaque{
 	alpha = 230;
@@ -4902,6 +4905,9 @@
 /mob/living/simple_animal/bot/cleanbot,
 /turf/open/floor/plasteel/white,
 /area/facility_hallway/command)
+"KG" = (
+/turf/closed/indestructible/reinforced,
+/area/department_main/manager)
 "KI" = (
 /obj/effect/turf_decal/siding/purple{
 	dir = 9
@@ -5388,6 +5394,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/facility_hallway/central)
+"Os" = (
+/obj/machinery/ntnet_relay,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/department_main/manager)
 "Ot" = (
 /obj/effect/turf_decal/siding/green/corner{
 	color = "#006400";
@@ -6242,6 +6252,10 @@
 	color = "a1a1a1"
 	},
 /area/facility_hallway/manager)
+"TJ" = (
+/obj/machinery/telecomms/relay/preset/station,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/department_main/manager)
 "TL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/cold/no_nightlight{
@@ -23753,9 +23767,9 @@ if
 if
 if
 if
-if
-if
-if
+KG
+KG
+KG
 if
 if
 if
@@ -24010,9 +24024,9 @@ if
 if
 if
 if
-if
-if
-if
+KG
+TJ
+KG
 if
 if
 if
@@ -24267,9 +24281,9 @@ if
 if
 if
 if
-if
-if
-if
+KG
+zJ
+KG
 if
 if
 if
@@ -24524,9 +24538,9 @@ if
 if
 if
 if
-if
-if
-if
+KG
+Os
+KG
 if
 if
 if
@@ -24781,9 +24795,9 @@ if
 if
 if
 if
-if
-if
-if
+KG
+KG
+KG
 if
 if
 if

--- a/_maps/map_files/Xi/xicorp.dmm
+++ b/_maps/map_files/Xi/xicorp.dmm
@@ -224,12 +224,6 @@
 	color = "a1a1a1"
 	},
 /area/facility_hallway/central)
-"bz" = (
-/obj/effect/spawner/randomcolavend,
-/turf/open/floor/facility/white{
-	color = "a1a1a1"
-	},
-/area/facility_hallway/south)
 "bA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -262,11 +256,6 @@
 /obj/item/grown/sunflower,
 /turf/open/floor/plating/grass/jungle,
 /area/department_main/command)
-"bS" = (
-/obj/structure/fluff/broken_flooring,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/facility_hallway/information)
 "bT" = (
 /obj/structure/disposalpipe/junction/yjunction{
 	dir = 1
@@ -293,13 +282,13 @@
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plasteel,
 /area/facility_hallway/command)
-"bY" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+"bZ" = (
+/obj/structure/window/reinforced/spawner{
+	max_integrity = 25
 	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/dark,
-/area/facility_hallway/south)
+/obj/structure/refinery,
+/turf/open/floor/facility/dark,
+/area/department_main/information)
 "ca" = (
 /obj/machinery/vending/lobotomyuniform,
 /obj/machinery/light/broken,
@@ -307,14 +296,6 @@
 	color = "a1a1a1"
 	},
 /area/facility_hallway/central)
-"cc" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/scanner_gate{
-	scangate_mode = "Guns"
-	},
-/turf/open/floor/plasteel/dark,
-/area/facility_hallway/south)
 "cg" = (
 /obj/structure/table/glass,
 /obj/structure/window/reinforced/spawner/north{
@@ -478,11 +459,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/facility_hallway/training)
-"dn" = (
-/obj/machinery/door/airlock/external/glass,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/dark,
-/area/facility_hallway/south)
 "ds" = (
 /obj/effect/turf_decal/plaque{
 	alpha = 230;
@@ -544,15 +520,6 @@
 	},
 /turf/open/floor/holofloor/carpet,
 /area/department_main/control)
-"dM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/junction{
-	dir = 4
-	},
-/turf/open/floor/facility/white{
-	color = "a1a1a1"
-	},
-/area/facility_hallway/information)
 "dN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
@@ -563,18 +530,6 @@
 	color = "a1a1a1"
 	},
 /area/facility_hallway/training)
-"dU" = (
-/obj/docking_port/stationary{
-	dheight = 10;
-	dir = 2;
-	dwidth = 1;
-	height = 23;
-	id = "emergency_home";
-	name = "Alphacorp emergency evac bay";
-	width = 8
-	},
-/turf/open/floor/plating,
-/area/facility_hallway/south)
 "dZ" = (
 /obj/effect/turf_decal/siding/yellow{
 	dir = 4
@@ -623,6 +578,9 @@
 /turf/open/floor/facility/white{
 	color = "a1a1a1"
 	},
+/area/facility_hallway/control)
+"eA" = (
+/turf/closed/indestructible/rock,
 /area/facility_hallway/control)
 "eC" = (
 /obj/machinery/light/broken{
@@ -713,12 +671,6 @@
 /obj/structure/closet/crate/freezer/surplus_limbs,
 /turf/open/floor/facility/white,
 /area/department_main/safety)
-"fk" = (
-/obj/structure/fluff/broken_flooring{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/facility_hallway/south)
 "fl" = (
 /turf/open/floor/facility/white{
 	color = "a1a1a1"
@@ -975,10 +927,6 @@
 	},
 /turf/open/floor/holofloor/carpet,
 /area/department_main/control)
-"gV" = (
-/obj/structure/chair/sofa/corp/right,
-/turf/open/floor/plasteel,
-/area/facility_hallway/south)
 "hb" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -1115,9 +1063,6 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/department_main/information)
-"hY" = (
-/turf/open/floor/plating,
-/area/facility_hallway/south)
 "ia" = (
 /obj/machinery/light/cold/no_nightlight{
 	brightness = 16;
@@ -1147,21 +1092,6 @@
 	color = "a1a1a1"
 	},
 /area/facility_hallway/command)
-"iq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/facility/white{
-	color = "a1a1a1"
-	},
-/area/facility_hallway/information)
-"is" = (
-/obj/structure/fluff/broken_flooring{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/facility_hallway/control)
 "iu" = (
 /obj/effect/turf_decal/siding/yellow{
 	dir = 9
@@ -1221,19 +1151,6 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/department_main/information)
-"iN" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/effect/turf_decal/delivery/red,
-/obj/machinery/door/poddoor/preopen{
-	id = "managerlockdown";
-	name = "Manager's Office Lockdown Blast Door"
-	},
-/turf/open/floor/facility/white{
-	color = "a1a1a1"
-	},
-/area/facility_hallway/manager)
 "iP" = (
 /obj/effect/turf_decal/siding/yellow{
 	dir = 5
@@ -1352,20 +1269,10 @@
 /turf/open/floor/carpet/green,
 /area/department_main/safety)
 "jE" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/effect/turf_decal/siding/yellow{
 	dir = 5
 	},
-/turf/open/floor/plasteel/sepia,
+/turf/open/floor/mineral/titanium/yellow,
 /area/department_main/command)
 "jF" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1538,14 +1445,6 @@
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plasteel,
 /area/facility_hallway/training)
-"kW" = (
-/obj/effect/turf_decal/caution/stand_clear/red,
-/obj/machinery/door/poddoor/preopen{
-	id = "managerlockdown";
-	name = "Manager's Office Lockdown Blast Door"
-	},
-/turf/open/floor/plasteel,
-/area/facility_hallway/manager)
 "kX" = (
 /obj/structure/sign/poster/ripped{
 	pixel_y = -32
@@ -1706,11 +1605,6 @@
 	color = "a1a1a1"
 	},
 /area/facility_hallway/control)
-"ma" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/facility_hallway/information)
 "mb" = (
 /obj/effect/turf_decal/delivery/red,
 /obj/machinery/light/cold/no_nightlight{
@@ -1903,15 +1797,6 @@
 	},
 /turf/open/floor/carpet/green,
 /area/department_main/safety)
-"nz" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/facility_hallway/south)
 "nA" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Central Command Department"
@@ -2017,9 +1902,6 @@
 /obj/item/flashlight/seclite,
 /turf/open/floor/facility/white,
 /area/facility_hallway/central)
-"ow" = (
-/turf/closed/indestructible/reinforced,
-/area/facility_hallway/south)
 "ox" = (
 /turf/open/floor/facility/dark,
 /area/department_main/training)
@@ -2098,23 +1980,6 @@
 /obj/effect/spawner/abnormality_room,
 /turf/closed/indestructible/reinforced,
 /area/facility_hallway/control)
-"oU" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/effect/turf_decal/delivery/red,
-/obj/machinery/light/cold/no_nightlight{
-	brightness = 16;
-	dir = 8
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "managerlockdown";
-	name = "Manager's Office Lockdown Blast Door"
-	},
-/turf/open/floor/facility/white{
-	color = "a1a1a1"
-	},
-/area/facility_hallway/manager)
 "oV" = (
 /obj/effect/decal/cleanable/plastic,
 /obj/structure/disposalpipe/segment{
@@ -2122,18 +1987,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/facility_hallway/training)
-"oX" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/sign/departments/evac{
-	pixel_x = -32
-	},
-/obj/effect/turf_decal/caution{
-	dir = 1
-	},
-/turf/open/floor/facility/white{
-	color = "a1a1a1"
-	},
-/area/facility_hallway/south)
 "pc" = (
 /obj/structure/window/reinforced/spawner/east{
 	max_integrity = 25
@@ -2260,7 +2113,7 @@
 /turf/open/floor/wood,
 /area/department_main/command)
 "qn" = (
-/turf/closed/indestructible/reinforced,
+/turf/closed/indestructible/rock,
 /area/facility_hallway/manager)
 "qt" = (
 /obj/effect/turf_decal/siding/purple{
@@ -2359,15 +2212,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/facility_hallway/training)
-"rh" = (
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
-/obj/structure/fluff/broken_flooring{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/facility_hallway/south)
 "rj" = (
 /obj/structure/disposalpipe/junction/yjunction,
 /turf/open/floor/plasteel,
@@ -2517,15 +2361,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/facility_hallway/command)
-"si" = (
-/obj/structure/chair/sofa/corp/left,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/facility/white{
-	color = "a1a1a1"
-	},
-/area/facility_hallway/south)
 "so" = (
 /obj/machinery/light/cold/no_nightlight{
 	brightness = 16;
@@ -2829,15 +2664,6 @@
 	},
 /turf/open/floor/plating,
 /area/facility_hallway/command)
-"uY" = (
-/obj/structure/chair/sofa/corp/right,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/facility/white{
-	color = "a1a1a1"
-	},
-/area/facility_hallway/south)
 "vd" = (
 /obj/effect/turf_decal/arrows/red{
 	dir = 1
@@ -2935,9 +2761,6 @@
 	},
 /turf/open/floor/carpet/orange,
 /area/department_main/training)
-"vI" = (
-/turf/open/floor/plasteel,
-/area/facility_hallway/south)
 "vJ" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 8
@@ -3261,6 +3084,10 @@
 	},
 /turf/open/floor/plating,
 /area/facility_hallway/training)
+"yg" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/indestructible/reinforced,
+/area/facility_hallway/information)
 "yi" = (
 /obj/machinery/door/airlock/highsecurity{
 	hackProof = 1;
@@ -3331,14 +3158,6 @@
 	},
 /turf/open/floor/facility/halls,
 /area/department_main/safety)
-"yE" = (
-/obj/machinery/door/airlock/external/glass,
-/obj/effect/turf_decal/stripes/full,
-/obj/structure/disposalpipe/junction/yjunction{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/facility_hallway/south)
 "yL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -3368,12 +3187,6 @@
 /obj/item/grown/novaflower,
 /turf/open/floor/plating/grass/jungle,
 /area/department_main/command)
-"zf" = (
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel,
-/area/facility_hallway/south)
 "zg" = (
 /obj/effect/turf_decal/siding/brown/end{
 	dir = 4
@@ -3436,18 +3249,6 @@
 	},
 /turf/open/floor/facility/dark,
 /area/department_main/information)
-"zy" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/sign/departments/evac{
-	pixel_x = 32
-	},
-/obj/effect/turf_decal/caution{
-	dir = 1
-	},
-/turf/open/floor/facility/white{
-	color = "a1a1a1"
-	},
-/area/facility_hallway/south)
 "zD" = (
 /obj/effect/turf_decal/siding{
 	color = "#7D6521";
@@ -3522,10 +3323,6 @@
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plasteel,
 /area/facility_hallway/command)
-"Am" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/facility_hallway/information)
 "Au" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/ripped{
@@ -3717,29 +3514,6 @@
 	color = "a1a1a1"
 	},
 /area/facility_hallway/safety)
-"BO" = (
-/turf/open/floor/plasteel/elevatorshaft,
-/area/facility_hallway/manager)
-"BS" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/turf/open/floor/facility/white{
-	color = "a1a1a1"
-	},
-/area/facility_hallway/south)
-"BZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/cold/no_nightlight{
-	brightness = 16;
-	dir = 1
-	},
-/obj/machinery/camera/autoname,
-/turf/open/floor/facility/white{
-	color = "a1a1a1"
-	},
-/area/facility_hallway/control)
 "Cc" = (
 /obj/machinery/light/broken{
 	dir = 1
@@ -3784,12 +3558,6 @@
 	},
 /turf/open/floor/carpet/red,
 /area/department_main/control)
-"Cl" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/closed/indestructible/reinforced,
-/area/facility_hallway/south)
 "Co" = (
 /obj/effect/turf_decal/plaque{
 	alpha = 230;
@@ -3985,18 +3753,6 @@
 	color = "a1a1a1"
 	},
 /area/facility_hallway/command)
-"Dv" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/spawner/randomsnackvend,
-/obj/machinery/camera/autoname{
-	dir = 9
-	},
-/turf/open/floor/facility/white{
-	color = "a1a1a1"
-	},
-/area/facility_hallway/south)
 "Dw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -4111,12 +3867,6 @@
 	color = "a1a1a1"
 	},
 /area/facility_hallway/command)
-"EC" = (
-/obj/structure/fluff/broken_flooring{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/facility_hallway/south)
 "ED" = (
 /obj/effect/turf_decal/siding/red{
 	color = "#440000";
@@ -4125,6 +3875,7 @@
 /turf/open/floor/carpet/red,
 /area/department_main/control)
 "EI" = (
+/obj/machinery/camera/autoname,
 /turf/open/floor/plasteel,
 /area/facility_hallway/control)
 "EJ" = (
@@ -4418,14 +4169,6 @@
 	color = "a1a1a1"
 	},
 /area/facility_hallway/control)
-"Hd" = (
-/obj/effect/turf_decal/stripes/full,
-/obj/machinery/door/poddoor{
-	id = "facilitylockdown";
-	name = "Facility Lockdown Blast Door"
-	},
-/turf/open/floor/plasteel/dark,
-/area/facility_hallway/south)
 "He" = (
 /obj/machinery/light/cold/no_nightlight{
 	brightness = 16;
@@ -4542,6 +4285,10 @@
 	},
 /turf/open/floor/facility/white,
 /area/facility_hallway/central)
+"HP" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/indestructible/reinforced,
+/area/facility_hallway/control)
 "HR" = (
 /obj/effect/turf_decal/plaque{
 	alpha = 230;
@@ -4551,18 +4298,6 @@
 	color = "a1a1a1"
 	},
 /area/facility_hallway/information)
-"HT" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/effect/spawner/randomcolavend,
-/obj/machinery/camera/autoname{
-	dir = 4
-	},
-/turf/open/floor/facility/white{
-	color = "a1a1a1"
-	},
-/area/facility_hallway/south)
 "HV" = (
 /turf/open/floor/carpet/royalblack,
 /area/department_main/information)
@@ -4576,9 +4311,6 @@
 	},
 /turf/open/floor/carpet/orange,
 /area/department_main/training)
-"HY" = (
-/turf/closed/indestructible/reinforced,
-/area/space)
 "Ii" = (
 /obj/machinery/computer/operating{
 	dir = 8
@@ -4604,15 +4336,6 @@
 	},
 /turf/open/floor/carpet/green,
 /area/department_main/safety)
-"Ir" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/caution{
-	dir = 1
-	},
-/turf/open/floor/facility/white{
-	color = "a1a1a1"
-	},
-/area/facility_hallway/south)
 "Is" = (
 /obj/effect/turf_decal/siding/purple{
 	dir = 6
@@ -4688,20 +4411,10 @@
 /turf/open/floor/facility/white,
 /area/department_main/safety)
 "IZ" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/effect/turf_decal/siding/yellow{
 	dir = 9
 	},
-/turf/open/floor/plasteel/sepia,
+/turf/open/floor/mineral/titanium/yellow,
 /area/department_main/command)
 "Ja" = (
 /obj/effect/decal/cleanable/dirt,
@@ -4728,13 +4441,6 @@
 	color = "a1a1a1"
 	},
 /area/facility_hallway/training)
-"Jm" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/scanner_gate{
-	scangate_mode = "Guns"
-	},
-/turf/open/floor/plasteel/dark,
-/area/facility_hallway/south)
 "Jq" = (
 /obj/effect/decal/cleanable/plastic,
 /turf/open/floor/facility/white{
@@ -4795,18 +4501,6 @@
 	},
 /turf/open/floor/facility/white,
 /area/department_main/safety)
-"JP" = (
-/obj/machinery/vending/coffee,
-/turf/open/floor/facility/white{
-	color = "a1a1a1"
-	},
-/area/facility_hallway/south)
-"JR" = (
-/obj/machinery/door/airlock/wood/glass{
-	name = "Manager's Office"
-	},
-/turf/open/floor/facility/halls,
-/area/facility_hallway/manager)
 "JS" = (
 /obj/item/target,
 /obj/effect/turf_decal/siding/red,
@@ -4854,20 +4548,10 @@
 	},
 /area/department_main/training)
 "Ke" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/effect/turf_decal/siding/yellow{
 	dir = 10
 	},
-/turf/open/floor/plasteel/sepia,
+/turf/open/floor/mineral/titanium/yellow,
 /area/department_main/command)
 "Kj" = (
 /obj/effect/landmark/department_center,
@@ -5001,10 +4685,6 @@
 "Ls" = (
 /turf/open/floor/facility/dark,
 /area/facility_hallway/central)
-"Ly" = (
-/obj/structure/sign/departments/evac,
-/turf/closed/indestructible/reinforced,
-/area/facility_hallway/south)
 "LA" = (
 /obj/effect/turf_decal/siding/red{
 	dir = 10
@@ -5017,10 +4697,6 @@
 	},
 /turf/open/floor/holofloor/carpet,
 /area/department_main/control)
-"LI" = (
-/obj/structure/fluff/broken_flooring,
-/turf/open/floor/plating,
-/area/facility_hallway/south)
 "LU" = (
 /obj/structure/fluff/arc/angela,
 /turf/open/floor/mineral/titanium/yellow,
@@ -5188,17 +4864,6 @@
 	color = "a1a1a1"
 	},
 /area/facility_hallway/command)
-"MZ" = (
-/obj/machinery/light/cold/no_nightlight{
-	brightness = 16
-	},
-/obj/machinery/camera/autoname{
-	dir = 10
-	},
-/turf/open/floor/facility/white{
-	color = "a1a1a1"
-	},
-/area/facility_hallway/information)
 "Nc" = (
 /obj/effect/turf_decal/plaque{
 	alpha = 230;
@@ -5451,15 +5116,6 @@
 	color = "a1a1a1"
 	},
 /area/facility_hallway/central)
-"Pf" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/turf/open/floor/facility/white{
-	color = "a1a1a1"
-	},
-/area/facility_hallway/south)
 "Ph" = (
 /obj/structure/disposalpipe/junction{
 	dir = 1
@@ -5634,16 +5290,6 @@
 /obj/item/food/grown/moonflower,
 /turf/open/floor/plating/grass/jungle,
 /area/department_main/command)
-"Qy" = (
-/obj/machinery/scanner_gate{
-	scangate_mode = "Guns"
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/camera/autoname{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/facility_hallway/south)
 "Qz" = (
 /obj/effect/turf_decal/delivery/red,
 /obj/effect/decal/cleanable/dirt,
@@ -5700,20 +5346,10 @@
 /turf/open/floor/wood,
 /area/department_main/command)
 "QO" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/effect/turf_decal/siding/yellow{
 	dir = 6
 	},
-/turf/open/floor/plasteel/sepia,
+/turf/open/floor/mineral/titanium/yellow,
 /area/department_main/command)
 "QP" = (
 /obj/machinery/computer/abnormality_archive,
@@ -5797,10 +5433,6 @@
 	},
 /turf/open/floor/carpet/orange,
 /area/department_main/training)
-"Rm" = (
-/obj/structure/chair/sofa/corp/left,
-/turf/open/floor/plasteel,
-/area/facility_hallway/south)
 "Rp" = (
 /obj/effect/spawner/randomcolavend,
 /turf/open/floor/facility/dark,
@@ -5886,15 +5518,6 @@
 	color = "a1a1a1"
 	},
 /area/facility_hallway/command)
-"RQ" = (
-/obj/effect/turf_decal/stripes/full,
-/obj/machinery/door/poddoor{
-	id = "facilitylockdown";
-	name = "Facility Lockdown Blast Door"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/dark,
-/area/facility_hallway/south)
 "RS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/broken,
@@ -6185,10 +5808,6 @@
 	},
 /turf/open/floor/carpet/stellar,
 /area/department_main/command)
-"TA" = (
-/obj/effect/turf_decal/arrows,
-/turf/open/floor/plasteel,
-/area/facility_hallway/south)
 "TC" = (
 /obj/effect/turf_decal/plaque{
 	alpha = 230;
@@ -6226,32 +5845,6 @@
 	},
 /turf/open/floor/carpet/stellar,
 /area/department_main/command)
-"TI" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/effect/turf_decal/delivery/red,
-/obj/machinery/computer/shuttle/mining{
-	dir = 8;
-	name = "elevator console";
-	possible_destinations = "elevator_home;elevator_away";
-	shuttleId = "manager"
-	},
-/obj/machinery/light/cold/no_nightlight{
-	brightness = 16;
-	dir = 4
-	},
-/obj/machinery/camera/autoname{
-	dir = 9
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "managerlockdown";
-	name = "Manager's Office Lockdown Blast Door"
-	},
-/turf/open/floor/facility/white{
-	color = "a1a1a1"
-	},
-/area/facility_hallway/manager)
 "TJ" = (
 /obj/machinery/telecomms/relay/preset/station,
 /turf/open/floor/circuit/telecomms/mainframe,
@@ -6347,20 +5940,8 @@
 	},
 /turf/open/floor/plating,
 /area/facility_hallway/safety)
-"Ul" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/facility_hallway/south)
 "Um" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /turf/open/floor/plasteel,
 /area/facility_hallway/information)
 "Un" = (
@@ -6377,12 +5958,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/facility/dark,
 /area/department_main/training)
-"Up" = (
-/obj/machinery/vending/cigarette,
-/turf/open/floor/facility/white{
-	color = "a1a1a1"
-	},
-/area/facility_hallway/south)
 "Ur" = (
 /obj/machinery/computer/cryopod,
 /turf/closed/indestructible/reinforced,
@@ -6402,12 +5977,6 @@
 	color = "a1a1a1"
 	},
 /area/facility_hallway/central)
-"UB" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/facility_hallway/south)
 "UI" = (
 /obj/effect/turf_decal,
 /obj/effect/turf_decal/caution{
@@ -6680,12 +6249,6 @@
 /obj/structure/sign/departments/info,
 /turf/closed/indestructible/reinforced,
 /area/department_main/information)
-"Wv" = (
-/obj/effect/spawner/randomsnackvend,
-/turf/open/floor/facility/white{
-	color = "a1a1a1"
-	},
-/area/facility_hallway/south)
 "Wy" = (
 /obj/structure/sign/poster/ripped{
 	pixel_y = -32
@@ -6888,10 +6451,6 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/facility_hallway/control)
-"XZ" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /area/facility_hallway/control)
 "Ya" = (
 /obj/effect/spawner/randomcolavend,
@@ -36919,16 +36478,16 @@ if
 if
 if
 if
-ow
-ow
-ow
-ow
-ow
-ow
-ow
-ow
-ow
-ow
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
 if
 if
 if
@@ -37176,16 +36735,16 @@ if
 if
 if
 if
-ow
-hY
-hY
-hY
-hY
-hY
-hY
-hY
-hY
-ow
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
 if
 if
 if
@@ -37433,16 +36992,16 @@ if
 if
 if
 if
-ow
-hY
-hY
-hY
-hY
-hY
-hY
-hY
-hY
-ow
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
 if
 if
 if
@@ -37690,16 +37249,16 @@ if
 if
 if
 if
-ow
-hY
-hY
-hY
-hY
-hY
-hY
-hY
-hY
-ow
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
 if
 if
 if
@@ -37947,16 +37506,16 @@ if
 if
 if
 if
-ow
-hY
-hY
-hY
-hY
-hY
-hY
-hY
-hY
-ow
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
 if
 if
 if
@@ -38199,21 +37758,21 @@ if
 if
 if
 if
-ow
-ow
-ow
-ow
-ow
-ow
-hY
-hY
-hY
-hY
-hY
-hY
-hY
-hY
-ow
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
 if
 if
 if
@@ -38455,22 +38014,22 @@ if
 if
 if
 if
-HY
-ow
-JP
-HT
-Wv
-ow
-ow
-hY
-hY
-hY
-hY
-hY
-hY
-hY
-hY
-ow
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
 if
 if
 if
@@ -38683,7 +38242,7 @@ pz
 PV
 kI
 PV
-Gt
+bZ
 Sf
 OI
 ST
@@ -38712,22 +38271,22 @@ if
 if
 if
 if
-ow
-Pf
-LI
-vI
-TA
-oX
-hY
-hY
-hY
-hY
-hY
-hY
-hY
-hY
-hY
-ow
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
 if
 if
 if
@@ -38969,22 +38528,22 @@ if
 if
 if
 if
-ow
-uY
-vI
-gV
-TA
-Ir
-hY
-hY
-hY
-hY
-hY
-hY
-hY
-hY
-hY
-ow
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
 if
 if
 if
@@ -39226,22 +38785,22 @@ if
 if
 if
 if
-ow
-si
-vI
-Rm
-TA
-Ir
-hY
-hY
-hY
-hY
-hY
-hY
-hY
-hY
-hY
-ow
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
 if
 if
 if
@@ -39364,12 +38923,12 @@ if
 if
 if
 qn
-BO
-BO
-BO
-BO
-BO
-oU
+qn
+qn
+qn
+qn
+qn
+qn
 qn
 ea
 ea
@@ -39476,29 +39035,29 @@ lw
 EW
 nh
 wy
-wy
-wy
-wy
-wy
-ow
-ow
-ow
-ow
-Cl
-UB
-vI
-TA
-Ir
-hY
-hY
-hY
-hY
-hY
-hY
-hY
-hY
-hY
-ow
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
 if
 if
 if
@@ -39621,18 +39180,18 @@ if
 if
 if
 qn
-BO
-BO
-BO
-BO
-BO
-iN
 qn
-YK
-eG
-pB
-pB
-pB
+qn
+qn
+qn
+qn
+qn
+qn
+eA
+eA
+eA
+eA
+HP
 yw
 pl
 Xy
@@ -39730,32 +39289,32 @@ Ds
 Mt
 cr
 zr
-dM
-iq
+tO
 EN
-EN
-ub
-fl
-MZ
-Ly
-nz
-Qy
-Hd
-Cl
-zf
-EC
-TA
-Ir
-hY
-hY
-hY
-hY
-hY
-hY
-hY
-hY
-hY
-ow
+yg
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
 if
 if
 if
@@ -39878,18 +39437,18 @@ if
 if
 if
 qn
-BO
-BO
-BO
-BO
-BO
-kW
-JR
-EI
-EI
-is
-XZ
-XZ
+qn
+qn
+qn
+qn
+qn
+qn
+qn
+eA
+eA
+eA
+eA
+HP
 EI
 ta
 MS
@@ -39989,30 +39548,30 @@ dF
 RZ
 Mm
 Um
-ma
-Am
-Am
-bS
-Am
-dn
-bY
-cc
-RQ
-yE
-vI
-vI
-TA
-Ir
-hY
-dU
-hY
-hY
-hY
-hY
-hY
-hY
-hY
-ow
+yg
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
 if
 if
 if
@@ -40135,18 +39694,18 @@ if
 if
 if
 qn
-BO
-BO
-BO
-BO
-BO
-iN
 qn
-BZ
-pB
-yw
-yw
-pB
+qn
+qn
+qn
+qn
+qn
+qn
+eA
+eA
+eA
+eA
+HP
 pB
 pl
 hp
@@ -40246,30 +39805,30 @@ BB
 qb
 tO
 fl
-fl
-fl
-fl
-EN
-Qb
-Ly
-Ul
-Jm
-Hd
-Cl
-rh
-vI
-TA
-Ir
-hY
-hY
-hY
-hY
-hY
-hY
-hY
-hY
-hY
-ow
+wy
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
 if
 if
 if
@@ -40392,12 +39951,12 @@ if
 if
 if
 qn
-BO
-BO
-BO
-BO
-BO
-TI
+qn
+qn
+qn
+qn
+qn
+qn
 qn
 ea
 ea
@@ -40504,29 +40063,29 @@ HR
 EW
 VN
 wy
-wy
-wy
-wy
-wy
-ow
-ow
-ow
-ow
-Cl
-UB
-vI
-TA
-Ir
-hY
-hY
-hY
-hY
-hY
-hY
-hY
-hY
-hY
-ow
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
 if
 if
 if
@@ -40768,22 +40327,22 @@ if
 if
 if
 if
-ow
-uY
-vI
-gV
-TA
-Ir
-hY
-hY
-hY
-hY
-hY
-hY
-hY
-hY
-hY
-ow
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
 if
 if
 if
@@ -41025,22 +40584,22 @@ if
 if
 if
 if
-ow
-si
-fk
-Rm
-TA
-Ir
-hY
-hY
-hY
-hY
-hY
-hY
-hY
-hY
-hY
-ow
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
 if
 if
 if
@@ -41282,22 +40841,22 @@ if
 if
 if
 if
-ow
-BS
-vI
-vI
-TA
-zy
-hY
-hY
-hY
-hY
-hY
-hY
-hY
-hY
-hY
-ow
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
 if
 if
 if
@@ -41539,22 +41098,22 @@ if
 if
 if
 if
-ow
-ow
-bz
-Dv
-Up
-ow
-ow
-hY
-hY
-hY
-hY
-hY
-hY
-hY
-hY
-ow
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
 if
 if
 if
@@ -41797,21 +41356,21 @@ if
 if
 if
 if
-ow
-ow
-ow
-ow
-ow
-ow
-hY
-hY
-hY
-hY
-hY
-hY
-hY
-hY
-ow
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
 if
 if
 if
@@ -42059,16 +41618,16 @@ if
 if
 if
 if
-ow
-hY
-hY
-hY
-hY
-hY
-hY
-hY
-hY
-ow
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
 if
 if
 if
@@ -42316,16 +41875,16 @@ if
 if
 if
 if
-ow
-hY
-hY
-hY
-hY
-hY
-hY
-hY
-hY
-ow
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
 if
 if
 if
@@ -42573,16 +42132,16 @@ if
 if
 if
 if
-ow
-hY
-hY
-hY
-hY
-hY
-hY
-hY
-hY
-ow
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
 if
 if
 if
@@ -42830,16 +42389,16 @@ if
 if
 if
 if
-ow
-hY
-hY
-hY
-hY
-hY
-hY
-hY
-hY
-ow
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
 if
 if
 if
@@ -43087,16 +42646,16 @@ if
 if
 if
 if
-ow
-hY
-hY
-hY
-hY
-hY
-hY
-hY
-hY
-ow
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
 if
 if
 if
@@ -43344,16 +42903,16 @@ if
 if
 if
 if
-ow
-hY
-hY
-hY
-hY
-hY
-hY
-hY
-hY
-ow
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
 if
 if
 if
@@ -43601,16 +43160,16 @@ if
 if
 if
 if
-ow
-hY
-hY
-hY
-hY
-hY
-hY
-hY
-hY
-ow
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
 if
 if
 if
@@ -43858,16 +43417,16 @@ if
 if
 if
 if
-ow
-ow
-ow
-ow
-ow
-ow
-ow
-ow
-ow
-ow
+if
+if
+if
+if
+if
+if
+if
+if
+if
+if
 if
 if
 if

--- a/_maps/map_files/Xi/xicorp.dmm
+++ b/_maps/map_files/Xi/xicorp.dmm
@@ -66,8 +66,8 @@
 	dir = 9
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /turf/open/floor/carpet/stellar,
 /area/department_main/command)
@@ -168,8 +168,8 @@
 /obj/structure/bed,
 /obj/item/bedsheet/cmo,
 /obj/effect/turf_decal/siding/green/corner{
-	dir = 8;
-	color = "#006400"
+	color = "#006400";
+	dir = 8
 	},
 /turf/open/floor/carpet/green,
 /area/department_main/safety)
@@ -401,8 +401,8 @@
 	dir = 1
 	},
 /obj/effect/turf_decal{
-	dir = 3;
-	color = "#FF0000"
+	color = "#FF0000";
+	dir = 3
 	},
 /turf/open/floor/facility/white,
 /area/department_main/control)
@@ -452,8 +452,8 @@
 /area/department_main/command)
 "df" = (
 /obj/effect/turf_decal/siding/green{
-	dir = 6;
-	color = "#006400"
+	color = "#006400";
+	dir = 6
 	},
 /obj/effect/turf_decal/siding/green/corner{
 	color = "#006400"
@@ -661,8 +661,8 @@
 	dir = 8
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /turf/open/floor/facility/white{
 	color = "a1a1a1"
@@ -688,8 +688,8 @@
 /area/department_main/information)
 "eY" = (
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /turf/open/floor/wood,
 /area/department_main/command)
@@ -737,8 +737,8 @@
 "fw" = (
 /obj/machinery/regenerator,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /turf/open/floor/facility/dark,
 /area/department_main/control)
@@ -747,8 +747,8 @@
 	pixel_x = -32
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -769,8 +769,8 @@
 	dir = 8
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /obj/machinery/camera/autoname{
 	dir = 8
@@ -787,8 +787,8 @@
 "fD" = (
 /obj/machinery/cryopod,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /turf/open/floor/facility/dark,
 /area/facility_hallway/central)
@@ -908,8 +908,8 @@
 "gG" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /turf/open/floor/facility/white{
 	color = "a1a1a1"
@@ -918,8 +918,8 @@
 "gH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -948,8 +948,8 @@
 "gN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /turf/open/floor/facility/white{
 	color = "a1a1a1"
@@ -958,8 +958,8 @@
 "gQ" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
 /obj/effect/turf_decal/siding/green{
-	dir = 10;
-	color = "#006400"
+	color = "#006400";
+	dir = 10
 	},
 /obj/machinery/light/cold/no_nightlight{
 	brightness = 16
@@ -1097,8 +1097,8 @@
 	},
 /obj/effect/turf_decal/siding/red/corner,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /turf/open/floor/holofloor/carpet,
 /area/department_main/control)
@@ -1120,8 +1120,8 @@
 /area/facility_hallway/south)
 "ia" = (
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -1170,8 +1170,8 @@
 	dir = 4
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /turf/open/floor/carpet/stellar,
 /area/department_main/command)
@@ -1210,8 +1210,8 @@
 /area/facility_hallway/information)
 "iI" = (
 /obj/effect/turf_decal/siding/green/corner{
-	dir = 4;
-	color = "#006400"
+	color = "#006400";
+	dir = 4
 	},
 /turf/open/floor/carpet/green,
 /area/department_main/safety)
@@ -1239,8 +1239,8 @@
 	dir = 5
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /turf/open/floor/carpet/stellar,
 /area/department_main/command)
@@ -1268,8 +1268,8 @@
 	dir = 9
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /turf/open/floor/carpet/red,
 /area/department_main/control)
@@ -1278,8 +1278,8 @@
 	dir = 8
 	},
 /obj/effect/turf_decal{
-	dir = 4;
-	color = "#FF0000"
+	color = "#FF0000";
+	dir = 4
 	},
 /turf/open/floor/facility/white,
 /area/department_main/control)
@@ -1302,8 +1302,8 @@
 	dir = 1
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /turf/open/floor/facility/dark,
 /area/facility_hallway/central)
@@ -1346,8 +1346,8 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/siding/green{
-	dir = 1;
-	color = "#006400"
+	color = "#006400";
+	dir = 1
 	},
 /turf/open/floor/carpet/green,
 /area/department_main/safety)
@@ -1371,8 +1371,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/vending/lobotomyarmband,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /turf/open/floor/facility/white{
 	color = "a1a1a1"
@@ -1394,8 +1394,8 @@
 	dir = 1
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /turf/open/floor/facility/white{
 	color = "a1a1a1"
@@ -1428,8 +1428,8 @@
 "jW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /turf/open/floor/facility/white{
 	color = "a1a1a1"
@@ -1457,8 +1457,8 @@
 /area/department_main/information)
 "ke" = (
 /obj/effect/turf_decal/siding/green{
-	dir = 1;
-	color = "#006400"
+	color = "#006400";
+	dir = 1
 	},
 /turf/open/floor/carpet/green,
 /area/department_main/safety)
@@ -1526,8 +1526,8 @@
 	dir = 1
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /turf/open/floor/holofloor/carpet,
 /area/department_main/control)
@@ -1667,8 +1667,8 @@
 "lM" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /turf/open/floor/facility/dark,
 /area/facility_hallway/command)
@@ -1696,8 +1696,8 @@
 "lZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -1714,8 +1714,8 @@
 "mb" = (
 /obj/effect/turf_decal/delivery/red,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /turf/open/floor/facility/white{
 	color = "a1a1a1"
@@ -1725,8 +1725,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /turf/open/floor/facility/white{
 	color = "a1a1a1"
@@ -1734,8 +1734,8 @@
 /area/facility_hallway/information)
 "mf" = (
 /obj/effect/turf_decal{
-	dir = 1;
-	color = "#FF0000"
+	color = "#FF0000";
+	dir = 1
 	},
 /obj/effect/turf_decal/caution/red,
 /obj/machinery/camera/autoname{
@@ -1792,8 +1792,8 @@
 	dir = 8
 	},
 /obj/effect/turf_decal{
-	dir = 4;
-	color = "#FF0000"
+	color = "#FF0000";
+	dir = 4
 	},
 /obj/machinery/camera/autoname,
 /turf/open/floor/facility/white,
@@ -1836,8 +1836,8 @@
 "mQ" = (
 /obj/machinery/fat_sucker,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /turf/open/floor/facility/white,
 /area/department_main/safety)
@@ -1898,8 +1898,8 @@
 /area/facility_hallway/control)
 "nx" = (
 /obj/effect/turf_decal/siding/green{
-	dir = 8;
-	color = "#006400"
+	color = "#006400";
+	dir = 8
 	},
 /turf/open/floor/carpet/green,
 /area/department_main/safety)
@@ -1941,8 +1941,8 @@
 /area/department_main/training)
 "nK" = (
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /turf/open/floor/facility/white{
 	color = "a1a1a1"
@@ -1981,8 +1981,8 @@
 /area/facility_hallway/command)
 "od" = (
 /obj/effect/turf_decal/siding/green/corner{
-	dir = 8;
-	color = "#006400"
+	color = "#006400";
+	dir = 8
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/department_main/safety)
@@ -2025,8 +2025,8 @@
 /area/department_main/training)
 "oB" = (
 /obj/effect/turf_decal{
-	dir = 1;
-	color = "#FF0000"
+	color = "#FF0000";
+	dir = 1
 	},
 /obj/effect/turf_decal/caution/red,
 /obj/machinery/conveyor_switch/oneway{
@@ -2040,15 +2040,15 @@
 	},
 /obj/effect/turf_decal/arrows/red,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /turf/open/floor/facility/white,
 /area/facility_hallway/command)
 "oJ" = (
 /obj/effect/turf_decal/siding/green{
-	dir = 6;
-	color = "#006400"
+	color = "#006400";
+	dir = 6
 	},
 /turf/open/floor/carpet/green,
 /area/department_main/safety)
@@ -2086,8 +2086,8 @@
 "oQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /obj/machinery/camera/autoname,
 /turf/open/floor/facility/white{
@@ -2104,8 +2104,8 @@
 	},
 /obj/effect/turf_decal/delivery/red,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /obj/machinery/door/poddoor/preopen{
 	id = "managerlockdown";
@@ -2171,12 +2171,12 @@
 /area/facility_hallway/control)
 "pq" = (
 /obj/effect/turf_decal/siding/green{
-	dir = 5;
-	color = "#006400"
+	color = "#006400";
+	dir = 5
 	},
 /obj/effect/turf_decal/siding/green/corner{
-	dir = 4;
-	color = "#006400"
+	color = "#006400";
+	dir = 4
 	},
 /turf/open/floor/carpet/green,
 /area/department_main/safety)
@@ -2230,8 +2230,8 @@
 /area/facility_hallway/information)
 "pV" = (
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -2274,12 +2274,12 @@
 	dir = 9
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /obj/machinery/bookbinder,
 /turf/open/floor/carpet/purple,
@@ -2297,8 +2297,8 @@
 	},
 /obj/structure/railing,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /turf/open/floor/carpet/stellar,
 /area/department_main/command)
@@ -2306,8 +2306,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/plastic,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /turf/open/floor/facility/white{
 	color = "a1a1a1"
@@ -2341,8 +2341,8 @@
 /area/facility_hallway/central)
 "qV" = (
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /turf/open/floor/facility/white{
 	color = "a1a1a1"
@@ -2350,8 +2350,8 @@
 /area/facility_hallway/information)
 "rb" = (
 /obj/effect/turf_decal/siding/green{
-	dir = 5;
-	color = "#006400"
+	color = "#006400";
+	dir = 5
 	},
 /turf/open/floor/carpet/green,
 /area/department_main/safety)
@@ -2422,8 +2422,8 @@
 /area/facility_hallway/safety)
 "rt" = (
 /obj/effect/turf_decal{
-	dir = 1;
-	color = "#FF0000"
+	color = "#FF0000";
+	dir = 1
 	},
 /obj/effect/turf_decal/caution/red,
 /obj/effect/turf_decal/tile/neutral,
@@ -2479,8 +2479,8 @@
 /obj/effect/turf_decal/caution/red,
 /obj/effect/turf_decal/arrows/red,
 /obj/effect/turf_decal{
-	dir = 1;
-	color = "#FF0000"
+	color = "#FF0000";
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/facility_hallway/command)
@@ -2535,8 +2535,8 @@
 /area/facility_hallway/south)
 "so" = (
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -2613,8 +2613,8 @@
 "sV" = (
 /obj/effect/turf_decal/caution/red,
 /obj/effect/turf_decal{
-	dir = 1;
-	color = "#FF0000"
+	color = "#FF0000";
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 1
@@ -2799,8 +2799,8 @@
 "uB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /turf/open/floor/facility/white{
 	color = "a1a1a1"
@@ -2885,8 +2885,8 @@
 	},
 /obj/effect/turf_decal/arrows/red,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /turf/open/floor/facility/white,
 /area/facility_hallway/command)
@@ -2976,8 +2976,8 @@
 	dir = 4
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /obj/machinery/camera/autoname{
 	dir = 4
@@ -3031,8 +3031,8 @@
 "wt" = (
 /obj/machinery/fat_sucker,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /turf/open/floor/facility/white,
 /area/department_main/safety)
@@ -3041,8 +3041,8 @@
 /obj/item/storage/bag/trash/bluespace,
 /obj/effect/turf_decal/bot,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/facility_hallway/command)
@@ -3125,8 +3125,8 @@
 /obj/item/roller,
 /obj/item/roller,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /turf/open/floor/facility/white,
 /area/department_main/safety)
@@ -3179,8 +3179,8 @@
 	brightness = 16
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /obj/effect/turf_decal/siding{
 	color = "#7D6521";
@@ -3253,8 +3253,8 @@
 	icon_state = "LC8"
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /turf/open/floor/facility/white{
 	color = "a1a1a1"
@@ -3285,8 +3285,8 @@
 /area/facility_hallway/training)
 "yi" = (
 /obj/machinery/door/airlock/highsecurity{
-	name = "Training Department";
-	hackProof = 1
+	hackProof = 1;
+	name = "Training Department"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -3528,8 +3528,8 @@
 "Ab" = (
 /obj/effect/turf_decal/delivery/red,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /turf/open/floor/facility/white,
 /area/facility_hallway/command)
@@ -3591,8 +3591,8 @@
 /area/facility_hallway/training)
 "AH" = (
 /obj/effect/turf_decal/siding/green{
-	dir = 4;
-	color = "#006400"
+	color = "#006400";
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -3602,8 +3602,8 @@
 "AL" = (
 /obj/machinery/regenerator/safety,
 /obj/effect/turf_decal/siding/green/corner{
-	dir = 4;
-	color = "#006400"
+	color = "#006400";
+	dir = 4
 	},
 /turf/open/floor/facility/white,
 /area/department_main/safety)
@@ -3619,8 +3619,8 @@
 /area/facility_hallway/control)
 "AU" = (
 /obj/effect/turf_decal/siding/green/corner{
-	dir = 1;
-	color = "#006400"
+	color = "#006400";
+	dir = 1
 	},
 /turf/open/floor/carpet/green,
 /area/department_main/safety)
@@ -3630,8 +3630,8 @@
 	},
 /obj/structure/window/reinforced/spawner/west,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /turf/open/floor/facility/dark,
 /area/facility_hallway/records)
@@ -3751,8 +3751,8 @@
 "BZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /obj/machinery/camera/autoname,
 /turf/open/floor/facility/white{
@@ -3780,8 +3780,8 @@
 "Ch" = (
 /obj/effect/turf_decal/caution/red,
 /obj/effect/turf_decal{
-	dir = 1;
-	color = "#FF0000"
+	color = "#FF0000";
+	dir = 1
 	},
 /obj/effect/turf_decal/arrows/red,
 /turf/open/floor/plasteel/white,
@@ -3931,8 +3931,8 @@
 "CV" = (
 /obj/machinery/cryopod,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /turf/open/floor/facility/white,
 /area/facility_hallway/central)
@@ -4102,12 +4102,12 @@
 /area/facility_hallway/control)
 "Ei" = (
 /obj/effect/turf_decal/siding/green{
-	dir = 9;
-	color = "#006400"
+	color = "#006400";
+	dir = 9
 	},
 /obj/effect/turf_decal/siding/green/corner{
-	dir = 1;
-	color = "#006400"
+	color = "#006400";
+	dir = 1
 	},
 /turf/open/floor/carpet/green,
 /area/department_main/safety)
@@ -4123,8 +4123,8 @@
 "Ep" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /turf/open/floor/facility/white{
 	color = "a1a1a1"
@@ -4161,8 +4161,8 @@
 	max_integrity = 25
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /turf/open/floor/facility/white,
 /area/department_main/safety)
@@ -4192,8 +4192,8 @@
 /area/department_main/information)
 "ES" = (
 /obj/structure/bodycontainer/crematorium{
-	id = "Ncorp1";
-	dir = 8
+	dir = 8;
+	id = "Ncorp1"
 	},
 /obj/machinery/button/crematorium/indestructible{
 	id = "Ncorp1";
@@ -4296,8 +4296,8 @@
 	max_integrity = 25
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /turf/open/floor/facility/white,
 /area/department_main/safety)
@@ -4342,8 +4342,8 @@
 "FZ" = (
 /obj/machinery/vending/coffee,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /turf/open/floor/facility/dark,
 /area/department_main/control)
@@ -4354,8 +4354,8 @@
 "Gb" = (
 /obj/machinery/blackbox_recorder,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /turf/open/floor/facility/dark,
 /area/department_main/information)
@@ -4447,8 +4447,8 @@
 /area/facility_hallway/south)
 "He" = (
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /turf/open/floor/facility/dark,
 /area/department_main/training)
@@ -4471,8 +4471,8 @@
 "Hm" = (
 /obj/structure/railing{
 	dir = 8;
-	name = "invincible railing";
-	max_integrity = 1e+007
+	max_integrity = 1e+007;
+	name = "invincible railing"
 	},
 /turf/open/floor/plasteel/stairs,
 /area/department_main/command)
@@ -4556,8 +4556,8 @@
 	dir = 1
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /turf/open/floor/facility/white,
 /area/facility_hallway/central)
@@ -4615,8 +4615,8 @@
 /area/department_main/training)
 "Il" = (
 /obj/effect/turf_decal/siding/green{
-	dir = 1;
-	color = "#006400"
+	color = "#006400";
+	dir = 1
 	},
 /obj/structure/chair/office/light{
 	dir = 1
@@ -4673,8 +4673,8 @@
 /area/department_main/information)
 "IQ" = (
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /turf/open/floor/wood,
 /area/department_main/command)
@@ -4684,15 +4684,15 @@
 /area/facility_hallway/command)
 "IU" = (
 /obj/effect/turf_decal/siding/green{
-	dir = 10;
-	color = "#006400"
+	color = "#006400";
+	dir = 10
 	},
 /obj/effect/turf_decal/siding/green/corner{
 	color = "#006400"
 	},
 /obj/effect/turf_decal/siding/green/corner{
-	dir = 8;
-	color = "#006400"
+	color = "#006400";
+	dir = 8
 	},
 /turf/open/floor/carpet/green,
 /area/department_main/safety)
@@ -4733,8 +4733,8 @@
 /area/facility_hallway/control)
 "Jc" = (
 /obj/effect/turf_decal/siding/green{
-	dir = 4;
-	color = "#006400"
+	color = "#006400";
+	dir = 4
 	},
 /turf/open/floor/carpet/green,
 /area/department_main/safety)
@@ -4865,8 +4865,8 @@
 	dir = 4
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /turf/open/floor/facility/white{
 	color = "a1a1a1"
@@ -4985,8 +4985,8 @@
 /obj/item/roller,
 /obj/item/roller,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /turf/open/floor/facility/white,
 /area/department_main/safety)
@@ -5097,8 +5097,8 @@
 /area/facility_hallway/information)
 "Mn" = (
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /turf/open/floor/facility/white{
 	color = "a1a1a1"
@@ -5126,8 +5126,8 @@
 /area/facility_hallway/information)
 "MB" = (
 /obj/effect/turf_decal/siding/green{
-	dir = 9;
-	color = "#006400"
+	color = "#006400";
+	dir = 9
 	},
 /turf/open/floor/carpet/green,
 /area/department_main/safety)
@@ -5180,12 +5180,12 @@
 	dir = 5
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /turf/open/floor/carpet/royalblack,
 /area/department_main/information)
@@ -5278,16 +5278,16 @@
 "No" = (
 /obj/machinery/blackbox_recorder,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /obj/machinery/camera/autoname,
 /turf/open/floor/facility/dark,
 /area/department_main/information)
 "Ns" = (
 /obj/effect/turf_decal/siding/green{
-	dir = 8;
-	color = "#006400"
+	color = "#006400";
+	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -5296,8 +5296,8 @@
 /area/department_main/safety)
 "Nw" = (
 /obj/effect/turf_decal/siding/green{
-	dir = 10;
-	color = "#006400"
+	color = "#006400";
+	dir = 10
 	},
 /turf/open/floor/carpet/green,
 /area/department_main/safety)
@@ -5360,8 +5360,8 @@
 	dir = 1
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /turf/open/floor/facility/dark,
 /area/facility_hallway/command)
@@ -5376,8 +5376,8 @@
 "Od" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /turf/open/floor/facility/dark,
 /area/facility_hallway/command)
@@ -5389,8 +5389,8 @@
 /area/facility_hallway/command)
 "Oh" = (
 /obj/effect/turf_decal{
-	dir = 1;
-	color = "#FF0000"
+	color = "#FF0000";
+	dir = 1
 	},
 /obj/effect/turf_decal/caution/red,
 /turf/open/floor/plasteel/white,
@@ -5418,8 +5418,8 @@
 /area/facility_hallway/central)
 "Ot" = (
 /obj/effect/turf_decal/siding/green/corner{
-	dir = 1;
-	color = "#006400"
+	color = "#006400";
+	dir = 1
 	},
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
@@ -5512,8 +5512,8 @@
 /area/facility_hallway/central)
 "PB" = (
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/department_main/training)
@@ -5528,8 +5528,8 @@
 /area/facility_hallway/control)
 "PE" = (
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /obj/machinery/camera/autoname,
 /turf/open/floor/plasteel/dark,
@@ -5579,16 +5579,16 @@
 "PV" = (
 /obj/machinery/blackbox_recorder,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /turf/open/floor/facility/dark,
 /area/department_main/information)
 "PX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /obj/machinery/camera/autoname,
 /turf/open/floor/facility/white{
@@ -5629,8 +5629,8 @@
 "Qu" = (
 /obj/effect/turf_decal/caution/red,
 /obj/effect/turf_decal{
-	dir = 1;
-	color = "#FF0000"
+	color = "#FF0000";
+	dir = 1
 	},
 /turf/open/floor/facility/white,
 /area/department_main/control)
@@ -5684,8 +5684,8 @@
 	pixel_y = 32
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /turf/open/floor/facility/white{
 	color = "a1a1a1"
@@ -5693,8 +5693,8 @@
 /area/facility_hallway/command)
 "QE" = (
 /obj/effect/turf_decal/siding/green{
-	dir = 1;
-	color = "#006400"
+	color = "#006400";
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 1
@@ -5712,8 +5712,8 @@
 /obj/effect/turf_decal/siding/wood/corner,
 /obj/structure/railing,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /turf/open/floor/wood,
 /area/department_main/command)
@@ -5760,8 +5760,8 @@
 "Re" = (
 /obj/effect/spawner/randomsnackvend,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /turf/open/floor/facility/dark,
 /area/department_main/control)
@@ -5826,8 +5826,8 @@
 "Rs" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
 /obj/effect/turf_decal/siding/green{
-	dir = 6;
-	color = "#006400"
+	color = "#006400";
+	dir = 6
 	},
 /obj/machinery/light/cold/no_nightlight{
 	brightness = 16
@@ -5852,8 +5852,8 @@
 /area/department_main/command)
 "RF" = (
 /obj/machinery/door/airlock/highsecurity{
-	name = "Records Office Secure Area";
-	hackProof = 1
+	hackProof = 1;
+	name = "Records Office Secure Area"
 	},
 /turf/open/floor/facility/halls,
 /area/department_main/training)
@@ -5880,8 +5880,8 @@
 "RN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /obj/machinery/camera/autoname,
 /turf/open/floor/facility/white{
@@ -6043,8 +6043,8 @@
 "SS" = (
 /obj/structure/chair/sofa/right,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /turf/open/floor/facility/white{
 	color = "a1a1a1"
@@ -6058,8 +6058,8 @@
 	brightness = 16
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /obj/machinery/bookbinder,
 /turf/open/floor/carpet/purple,
@@ -6192,8 +6192,8 @@
 /area/department_main/training)
 "Tw" = (
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /turf/open/floor/facility/dark,
 /area/department_main/training)
@@ -6256,14 +6256,14 @@
 	},
 /obj/effect/turf_decal/delivery/red,
 /obj/machinery/computer/shuttle/mining{
+	dir = 8;
 	name = "elevator console";
 	possible_destinations = "elevator_home;elevator_away";
-	shuttleId = "manager";
-	dir = 8
+	shuttleId = "manager"
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /obj/machinery/camera/autoname{
 	dir = 9
@@ -6551,8 +6551,8 @@
 "Vu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /turf/open/floor/facility/white{
 	color = "a1a1a1"
@@ -6577,8 +6577,8 @@
 	dir = 8
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /turf/open/floor/holofloor/carpet,
 /area/department_main/control)
@@ -6611,12 +6611,12 @@
 	dir = 8
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /turf/open/floor/holofloor/carpet,
 /area/department_main/control)
@@ -6701,8 +6701,8 @@
 "Wo" = (
 /obj/structure/railing{
 	dir = 4;
-	name = "invincible railing";
-	max_integrity = 1e+007
+	max_integrity = 1e+007;
+	name = "invincible railing"
 	},
 /turf/open/floor/plasteel/stairs,
 /area/department_main/command)
@@ -6797,19 +6797,19 @@
 	dir = 8
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /turf/open/floor/facility/dark,
 /area/facility_hallway/records)
 "Xb" = (
 /obj/structure/bodycontainer/crematorium{
-	id = "Ncorp2";
-	dir = 4
+	dir = 4;
+	id = "Ncorp2"
 	},
 /obj/machinery/button/crematorium/indestructible{
-	pixel_x = -27;
-	id = "Ncorp2"
+	id = "Ncorp2";
+	pixel_x = -27
 	},
 /turf/open/floor/plasteel/dark,
 /area/facility_hallway/command)
@@ -6839,8 +6839,8 @@
 	},
 /obj/structure/railing,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /turf/open/floor/wood,
 /area/department_main/command)
@@ -6955,8 +6955,8 @@
 /obj/machinery/vending/coffee,
 /obj/structure/railing,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /turf/open/floor/carpet/stellar,
 /area/department_main/command)
@@ -6974,8 +6974,8 @@
 	dir = 1
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /obj/machinery/light/cold/no_nightlight{
 	brightness = 16
@@ -7082,8 +7082,8 @@
 	id = "Ncorp1"
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -7096,8 +7096,8 @@
 	dir = 1
 	},
 /obj/machinery/light/cold/no_nightlight{
-	dir = 4;
-	brightness = 16
+	brightness = 16;
+	dir = 4
 	},
 /turf/open/floor/facility/dark,
 /area/facility_hallway/command)
@@ -7144,8 +7144,8 @@
 	},
 /obj/structure/window/reinforced/spawner,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /obj/machinery/camera/autoname,
 /turf/open/floor/facility/dark,
@@ -7175,8 +7175,8 @@
 "ZM" = (
 /obj/effect/turf_decal/delivery/red,
 /obj/machinery/light/cold/no_nightlight{
-	dir = 8;
-	brightness = 16
+	brightness = 16;
+	dir = 8
 	},
 /turf/open/floor/facility/white,
 /area/facility_hallway/command)
@@ -7187,8 +7187,8 @@
 /area/facility_hallway/central)
 "ZR" = (
 /obj/machinery/light/cold/no_nightlight{
-	dir = 1;
-	brightness = 16
+	brightness = 16;
+	dir = 1
 	},
 /turf/open/floor/facility/white{
 	color = "a1a1a1"
@@ -41768,7 +41768,7 @@ XF
 XF
 XF
 XF
-nA
+XF
 XF
 XF
 XF

--- a/_maps/map_files/Xi/xicorp.dmm
+++ b/_maps/map_files/Xi/xicorp.dmm
@@ -2145,13 +2145,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/facility_hallway/training)
-"pe" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/facility/dark,
-/area/facility_hallway/command)
 "pf" = (
 /obj/machinery/vending/lobotomyheadset,
 /turf/open/floor/facility/white{
@@ -2969,21 +2962,6 @@
 	},
 /turf/open/floor/wood,
 /area/department_main/command)
-"vT" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/modular_computer/console,
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/machinery/light/cold/no_nightlight{
-	brightness = 16;
-	dir = 1
-	},
-/obj/machinery/camera/autoname{
-	dir = 4
-	},
-/turf/open/floor/facility/dark,
-/area/facility_hallway/command)
 "vU" = (
 /obj/effect/turf_decal/siding/red{
 	color = "#440000";
@@ -4924,12 +4902,6 @@
 /mob/living/simple_animal/bot/cleanbot,
 /turf/open/floor/plasteel/white,
 /area/facility_hallway/command)
-"KG" = (
-/obj/effect/turf_decal/caution/stand_clear{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/facility_hallway/command)
 "KI" = (
 /obj/effect/turf_decal/siding/purple{
 	dir = 9
@@ -6197,12 +6169,6 @@
 	},
 /turf/open/floor/facility/dark,
 /area/department_main/training)
-"Tx" = (
-/turf/open/floor/plasteel/elevatorshaft{
-	density = 1;
-	name = "Elevatorshaft"
-	},
-/area/facility_hallway/command)
 "Ty" = (
 /obj/structure/musician/piano{
 	icon_state = "piano"
@@ -6407,16 +6373,6 @@
 /obj/machinery/computer/cryopod,
 /turf/closed/indestructible/reinforced,
 /area/facility_hallway/central)
-"Ut" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/light/cold/no_nightlight{
-	brightness = 16
-	},
-/turf/open/floor/facility/dark,
-/area/facility_hallway/command)
 "Ux" = (
 /obj/effect/turf_decal/plaque{
 	alpha = 230;
@@ -42022,13 +41978,13 @@ xx
 if
 if
 if
-xx
-vT
-pe
-KG
-pe
-Ut
-xx
+if
+if
+if
+if
+if
+if
+if
 if
 if
 if
@@ -42279,13 +42235,13 @@ if
 if
 if
 if
-xx
-Tx
-Tx
-Tx
-Tx
-Tx
-xx
+if
+if
+if
+if
+if
+if
+if
 if
 if
 if
@@ -42536,13 +42492,13 @@ if
 if
 if
 if
-xx
-Tx
-Tx
-Tx
-Tx
-Tx
-xx
+if
+if
+if
+if
+if
+if
+if
 if
 if
 if
@@ -42793,13 +42749,13 @@ if
 if
 if
 if
-xx
-Tx
-Tx
-Tx
-Tx
-Tx
-xx
+if
+if
+if
+if
+if
+if
+if
 if
 if
 if
@@ -43050,13 +43006,13 @@ if
 if
 if
 if
-xx
-Tx
-Tx
-Tx
-Tx
-Tx
-xx
+if
+if
+if
+if
+if
+if
+if
 if
 if
 if
@@ -43307,13 +43263,13 @@ if
 if
 if
 if
-xx
-Tx
-Tx
-Tx
-Tx
-Tx
-xx
+if
+if
+if
+if
+if
+if
+if
 if
 if
 if
@@ -43564,13 +43520,13 @@ if
 if
 if
 if
-xx
-xx
-xx
-xx
-xx
-xx
-xx
+if
+if
+if
+if
+if
+if
+if
 if
 if
 if

--- a/_maps/xicorp.json
+++ b/_maps/xicorp.json
@@ -21,5 +21,5 @@
 		}
 	],
 	"minetype": "none",
-	"maptype": "Wonderlabs"
+	"maptype": "wonderlabs"
 }

--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -273,7 +273,7 @@
 	rest_icon.hud = src
 	static_inventory += rest_icon
 
-	if(!(SSmaptype.maptype in SSmaptype.citymaps))
+	if(!(SSmaptype.maptype in SSmaptype.citymaps) && SSmaptype.maptype != "wonderlabs")
 		internals = new /atom/movable/screen/stats()
 		internals.hud = src
 		infodisplay += internals

--- a/code/controllers/subsystem/lobotomy_corp.dm
+++ b/code/controllers/subsystem/lobotomy_corp.dm
@@ -144,10 +144,6 @@ SUBSYSTEM_DEF(lobotomy_corp)
 		priority_announce("This shift is a 'Blitz' Shift. Cores have been disabled.", \
 						"Core Suppression", sound = 'sound/machines/dun_don_alert.ogg')
 		return
-	if(!(SSmaptype.maptype in SS.maptype.lc13_maps))	//Does not include Wonderlab and maps that are not standard becuase they will cause issues.
-		priority_announce("This shift is incompatible with Core Suppressions.", \
-						"Core Suppression", sound = 'sound/machines/dun_don_alert.ogg')
-		return
 	if(istype(core_suppression))
 		return
 	var/obj/machinery/computer/abnormality_auxiliary/aux_cons = locate() in GLOB.lobotomy_devices

--- a/code/controllers/subsystem/lobotomy_corp.dm
+++ b/code/controllers/subsystem/lobotomy_corp.dm
@@ -144,6 +144,10 @@ SUBSYSTEM_DEF(lobotomy_corp)
 		priority_announce("This shift is a 'Blitz' Shift. Cores have been disabled.", \
 						"Core Suppression", sound = 'sound/machines/dun_don_alert.ogg')
 		return
+	if(!(SSmaptype.maptype in SS.maptype.lc13_maps))	//Does not include Wonderlab and maps that are not standard becuase they will cause issues.
+		priority_announce("This shift is incompatible with Core Suppressions.", \
+						"Core Suppression", sound = 'sound/machines/dun_don_alert.ogg')
+		return
 	if(istype(core_suppression))
 		return
 	var/obj/machinery/computer/abnormality_auxiliary/aux_cons = locate() in GLOB.lobotomy_devices

--- a/code/modules/jobs/job_types/city/workshop.dm
+++ b/code/modules/jobs/job_types/city/workshop.dm
@@ -20,7 +20,7 @@ Workshop employee
 	job_attribute_limit = 0
 
 	allow_bureaucratic_error = FALSE
-	maptype = list("wonderlabs", "fixers")
+	maptype = list("fixers")
 
 
 //My guy you work in a workshop

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -49,6 +49,9 @@
 /mob/living/carbon/human/verb/show_attributes_self()
 	set category = "IC"
 	set name = "View Attributes"
+	if(SSmaptype.maptype == "wonderlabs")
+		show_attributes()
+
 	if(SSmaptype.maptype in SSmaptype.citymaps)
 		to_chat(src, "<span class='notice'>You have no clue what your potential is.</span>")
 		return

--- a/code/modules/mob/living/simple_animal/hostile/ordeal/amber.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/amber.dm
@@ -148,7 +148,10 @@
 
 /mob/living/simple_animal/hostile/ordeal/amber_bug/spawned/Initialize()
 	. = ..()
-	burrow_cooldown = world.time + burrow_cooldown_time
+	if(!(SSmaptype.maptype in SSmaptype.citymaps))
+		burrow_cooldown = world.time + burrow_cooldown_time
+	burrow_cooldown = 10 HOURS	//Dogshit code
+	burrow_cooldown_time = 10 HOURS
 
 /mob/living/simple_animal/hostile/ordeal/amber_bug/spawned/death(gibbed)
 	density = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Moves some minor map elements around to make xicorp playable.
In specifics:

Adds in the second fixer office
Removes the latejoins from the L-Corp facility (I don't want anyone spawning in there
Adds back the old sephirah equivalent rooms for department heads
Removes Clerk botany and clerk kitchen (Fuck 'em)
Makes the map actually compatible with the WL gamemode code-wise
Removes the Workshop fixer and gives east office their own mini workshop
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Changelog
:cl:
fix: fixed up xicorp to actually work with the gamemode as intended
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
