### PR TITLE
K-Corp drones now capable of differentiating flesh from steel

### DIFF
--- a/ModularTegustation/tegu_items/representative/items/kcorp.dm
+++ b/ModularTegustation/tegu_items/representative/items/kcorp.dm
@@ -98,7 +98,11 @@
 /mob/living/simple_animal/hostile/khealing/CanAttack(atom/the_target)
 	if(!ishuman(the_target))
 		return FALSE
-	var/mob/living/H = the_target
+	var/mob/living/carbon/human/H = the_target
+	for(var/X in H.bodyparts)
+		var/obj/item/bodypart/BP = X
+		if(BP.status == BODYPART_ROBOTIC)
+			return FALSE
 	if(H.health != H.maxHealth)
 		return TRUE
 	return FALSE
@@ -109,6 +113,9 @@
 		H.adjustStaminaLoss(rand(14, 18))
 		if(!defective)
 			H.adjustBruteLoss(-20)
+			H.adjustFireLoss(-10)
+			H.adjustToxLoss(-5)
+			H.adjustOxyLoss(-5)
 			to_chat(H, span_nicegreen("You feel your injuries painfully close!"))
 			if(prob(25))
 				H.emote("scream")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
K-Corp drones now avoid healing those with prosthetics (it stops you getting stunlocked because your arm had 1 brute) and now heal more damage types at a reduced rate to avoid stunlocking the player on a damage type it can't heal.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The drone quite honestly sucks, it griefs more than it helps with it often killing players trying to heal something it cant fix.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: tweaked khealdrone to not target prosthetic users and heal burn/toxin/oxy
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
