### PR TITLE
Claw and arbiter given brutepale trait

### DIFF
--- a/code/modules/antagonists/head/claw.dm
+++ b/code/modules/antagonists/head/claw.dm
@@ -63,6 +63,7 @@
 	ADD_TRAIT(M, TRAIT_NOFIRE, "Claw")
 	ADD_TRAIT(M, TRAIT_NODISMEMBER, "Claw")
 	ADD_TRAIT(M, TRAIT_SANITYIMMUNE, "Claw")
+	ADD_TRAIT(M, TRAIT_BRUTEPALE, "Claw")
 	M.adjust_attribute_buff(FORTITUDE_ATTRIBUTE, 250) // Half of Arbiter, you're the claw not getting hit is part of your training
 
 /datum/antagonist/claw/remove_innate_effects(mob/living/mob_override)
@@ -79,6 +80,7 @@
 	REMOVE_TRAIT(M, TRAIT_NOFIRE, "Claw")
 	REMOVE_TRAIT(M, TRAIT_NODISMEMBER, "Claw")
 	REMOVE_TRAIT(M, TRAIT_SANITYIMMUNE, "Claw")
+	REMOVE_TRAIT(M, TRAIT_BRUTEPALE, "Claw")
 	M.adjust_attribute_buff(FORTITUDE_ATTRIBUTE, -250)
 
 /datum/outfit/claw

--- a/code/modules/antagonists/wizard/arbiter.dm
+++ b/code/modules/antagonists/wizard/arbiter.dm
@@ -41,6 +41,7 @@
 	ADD_TRAIT(M, TRAIT_NODISMEMBER, "Arbiter")
 	ADD_TRAIT(M, TRAIT_SANITYIMMUNE, "Arbiter")
 	ADD_TRAIT(M, TRAIT_BRUTEPALE, "Arbiter")
+	ADD_TRAIT(M, TRAIT_BRUTESANITY, "Arbiter")
 	M.adjust_attribute_buff(FORTITUDE_ATTRIBUTE, 500) // Obviously they are very tough
 	for(var/spell_type in spell_types)
 		var/obj/effect/proc_holder/spell/S = new spell_type
@@ -61,6 +62,7 @@
 	REMOVE_TRAIT(M, TRAIT_NODISMEMBER, "Arbiter")
 	REMOVE_TRAIT(M, TRAIT_SANITYIMMUNE, "Arbiter")
 	REMOVE_TRAIT(M, TRAIT_BRUTEPALE, "Arbiter")
+	REMOVE_TRAIT(M, TRAIT_BRUTESANITY, "Arbiter")
 	M.adjust_attribute_buff(FORTITUDE_ATTRIBUTE, -500)
 
 /datum/outfit/arbiter

--- a/code/modules/antagonists/wizard/arbiter.dm
+++ b/code/modules/antagonists/wizard/arbiter.dm
@@ -40,6 +40,7 @@
 	ADD_TRAIT(M, TRAIT_NOFIRE, "Arbiter")
 	ADD_TRAIT(M, TRAIT_NODISMEMBER, "Arbiter")
 	ADD_TRAIT(M, TRAIT_SANITYIMMUNE, "Arbiter")
+	ADD_TRAIT(M, TRAIT_BRUTEPALE, "Arbiter")
 	M.adjust_attribute_buff(FORTITUDE_ATTRIBUTE, 500) // Obviously they are very tough
 	for(var/spell_type in spell_types)
 		var/obj/effect/proc_holder/spell/S = new spell_type
@@ -59,6 +60,7 @@
 	REMOVE_TRAIT(M, TRAIT_NOFIRE, "Arbiter")
 	REMOVE_TRAIT(M, TRAIT_NODISMEMBER, "Arbiter")
 	REMOVE_TRAIT(M, TRAIT_SANITYIMMUNE, "Arbiter")
+	REMOVE_TRAIT(M, TRAIT_BRUTEPALE, "Arbiter")
 	M.adjust_attribute_buff(FORTITUDE_ATTRIBUTE, -500)
 
 /datum/outfit/arbiter

--- a/code/modules/clothing/suits/ego_gear/non_abnormality/lcorp.dm
+++ b/code/modules/clothing/suits/ego_gear/non_abnormality/lcorp.dm
@@ -74,7 +74,7 @@ It's not great though.
 /obj/item/clothing/suit/armor/extraction/arbiter
 	name = "arbiter's armored coat"
 	desc = "A coat made out of quality cloth, providing immense protection against most damage sources. It is quite heavy."
-	armor = list(RED_DAMAGE = 90, WHITE_DAMAGE = 100, BLACK_DAMAGE = 90, PALE_DAMAGE = 90)
+	armor = list(RED_DAMAGE = 90, WHITE_DAMAGE = 90, BLACK_DAMAGE = 90, PALE_DAMAGE = 90)
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS|HEAD
 	cold_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS|HEAD
 	heat_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS|HEAD


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Claw gets brutepale, arbiter gets brutepale and brutesanity. The arbiter armor is also changed to IX/IX/IX/IX as all damage done to them is identical.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
These changes stop issues with admins being vaporized by pale and lets arbiter perform better in R-Corp assault.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Gave the claw and arbiter brutepale trait, arbiter also gets brutesanity.
balance: Changed arbiter armor from IX/X/IX/IX to IX/IX/IX/IX
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
