### PR TITLE
Makes Runaway Crows Able to be Shot

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/waw/judgement_bird.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/judgement_bird.dm
@@ -183,7 +183,6 @@
 	icon_living = "runaway_bird"
 	pass_flags = PASSTABLE
 	is_flying_animal = TRUE
-	density = FALSE
 	health = 100
 	maxHealth = 100
 	melee_damage_lower = 5

--- a/code/modules/mob/living/simple_animal/abnormality/waw/judgement_bird.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/judgement_bird.dm
@@ -183,6 +183,8 @@
 	icon_living = "runaway_bird"
 	pass_flags = PASSTABLE
 	is_flying_animal = TRUE
+	density = FALSE
+	status_flags = MUST_HIT_PROJECTILE
 	health = 100
 	maxHealth = 100
 	melee_damage_lower = 5


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
It makes Judgement Bird's Crows shootable
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Considering the birds will knock you the split second you are in range, it just is more CBT than needed to deal with them. Since it wouldn't likely be removed for them to hit immediately, this is the best idea i have to balance them on the top of my head.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: rebalanced crows
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
