### PR TITLE
TGChat no longer shared with tgstation/others

### DIFF
--- a/tgui/packages/common/storage.js
+++ b/tgui/packages/common/storage.js
@@ -149,6 +149,8 @@ class IndexedDbBackend {
   }
 }
 
+let namespace = 'lc13-';
+
 /**
  * Web Storage Proxy object, which selects the best backend available
  * depending on the environment.
@@ -173,17 +175,17 @@ class StorageProxy {
 
   async get(key) {
     const backend = await this.backendPromise;
-    return backend.get(key);
+    return backend.get(namespace + key);
   }
 
   async set(key, value) {
     const backend = await this.backendPromise;
-    return backend.set(key, value);
+    return backend.set(namespace + key, value);
   }
 
   async remove(key) {
     const backend = await this.backendPromise;
-    return backend.remove(key);
+    return backend.remove(namespace + key);
   }
 
   async clear() {


### PR DESCRIPTION
This annoyed me enough to fix it

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
TGChat now adds a "lc13-" prefix to all its message keys which theoretically should mean that it only deals with lc13-specific chat messages now.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Chat more better-ish

# This probably changes everyones' chat settings. Merge when communicated.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Attribution

This is more or less how Aurora does/did it, specifically
https://github.com/Aurorastation/Aurora.3/pull/16538

## Changelog

:cl:
fix: TGChat is no longer shared with tgstation/other unconfigured codebases
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
