### PR TITLE
Nobody Is Improvements/Nothing there fixes

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/aleph/nobody_is.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/nobody_is.dm
@@ -56,7 +56,6 @@
 
 	//Contained Variables
 	var/reflect_timer
-	var/mob/living/disguise = null
 	var/shelled = FALSE
 	var/mob/living/carbon/human/chosen = null
 	var/can_act = TRUE
@@ -189,12 +188,12 @@
 		HD.update_limb()
 		chosen.hairstyle = oldhair
 		chosen.facial_hairstyle = oldbeard
-	HD.update_limb()
 	headicon = new(get_turf(src))
 	headicon.add_overlay(HD.get_limb_icon(TRUE,TRUE))
 	headicon.pixel_y -= 5
 	headicon.alpha = 150
 	headicon.desc = "It looks like [chosen] is reflected in the mirror."
+	HD.update_limb()
 	//Handles connected structure part
 	datum_reference.connected_structures = list(headicon = list(0,-5))
 
@@ -232,7 +231,7 @@
 	datum_reference.qliphoth_change(-1)
 
 /mob/living/simple_animal/hostile/abnormality/nobody_is/BreachEffect(mob/living/carbon/human/user, breach_type)
-	if(current_stage > 1)
+	if(!(status_flags & GODMODE) && breach_type != BREACH_MINING) // Already breaching
 		return
 	if(reflect_timer)
 		deltimer(reflect_timer)
@@ -241,7 +240,7 @@
 		return
 	CheckMirrorIcon() //Clear overlays
 	next_stage()
-	if(breach_type == BREACH_MINING)
+	if(breach_type == BREACH_MINING) // Keeps it from teleporting off when uncovered
 		return
 	// Teleport us somewhere where nobody will see us at first
 	var/list/priority_list = list()
@@ -373,29 +372,31 @@
 		Oberon_Fusion(T)
 
 /mob/living/simple_animal/hostile/abnormality/nobody_is/proc/Oberon_Fusion(mob/living/simple_animal/hostile/abnormality/titania/T)
