### PR TITLE
K-Corp drones have been reprogrammed to avoid flashing K-Corp staff.

### DIFF
--- a/ModularTegustation/tegu_items/representative/outfits.dm
+++ b/ModularTegustation/tegu_items/representative/outfits.dm
@@ -97,6 +97,7 @@
 /datum/outfit/kcorp/level3
 	name = "K Corp Class 3"
 	suit = /obj/item/clothing/suit/armor/ego_gear/city/kcorp_l3/ert
+	head = /obj/item/clothing/head/ego_hat/helmet/kcorp_l3
 
 /datum/outfit/kcorp/level3/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	var/belt = pick(
@@ -113,6 +114,7 @@
 
 /datum/outfit/kcorp/level3/kill
 	name = "K Corp Asset Protection Staff"
+	glasses = /obj/item/clothing/glasses/sunglasses
 	r_hand = /obj/item/grenade/spawnergrenade/kcorpdrone
 	l_pocket = /obj/item/ksyringe
 	r_pocket = /obj/item/krevive

--- a/ModularTegustation/tegu_mobs/lc13_outskirtdwellers.dm
+++ b/ModularTegustation/tegu_mobs/lc13_outskirtdwellers.dm
@@ -442,7 +442,9 @@
 	playsound(src, 'sound/weapons/flash.ogg', 100, TRUE)
 
 	for (var/mob/living/L in viewers(flash_range,src)) //The actual flashing
-		if (!ishuman(L))
+		if(!ishuman(L))
+			continue
+		if(faction_check(L.faction, list("kcorp")))
 			continue
 		L.flash_act()
 		L.Paralyze(5 SECONDS) //you better dodge it

--- a/code/modules/clothing/outfits/ert.dm
+++ b/code/modules/clothing/outfits/ert.dm
@@ -461,6 +461,7 @@
 
 	ears = /obj/item/radio/headset/headset_cent/alt
 	r_pocket = /obj/item/reagent_containers/hypospray/medipen/mental
+	belt = /obj/item/ego_weapon/city/reindeer
 
 /datum/outfit/job/reindeer/berserker/ert/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	if(visualsOnly)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
K-Corp drones check for K-Corp faction when flashing, K-Corp killteam gets sunglasses, ERT beserkers get the staff and mindwhip.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
K-Corp killteam kept miserably failing to kill people due to being too lazy to dodge their own drones
Beserkers kept gibbing each other as they only spawned with the beam weapon
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: gave K-Corp killteam helmet and sunglasses
tweak: made kcorp drones check for kcorp faction when flashing
tweak: gave ERT beserkers reindeer staff
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
