### PR TITLE
Sphinx, Jbird, Fairy Gentleman and GWSS added to LCL

### DIFF
--- a/ModularTegustation/tegu_items/limbus_labs/!abno_overwrites.dm
+++ b/ModularTegustation/tegu_items/limbus_labs/!abno_overwrites.dm
@@ -191,4 +191,15 @@
 /mob/living/simple_animal/hostile/runawaybird/Initialize()
 	. = ..()
 	if(SSmaptype.maptype == "limbus_labs")
+		faction = list("neutral", "bird")
 		status_flags = MUST_HIT_PROJECTILE
+
+/mob/living/simple_animal/hostile/runawaybird/Login()
+	. = ..()
+	if(SSmaptype.maptype == "limbus_labs")
+		faction = list("hostile", "bird")
+
+/mob/living/simple_animal/hostile/runawaybird/Logout()
+	. = ..()
+	if(SSmaptype.maptype == "limbus_labs")
+		faction = list("neutral", "bird")

--- a/ModularTegustation/tegu_items/limbus_labs/!abno_overwrites.dm
+++ b/ModularTegustation/tegu_items/limbus_labs/!abno_overwrites.dm
@@ -41,10 +41,28 @@
 /mob/living/simple_animal/hostile/abnormality/nosferatu/Initialize()
 	. = ..()
 	if(SSmaptype.maptype == "limbus_labs")
-		ChangeResistances(list(RED_DAMAGE = 1, WHITE_DAMAGE = 1.2, BLACK_DAMAGE = 0.4, PALE_DAMAGE = 1.5))
+		ChangeResistances(list(RED_DAMAGE = 2, WHITE_DAMAGE = 1.2, BLACK_DAMAGE = 0.4, PALE_DAMAGE = 1.5))
 		summon_cooldown_time = 60 MINUTES
 		bat_spawn_number = 0
 		faction = list("neutral", "nosferatu")
+
+/mob/living/simple_animal/hostile/abnormality/laetitia/Initialize()
+	. = ..()
+	if(SSmaptype.maptype == "limbus_labs")
+		faction = list("neutral", "laetitia")
+
+/mob/living/simple_animal/hostile/abnormality/judgement_bird/Initialize()
+	. = ..()
+	if(SSmaptype.maptype == "limbus_labs")
+		faction = list("neutral", "bird")
+		var/mob/living/simple_animal/hostile/runawaybird/V = new(get_turf(src))
+		birdlist+=V
+		V = new(get_turf(src))
+
+/mob/living/simple_animal/hostile/abnormality/schadenfreude/Life()//Hes just a little guy, let him schmoove a bit
+	. = ..()
+	if(SSmaptype.maptype == "limbus_labs")
+		seen = TRUE
 
 //The faction changes let them kill each other with their abilities while sentient
 /mob/living/simple_animal/hostile/abnormality/nosferatu/Login()
@@ -135,17 +153,42 @@
 	if(SSmaptype.maptype == "limbus_labs")
 		faction = list("neutral", "bee")
 
-/mob/living/simple_animal/hostile/laetitia/Initialize()
-	. = ..()
-	if(SSmaptype.maptype == "limbus_labs")
-		faction = list("neutral", "laetitia")
-
-/mob/living/simple_animal/hostile/laetitia/Login()
+/mob/living/simple_animal/hostile/abnormality/laetitia/Login()
 	. = ..()
 	if(SSmaptype.maptype == "limbus_labs")
 		faction = list("laetitia")
 
-/mob/living/simple_animal/hostile/laetitia/Logout()
+/mob/living/simple_animal/hostile/abnormality/laetitia/Logout()
 	. = ..()
 	if(SSmaptype.maptype == "limbus_labs")
 		faction = list("neutral", "laetitia")
+
+/mob/living/simple_animal/hostile/abnormality/fairy_gentleman/Login()
+	. = ..()
+	if(SSmaptype.maptype == "limbus_labs")
+		faction = list("fairy")
+
+/mob/living/simple_animal/hostile/abnormality/fairy_longlegs/Login()
+	. = ..()
+	if(SSmaptype.maptype == "limbus_labs")
+		faction = list("fairy")
+
+/mob/living/simple_animal/hostile/abnormality/scarecrow/Login()
+	. = ..()
+	if(SSmaptype.maptype == "limbus_labs")
+		faction = list("oz")
+
+/mob/living/simple_animal/hostile/abnormality/sphinx/Login()
+	. = ..()
+	if(SSmaptype.maptype == "limbus_labs")
+		faction = list("pharaoh")
+
+/mob/living/simple_animal/hostile/abnormality/judgement_bird/Login()
+	. = ..()
+	if(SSmaptype.maptype == "limbus_labs")
+		faction = list("bird")
+
+/mob/living/simple_animal/hostile/runawaybird/Initialize()
+	. = ..()
+	if(SSmaptype.maptype == "limbus_labs")
+		status_flags = MUST_HIT_PROJECTILE

