### PR TITLE
gives box seph languages other sephs have

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/sephirah.dm
+++ b/code/modules/mob/living/carbon/human/species_types/sephirah.dm
@@ -3,6 +3,7 @@
 	id = "sephirah"
 	mutant_bodyparts = list()
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | ERT_SPAWN
+	species_language_holder = /datum/language_holder/synthetic
 
 	inherent_biotypes = MOB_ROBOTIC
 	sexes = 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Gives box sephirah the same language holder as human-appearing sephirah.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Parity. If this isn't wanted it should be removed from the human-looking ones.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Box-appearing sephirah now know the languages their human-resembling counterparts do.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
