### PR TITLE
Thumb Grenades replaced with less destructive ones to avoid destroying their businesses.

### DIFF
--- a/_maps/templates/syndicate_office/thumbfinger.dmm
+++ b/_maps/templates/syndicate_office/thumbfinger.dmm
@@ -313,10 +313,12 @@
 /obj/item/ego_weapon/ranged/city/thumb/capo/weak,
 /obj/item/clothing/suit/armor/ego_gear/city/thumb_capo,
 /obj/item/ego_weapon/city/thumbmelee/weak,
-/obj/item/grenade/frag,
 /obj/structure/window/reinforced/tinted{
 	dir = 1
 	},
+/obj/item/grenade/r_corp/thumb,
+/obj/item/grenade/r_corp/thumb,
+/obj/item/grenade/r_corp/thumb,
 /turf/open/floor/carpet/red,
 /area/city/backstreets_room)
 "qC" = (
@@ -777,7 +779,9 @@
 /obj/item/ego_weapon/ranged/city/thumb/capo/weak,
 /obj/item/clothing/suit/armor/ego_gear/city/thumb_capo,
 /obj/item/ego_weapon/city/thumbmelee/weak,
-/obj/item/grenade/frag,
+/obj/item/grenade/r_corp/thumb,
+/obj/item/grenade/r_corp/thumb,
+/obj/item/grenade/r_corp/thumb,
 /turf/open/floor/carpet/red,
 /area/city/backstreets_room)
 "Us" = (

--- a/code/game/objects/items/grenades/r_corp.dm
+++ b/code/game/objects/items/grenades/r_corp.dm
@@ -33,3 +33,9 @@
 	icon_state = "r_corp_pale"
 	explosion_damage_type = PALE_DAMAGE
 	explosion_damage = 150
+
+/obj/item/grenade/r_corp/thumb
+	name = "frag grenade"
+	desc = "An anti-personnel fragmentation grenade, this weapon is used by a select few Capos of the Thumb."
+	icon_state = "frag"
+	explosion_damage = 550


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This is just a R-Corp grenade with a different description, sprite and 550 damage, you may think the number is overkill however they do halved damage to players, dont have as much range, dont delimb, dont permanently destroy atmos, dont permanently set things on fire and dont pierce armor.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The old frag grenades did over 800 combined armor piercing brute and burn damage, if you somehow survive that you get delimbed and they fucked with atmos requiring admin intervention whenever used, these ones dont.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added reskinned R-Corp grenades with rebalanced damage
add: Added said reskinned R-Corp grenades to the Thumb Capo lockers.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