--- a/ModularTegustation/tegu_items/limbus_labs/!other_overwrites.dm
+++ b/ModularTegustation/tegu_items/limbus_labs/!other_overwrites.dm
@@ -46,3 +46,14 @@
 	if(SSmaptype.maptype == "limbus_labs")
 		prosthetic_cost = 0
 		organic_cost = 100
+
+/obj/structure/statue/petrified/deconstruct(disassembled = TRUE)
+	if(!disassembled)
+		if(petrified_mob)
+			if(SSmaptype.maptype == "limbus_labs")
+				visible_message(span_danger("[src] shatters!."))
+				qdel(src)
+				return
+			petrified_mob.dust()
+	visible_message(span_danger("[src] shatters!."))
+	qdel(src)

--- a/ModularTegustation/tegu_items/limbus_labs/spawners.dm
+++ b/ModularTegustation/tegu_items/limbus_labs/spawners.dm
@@ -17,7 +17,9 @@ GLOBAL_LIST_INIT(low_security, list(
 	/mob/living/simple_animal/hostile/abnormality/galaxy_child,
 	/mob/living/simple_animal/hostile/abnormality/woodsman,
 	/mob/living/simple_animal/hostile/abnormality/steam,
-	/mob/living/simple_animal/hostile/abnormality/laetitia
+	/mob/living/simple_animal/hostile/abnormality/laetitia,
+	/mob/living/simple_animal/hostile/abnormality/fairy_gentleman,
+	/mob/living/simple_animal/hostile/abnormality/smile,
 
 ))
 
@@ -31,6 +33,8 @@ GLOBAL_LIST_INIT(high_security, list(
 	/mob/living/simple_animal/hostile/abnormality/general_b,
 	/mob/living/simple_animal/hostile/abnormality/hatred_queen,
 	/mob/living/simple_animal/hostile/abnormality/nosferatu,
+	/mob/living/simple_animal/hostile/abnormality/sphinx,
+	/mob/living/simple_animal/hostile/abnormality/judgement_bird,
 
 ))
 

--- a/code/game/objects/structures/petrified_statue.dm
+++ b/code/game/objects/structures/petrified_statue.dm
@@ -73,7 +73,6 @@
 	visible_message(span_danger("[src] shatters!."))
 	qdel(src)
 
-
 /mob/proc/petrify(statue_timer)
 
 /mob/living/carbon/human/petrify(statue_timer)

--- a/code/modules/mob/living/simple_animal/abnormality/teth/fairy_gentleman.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/fairy_gentleman.dm
@@ -86,7 +86,10 @@
 	)
 
 //Action Buttons
-	attack_action_types = list(/datum/action/innate/abnormality_attack/toggle/FairyJump)
+	attack_action_types = list(
+	/datum/action/innate/abnormality_attack/toggle/FairyJump,
+	/datum/action/cooldown/gentleman_drink,
+	)
 
 /datum/action/innate/abnormality_attack/toggle/FairyJump
 	name = "Toggle Jump"
@@ -97,6 +100,23 @@
 	toggle_attack_num = 1
 	toggle_message = span_colossus("You will now jump with your next attack when possible.")
 	button_icon_toggle_deactivated = "generic_toggle0"
+
+/datum/action/cooldown/gentleman_drink
+	name = "Offer a drink"
+	icon_icon = 'icons/obj/drinks.dmi'
+	button_icon_state = "fairy_wine"
+	check_flags = AB_CHECK_CONSCIOUS
+	transparent_when_unavailable = TRUE
+	cooldown_time = 5 SECONDS
+
+/datum/action/cooldown/gentleman_drink/Trigger()
+	if(!..())
+		return FALSE
+	if(!istype(owner, /mob/living/simple_animal/hostile/abnormality/fairy_gentleman))
+		return FALSE
+	if(SSmaptype.maptype == "limbus_labs")
+		new /obj/item/reagent_containers/food/drinks/fairywine(owner.loc)
+		owner.visible_message(span_notice("[owner] produces a round of drinks"))
 
 //Work mechanics
 /mob/living/simple_animal/hostile/abnormality/fairy_gentleman/SuccessEffect(mob/living/carbon/human/user, work_type, pe)

--- a/code/modules/mob/living/simple_animal/abnormality/waw/judgement_bird.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/judgement_bird.dm
@@ -191,7 +191,6 @@
 	melee_damage_type = PALE_DAMAGE
 	obj_damage = 0
 	environment_smash = ENVIRONMENT_SMASH_NONE
-	faction = list("hostile", "bird")
 	attack_verb_continuous = "pecks"
 	attack_verb_simple = "peck"
 	attack_sound = 'sound/weapons/fixer/generic/nail1.ogg'

