### PR TITLE
Limbus Company Labs now captures a wider variety of Peccatula

### DIFF
--- a/code/modules/jobs/job_types/labs/command/assetprot.dm
+++ b/code/modules/jobs/job_types/labs/command/assetprot.dm
@@ -24,7 +24,7 @@
 	..()
 	ADD_TRAIT(H, TRAIT_WORK_FORBIDDEN, JOB_TRAIT)
 	ADD_TRAIT(H, TRAIT_COMBATFEAR_IMMUNE, JOB_TRAIT)
-	add_verb(H, /mob/living/carbon/human/proc/peccetulum_spawn)
+	add_verb(H, /mob/living/carbon/human/proc/peccatulum_spawn)
 
 /datum/outfit/job/asset_protection
 	name = "LC Asset Protection"
@@ -38,38 +38,38 @@
 	l_pocket = /obj/item/radio
 
 
-/mob/living/carbon/human/proc/peccetulum_spawn()
-	set name = "Spawn Peccetulum"
+/mob/living/carbon/human/proc/peccatulum_spawn()
+	set name = "Spawn Peccatulum"
 	set category = "Gamemaster"
 
-	var/list/peccetulum = list(
+	var/list/peccatulum = list(
 		/mob/living/simple_animal/hostile/ordeal/sin_gloom,
-		/mob/living/simple_animal/hostile/ordeal/sin_gloom,
-		/mob/living/simple_animal/hostile/ordeal/sin_gloom/noon,
 		/mob/living/simple_animal/hostile/ordeal/sin_gluttony,
-		/mob/living/simple_animal/hostile/ordeal/sin_gluttony,
-		/mob/living/simple_animal/hostile/ordeal/sin_gluttony/noon,
 		/mob/living/simple_animal/hostile/ordeal/sin_pride,
-		/mob/living/simple_animal/hostile/ordeal/sin_pride,
-		/mob/living/simple_animal/hostile/ordeal/sin_pride/noon,
 		/mob/living/simple_animal/hostile/ordeal/sin_lust,
-		/mob/living/simple_animal/hostile/ordeal/sin_lust,
-		/mob/living/simple_animal/hostile/ordeal/sin_lust/noon,
 		/mob/living/simple_animal/hostile/ordeal/sin_wrath,
-		/mob/living/simple_animal/hostile/ordeal/sin_wrath,
-		/mob/living/simple_animal/hostile/ordeal/sin_wrath/noon,
 		/mob/living/simple_animal/hostile/ordeal/sin_sloth,
-		/mob/living/simple_animal/hostile/ordeal/sin_sloth,
-		/mob/living/simple_animal/hostile/ordeal/sin_sloth/noon,
 		/mob/living/simple_animal/hostile/ordeal/sin_envy,
 	)
 
-	message_admins("<span class='notice'>Asset Protection ([src.ckey]) has spawned Peccetulum.</span>")
+	var/list/peccatulum_noon = list(
+		/mob/living/simple_animal/hostile/ordeal/sin_gloom/noon,
+		/mob/living/simple_animal/hostile/ordeal/sin_gluttony/noon,
+		/mob/living/simple_animal/hostile/ordeal/sin_pride/noon,
+		/mob/living/simple_animal/hostile/ordeal/sin_lust/noon,
+		/mob/living/simple_animal/hostile/ordeal/sin_wrath/noon,
+		/mob/living/simple_animal/hostile/ordeal/sin_sloth/noon,
+	)
+
+	message_admins("<span class='notice'>Asset Protection ([src.ckey]) has spawned Peccatulum.</span>")
 	var/turf/W = pick(GLOB.xeno_spawn)
 	for(var/turf/T in orange(1, W))
-		var/spawning = pick(peccetulum)
-		if(prob(40))
+		var/spawning = pick(peccatulum)
+		var/spawning_noon = pick(peccatulum_noon)
+		if(prob(67))
 			new spawning (T)
+		if(prob(33))
+			new spawning_noon (T)
 	minor_announce("LCD and Asset acquisition has delivered new minor abnormalities to study. Caution, they may be extremely hostile.", "LCD Team update:", TRUE)
 
 

--- a/code/modules/jobs/job_types/labs/command/assetprot.dm
+++ b/code/modules/jobs/job_types/labs/command/assetprot.dm
@@ -44,10 +44,24 @@
 
 	var/list/peccetulum = list(
 		/mob/living/simple_animal/hostile/ordeal/sin_gloom,
+		/mob/living/simple_animal/hostile/ordeal/sin_gloom,
+		/mob/living/simple_animal/hostile/ordeal/sin_gloom/noon,
 		/mob/living/simple_animal/hostile/ordeal/sin_gluttony,
+		/mob/living/simple_animal/hostile/ordeal/sin_gluttony,
+		/mob/living/simple_animal/hostile/ordeal/sin_gluttony/noon,
 		/mob/living/simple_animal/hostile/ordeal/sin_pride,
+		/mob/living/simple_animal/hostile/ordeal/sin_pride,
+		/mob/living/simple_animal/hostile/ordeal/sin_pride/noon,
 		/mob/living/simple_animal/hostile/ordeal/sin_lust,
-		/mob/living/simple_animal/hostile/ordeal/sin_wrath
+		/mob/living/simple_animal/hostile/ordeal/sin_lust,
+		/mob/living/simple_animal/hostile/ordeal/sin_lust/noon,
+		/mob/living/simple_animal/hostile/ordeal/sin_wrath,
+		/mob/living/simple_animal/hostile/ordeal/sin_wrath,
+		/mob/living/simple_animal/hostile/ordeal/sin_wrath/noon,
+		/mob/living/simple_animal/hostile/ordeal/sin_sloth,
+		/mob/living/simple_animal/hostile/ordeal/sin_sloth,
+		/mob/living/simple_animal/hostile/ordeal/sin_sloth/noon,
+		/mob/living/simple_animal/hostile/ordeal/sin_envy,
 	)
 
 	message_admins("<span class='notice'>Asset Protection ([src.ckey]) has spawned Peccetulum.</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
adds the new pecctula to possible LCL spawwns, dawns appear twice to make noons rarer.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
More Peccatula give higher RP variety and something of interest to security, especially as dawns have been rebalanced.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: added the new noon peccatulas to the LCL "spawn peccatula" ability.
fix: Fixed a typo with asset protections ability
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
