### PR TITLE
Limbus Labs has scrubbed out all invisible ink from their uniforms and added a Enkephalin supply to their chemistry dispensers

### DIFF
--- a/_maps/map_files/Event/laboratory.dmm
+++ b/_maps/map_files/Event/laboratory.dmm
@@ -37,7 +37,7 @@
 /obj/structure/chair/comfy/teal{
 	dir = 4;
 	pixel_y = 15;
-	pixel_x = -5;
+	pixel_x = -5
 	},
 /obj/structure/table/wood{
 	alpha = 0;
@@ -4032,7 +4032,7 @@
 /obj/machinery/chem_dispenser/fullupgrade{
 	pixel_y = 14;
 	emagged_reagents = list();
-	dispensable_reagents = list(/datum/reagent/aluminium,/datum/reagent/bromine,/datum/reagent/carbon,/datum/reagent/chlorine,/datum/reagent/copper,/datum/reagent/consumable/ethanol,/datum/reagent/fluorine,/datum/reagent/hydrogen,/datum/reagent/iodine,/datum/reagent/iron,/datum/reagent/lithium,/datum/reagent/mercury,/datum/reagent/nitrogen,/datum/reagent/oxygen,/datum/reagent/phosphorus,/datum/reagent/potassium,/datum/reagent/uranium/radium,/datum/reagent/silicon,/datum/reagent/sodium,/datum/reagent/silver,/datum/reagent/stable_plasma,/datum/reagent/consumable/sugar,/datum/reagent/sulfur,/datum/reagent/toxin/acid,/datum/reagent/water,/datum/reagent/fuel)
+	dispensable_reagents = list(/datum/reagent/aluminium,/datum/reagent/bromine,/datum/reagent/carbon,/datum/reagent/chlorine,/datum/reagent/copper,/datum/reagent/consumable/ethanol,/datum/reagent/fluorine,/datum/reagent/hydrogen,/datum/reagent/iodine,/datum/reagent/iron,/datum/reagent/lithium,/datum/reagent/mercury,/datum/reagent/nitrogen,/datum/reagent/oxygen,/datum/reagent/phosphorus,/datum/reagent/potassium,/datum/reagent/uranium/radium,/datum/reagent/silicon,/datum/reagent/sodium,/datum/reagent/silver,/datum/reagent/stable_plasma,/datum/reagent/consumable/sugar,/datum/reagent/sulfur,/datum/reagent/toxin/acid,/datum/reagent/water,/datum/reagent/fuel,/datum/reagent/drug/enkephalin)
 	},
 /turf/open/floor/noslip,
 /area/centcom)

--- a/code/modules/clothing/under/limbus_suits.dm
+++ b/code/modules/clothing/under/limbus_suits.dm
@@ -28,22 +28,25 @@
 	desc = "For prisoners, but fancy."
 
 //Limbus Labs stuff
-/obj/item/clothing/under/limbus/lowsec
+/obj/item/clothing/under/limbus/labs
+	icon = 'icons/mob/clothing/ego_gear/under.dmi'
+
+/obj/item/clothing/under/limbus/labs/lowsec
 	name = "Low-security uniform"
 	icon_state = "lowsec"
 	desc = "Always worn by Low-sec officers. Smells of sweat and sugar."
 
-/obj/item/clothing/under/limbus/highsec
+/obj/item/clothing/under/limbus/labs/highsec
 	name = "High-security uniform"
 	icon_state = "highsec"
 	desc = "Always worn by High security officers."
 
-/obj/item/clothing/under/limbus/commandsec
+/obj/item/clothing/under/limbus/labs/commandsec
 	name = "Command Security uniform"
 	icon_state = "commandsec"
 	desc = "Worn by damage mitigation and exasperation officers. Well-cleaned, and smells faintly of perfume."
 
-/obj/item/clothing/under/limbus/officer
+/obj/item/clothing/under/limbus/labs/officer
 	name = "limbus officer uniform"
 	icon_state = "officer"
 	desc = "Worn by low security and high security commanders."

--- a/code/modules/jobs/job_types/labs/command/commandsec.dm
+++ b/code/modules/jobs/job_types/labs/command/commandsec.dm
@@ -43,7 +43,7 @@
 	belt = /obj/item/pda/security
 	ears = /obj/item/radio/headset/agent_lieutenant
 	glasses = /obj/item/clothing/glasses/sunglasses