-		abno_host = T
-		T.pass_flags = PASSTABLE | PASSMOB
-		T.is_flying_animal = FALSE
-		T.density = FALSE
-		T.forceMove(src)
-		T.fairy_spawn_time = 10 SECONDS
-		T.melee_damage_lower = 0
-		T.melee_damage_upper = 0
-		can_act = TRUE
-		fairy_aura = new/obj/effect/titania_aura(get_turf(src))
-		cut_overlay(icon('icons/effects/effects.dmi', "nobody_overlay_face", GLASSES_LAYER))
-		add_overlay(mutable_appearance('icons/effects/effects.dmi', "nobody_overlay_face_oberon", GLASSES_LAYER))
-		ChangeResistances(list(BRUIT = 1, RED_DAMAGE = 0.6, WHITE_DAMAGE = 0.3, BLACK_DAMAGE = 0, PALE_DAMAGE = 0.5))
-		heal_percent_per_second = 0.00425//half of what it was when it had just 5k hp
-		maxHealth = 10000
-		adjustBruteLoss(-maxHealth, forced = TRUE) // It's not over yet!.
-		melee_damage_lower = 45
-		melee_damage_upper = 65
-		grab_damage = 140
-		strangle_damage = 35
-		whip_damage = 15
-		whip_count = 6
-		loot = list(
+	abno_host = T
+	T.pass_flags = PASSTABLE | PASSMOB
+	T.is_flying_animal = FALSE
+	T.density = FALSE
+	T.forceMove(src)
+	T.fairy_spawn_time = 10 SECONDS
+	T.melee_damage_lower = 0
+	T.melee_damage_upper = 0
+	can_act = TRUE
+	fairy_aura = new/obj/effect/titania_aura(get_turf(src))
+	cut_overlay(icon('icons/effects/effects.dmi', "nobody_overlay_face", GLASSES_LAYER))
+	add_overlay(mutable_appearance('icons/effects/effects.dmi', "nobody_overlay_face_oberon", GLASSES_LAYER))
+	ChangeResistances(list(BRUIT = 1, RED_DAMAGE = 0.6, WHITE_DAMAGE = 0.3, BLACK_DAMAGE = 0, PALE_DAMAGE = 0.5))
+	heal_percent_per_second = 0.00425//half of what it was when it had just 5k hp
+	maxHealth = 10000
+	adjustBruteLoss(-maxHealth, forced = TRUE) // It's not over yet!.
+	melee_damage_lower = 45
+	melee_damage_upper = 65
+	grab_damage = 140
+	strangle_damage = 35
+	whip_damage = 15
+	whip_count = 6
+	name = "Oberon"
+	desc = "Two horrifying and dangerous abnormalities fused into one. This can only end well."
+	loot = list(
 		/obj/item/ego_weapon/oberon
 		)
 
@@ -570,13 +571,13 @@
 		if(3)
 			playsound(get_turf(src), 'sound/effects/wounds/crack2.ogg', 200, 0, 7)
 			to_chat(grab_victim, span_userdanger("[src]'s grip on you is tightening!"))
-		if(4)	//Apply double damage
+		if(4) //Apply double damage
 			playsound(get_turf(src), 'sound/effects/wounds/crackandbleed.ogg', 200, 0, 7)
 			to_chat(grab_victim, span_userdanger("It hurts so much!"))
 			grab_victim.deal_damage(strangle_damage, BLACK_DAMAGE)
-		else	//Apply ramping damage
+		else //Apply ramping damage
 			playsound(get_turf(src), 'sound/effects/wounds/crackandbleed.ogg', 200, 0, 7)
-			grab_victim.deal_damage((strangle_damage * (3 - count)), BLACK_DAMAGE)
+			grab_victim.deal_damage((strangle_damage * (count - 3)), BLACK_DAMAGE)
 	count += 1
 	if(grab_victim.sanity_lost) //This should prevent weird things like panics running away halfway through
 		grab_victim.Stun(10) //Immobilize does not stop AI controllers from moving, for some reason.
@@ -643,6 +644,8 @@
 	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/nobody_is/patrol_select() //Hunt down the chosen one
+	if(shelled) // We don't need a chosen anymore, or any special pathfinding behavior
+		return ..()
 	if(chosen) //YOU'RE MINE
 		SEND_SIGNAL(src, COMSIG_PATROL_START, src, get_turf(chosen)) //Overrides the usual proc to target a specific tile
 		SEND_GLOBAL_SIGNAL(src, COMSIG_GLOB_PATROL_START, src, get_turf(chosen))
@@ -675,7 +678,6 @@
 		return //We screwed up or the player successfully committed self-delete. Try again next time!
 	SetOccupiedTiles()
 	offsets_pixel_x = list("south" = 0, "north" = 0, "west" = 0, "east" = 0)
-	//UnregisterSignal(src, COMSIG_ATOM_DIR_CHANGE)
 	for(var/turf/open/T in view(2, src))
 		var/obj/effect/temp_visual/flesh/pinkflesh =  new(T)
 		pinkflesh.color = COLOR_PINK
@@ -698,8 +700,6 @@
 	if(M.back)
 		M.dropItemToGround(M.back)
 		M.update_inv_back()
-	M.set_lying_angle(0)
-	M.set_body_position(STANDING_UP)
 	M.forceMove(src) // Hide them for examine message to work
 	adjustBruteLoss(-maxHealth, forced = TRUE)
 	Transform(M)
@@ -709,11 +709,11 @@
 	SLEEP_CHECK_DEATH(5)
 	if(!M || QDELETED(M))
 		return //We screwed up or the player successfully committed self-delete. Try again next time!
-	disguise = M
 	shelled = TRUE
+	CopyHumanAppearance(M)
 	add_overlay(mutable_appearance('icons/effects/effects.dmi', "nobody_overlay", SUIT_LAYER))
 	add_overlay(mutable_appearance('icons/effects/effects.dmi', "nobody_overlay_face", GLASSES_LAYER))
-	appearance = M.appearance
+	SLEEP_CHECK_DEATH(2)
 	if(target)
 		LoseTarget(target)
 	M.gib()
@@ -737,8 +737,6 @@
 		addtimer(CALLBACK(src, PROC_REF(ZeroQliphoth)), rand(5 SECONDS, 10 SECONDS))
 
 /mob/living/simple_animal/hostile/abnormality/nobody_is/examine(mob/user)
-	if(disguise)
-		return disguise.examine(user)
 	. = ..()
 	if(current_stage >= 1)
 		. += (span_notice("It looks angry!"))
@@ -759,8 +757,8 @@
 		forceMove(get_turf(talker))
 		GiveTarget(talker)
 		return
-	var/new_message = Gibberish(raw_message, TRUE, 40)
-	say(new_message)
+	var/new_message = reverse_text(Gibberish(raw_message, TRUE, 40))
+	say(html_decode(new_message))  // Prevents html characters such as < > from being used, as they don't display properly
 
 //Objects
 /obj/effect/reflection // Hopefully temporary or at least removed someday
@@ -779,16 +777,16 @@
 
 //A simple test function to force oberon to happen without killing the reflected
 
-/mob/living/simple_animal/hostile/abnormality/nobody_is/proc/Transform_No_Kill(mob/living/carbon/human/M)
+/mob/living/simple_animal/hostile/abnormality/nobody_is/proc/TransformNoKill(mob/living/carbon/human/M)
 	set waitfor = FALSE
 	SLEEP_CHECK_DEATH(5)
 	if(!M || QDELETED(M))
 		return //We screwed up or the player successfully committed self-delete. Try again next time!
-	disguise = M
 	shelled = TRUE
+	CopyHumanAppearance(M)
 	add_overlay(mutable_appearance('icons/effects/effects.dmi', "nobody_overlay", SUIT_LAYER))
 	add_overlay(mutable_appearance('icons/effects/effects.dmi', "nobody_overlay_face", GLASSES_LAYER))
-	appearance = M.appearance
+	SLEEP_CHECK_DEATH(2)
 	if(target)
 		LoseTarget(target)
 	attack_verb_continuous = "strikes"
@@ -810,10 +808,10 @@
 	if(status_flags & GODMODE) // Still contained
 		ZeroQliphoth()
 
-/mob/living/simple_animal/hostile/abnormality/nobody_is/proc/Quick_Oberon_Spawn()
+/mob/living/simple_animal/hostile/abnormality/nobody_is/proc/QuickOberonSpawn()
 	if(!chosen || oberon_mode)//makes sure it doesn't continue if its already oberon or if there's no chosen.)
 		return
-	Transform_No_Kill(chosen)
+	TransformNoKill(chosen)
 	oberon_mode = TRUE
 	name = "Oberon"
 	var/mob/living/simple_animal/hostile/abnormality/titania/T = new(get_turf(src))
@@ -822,3 +820,58 @@
 	T.fused = TRUE
 	T.ChangeResistances(list(BRUIT = 0, RED_DAMAGE = 0, WHITE_DAMAGE = 0, BLACK_DAMAGE = 0, PALE_DAMAGE = 0))//fuck you no damaging while they erp
 	Oberon_Fusion(T)
+
+/*
+ * Make a copy of a human and copy their appearance without copying any special overlays. Notice that this currently doesn't include held items!
+ */
+/mob/living/simple_animal/hostile/abnormality/proc/CopyHumanAppearance(mob/the_target)
+	if(!istype(the_target))
+		return
+	var/mob/living/carbon/human/copycat = new(get_turf(src))
+	copycat.status_flags = GODMODE
+	copycat.stat = DEAD // prevents the copycat from getting fear effects, attacks, etc that could add overlays.
+
+	if(iscarbon(the_target))
+		var/mob/living/carbon/carbon_target = the_target
+		carbon_target.dna.transfer_identity(copycat, transfer_SE = TRUE)
+
+		if(ishuman(the_target))
+			var/mob/living/carbon/human/human_target = the_target
+			human_target.copy_clothing_prefs(copycat)
+			copycat.gender = human_target.gender
+			copycat.body_type = human_target.body_type
+			copycat.real_name = human_target.real_name
+			copycat.name = human_target.name
+			copycat.skin_tone = human_target.skin_tone
+			copycat.hairstyle = human_target.hairstyle
+			copycat.facial_hairstyle = human_target.facial_hairstyle
+			copycat.hair_color = human_target.hair_color
+			copycat.facial_hair_color = human_target.facial_hair_color
+			copycat.eye_color = human_target.eye_color
+			copycat.regenerate_icons()
+
+			//We're just stealing their clothes
+			for(var/obj/item/slotitem in human_target.get_all_slots())
+				if(istype(slotitem, /obj/item/clothing/suit/armor/ego_gear))
+					var/obj/item/clothing/suit/armor/ego_gear/equippable_gear = new slotitem.type(get_turf(copycat))
+					equippable_gear.equip_slowdown = 0
+					equippable_gear.attribute_requirements = list()
+					copycat.equip_to_appropriate_slot(equippable_gear, TRUE)
+				else
+					var/obj/item/itemcopy = new slotitem.type(get_turf(copycat))
+					copycat.equip_to_appropriate_slot(itemcopy, TRUE)
+
+	else
+		//even if target isn't a carbon, if they have a client we can make the
+		//dummy look like what their human would look like based on their prefs
+		the_target?.client?.prefs?.copy_to(copycat, icon_updates=TRUE, roundstart_checks=FALSE)
+	SLEEP_CHECK_DEATH(1)
+	var/icon/out_icon = icon('icons/effects/effects.dmi', "nothing")
+	COMPILE_OVERLAYS(copycat)
+	for(var/D in GLOB.cardinals)
+		var/icon/partial = getFlatIcon(copycat, defdir=D)
+		out_icon.Insert(partial,dir=D)
+	icon = out_icon
+	name = "[copycat.name]?"
+	desc = "Is it [copycat.name]? You can't be sure..."
+	qdel(copycat)

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/nothing_there.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/nothing_there.dm
@@ -62,7 +62,8 @@
 			It smiles. <br>No, it pretends to smile. <br>Who could be it?"),
 	)
 
