### PR TITLE
Balance changes to 2 gacha outlets

### DIFF
--- a/ModularTegustation/tegu_items/refinery/crates/corporation.dm
+++ b/ModularTegustation/tegu_items/refinery/crates/corporation.dm
@@ -112,7 +112,6 @@
 	veryrarechance = 5
 	cosmeticchance = 33
 	lootlist =	list(
-		/obj/item/powered_gadget/detector_gadget/ordeal,
 		/obj/item/clothing/suit/space/hardsuit/rabbit,
 		/obj/item/clothing/suit/space/hardsuit/rabbit/leader,
 		/obj/item/gun/energy/e_gun/rabbitdash,
@@ -143,6 +142,7 @@
 		/obj/item/clothing/under/suit/lobotomy/rcorp_command,
 		/obj/item/clothing/head/beret/tegu/rcorp,
 		/obj/item/clothing/neck/cloak/rcorp,
+		/obj/item/powered_gadget/detector_gadget/ordeal,
 	)
 
 //S Corporation
@@ -190,7 +190,6 @@
 	lootlist =	list(
 		/obj/item/ego_weapon/city/wcorp,
 		/obj/item/clothing/suit/armor/ego_gear/wcorp,
-		/obj/item/powered_gadget/teleporter,
 	)
 
 	rareloot =	list(
@@ -212,4 +211,5 @@
 	cosmeticloot = list(
 		/obj/item/clothing/head/ego_hat/wcorp,
 		/obj/item/clothing/under/suit/lobotomy/wcorp,
+		/obj/item/powered_gadget/teleporter,
 	)

--- a/ModularTegustation/tegu_items/refinery/sales.dm
+++ b/ModularTegustation/tegu_items/refinery/sales.dm
@@ -103,7 +103,7 @@
 	desc = "A machine used to send PE to R-Corp."
 	icon_state = "machiner"
 	crate = /obj/structure/lootcrate/r_corp
-	crate_timer = 420	//The most expensive because it's R corp stuff
+	crate_timer = 360	//One of the most expensive because it's R corp stuff
 	our_corporation = "R corp"
 
 /obj/structure/pe_sales/s_corp


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
It makes R corp cost 3 boxes and moves the ordeal scanner from R corp and the teleporter from W corp to their respective cosmetic Loot boxes.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
R corp is too expensive to be reliable for people, especially considering how the very good stuff is quite rare. And both corps with their costs shouldn't have a cheap gadget you can spend with cargo in their pools since the pools arent that big for common stuff.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: rebalanced gacha
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
