### PR TITLE
City Raids Update [COMPLETE]

### DIFF
--- a/code/controllers/subsystem/city_events.dm
+++ b/code/controllers/subsystem/city_events.dm
@@ -14,7 +14,7 @@ SUBSYSTEM_DEF(cityevents)
 	var/list/total_events = list()
 	var/list/distortions_available = list()
 	var/helpful_events = list("chickens", "money", "tresmetal", "hppens", "sppens")
-	var/harmful_events = list("drones", "beaks", "shrimps", "lovetowneasy", "lovetownhard", "sweepers", "scouts", "bots", "gbugs")
+	var/harmful_events = list("drones", "beaks", "shrimps", "lovetowneasy", "lovetownhard", "sweepers", "scouts", "bots", "gbugs", "clan", "bloodbag")
 	var/neutral_events = list("swag")
 	var/boss_events = list("sweeper", "lovetown", "factory", "gcorp")
 	var/list/generated = list()	//Which ckeys have generated stats
@@ -172,6 +172,9 @@ SUBSYSTEM_DEF(cityevents)
 		nighttime_remove() //End the raid.
 		raiding = FALSE
 
+	if(globalillumination == 0 && daystatus)
+		minor_announce("The night in the backstreets will begin in T-100 Seconds, Please be ready.", "Local Activity Alert:", TRUE)
+
 	if(daystatus)	//After noon
 		globalillumination -= 0.02
 		addtimer(CALLBACK(src, PROC_REF(Daynight)), 10 SECONDS)
@@ -189,48 +192,49 @@ SUBSYSTEM_DEF(cityevents)
 
 	switch (chosen_event)
 		if("sweepers")
-			nighttime_spawn(/mob/living/simple_animal/hostile/ordeal/indigo_noon, 20)
+			nighttime_spawn(/mob/living/simple_animal/hostile/ordeal/indigo_noon)
 		if("scouts")
-			nighttime_spawn(/mob/living/simple_animal/hostile/ordeal/indigo_dawn, 40)
+			nighttime_spawn(/mob/living/simple_animal/hostile/ordeal/indigo_dawn)
 		if("bots")
-			nighttime_spawn(/mob/living/simple_animal/hostile/ordeal/green_bot, 10)
+			nighttime_spawn(/mob/living/simple_animal/hostile/ordeal/green_bot)
 		if("gbugs")
-			nighttime_spawn(/mob/living/simple_animal/hostile/ordeal/steel_dawn, 30)
+			nighttime_spawn(/mob/living/simple_animal/hostile/ordeal/steel_dawn)
 		if("shrimps")
-			nighttime_spawn(/mob/living/simple_animal/hostile/shrimp, 20)
+			nighttime_spawn(/mob/living/simple_animal/hostile/shrimp)
 		if("beaks")
-			nighttime_spawn(/mob/living/simple_animal/hostile/ordeal/bigBirdEye, 10)
+			nighttime_spawn(/mob/living/simple_animal/hostile/ordeal/bigBirdEye)
 		if("drones")
-			nighttime_spawn(/mob/living/simple_animal/hostile/kcorp/drone, -10)//extremely low chance
+			nighttime_spawn(/mob/living/simple_animal/hostile/kcorp/drone)
 		if("lovetowneasy")
 			nighttime_spawn(pick(/mob/living/simple_animal/hostile/lovetown/slasher,
-			/mob/living/simple_animal/hostile/lovetown/stabber), 25)
+			/mob/living/simple_animal/hostile/lovetown/stabber))
 		if("lovetownhard")
 			nighttime_spawn(pick(/mob/living/simple_animal/hostile/lovetown/shambler,
-			/mob/living/simple_animal/hostile/lovetown/slumberer), 5)
+			/mob/living/simple_animal/hostile/lovetown/slumberer))
+		if("clan")
+			nighttime_spawn(/mob/living/simple_animal/hostile/clan/scout)
+		if("bloodbag")
+			nighttime_spawn(/mob/living/simple_animal/hostile/humanoid/blood/bag)
 	wavetime+=1
 
-/datum/controller/subsystem/cityevents/proc/nighttime_spawn(mob/living/L, chance)
-	chance += wavetime*8
+/datum/controller/subsystem/cityevents/proc/nighttime_spawn(mob/living/L)
 	for(var/J in spawners)
-		if(!prob(chance))
-			continue
 		new /obj/effect/bloodpool(get_turf(J))
 		sleep(10)
 		//This is less intensive than a loop
 
 		var/mob/living/hostile1 = new L (get_turf(J))
-		hostile1 += nighttime_raiders
+		nighttime_raiders += hostile1
 
 		var/mob/living/hostile2 = new L (get_turf(J))
-		hostile2 += nighttime_raiders
+		nighttime_raiders += hostile2
 