-	var/mob/living/disguise = null
+	var/shelled
+	var/mob/living/disguise_ref
 	var/saved_appearance
 	var/can_act = TRUE
 	var/current_stage = 1
@@ -152,11 +153,6 @@
 	soundloop.start() // We only play the ambience if we're spawned in containment
 	return
 
-/mob/living/simple_animal/hostile/abnormality/nothing_there/examine(mob/user)
-	if(istype(disguise))
-		return disguise.examine(user)
-	return ..()
-
 /mob/living/simple_animal/hostile/abnormality/nothing_there/Move()
 	if(!can_act)
 		return FALSE
@@ -199,13 +195,13 @@
 	return
 
 /mob/living/simple_animal/hostile/abnormality/nothing_there/ListTargets()
-	if(istype(disguise))
+	if(shelled)
 		return list()
 	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/nothing_there/adjustHealth(amount, updating_health = TRUE, forced = FALSE)
 	. = ..()
-	if(istype(disguise) && (health < maxHealth * 0.95))
+	if((shelled) && (health < maxHealth * 0.95))
 		drop_disguise()
 
 /mob/living/simple_animal/hostile/abnormality/nothing_there/Life()
@@ -218,8 +214,8 @@
 			say(pick(speak_list))
 		return
 	if(.)
-		if(!isnull(disguise) && LAZYLEN(heard_words[disguise]) && prob(utterance*2))
-			speak_list = heard_words[disguise]
+		if((shelled) && LAZYLEN(heard_words[disguise_ref]) && prob(utterance*2))
+			speak_list = heard_words[disguise_ref]
 			say(pick(speak_list))
 		else
 			if(LAZYLEN(heard_words) && prob(utterance))
