### PR TITLE
Slightly alters Red Blooded American's work rates

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/teth/redblooded.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/redblooded.dm
@@ -32,9 +32,9 @@
 	start_qliphoth = 2
 	work_chances = list(
 		ABNORMALITY_WORK_INSTINCT = 45,
-		ABNORMALITY_WORK_INSIGHT = 30,
+		ABNORMALITY_WORK_INSIGHT = 35,
 		ABNORMALITY_WORK_ATTACHMENT = 0,
-		ABNORMALITY_WORK_REPRESSION = list(55, 55, 55, 60, 60),
+		ABNORMALITY_WORK_REPRESSION = list(60, 60, 60, 55, 55),
 	)
 	max_boxes = 14
 	work_damage_amount = 6
@@ -109,7 +109,7 @@
 	else
 		icon_state = "american_idle"
 	return ..()
-
+	
 /mob/living/simple_animal/hostile/abnormality/redblooded/NeutralEffect(mob/living/carbon/human/user, work_type, pe)
 	. = ..()
 	if(prob(50)) //slightly higher than other TETHs, given that the counter can be raised


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
There's nothing much to it, it just increases the work chance of INSIGHT and REPRESSION work by 5. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
There's no real reason for Repression to get better at the point where you'd stop working on RBA all together.

Insight is slightly improved to make it slightly better at training.  Just fixing a small thing that nags me about my own abno since I was a bit inexperienced when I was deciding work rates. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Makes RBA a tiny bit better at training.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
