### PR TITLE
Adventure Console 2.1

### DIFF
--- a/ModularTegustation/lc13_obj/_adventure_console/adventure_events/_event.dm
+++ b/ModularTegustation/lc13_obj/_adventure_console/adventure_events/_event.dm
@@ -15,6 +15,8 @@
 	var/extra_chance = 0
 	//Short lived text that says things that had happened.
 	var/temp_text = ""
+	//Determines if the event can only be encountered once.
+	var/spend_event = FALSE
 	//The adventure datum that this event is connected to. Hopefully is set upon being created by it.
 	var/datum/adventure_layout/gamer
 	//If we need a certain abnormality to appear as a option. If no abnormality is listed this event will occur normally
@@ -34,6 +36,8 @@
 	* Capitalization and spaces will be considered.
 	*/
 	var/event_locks = ""
+	//Should this encounter be unavoidable?
+	var/force_encounter = FALSE
 
 /datum/adventure_event/New(datum/adventure_layout/player)
 	. = ..()
@@ -84,6 +88,8 @@
 	gamer.event_data = null
 	cords = 1
 	M.updateUsrDialog()
+	if(spend_event)
+		gamer.spent_events += src.type
 	qdel(src)
 
 //Called by console after a choice is recieved.

--- a/ModularTegustation/lc13_obj/_adventure_console/adventure_events/general/legacy.dm
+++ b/ModularTegustation/lc13_obj/_adventure_console/adventure_events/general/legacy.dm
@@ -14,6 +14,7 @@
 		"The figure looks towards you, and so do the shadows.<br>\
 		You are not alone.",
 	)
+	force_encounter = TRUE
 
 /datum/adventure_event/legacy/EventChoiceFormat(obj/machinery/M, mob/living/carbon/human/H)
 	switch(cords)
@@ -28,4 +29,5 @@
 			playsound(get_turf(H), 'sound/effects/creak1.ogg', 20, FALSE)
 			AdjustStatNum(GLOOM_STAT,ADV_EVENT_STAT_EASY)
 			RewardKey("FACE THE FEAR COFFEE MUG")
+			spend_event = TRUE
 	return ..()

--- a/ModularTegustation/lc13_obj/_adventure_console/adventure_events/general/ncorp_start.dm
+++ b/ModularTegustation/lc13_obj/_adventure_console/adventure_events/general/ncorp_start.dm
@@ -45,4 +45,6 @@
 
 		if(6)
 			RewardKey("NAGEL INITIATION")
+			//Event cannot be encountered again if you get the invitation.
+			spend_event = TRUE
 	return ..()

--- a/ModularTegustation/lc13_obj/_adventure_console/adventure_layout.dm
+++ b/ModularTegustation/lc13_obj/_adventure_console/adventure_layout.dm
@@ -1,5 +1,5 @@
 /**
- * ADVENTURE CONSOLE V2.0
+ * ADVENTURE CONSOLE V2.1
  * TEXT BASED ADVENTURES
  * Adventures that are mostly predefined paths.
  * This was difficult to finalize since i havent made a text based adventure before.
@@ -55,6 +55,8 @@
 	var/list/paths_to_tread = list()
 	///Events we can choose from.
 	var/list/event_options = list()
+	///Events we cannot encounter again
+	var/list/spent_events = list()
 	///list of all events.
 	var/static/list/events = list()
 	//Keys required for events to appear.
@@ -263,8 +265,10 @@
 	if(event_data)
 		. += event_data.Event(requester, H)
 		if(!event_data)
+			//Due to a quirk of the code we have to set it to main menu before we can actually change back to where we were.
+			display_mode = NORMAL_TEXT_DISPLAY
 			//Emergency Exit because the event can lead to a empty screen due to the event deleting itself.
-			GENERAL_BUTTON(REF(requester),"set_display",NORMAL_TEXT_DISPLAY,"RETURN TO MAIN PROGRAM")
+			GENERAL_BUTTON(REF(requester),"set_display",ADVENTURE_TEXT_DISPLAY,"RETURN TO THE PATH")
 	else
 		//STATS! ARE HERE
 		. = "<tt>\
@@ -453,17 +457,35 @@
 	enemy_key = null
 
 /datum/adventure_layout/proc/GeneratePaths(max_paths)
+	var/datum/adventure_event/forced_event
+	var/list/editable_paths = list()
 	for(var/i=1 to max_paths)
 		//Unsure if i should put in a check in order to prevent 3% chance events.-IP
 		//A minimum is fine, I set it to 15%. - KK
 		if(prob(program_progress) && program_progress > 15)
-			paths_to_tread += GrabEvent()
+			var/datum/adventure_event/P = GrabEvent()
+			editable_paths += P
+			if(P.force_encounter == TRUE)
+				forced_event = P
+				break
 			continue
 		if(prob(program_progress + 10))
-			paths_to_tread += ADVENTURE_MODE_BATTLE
+			editable_paths += ADVENTURE_MODE_BATTLE
 			continue
 		else
-			paths_to_tread += ADVENTURE_MODE_TRAVEL
+			editable_paths += ADVENTURE_MODE_TRAVEL
+
+	//Should we force the player to only take this path?
+	if(forced_event)
+		for(var/path_to_take in editable_paths)
+			var/datum/adventure_event/A = editable_paths[path_to_take]
+			if(forced_event && A == forced_event)
+				continue
+			editable_paths -= A
+			if(istype(A, /datum/adventure_event))
+				qdel(A)
+
+	paths_to_tread = editable_paths.Copy()
 	return paths_to_tread
 
 //Creates and sets a event. 2nd part to GrabEvent().
@@ -694,10 +716,15 @@
 
 //Updates event list to see if we can have any new events
 /datum/adventure_layout/proc/CheckEventList()
+	//Remove spent events
+	event_options.Remove(spent_events)
 	//The event list except all events we already have are removed.
 	var/list/new_events = events - event_options
 	for(var/_option in new_events)
 		var/datum/adventure_event/A = _option
+		//Do not add already spent events.
+		if(locate(A) in spent_events)
+			continue
 		//Lets see if i can make a lock + key event criteria.
 		if(FormatNonexistentEventCriteria(initial(A.event_locks)))
 			continue


### PR DESCRIPTION
## About The Pull Request
Adventure Events now have new Variables
var/spend_event is false by default. If a option in the event changes it to TRUE then it will no longer be encountered after that option.
var/force_encounter removes all other path options when this event is generated.
Adventure Console now has a new Variable
var/list/spent_events is a list of events that cannot be encountered again. This comes into play when events are being generated. Events are added to this list if completed with the spend_event variable as TRUE.
Adventure Console will now return players to the adventure screen instead of the main menu.

Event Edits:
As a example, legacy.dm has force_encounter and spend_event turned to TRUE.

## Why It's Good For The Game
Requested features by writers and players.

## Changelog
:cl:
add: Adventure Console Support for One Time and Forced Encounters.
tweak: Exiting events in adventure_console now sends the player back to adventure screen. The screen confirming that you want to return to the paths however still remains.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
