### PR TITLE
Fixes God of the Seasons being invisible when spawned without an assigned containment cell.

### DIFF
--- a/code/controllers/subsystem/lobotomy_events.dm
+++ b/code/controllers/subsystem/lobotomy_events.dm
@@ -219,9 +219,9 @@ SUBSYSTEM_DEF(lobotomy_events)
 			return
 	var/mob/living/simple_animal/hostile/abnormality/seasons/S = locate() in GLOB.abnormality_mob_list
 	if(S)
-		if(S.datum_reference.working)
-			return
 		if(!S.IsContained())
+			return
+		if(S.datum_reference.working)
 			return
 	season_last_change = world.time + season_change_time
 	var/index = seasons.Find(current_season)

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/seasons.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/seasons.dm
@@ -173,15 +173,19 @@
 /mob/living/simple_animal/hostile/abnormality/seasons/Initialize()
 	. = ..()
 	RegisterSignal(SSdcs, COMSIG_GLOB_SEASON_CHANGE, PROC_REF(Transform))
+	addtimer(CALLBACK(src, PROC_REF(TryTransform)), 1)
+
+/mob/living/simple_animal/hostile/abnormality/seasons/proc/TryTransform()
+	dir = SOUTH
+ 	Transform()
 
 /mob/living/simple_animal/hostile/abnormality/seasons/PostSpawn()
 	. = ..()
-	dir = SOUTH
-	Transform()
 	work_timer = addtimer(CALLBACK(src, PROC_REF(WorkCheck)), 9 MINUTES, TIMER_OVERRIDE & TIMER_UNIQUE & TIMER_STOPPABLE)
 	if((locate(/obj/effect/season_turf) in range(1, src)))
 		return
-	Downgrade()
+	if(datum_reference != null) // Can't downgrade if GotS is not even contained.
+		Downgrade()
 
 //Work Stuff
 /mob/living/simple_animal/hostile/abnormality/seasons/PostWorkEffect(mob/living/carbon/human/user, work_type, pe)
@@ -227,9 +231,6 @@
 //Transformations
 /mob/living/simple_animal/hostile/abnormality/seasons/proc/Transform()
 	current_season = SSlobotomy_events.current_season
-	var/list/new_work_chances = modular_work_chance[current_season]
-	work_chances = new_work_chances.Copy()
-	datum_reference.available_work = work_chances
 	ChangeResistances(modular_damage_coeff[current_season])
 	work_damage_type = season_stats[current_season][2]
 	melee_damage_type = season_stats[current_season][2]
@@ -241,6 +242,10 @@
 	projectilesound = breaching_stats[current_season][1]
 	playsound(get_turf(src), "[breaching_stats[current_season][2]]", 30, 0, 8)
 	projectiletype = breaching_stats[current_season][3]
+	if(datum_reference != null) // Do not change containment conditions if it does not have a containment cell assigned.
+		var/list/new_work_chances = modular_work_chance[current_season]
+		work_chances = new_work_chances.Copy()
+		datum_reference.available_work = work_chances
 	if(downgraded)
 		icon_state = "[current_season]_mini"
 		portrait = "[current_season]"


### PR DESCRIPTION
## About The Pull Request

This PR aims to fix various runtimes when God of the Seasons is spawned without a containment cell, which resulted in it's sprite being unable to load and the seasons subsystem breaking.

## Why It's Good For The Game

It allows God of the Seasons to be spawned correctly even without a containment cell assigned to it.

## Changelog
:cl:
fix: Fixed God of the Seasons being invisible when spawned without an assigned containment cell.
/:cl:

