### PR TITLE
Replaces observation implant in dispenser with thermal+wall eyes

### DIFF
--- a/ModularTegustation/tegu_items/associations/vending.dm
+++ b/ModularTegustation/tegu_items/associations/vending.dm
@@ -252,7 +252,7 @@
 		/obj/item/organ/cyberimp/arm/briefcase = 100,
 		/obj/item/organ/cyberimp/arm/surgery = 100,
 		/obj/item/organ/cyberimp/arm/overdrive = 100,
-		/obj/item/organ/cyberimp/arm/observation = 100,
+		/obj/item/organ/eyes/robotic/infofixer = 100,
 		/obj/item/extra_arm = 100,
 		/obj/item/extra_arm/double = 100,
 	)

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -181,7 +181,7 @@
 	name = "high-information eyes"
 	desc = "Many fixers who work in dangerous locations swear by these cybernetic eyes' ability to detect threats ahead of time."
 	eye_color = "F00"
-	sight_flags = SEE_MOBS | SEE_OBJS | SEE_TURFS
+	sight_flags = SEE_MOBS | SEE_TURFS
 	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE
 	flash_protect = FLASH_PROTECTION_SENSITIVE
 	see_in_dark = 8

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -185,7 +185,6 @@
 	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE
 	flash_protect = FLASH_PROTECTION_SENSITIVE
 	see_in_dark = 8
-	custom_premium_price = 1800
 
 /obj/item/organ/eyes/robotic/flashlight
 	name = "flashlight eyes"

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -177,6 +177,16 @@
 	flash_protect = FLASH_PROTECTION_SENSITIVE
 	see_in_dark = 8
 
+/obj/item/organ/eyes/robotic/infofixer
+	name = "high-information eyes"
+	desc = "Many fixers who work in dangerous locations swear by these cybernetic eyes' ability to detect threats ahead of time."
+	eye_color = "F00"
+	sight_flags = SEE_MOBS | SEE_OBJS | SEE_TURFS
+	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE
+	flash_protect = FLASH_PROTECTION_SENSITIVE
+	see_in_dark = 8
+	custom_premium_price = 1800
+
 /obj/item/organ/eyes/robotic/flashlight
 	name = "flashlight eyes"
 	desc = "It's two flashlights rigged together with some wire. Why would you put these in someone's head?"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes observation implant from vending machine.
Adds new eyes that see tiles and mobs with night vision.
Adds those eyes to vending machine.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Observation implant is widely considered not very good for the game. These eyes give many of the benefits of it without being an aghost button. The implant is still in the game if you want it as a cool dangerous loot reward or something.
![image](https://github.com/user-attachments/assets/bace55b5-eacd-430b-b9c5-d9ea96e19caa)
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: New eyes at the prosthetics surgeon let you see layouts and enemies in the dark.
del: Observation implant now gone from prosthetic surgeon dispenser.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