@@ -280,25 +276,24 @@
 	playsound(get_turf(src), 'sound/abnormalities/nothingthere/disguise.ogg', 75, 0, 5)
 	new /obj/effect/gibspawner/generic(get_turf(M))
 	to_chat(M, span_userdanger("Oh no..."))
-	disguise = M
-	// The following code makes it so that even if a disguised mob is resting, Nothing There's shell will still be standing up.
-	M.set_lying_angle(0)
-	M.set_body_position(STANDING_UP)
-	appearance = M.appearance
+	shelled = TRUE
+	CopyHumanAppearance(M) // This is the same proc used by Nobody Is for stealing skin. Should be less buggy than copying appearance var.
+	disguise_ref = M // We keep a reference to the "shell" for utterances and the like, but it's not absolutely necessary in case they gib somehow
 	M.death()
-	M.forceMove(src) // Hide them for examine message to work
+	M.forceMove(src) // Hide them
 	disguiseloop.start()
 	addtimer(CALLBACK(src, PROC_REF(ZeroQliphoth)), rand(20 SECONDS, 50 SECONDS))
 
 /mob/living/simple_animal/hostile/abnormality/nothing_there/proc/drop_disguise()
-	if(!istype(disguise))
+	if(!shelled)
 		return
 	next_transform = world.time + rand(30 SECONDS, 40 SECONDS)
 	ChangeMoveToDelayBy(1.5)
 	appearance = saved_appearance
