### PR TITLE
DRV, Puss and apex buffs for R-Corp assault

### DIFF
--- a/ModularTegustation/tegu_items/rcorp/!abno_overwrites.dm
+++ b/ModularTegustation/tegu_items/rcorp/!abno_overwrites.dm
@@ -9,10 +9,14 @@
 		healthmodifier = 0.02
 	return ..()
 
-//Jangsen is slow, and blocks bullets fully now to let them function as a tank
+//Jangsan blocks ranged damage up to 200 and kills those of lower level
+//Jangsan is slow, and blocks bullets fully now to let them function as a tank
+//Jangsans oneshot was pointless only killing enemies who would never be in melee range in the first place
+//These changes should allow him to tank with his low HP pool while still being threatened by: rhinos, reindeers, roadrunners, raven captains, rooster captains
 /mob/living/simple_animal/hostile/abnormality/jangsan/Initialize()
-	if(IsCombatMap())
-		bullet_threshold = 150
+	if(SSmaptype.maptype == "rcorp")
+		bullet_threshold = 300
+		weak_attribute = 61 //What triggers the clerkoid meter
 	return ..()
 
 //R-Corp cannot eat 180 white damage
@@ -121,4 +125,23 @@
 	if(IsCombatMap())
 		initial_charge_damage = 200
 		growing_charge_damage = 80
+	return ..()
+
+//apex predator backstabs do 150% more damage
+//apex predator backstabs are highly choreographed and reveal apex, the apex player should be rewarded for pulling it off
+/mob/living/simple_animal/hostile/abnormality/apex_predator/Initialize()
+	if(SSmaptype.maptype == "rcorp")
+		backstab_damage = 500
+	return ..()
+
+//puss in boots finishers do 100% more damage
+//puss in boots has a highly choreographed attack which also stuns himself and the target if he hits it, often meaning death for Puss
+/mob/living/simple_animal/hostile/abnormality/puss_in_boots/Initialize()
+	if(SSmaptype.maptype == "rcorp")
+		finisher_damage = 200
+	return ..()
+
+/mob/living/simple_animal/hostile/abnormality/dimensional_refraction/Initialize()
+	if(SSmaptype.maptype == "rcorp")
+		invisibility_level = 10
 	return ..()

--- a/code/modules/mob/living/simple_animal/abnormality/he/jangsan.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/jangsan.dm
@@ -60,7 +60,10 @@
 	var/teleport_cooldown
 	var/teleport_cooldown_time = 120 SECONDS
 	var/strong_counter
+	var/strong_attribute = 60 //How many stats you need to be strong
 	var/weak_counter
