### PR TITLE
Tuning up Thumb firearms

### DIFF
--- a/ModularTegustation/ego_weapons/melee/non_abnormality/thumb.dm
+++ b/ModularTegustation/ego_weapons/melee/non_abnormality/thumb.dm
@@ -44,11 +44,12 @@
 //Sottoacpo
 /obj/item/ego_weapon/ranged/city/thumb/sottocapo
 	name = "thumb sottocapo shotgun"
-	desc = "A pistol used by thumb sottocapos. While expensive, it's power is rarely matched among syndicates."
+	desc = "A handgun used by thumb sottocapos. While expensive, it's power is rarely matched among syndicates."
 	icon_state = "thumb_sottocapo"
 	inhand_icon_state = "thumb_sottocapo"
 	force = 20	//It's a pistol
-	projectile_path = /obj/projectile/ego_bullet/tendamage // does 10 damage
+	projectile_path = /obj/projectile/ego_bullet/tendamage // does 30 damage (odd, there's no force mod on this one)
+	weapon_weight = WEAPON_MEDIUM
 	pellets = 8
 	variance = 16
 	attribute_requirements = list(

--- a/ModularTegustation/ego_weapons/melee/non_abnormality/weak_edits/city.dm
+++ b/ModularTegustation/ego_weapons/melee/non_abnormality/weak_edits/city.dm
@@ -126,7 +126,7 @@
 //Thumb
 /obj/item/ego_weapon/ranged/city/thumb/weak
 	force = 20
-	projectile_damage_multiplier = 2 //20 damage per bullet
+	projectile_damage_multiplier = 1.8 //18 damage per bullet
 	attribute_requirements = list(
 		FORTITUDE_ATTRIBUTE = 60,
 		PRUDENCE_ATTRIBUTE = 60,
@@ -137,7 +137,7 @@
 //Capo
 /obj/item/ego_weapon/ranged/city/thumb/capo/weak
 	force = 25
-	projectile_damage_multiplier = 3 //30 damage per bullet
+	projectile_damage_multiplier = 3.5 //35 damage per bullet
 	attribute_requirements = list(
 		FORTITUDE_ATTRIBUTE = 80,
 		PRUDENCE_ATTRIBUTE = 80,
@@ -148,10 +148,11 @@
 //Sottocapo
 /obj/item/ego_weapon/ranged/city/thumb/sottocapo/weak
 	force = 10	//It's a pistol
-	projectile_damage_multiplier = 0.7 //5 damage per bullet
-	projectile_path = /obj/projectile/ego_bullet/tendamage // total 56 damage
+	projectile_damage_multiplier = 1.1 //11 damage per bullet
+	projectile_path = /obj/projectile/ego_bullet/tendamage // total 88 damage
 	pellets = 8
 	variance = 16
+	reloadtime = 7 SECONDS // it is a bit stronger, but requires a bit longer reload time. (either hit with it or step back for downtime)
 	attribute_requirements = list(
 		FORTITUDE_ATTRIBUTE = 100,
 		PRUDENCE_ATTRIBUTE = 100,

--- a/code/modules/vending/medical.dm
+++ b/code/modules/vending/medical.dm
@@ -59,6 +59,7 @@
 					/obj/item/reagent_containers/glass/bottle/multiver = 2,
 					/obj/item/reagent_containers/glass/bottle/syriniver = 2,
 					/obj/item/reagent_containers/glass/bottle/epinephrine = 3,
+                    /obj/item/reagent_containers/glass/bottle/salbutamol = 5,
 					/obj/item/reagent_containers/glass/bottle/morphine = 4,
 					/obj/item/reagent_containers/glass/bottle/potass_iodide = 1,
 					/obj/item/reagent_containers/glass/bottle/salglu_solution = 3,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
- Buffs up the entirety of CoL variant Thumb guns to deal a bit more damage.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
- Soldatos, Capos and Sottocapo are now bigger of a force to both low to mid grade fixers and a considerable advesary to high grade fixers. As the Thumb should be for a SotC level threat.

## Changelog
:cl:
bal: soldato rifles deal 18 RED instead of 10 RED.
capo rifles deal 35 Red instead of 20 RED.
sottocapo shotgun deals 11 RED instead of 7 RED, but with a drawback in form of reload time (7 seconds instead of 5 seconds)
tweak: sottocapo shotgun is a medium weight weapon now (can be used one handed, can't be sheathed into EGO belts) to make up for being a handgun.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
