### PR TITLE
Fixes a issue with Zwei West, adds it to roaming fixers.

### DIFF
--- a/ModularTegustation/ego_weapons/melee/non_abnormality/zwei.dm
+++ b/ModularTegustation/ego_weapons/melee/non_abnormality/zwei.dm
@@ -144,7 +144,7 @@
 /obj/item/ego_weapon/city/zweiwest
 	name = "zwei knight greatsword"
 	desc = "A bulky rectangular greatsword used by the zwei of the west."
-	special = "If used at 2 range you will lunge fowards then block"
+	special = "If used at 2 range you will lunge fowards then block, if you fail to lunge you will hesitate."
 	icon_state = "zweiwest"
 	inhand_icon_state = "zweiwest"
 	force = 50
@@ -168,11 +168,12 @@
 	..()
 	if(!CanUseEgo(user))
 		return
-
-	var/distance = get_dist(target, user)
-
-	if(distance != 2)
+	if(!isliving(target))
 		return
+
+	if(get_dist(target, user) < 2)//You need to use your range to trigger the guard
+		return
+
 	var/dodgelanding
 	if(user.dir == 1)
 		dodgelanding = locate(user.x, user.y + 1, user.z)
@@ -183,6 +184,14 @@
 	if(user.dir == 8)
 		dodgelanding = locate(user.x - 1, user.y, user.z)
 	user.throw_at(dodgelanding, 1, 1, spin = FALSE)
+	sleep(1)
+
+	if(get_dist(target, user) > 1)//If you try to use the greatsword like a spear you deserve this
+		user.changeNext_move(CLICK_CD_MELEE * 1.5)
+		user.Immobilize(2 SECONDS)
+		to_chat(user, span_userdanger("You hesitate to lunge fowards leaving you open to gaps."))
+		return
+
 	user.Immobilize(2 SECONDS)
 	user.physiology.red_mod *= defense_buff
 	user.physiology.white_mod *= defense_buff

--- a/ModularTegustation/ego_weapons/melee/non_abnormality/zwei.dm
+++ b/ModularTegustation/ego_weapons/melee/non_abnormality/zwei.dm
@@ -168,7 +168,7 @@
 	..()
 	if(!CanUseEgo(user))
 		return
-	if(!isliving(target))
+	if(target.stat == DEAD)
 		return
 
 	if(get_dist(target, user) < 2)//You need to use your range to trigger the guard
@@ -184,12 +184,17 @@
 	if(user.dir == 8)
 		dodgelanding = locate(user.x - 1, user.y, user.z)
 	user.throw_at(dodgelanding, 1, 1, spin = FALSE)
-	sleep(1)
 
-	if(get_dist(target, user) > 1)//If you try to use the greatsword like a spear you deserve this
-		user.changeNext_move(CLICK_CD_MELEE * 1.5)
-		user.Immobilize(2 SECONDS)
-		to_chat(user, span_userdanger("You hesitate to lunge fowards leaving you open to gaps."))
+	if(isliving(target))
+		if(get_dist(target, user) > 1)//If you try to use the greatsword like a spear you deserve this
+			user.changeNext_move(CLICK_CD_MELEE * 2)
+			user.Knockdown(2 SECONDS)
+			var/obj/item/held = user.get_active_held_item()
+			user.dropItemToGround(held)
+			to_chat(user, span_userdanger("Your swing is too wide leading you to lose your balance!"))
+			return
+
+	if(!isliving(target))
 		return
 
 	user.Immobilize(2 SECONDS)

--- a/code/modules/jobs/job_types/trusted_players/association/roaming.dm
+++ b/code/modules/jobs/job_types/trusted_players/association/roaming.dm
@@ -28,7 +28,7 @@
 		You are a fixer that recently blew into town to assist the local offices in their endeavors."
 
 	var/list/associations = list("zwei","shi5", "liu5", "seven")
-	var/list/uncommon_associations = list("shi2", "cinq", "liu1")
+	var/list/uncommon_associations = list("shi2", "cinq", "liu1", "zweiw")
 	var/list/rare_associations = list("hana", "liu2")
 
 /datum/job/associateroaming/after_spawn(mob/living/carbon/human/H, mob/M)
@@ -56,6 +56,10 @@
 		if("zwei")
 			armor = /obj/item/clothing/suit/armor/ego_gear/city/zwei
 			weapon = /obj/item/ego_weapon/city/zweihander
+
+		if("zweiw")
+			armor = /obj/item/clothing/suit/armor/ego_gear/city/zweiwest
+			weapon = /obj/item/ego_weapon/city/zweiwest
 
 		if("shi2")
 			armor = /obj/item/clothing/suit/armor/ego_gear/city/shi


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Players would use the weapon like a spear to trigger its guard, so the weapon doubles its attack speed and immobilizes without any of the benefits if the player fails to dash, also adds a Zwei West option to roaming association.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Roaming association let's players try out Zwei West and the weapon change should stop the issue where its treated like a high DPS spear.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added Zwei West gear to roaming assoc at an uncommon rate
fix: fixed zwei west being able to trigger its lunge without lunging
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
