### PR TITLE
It is no longer taboo for doctors to have access to their anesthetic lockers

### DIFF
--- a/_maps/map_files/Event/city.dmm
+++ b/_maps/map_files/Event/city.dmm
@@ -1049,7 +1049,7 @@
 /turf/open/floor/facility/white,
 /area/city/fixers)
 "mW" = (
-/obj/structure/closet/secure_closet/medical2,
+/obj/structure/closet/secure_closet/medical2/city,
 /turf/open/indestructible/white,
 /area/city/shop)
 "mZ" = (

--- a/_maps/map_files/Event/city_fixer.dmm
+++ b/_maps/map_files/Event/city_fixer.dmm
@@ -1844,7 +1844,7 @@
 /turf/open/indestructible/white,
 /area/city/shop)
 "yY" = (
-/obj/structure/closet/secure_closet/medical2,
+/obj/structure/closet/secure_closet/medical2/city,
 /turf/open/indestructible/white,
 /area/city/shop)
 "yZ" = (

--- a/_maps/shuttles/emergency_asteroid.dmm
+++ b/_maps/shuttles/emergency_asteroid.dmm
@@ -353,7 +353,7 @@
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "bD" = (
-/obj/structure/closet/secure_closet/medical2,
+/obj/structure/closet/secure_closet/medical2/city,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "bE" = (

--- a/code/game/objects/structures/crates_lockers/closets/secure/lc13.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/lc13.dm
@@ -37,3 +37,6 @@
 			/obj/item/combat_page/level2,
 		)
 
+//Doing it here to avoid conflicts if anything in the future touches medical.dm
+/obj/structure/closet/secure_closet/medical2/city
+	req_access = list(ACCESS_MEDICAL)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes anesthetic locker access by making another anesthetic locker
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Finally, anesthetic. No more asking people to break open your lockers.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added a locker variant which doctors can actually access
tweak: replaced the surgery access lockers with the medical access lockers in CF, CoL and Emergency asteroid
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