-	uniform = /obj/item/clothing/under/limbus/commandsec
+	uniform = /obj/item/clothing/under/limbus/labs/commandsec
 	suit = /obj/item/clothing/suit/armor/ego_gear/limbus_labs/jacket
 	backpack_contents = list(/obj/item/melee/classic_baton=1)
 	shoes = /obj/item/clothing/shoes/laceup
@@ -97,7 +97,7 @@
 	belt = /obj/item/pda/security
 	ears = /obj/item/radio/headset/agent_lieutenant
 	glasses = /obj/item/clothing/glasses/sunglasses
-	uniform = /obj/item/clothing/under/limbus/commandsec
+	uniform = /obj/item/clothing/under/limbus/labs/commandsec
 	suit = /obj/item/clothing/suit/armor/ego_gear/limbus_labs/jacket
 	backpack_contents = list(/obj/item/melee/classic_baton=1)
 	shoes = /obj/item/clothing/shoes/laceup
@@ -151,7 +151,7 @@
 	belt = /obj/item/pda/security
 	ears = /obj/item/radio/headset/agent_lieutenant
 	glasses = /obj/item/clothing/glasses/sunglasses
-	uniform = /obj/item/clothing/under/limbus/commandsec
+	uniform = /obj/item/clothing/under/limbus/labs/commandsec
 	suit = /obj/item/clothing/suit/armor/ego_gear/limbus_labs/jacket
 	backpack_contents = list(/obj/item/melee/classic_baton=1)
 	shoes = /obj/item/clothing/shoes/laceup

--- a/code/modules/jobs/job_types/labs/security/highsec.dm
+++ b/code/modules/jobs/job_types/labs/security/highsec.dm
@@ -44,7 +44,7 @@
 	belt = /obj/item/pda/security
 	ears = /obj/item/radio/headset/headset_discipline
 	glasses = /obj/item/clothing/glasses/sunglasses
-	uniform = /obj/item/clothing/under/limbus/highsec
+	uniform = /obj/item/clothing/under/limbus/labs/highsec
 	shoes = /obj/item/clothing/shoes/jackboots
 	gloves = /obj/item/clothing/gloves/color/black
 	implants = list(/obj/item/organ/cyberimp/eyes/hud/security)
@@ -93,7 +93,7 @@
 	belt = /obj/item/pda/security
 	ears = /obj/item/radio/headset/heads/headset_discipline
 	glasses = /obj/item/clothing/glasses/sunglasses
-	uniform = /obj/item/clothing/under/limbus/officer
+	uniform = /obj/item/clothing/under/limbus/labs/officer
 	suit = /obj/item/clothing/suit/armor/ego_gear/limbus_labs/hsc
 	head = /obj/item/clothing/head/beret/sec/lccb_commander
 	shoes = /obj/item/clothing/shoes/jackboots

--- a/code/modules/jobs/job_types/labs/security/lowsec.dm
+++ b/code/modules/jobs/job_types/labs/security/lowsec.dm
@@ -43,7 +43,7 @@
 	belt = /obj/item/pda/security
 	ears = /obj/item/radio/headset/headset_control
 	glasses = /obj/item/clothing/glasses/sunglasses
-	uniform = /obj/item/clothing/under/limbus/lowsec
+	uniform = /obj/item/clothing/under/limbus/labs/lowsec
 	shoes = /obj/item/clothing/shoes/laceup
 	gloves = /obj/item/clothing/gloves/color/black
 	implants = list(/obj/item/organ/cyberimp/eyes/hud/security)
@@ -94,7 +94,7 @@
 	belt = /obj/item/pda/security
 	ears = /obj/item/radio/headset/heads/headset_control
 	glasses = /obj/item/clothing/glasses/sunglasses
-	uniform = /obj/item/clothing/under/limbus/officer
+	uniform = /obj/item/clothing/under/limbus/labs/officer
 	suit = /obj/item/clothing/suit/armor/ego_gear/limbus_labs/lsc
 	head = /obj/item/clothing/head/beret/sec/lccb_commander
 	shoes = /obj/item/clothing/shoes/laceup


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Gives the obj sprite for Limbus labs uniforms the worn sprite and var edits Enkephalin into the limbus labs chem dispenser
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bugfixing, also I guess its good to be able to see your uniforms and do chemistry
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixed invisible uniforms
fix: fixed chem dispenser lacking enkephalin
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