-	disguise.forceMove(get_turf(src))
-	disguise.gib()
-	disguise = null
+	if(disguise_ref)
+		disguise_ref.forceMove(get_turf(src))
+		disguise_ref.gib()
+		disguise_ref = null
 	fear_level = ALEPH_LEVEL
 	FearEffect()
 	disguiseloop.stop()
@@ -387,7 +382,7 @@
 	can_act = TRUE
 
 /mob/living/simple_animal/hostile/abnormality/nothing_there/AttemptWork(mob/living/carbon/human/user, work_type)
-	if(istype(disguise))
+	if(shelled)
 		return FALSE
 	worker = user
 	var/growl_prob = (work_type in list(ABNORMALITY_WORK_REPRESSION, ABNORMALITY_WORK_INSIGHT)) ? 100 : 25
@@ -405,7 +400,7 @@
 /mob/living/simple_animal/hostile/abnormality/nothing_there/PostWorkEffect(mob/living/carbon/human/user, work_type, pe, work_time)
 	worker = null
 	if(get_attribute_level(user, JUSTICE_ATTRIBUTE) < 80)
-		if(!istype(disguise)) // Not work failure
+		if(!shelled) // Not work failure
 			datum_reference.qliphoth_change(-1)
 	return
 
@@ -421,7 +416,7 @@
 		return
 	. = ..()
 	soundloop.stop()
-	if(!istype(disguise))
+	if(!shelled)
 		next_transform = world.time + rand(30 SECONDS, 40 SECONDS)
 		playsound(get_turf(src), 'sound/abnormalities/nothingthere/breach.ogg', 50, 0, 5)
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR adds the new CopyHumanAppearance() Proc, which creates a dummy mob with the same appearance as a target then copies that dummy. This prevents things like overlays from panic halos or buffs from making the copied appearance look weird. This proc can also be used for other things in the future. Also fixes some major bugs.

TL;DR VERSION

- Fixes weirdness when Nobody Is Shells someone
- Fixes the strangle attack dealing negative damage, and thus healing people.
- Properly implements the voice copying feature I never actually finished.
- Fixes pathing issues and NI occasionally derping out and not doing anything.
- Fixes Nothing There being invisible if someone somehow actually gibs while being turned into a shell
- Slightly changes examine text on humans used as shells.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
No more Oberon running around with a giant holographic brain floating over his head, being invisible, and other sprite shenanigans. Hopefully.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixed Nobody Is sprite stealing issues
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