--- a/code/modules/mob/living/simple_animal/abnormality/waw/judgement_bird.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/judgement_bird.dm
@@ -102,31 +102,42 @@
 	playsound(get_turf(src), 'sound/abnormalities/judgementbird/pre_ability.ogg', 50, 0, 2)
 	SLEEP_CHECK_DEATH(2 SECONDS)
 	playsound(get_turf(src), 'sound/abnormalities/judgementbird/ability.ogg', 75, 0, 7)
-	for(var/mob/living/L in urange(judgement_range, src))
-		if(faction_check_mob(L, FALSE))
-			continue
-		if(L.stat == DEAD)
-			continue
-		new /obj/effect/temp_visual/judgement(get_turf(L))
-		L.deal_damage(judgement_damage, PALE_DAMAGE)
+	if(SSmaptype.maptype == "limbus_labs")
+		for(var/mob/living/L in oview(judgement_range, src))//Listen I need jbird to not kill people through walls if hes going to play nice
+			if(faction_check_mob(L, FALSE))
+				continue
+			if(L.stat == DEAD)
+				continue
+			new /obj/effect/temp_visual/judgement(get_turf(L))
+			L.deal_damage(judgement_damage, PALE_DAMAGE)
 
-		if(L.stat == DEAD)	//Gotta fucking check again in case it kills you. Real moment
-			if(!IsCombatMap())
-				var/turf/T = get_turf(L)
-				if(locate(/obj/structure/jbird_noose) in T)
-					T = pick_n_take(T.reachableAdjacentTurfs())//if a noose is on this tile, it'll still create another one. You probably shouldn't be letting this many people die to begin with
-					L.forceMove(T)
-				var/obj/structure/jbird_noose/N = new(get_turf(L))
-				N.buckle_mob(L)
-				playsound(get_turf(L), 'sound/abnormalities/judgementbird/kill.ogg', 75, 0, 7)
-				playsound(get_turf(L), 'sound/abnormalities/judgementbird/hang.ogg', 100, 0, 7)
-				var/mob/living/simple_animal/hostile/runawaybird/V = new(get_turf(L))
-				birdlist+=V
-				V = new(get_turf(L))
-				birdlist+=V
+	else
+		for(var/mob/living/L in urange(judgement_range, src))
+			if(faction_check_mob(L, FALSE))
+				continue
+			if(L.stat == DEAD)
+				continue
+			new /obj/effect/temp_visual/judgement(get_turf(L))
+			L.deal_damage(judgement_damage, PALE_DAMAGE)
+
+			if(L.stat == DEAD)	//Gotta fucking check again in case it kills you. Real moment
+				if(!IsCombatMap())
+					var/turf/T = get_turf(L)
+					if(locate(/obj/structure/jbird_noose) in T)
+						T = pick_n_take(T.reachableAdjacentTurfs())//if a noose is on this tile, it'll still create another one. You probably shouldn't be letting this many people die to begin with
+						L.forceMove(T)
+					var/obj/structure/jbird_noose/N = new(get_turf(L))
+					N.buckle_mob(L)
+					playsound(get_turf(L), 'sound/abnormalities/judgementbird/kill.ogg', 75, 0, 7)
+					playsound(get_turf(L), 'sound/abnormalities/judgementbird/hang.ogg', 100, 0, 7)
+					var/mob/living/simple_animal/hostile/runawaybird/V = new(get_turf(L))
+					birdlist+=V
+					V = new(get_turf(L))
+					birdlist+=V
 
 	icon_state = icon_living
 	judging = FALSE
+	return
 
 /mob/living/simple_animal/hostile/abnormality/judgement_bird/NeutralEffect(mob/living/carbon/human/user, work_type, pe)
 	. = ..()
@@ -180,6 +191,7 @@
 	melee_damage_type = PALE_DAMAGE
 	obj_damage = 0
 	environment_smash = ENVIRONMENT_SMASH_NONE
+	faction = list("hostile", "bird")
 	attack_verb_continuous = "pecks"
 	attack_verb_simple = "peck"
 	attack_sound = 'sound/weapons/fixer/generic/nail1.ogg'


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
adds Sphinx, Jbird, Fairy Gentleman and GWSS, makes it so statues dont dust when broken on LCL and makes jbird not pierce on LCL. Nerfs Nosferatu based on recent perfomance and makes it so Schadenfreude is always seen.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
More abnos means more RP variety, Nosferatu was far too overwhelming for security with its oppressive healing and Schadenfreude had a hard time simply moving around due to his sight mechanics which highly restricted what it could do.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added fairy gentleman to LCL with a ability to spawn wine
add: added Sphinx to LCL
add: added jbird to LCL
add: added GWSS to LCL
tweak: made it so jbird swaps from urange to oview for his judgement in LCL
tweak: made statues not dust when broken on LCL
balance: made Nosf RED fatal on LCL
balance: made Schadenfreude always seen on LCL
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
