### PR TITLE
Tuning up Thumb firearms

### DIFF
--- a/ModularTegustation/ego_weapons/melee/non_abnormality/thumb.dm
+++ b/ModularTegustation/ego_weapons/melee/non_abnormality/thumb.dm
@@ -44,11 +44,12 @@
 //Sottoacpo
 /obj/item/ego_weapon/ranged/city/thumb/sottocapo
 	name = "thumb sottocapo shotgun"
-	desc = "A pistol used by thumb sottocapos. While expensive, it's power is rarely matched among syndicates."
+	desc = "A handgun used by thumb sottocapos. While expensive, it's power is rarely matched among syndicates."
 	icon_state = "thumb_sottocapo"
 	inhand_icon_state = "thumb_sottocapo"
 	force = 20	//It's a pistol
-	projectile_path = /obj/projectile/ego_bullet/tendamage // does 10 damage
+	projectile_path = /obj/projectile/ego_bullet/tendamage // does 30 damage (odd, there's no force mod on this one)
+	weapon_weight = WEAPON_MEDIUM
 	pellets = 8
 	variance = 16
 	attribute_requirements = list(

--- a/ModularTegustation/ego_weapons/melee/non_abnormality/weak_edits/city.dm
+++ b/ModularTegustation/ego_weapons/melee/non_abnormality/weak_edits/city.dm
@@ -126,7 +126,7 @@
 //Thumb
 /obj/item/ego_weapon/ranged/city/thumb/weak
 	force = 20
-	projectile_damage_multiplier = 1.8 //18 damage per bullet
+	projectile_damage_multiplier = 2.5 //25 damage per bullet
 	attribute_requirements = list(
 		FORTITUDE_ATTRIBUTE = 60,
 		PRUDENCE_ATTRIBUTE = 60,

--- a/ModularTegustation/ego_weapons/melee/non_abnormality/weak_edits/city.dm
+++ b/ModularTegustation/ego_weapons/melee/non_abnormality/weak_edits/city.dm
@@ -126,7 +126,7 @@
 //Thumb
 /obj/item/ego_weapon/ranged/city/thumb/weak
 	force = 20
-	projectile_damage_multiplier = 2 //20 damage per bullet
+	projectile_damage_multiplier = 1.8 //18 damage per bullet
 	attribute_requirements = list(
 		FORTITUDE_ATTRIBUTE = 60,
 		PRUDENCE_ATTRIBUTE = 60,
@@ -137,7 +137,7 @@
 //Capo
 /obj/item/ego_weapon/ranged/city/thumb/capo/weak
 	force = 25
-	projectile_damage_multiplier = 3 //30 damage per bullet
+	projectile_damage_multiplier = 3.5 //35 damage per bullet
 	attribute_requirements = list(
 		FORTITUDE_ATTRIBUTE = 80,
 		PRUDENCE_ATTRIBUTE = 80,
@@ -148,10 +148,11 @@
 //Sottocapo
 /obj/item/ego_weapon/ranged/city/thumb/sottocapo/weak
 	force = 10	//It's a pistol
-	projectile_damage_multiplier = 0.7 //5 damage per bullet
-	projectile_path = /obj/projectile/ego_bullet/tendamage // total 56 damage
+	projectile_damage_multiplier = 1.1 //11 damage per bullet
+	projectile_path = /obj/projectile/ego_bullet/tendamage // total 88 damage
 	pellets = 8
 	variance = 16
+	reloadtime = 7 SECONDS // it is a bit stronger, but requires a bit longer reload time. (either hit with it or step back for downtime)
 	attribute_requirements = list(
 		FORTITUDE_ATTRIBUTE = 100,
 		PRUDENCE_ATTRIBUTE = 100,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
- Makes the Thumb firearms stronger for CoL mode

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
- The ranged damage isn't fun on those, dealing about 8 RED damage per shot (Soldato Rifle) to anyone in a fixer suit while being one of the Five Fingers is just not it.

## Changelog
:cl:
balance: Soldato rifles deal 18 Red instead of 10. Capo rifles deal 35 Red instead of 20 and Sottocapo shotgun deals 11 Red per pellet instead of 7 in exchange for a bit longer reload (7 seconds instead of 5)
Sottocapo shotgun is now a medium weight weapon, meaning it can be shot onehanded.
tweak: Tweaked the Sottocapo shotgun description a bit. Pistols, uh... Don't shoot buckshot shells.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