-		var/mob/living/hostile3 = new L (get_turf(J))
-		hostile3 += nighttime_raiders
+		var/mob/living/hostile2 = new L (get_turf(J))
+		nighttime_raiders += hostile2
 
 /datum/controller/subsystem/cityevents/proc/nighttime_remove()
 	for(var/mob/living/L in nighttime_raiders)
-		L -= nighttime_raiders
+		nighttime_raiders -= L
 		if (L.stat != DEAD)
 			qdel(L)
 	minor_announce("The night in the backstreets has now concluded.", "Local Activity Alert:", TRUE)

--- a/code/controllers/subsystem/city_events.dm
+++ b/code/controllers/subsystem/city_events.dm
@@ -7,13 +7,14 @@ SUBSYSTEM_DEF(cityevents)
 	var/list/itemdrops = list()
 	var/list/distortion = list()
 	var/list/lights = list()
+	var/list/nighttime_raiders = list()
 	var/daystatus = TRUE	//True to darken lights, false to lighten them
+	var/raiding = FALSE
 	var/globalillumination = 1
 	var/list/total_events = list()
 	var/list/distortions_available = list()
 	var/helpful_events = list("chickens", "money", "tresmetal", "hppens", "sppens")
-	var/harmful_events = list("drones", "beaks", "shrimps", "lovetowneasy", "lovetownhard")
-	var/ordeal_events = list("sweepers", "scouts", "bots", "gbugs")
+	var/harmful_events = list("drones", "beaks", "shrimps", "lovetowneasy", "lovetownhard", "sweepers", "scouts", "bots", "gbugs")
 	var/neutral_events = list("swag")
 	var/boss_events = list("sweeper", "lovetown", "factory", "gcorp")
 	var/list/generated = list()	//Which ckeys have generated stats
@@ -51,10 +52,6 @@ SUBSYSTEM_DEF(cityevents)
 	total_events += pick(helpful_events)
 	total_events += pick(helpful_events)
 	total_events += pick(helpful_events)
-	total_events += pick(harmful_events)
-	total_events += pick(ordeal_events)
-	total_events += pick(ordeal_events)
-//	total_events += pick(ordeal_events)
 	total_events += pick(neutral_events)
 	total_events += pick(neutral_events)
 	total_events += pick("money")			//Always get money
@@ -68,37 +65,11 @@ SUBSYSTEM_DEF(cityevents)
 
 //Events
 /datum/controller/subsystem/cityevents/proc/Event()
-	addtimer(CALLBACK(src, PROC_REF(Event)), 5 MINUTES)
+	addtimer(CALLBACK(src, PROC_REF(Event)), 10 MINUTES)
 	var/chosen_event
-	if(wavetime == 10 && wavetime !=0)	//after 50 minutes
-		chosen_event = Boss()
-	else
-		chosen_event = pick(total_events)
+	chosen_event = pick(total_events)
 
 	switch (chosen_event)
-		if("sweepers")
-			spawnatlandmark(/mob/living/simple_animal/hostile/ordeal/indigo_noon, 20)
-		if("scouts")
-			spawnatlandmark(/mob/living/simple_animal/hostile/ordeal/indigo_dawn, 40)
-		if("bots")
-			spawnatlandmark(/mob/living/simple_animal/hostile/ordeal/green_bot, 10)
-		if("gbugs")
-			spawnatlandmark(/mob/living/simple_animal/hostile/ordeal/steel_dawn, 30)
-
-		//Harmful events
-		if("shrimps")
-			spawnatlandmark(/mob/living/simple_animal/hostile/shrimp, 20)
-		if("beaks")
-			spawnatlandmark(/mob/living/simple_animal/hostile/ordeal/bigBirdEye, 10)
-		if("drones")
-			spawnatlandmark(/mob/living/simple_animal/hostile/kcorp/drone, -10)//extremely low chance
-		if("lovetowneasy")
-			spawnatlandmark(pick(/mob/living/simple_animal/hostile/lovetown/slasher,
-			/mob/living/simple_animal/hostile/lovetown/stabber), 25)
-		if("lovetownhard")
-			spawnatlandmark(pick(/mob/living/simple_animal/hostile/lovetown/shambler,
-			/mob/living/simple_animal/hostile/lovetown/slumberer), 5)
-
 		//Good events
 		if("chickens")
 			spawnatlandmark(/mob/living/simple_animal/chick, 20)
@@ -114,7 +85,6 @@ SUBSYSTEM_DEF(cityevents)
 		//Neutral events
 		if("swag")
 			spawnitem(/obj/item/clothing/shoes/swagshoes, 2)	// Swag out, man
-	wavetime+=1
 	if(prob(50))
 		JobAddition()
 
@@ -158,7 +128,7 @@ SUBSYSTEM_DEF(cityevents)
 				processing.total_positions += 1
 
 /datum/controller/subsystem/cityevents/proc/Boss()
-	minor_announce("Warning, large hostile detected. Suppression required.", "Local Activity Alert:", TRUE)
+	minor_announce("Warning, large hostile detected during this night. Suppression required.", "Local Activity Alert:", TRUE)
 	var/T = pick(spawners)
 	var/chosen_boss = pick(boss_events)
 	var/chosen_event
