### PR TITLE
Insane People are no longer possessable by Evil Gamer Ghosts

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -651,9 +651,12 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 			var/mob/living/simple_animal/hostile/abnormality/abnormality = L
 			if(abnormality.do_not_possess)
 				continue
-
-		if(istype(L, /mob/living/carbon/human/dummy) || !get_turf(L)) //Haha no.
+		if(!get_turf(L))
 			continue
+		if(istype(L, /mob/living/carbon/human))
+			var/mob/living/carbon/human/H = L
+			if(istype(H, /mob/living/carbon/human/dummy) || H.sanity_lost) //Haha no.
+				continue
 		// LOBOTOMYCORPORATION ADDITION END
 
 		if(!(L in GLOB.player_list) && !L.mind)


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
For a while now humans who were clientless due to going insane were possessable by ghosts. This was not good.
Now ghosts should be prevented from possessing people who have the sanity_lost variable.

## Changelog
:cl:
fix: Evil Gamer Ghosts can no longer possess the mentally insane.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
