### PR TITLE
Containment Engineers have found and closed up the tunnel Blue Shepherd was using to escape into the maintenance shaft.

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/he/blue_shepherd.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/blue_shepherd.dm
@@ -193,6 +193,9 @@
 	return
 
 /mob/living/simple_animal/hostile/abnormality/blue_shepherd/BreachEffect(mob/living/carbon/human/user, breach_type)
+	if(SSmaptype.maptype == "limbus_labs")
+		return
+
 	var/sighted = FALSE
 	for(var/mob/living/carbon/human/L in view(4, src))
 		sighted = TRUE

--- a/code/modules/mob/living/simple_animal/abnormality/he/pisc_mermaid.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/pisc_mermaid.dm
@@ -80,7 +80,7 @@
 
 /datum/action/innate/change_icon_merm
 	name = "Toggle Icon"
-	desc = "Toggle your icon between breached and contained. (Works only for Limbus Company Labratories)"
+	desc = "Toggle your icon between breached and contained. (Works only for Limbus Company Laboratories)"
 
 /datum/action/innate/change_icon_merm/Activate()
 	. = ..()

--- a/code/modules/mob/living/simple_animal/abnormality/waw/nosferatu.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/nosferatu.dm
@@ -223,7 +223,9 @@
 	else
 		bloodlust -= 1
 	AdjustThirst(40)
-	if(H.health < 0 && !SSmaptype.maptype == "limbus_labs"|| H.stat == DEAD && !SSmaptype.maptype == "limbus_labs")
+	if(SSmaptype.maptype == "limbus_labs")
+		return ..()
+	if(H.health < 0 || H.stat == DEAD)
 		H.Drain()
 	return ..()
 
@@ -254,7 +256,12 @@
 		var/obj/effect/temp_visual/smash_effect/bloodeffect =  new(T)
 		bloodeffect.color = "#b52e19"
 		for(var/mob/living/carbon/human/H in HurtInTurf(T, list(), banquet_damage, BLACK_DAMAGE, null, TRUE, FALSE, TRUE, FALSE, TRUE, TRUE))
-			if(H.health < 0 && !SSmaptype.maptype == "limbus_labs")
+			if(SSmaptype.maptype == "limbus_labs")
+				playsound(get_turf(src), 'sound/abnormalities/nosferatu/attack_special.ogg', 50, 0, 5)
+				SLEEP_CHECK_DEATH(3)
+				can_act = TRUE
+				return
+			if(H.health < 0)
 				H.Drain()
 	playsound(get_turf(src), 'sound/abnormalities/nosferatu/attack_special.ogg', 50, 0, 5)
 	SLEEP_CHECK_DEATH(3)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes a typo with Piscs sprite change ability, stops Shepherd from teleporting into maints on breach on LCL and fixes the issue where Nosf wasnt husking on the main mode
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Its all bugfixing really
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixed shepherd teleporting to the maintenance xenospawns on LCL
fix: fixed a typo with Piscs sprite change ability
fix: fixed Nosferatu not husking on the main mode (oops)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