@@ -188,6 +158,8 @@ SUBSYSTEM_DEF(cityevents)
 		addtimer(CALLBACK(src, PROC_REF(Daynight)), 5 MINUTES)
 		daystatus = FALSE
 		globalillumination = -0.18	//Ship it back up
+		Nighttime() //And being the nighttime raid
+		raiding = TRUE
 		return
 
 	if(globalillumination >= 1.1)	//Go back down.
@@ -196,9 +168,69 @@ SUBSYSTEM_DEF(cityevents)
 		globalillumination = 1.08	//Ship it back down
 		return
 
+	if(globalillumination >= 0.54 && !daystatus && raiding)
+		nighttime_remove() //End the raid.
+		raiding = FALSE
+
 	if(daystatus)	//After noon
 		globalillumination -= 0.02
 		addtimer(CALLBACK(src, PROC_REF(Daynight)), 10 SECONDS)
 	else		//before noon
 		globalillumination += 0.02
 		addtimer(CALLBACK(src, PROC_REF(Daynight)), 10 SECONDS)
+
+/datum/controller/subsystem/cityevents/proc/Nighttime()
+	var/chosen_event
+	if(wavetime == 8 && wavetime !=0)
+		chosen_event = Boss()
+	else
+		minor_announce("Warning, the night in the backstreets has begun.", "Local Activity Alert:", TRUE)
+		chosen_event = pick(harmful_events)
+
+	switch (chosen_event)
+		if("sweepers")
+			nighttime_spawn(/mob/living/simple_animal/hostile/ordeal/indigo_noon, 20)
+		if("scouts")
+			nighttime_spawn(/mob/living/simple_animal/hostile/ordeal/indigo_dawn, 40)
+		if("bots")
+			nighttime_spawn(/mob/living/simple_animal/hostile/ordeal/green_bot, 10)
+		if("gbugs")
+			nighttime_spawn(/mob/living/simple_animal/hostile/ordeal/steel_dawn, 30)
+		if("shrimps")
+			nighttime_spawn(/mob/living/simple_animal/hostile/shrimp, 20)
+		if("beaks")
+			nighttime_spawn(/mob/living/simple_animal/hostile/ordeal/bigBirdEye, 10)
+		if("drones")
+			nighttime_spawn(/mob/living/simple_animal/hostile/kcorp/drone, -10)//extremely low chance
+		if("lovetowneasy")
+			nighttime_spawn(pick(/mob/living/simple_animal/hostile/lovetown/slasher,
+			/mob/living/simple_animal/hostile/lovetown/stabber), 25)
+		if("lovetownhard")
+			nighttime_spawn(pick(/mob/living/simple_animal/hostile/lovetown/shambler,
+			/mob/living/simple_animal/hostile/lovetown/slumberer), 5)
+	wavetime+=1
+
+/datum/controller/subsystem/cityevents/proc/nighttime_spawn(mob/living/L, chance)
+	chance += wavetime*8
+	for(var/J in spawners)
+		if(!prob(chance))
+			continue
+		new /obj/effect/bloodpool(get_turf(J))
+		sleep(10)
+		//This is less intensive than a loop
+
+		var/mob/living/hostile1 = new L (get_turf(J))
+		hostile1 += nighttime_raiders
+
+		var/mob/living/hostile2 = new L (get_turf(J))
+		hostile2 += nighttime_raiders
+
+		var/mob/living/hostile3 = new L (get_turf(J))
+		hostile3 += nighttime_raiders
+
+/datum/controller/subsystem/cityevents/proc/nighttime_remove()
+	for(var/mob/living/L in nighttime_raiders)
+		L -= nighttime_raiders
+		if (L.stat != DEAD)
+			qdel(L)
+	minor_announce("The night in the backstreets has now concluded.", "Local Activity Alert:", TRUE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR updates how hostile spawns work in City gamemodes. Now, it will use the daytime/nighttime system to spawn them. Once lighting reaches it's absolute minimum, (About 10 minutes, and 20 minutes after the first between raids.) At raid will happen, which will spawn 3 mobs in all spawners. There is a warning of this event 100 seconds before it raid happens.

210 seconds after the raid starts, the raid will end, and all of the mobs will disappear.

This update also makes the 5th raid that happens a "Boss" raid, where a boss mob spawns that doesn't despawn when the night ends.

This update also adds 2 more mobs to the possible raids: Resurgence Clan Scouts, and Bloodbags

## Why It's Good For The Game

This makes raids on the city much more convenient and natural for the players, as they will know when they will happen and can plan their goals around that. If they get good at reading the environment they can predict it even better. Also, Raids will no longer stack up when ignored, since the nighttime mobs will not persist throughout the day.

Adding new mobs to the raid pool, should be a breath of fresh air for players, getting to fight something new.
## Changelog
:cl:
tweak: tweaked city events, to spawn mobs at night
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
