### PR TITLE
Fix Snow Queen Sword being Stuck in Belts and Doorstuck

### DIFF
--- a/code/game/machinery/doors/airlock_types.dm
+++ b/code/game/machinery/doors/airlock_types.dm
@@ -572,7 +572,7 @@
 /*
 	LC13 Airlocks
 */
-
+//One day ill replace this with a structure similar to the necropolis gate. -IP
 /obj/machinery/door/airlock/snowqueen
 	name = "Snow Queen's Gate"
 	desc = "Are you ready for what lies ahead?"
@@ -583,7 +583,7 @@
 	assemblytype = null
 	glass = TRUE
 	bound_width = 128
-	bound_height = 128
+	aiControlDisabled = AI_WIRE_DISABLED
 	hackProof = TRUE
 	autoclose = TRUE
 	resistance_flags = INDESTRUCTIBLE

--- a/code/modules/mob/living/simple_animal/abnormality/he/snow_queen.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/snow_queen.dm
@@ -913,6 +913,7 @@
 	hit_message = "parries the attack!"
 	block_cooldown_message = "You rearm your blade."
 	//For deleting it whenever seperated from user.
+	slot_flags = null
 	item_flags = DROPDEL
 
 /obj/item/ego_weapon/shield/ice_sword/Initialize()

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/hammer_light.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/hammer_light.dm
@@ -251,6 +251,7 @@
 	attack_verb_continuous = list("slams", "strikes", "smashes")
 	attack_verb_simple = list("slam", "strike", "smash")
 	hitsound = 'sound/abnormalities/lighthammer/hammer_filter.ogg'
+	slot_flags = null
 	var/list/spawned_mobs = list()
 	var/spawned_mob_max = 4
 	var/spawn_cooldown = 0


### PR DESCRIPTION
## About The Pull Request
Fixes snow queen sword being stuck in belt slots.
The issue came from it being a cursed weapon and retaining its storage slots. So i set the storage slots to null. Preemptively adds this fix to hammer of light to avoid any bugs since it is also a cursed weapon. Also fixed another bug where if your standing in the snow queen door while it closed you would be trapped forever.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->



## Changelog
:cl:
fix: Snow Queens Sword and Hammer of Light being put in belt slots despite being Cursed
fix: Snow Queens door trapping people forever if it closes on them.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