+	var/weak_attribute = 40 //How many stats you need to be weak
+	var/clerkoidmeter = 4 //How many weak stats you need to trigger the clerkoidmeter
 	pet_bonus = "meows" //saves a few lines of code by allowing funpet() to be called by attack_hand()
 	var/list/stats = list(
 		FORTITUDE_ATTRIBUTE,
@@ -142,20 +145,12 @@
 /mob/living/simple_animal/hostile/abnormality/jangsan/proc/StatCheck(mob/living/carbon/human/user)
 	strong_counter = 0 //Counts how many stats are at or above 60 AKA level 3 or higher
 	weak_counter = 0 //Counts how many stats are below 40 AKA level 1
-	if(SSmaptype.maptype == "rcorp") //Buff for Jangsan for the R-Corp mode
-		for(var/attribute in stats)
-			if(get_attribute_level(user, attribute)< 61)
-				weak_counter += 1
-			if(get_attribute_level(user, attribute)>= 60) //This doesnt matter for rca
-				strong_counter += 1
-		return
-	else
-		for(var/attribute in stats)
-			if(get_attribute_level(user, attribute)< 40)
-				weak_counter += 1
-			if(get_attribute_level(user, attribute)>= 60)
-				strong_counter += 1
-		return
+	for(var/attribute in stats)
+		if(get_attribute_level(user, attribute)< weak_attribute)
+			weak_counter += 1
+		if(get_attribute_level(user, attribute)>= strong_attribute)
+			strong_counter += 1
+	return
 
 //Too weak and it kills you
 /mob/living/simple_animal/hostile/abnormality/jangsan/PostWorkEffect(mob/living/carbon/human/user, work_type, pe, work_time)
@@ -271,7 +266,7 @@
 		return
 	var/mob/living/carbon/human/H = target
 	StatCheck(H)
-	if(weak_counter >= 4)
+	if(weak_counter >= clerkoidmeter)
 		var/obj/item/bodypart/head/head = H.get_bodypart("head")
 		if(QDELETED(head))
 			return
@@ -299,7 +294,7 @@
 			continue
 		if(H.stat == DEAD)
 			continue
-		if(weak_counter >= 4)
+		if(weak_counter >= clerkoidmeter)
 			icon_state = "jangsan_bite"
 			FearStun(H)
 			chase_cooldown = world.time + chase_cooldown_time
@@ -314,7 +309,7 @@
 			continue
 		if(ishuman(L))
 			StatCheck(L)
-			if(weak_counter >= 4)
+			if(weak_counter >= clerkoidmeter)
 				highest_priority += L
 			else
 				lower_priority += L
@@ -332,7 +327,7 @@
 			return ..()
 		var/mob/living/carbon/human/H = target
 		StatCheck(H)
-		if(weak_counter >= 4 && get_dist(src, target) < 4) //clerk got too close time to die
+		if(weak_counter >= clerkoidmeter && get_dist(src, target) < 4) //clerk got too close time to die
 			icon_state = "jangsan_bite"
 			FearStun(target)
 			chase_cooldown = world.time + chase_cooldown_time

--- a/code/modules/mob/living/simple_animal/abnormality/he/puss_in_boots.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/puss_in_boots.dm
@@ -64,6 +64,7 @@
 	var/return_timer
 	var/finisher_cooldown = 0
 	var/finisher_cooldown_time = 60 SECONDS
+	var/finisher_damage = 100
 	var/can_act = TRUE
 	var/finishing = FALSE
 
@@ -291,7 +292,7 @@
 	target.apply_damage(50, PALE_DAMAGE, null, target.run_armor_check(null, RED_DAMAGE), spread_damage = TRUE) //50% of your health in red damage
 	to_chat(target, span_danger("[src] is trying to cut you in half!"))
 	if(!ishuman(target))
-		target.deal_damage(100, PALE_DAMAGE) //bit more than usual DPS in pale damage
+		target.deal_damage(finisher_damage, PALE_DAMAGE) //bit more than usual DPS in pale damage
 		return
 	if(target.health > 0)
 		return

--- a/code/modules/mob/living/simple_animal/abnormality/waw/dimension_refraction.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/dimension_refraction.dm
@@ -51,6 +51,7 @@
 
 	var/cooldown_time = 3
 	var/aoe_damage = 12
+	var/invisibility_level = 30
 
 /mob/living/simple_animal/hostile/abnormality/dimensional_refraction/proc/Melter()
 	for(var/mob/living/L in livinginview(1, src))
@@ -74,7 +75,7 @@
 /* Qliphoth/Breach effects */
 /mob/living/simple_animal/hostile/abnormality/dimensional_refraction/BreachEffect(mob/living/carbon/human/user, breach_type)
 	. = ..()
-	alpha = 30
+	alpha = invisibility_level
 	addtimer(CALLBACK(src, PROC_REF(Melter)), cooldown_time)
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Optimizes Jangsan code so it doesnt look horrible and raises his threshold to 300 (this only affects Der Freischutz friendly fire)
Makes DRV have alpha 10 on RCorp like apex
Makes puss execution do 200 due to highly choreographed attacks
apex backstabs do 500 to punish you for sleeping during rca
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Puss and apex use highly choreographed attacks which hurt themselves more than the people they hit
DRV alpha is too high so he just gets brutally killed, hes also one of the worst piercers due to lack of crowd control so he deserves the stealth element
Jangsan kept friendly firing others, the rest is optimizing my atrocious code
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: tweaked Jangsan threshold to 300 for Freischutz
balance: apex backstabs do 500
balance: Puss executions do 200
balance: DRV is slightly more invisible
code: improved my Jangsan code
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
