### PR TITLE
Armor datum cleanup + silk upgrading improvement.

### DIFF
--- a/code/datums/armor.dm
+++ b/code/datums/armor.dm
@@ -1,9 +1,9 @@
 #define ARMORID "armor-[red]-[white]-[black]-[pale]-[melee]-[bullet]-[laser]-[energy]-[bomb]-[bio]-[rad]-[fire]-[acid]-[magic]-[wound]"
 
-/proc/getArmor(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0, magic = 0, wound = 0, red = 0, white = 0, black = 0, pale = 0)
+/proc/getArmor(red = 0, white = 0, black = 0, pale = 0, melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0, magic = 0, wound = 0)
 	. = locate(ARMORID)
 	if (!.)
-		. = new /datum/armor(melee, bullet, laser, energy, bomb, bio, rad, fire, acid, magic, wound, red, white, black, pale)
+		. = new /datum/armor(red, white, black, pale, melee, bullet, laser, energy, bomb, bio, rad, fire, acid, magic, wound)
 
 /datum/armor
 	datum_flags = DF_USE_TAG
@@ -23,7 +23,7 @@
 	var/magic
 	var/wound
 
-/datum/armor/New(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0, magic = 0, wound = 0, red = 0, white = 0, black = 0, pale = 0)
+/datum/armor/New(red = 0, white = 0, black = 0, pale = 0, melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0, magic = 0, wound = 0)
 	src.red = red
 	src.white = white
 	src.black = black
@@ -41,13 +41,13 @@
 	src.wound = wound
 	tag = ARMORID
 
-/datum/armor/proc/modifyRating(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0, magic = 0, wound = 0, red = 0, white = 0, black = 0, pale = 0)
-	return getArmor(src.melee+melee, src.bullet+bullet, src.laser+laser, src.energy+energy, src.bomb+bomb, src.bio+bio, src.rad+rad, src.fire+fire, src.acid+acid, src.magic+magic, src.wound+wound, src.red+red, src.white+white, src.black+black, src.pale+pale)
+/datum/armor/proc/modifyRating(red = 0, white = 0, black = 0, pale = 0, melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0, magic = 0, wound = 0)
+	return getArmor(src.red+red, src.white+white, src.black+black, src.pale+pale, src.melee+melee, src.bullet+bullet, src.laser+laser, src.energy+energy, src.bomb+bomb, src.bio+bio, src.rad+rad, src.fire+fire, src.acid+acid, src.magic+magic, src.wound+wound)
 
 /datum/armor/proc/modifyAllRatings(modifier = 0)
-	return getArmor(melee+modifier, bullet+modifier, laser+modifier, energy+modifier, bomb+modifier, bio+modifier, rad+modifier, fire+modifier, acid+modifier, magic+modifier, wound+modifier, red+modifier, white+modifier, black+modifier, pale+modifier)
+	return getArmor(red+modifier, white+modifier, black+modifier, pale+modifier, melee+modifier, bullet+modifier, laser+modifier, energy+modifier, bomb+modifier, bio+modifier, rad+modifier, fire+modifier, acid+modifier, magic+modifier, wound+modifier)
 
-/datum/armor/proc/setRating(melee, bullet, laser, energy, bomb, bio, rad, fire, acid, magic, wound, red, white, black, pale)
+/datum/armor/proc/setRating(red, white, black, pale, melee, bullet, laser, energy, bomb, bio, rad, fire, acid, magic, wound)
 	return getArmor((isnull(red) ? src.red : red),\
 					(isnull(white) ? src.white : white),\
 					(isnull(black) ? src.black : black),\
@@ -68,13 +68,13 @@
 	return vars[rating]
 
 /datum/armor/proc/getList()
-	return list(MELEE = melee, BULLET = bullet, LASER = laser, ENERGY = energy, BOMB = bomb, BIO = bio, RAD = rad, FIRE = fire, ACID = acid, MAGIC = magic, WOUND = wound, RED_DAMAGE = red, WHITE_DAMAGE = white, BLACK_DAMAGE = black, PALE_DAMAGE = pale)
+	return list(RED_DAMAGE = red, WHITE_DAMAGE = white, BLACK_DAMAGE = black, PALE_DAMAGE = pale, MELEE = melee, BULLET = bullet, LASER = laser, ENERGY = energy, BOMB = bomb, BIO = bio, RAD = rad, FIRE = fire, ACID = acid, MAGIC = magic, WOUND = wound)
 
 /datum/armor/proc/attachArmor(datum/armor/AA)
-	return getArmor(melee+AA.melee, bullet+AA.bullet, laser+AA.laser, energy+AA.energy, bomb+AA.bomb, bio+AA.bio, rad+AA.rad, fire+AA.fire, acid+AA.acid, magic+AA.magic, wound+AA.wound, red+AA.red, white+AA.white, black+AA.black, pale+AA.pale)
+	return getArmor(red+AA.red, white+AA.white, black+AA.black, pale+AA.pale, melee+AA.melee, bullet+AA.bullet, laser+AA.laser, energy+AA.energy, bomb+AA.bomb, bio+AA.bio, rad+AA.rad, fire+AA.fire, acid+AA.acid, magic+AA.magic, wound+AA.wound)
 
 /datum/armor/proc/detachArmor(datum/armor/AA)
-	return getArmor(melee-AA.melee, bullet-AA.bullet, laser-AA.laser, energy-AA.energy, bomb-AA.bomb, bio-AA.bio, rad-AA.rad, fire-AA.fire, acid-AA.acid, magic-AA.magic, wound-AA.wound, red-AA.red, white-AA.white, black-AA.black, pale-AA.pale)
+	return getArmor(red-AA.red, white-AA.white, black-AA.black, pale-AA.pale, melee-AA.melee, bullet-AA.bullet, laser-AA.laser, energy-AA.energy, bomb-AA.bomb, bio-AA.bio, rad-AA.rad, fire-AA.fire, acid-AA.acid, magic-AA.magic, wound-AA.wound)
 
 /datum/armor/vv_edit_var(var_name, var_value)
 	if (var_name == NAMEOF(src, tag))

--- a/code/datums/components/silkweave.dm
+++ b/code/datums/components/silkweave.dm
@@ -26,18 +26,18 @@
 	var/new_white = newArmor.white
 	var/new_black = newArmor.black
 	var/new_pale = newArmor.pale
-	if (new_red > MAX_ARMOR)
+	if (new_red > MAX_ARMOR && new_red > old_red)
 		to_chat(user, span_notice("Red armor cannot be upgraded any further."))
-		new_red = old_red
-	if (new_white > MAX_ARMOR)
+		new_red = max(old_red, MAX_ARMOR)
+	if (new_white > MAX_ARMOR && new_white > old_white)
 		to_chat(user, span_notice("White armor cannot be upgraded any further."))
-		new_white = old_white
-	if (new_black > MAX_ARMOR)
+		new_white = max(old_white, MAX_ARMOR)
+	if (new_black > MAX_ARMOR && new_black > old_black)
 		to_chat(user, span_notice("Black armor cannot be upgraded any further."))
-		new_black = old_black
-	if (new_pale > MAX_ARMOR)
+		new_black = max(old_black, MAX_ARMOR)
+	if (new_pale > MAX_ARMOR && new_pale > old_pale)
 		to_chat(user, span_notice("Pale armor cannot be upgraded any further."))
-		new_pale = old_pale
+		new_pale = max(old_pale, MAX_ARMOR)
 
 	O.armor = newArmor.setRating(red = new_red, white = new_white, black = new_black, pale = new_pale);
 	to_chat(user, span_notice("New armor: RED [O.armor.red], WHITE [O.armor.white], BLACK [O.armor.black], PALE [O.armor.pale]."))

--- a/code/datums/components/silkweave.dm
+++ b/code/datums/components/silkweave.dm
@@ -18,18 +18,26 @@
 
 	var/obj/O = parent
 	var/datum/armor/newArmor = O.armor.attachArmor(S.added_armor)
-	to_chat(user, "<span class='notice'>New armor [newArmor.tag].</span>")
-	if (newArmor.red > MAX_ARMOR)
-		to_chat(user, "<span class='notice'>Max armor [newArmor.red].</span>")
-		newArmor.red = MAX_ARMOR
-	if (newArmor.white > MAX_ARMOR)
-		to_chat(user, "<span class='notice'>Max armor [newArmor.white].</span>")
-		newArmor.white = MAX_ARMOR
-	if (newArmor.black > MAX_ARMOR)
-		to_chat(user, "<span class='notice'>Max armor [newArmor.black].</span>")
-		newArmor.black = MAX_ARMOR
-	if (newArmor.pale > MAX_ARMOR)
-		to_chat(user, "<span class='notice'>Max armor [newArmor.pale].</span>")
-		newArmor.pale = MAX_ARMOR
+	var/old_red = O.armor.red
+	var/old_white = O.armor.white
+	var/old_black = O.armor.black
+	var/old_pale = O.armor.pale
+	var/new_red = newArmor.red
+	var/new_white = newArmor.white
+	var/new_black = newArmor.black
+	var/new_pale = newArmor.pale
+	if (new_red > MAX_ARMOR)
+		to_chat(user, span_notice("Red armor cannot be upgraded any further."))
+		new_red = old_red
+	if (new_white > MAX_ARMOR)
+		to_chat(user, span_notice("White armor cannot be upgraded any further."))
+		new_white = old_white
+	if (new_black > MAX_ARMOR)
+		to_chat(user, span_notice("Black armor cannot be upgraded any further."))
+		new_black = old_black
+	if (new_pale > MAX_ARMOR)
+		to_chat(user, span_notice("Pale armor cannot be upgraded any further."))
+		new_pale = old_pale
 
-	O.armor = newArmor;
+	O.armor = newArmor.setRating(red = new_red, white = new_white, black = new_black, pale = new_pale);
+	to_chat(user, span_notice("New armor: RED [O.armor.red], WHITE [O.armor.white], BLACK [O.armor.black], PALE [O.armor.pale]."))

--- a/code/game/objects/items/stacks/sheets/silk.dm
+++ b/code/game/objects/items/stacks/sheets/silk.dm
@@ -91,6 +91,11 @@
 							RARITY_ELEGANT = 15,
 							RARITY_MASTERPIECE = 20)*/
 
+/obj/item/stack/sheet/silk/Initialize(mapload, new_amount, merge, list/mat_override, mat_amt)
+	. = ..()
+	if(islist(added_armor))
+		added_armor = getArmor(arglist(added_armor))
+
 /*/obj/item/stack/sheet/silk/New(var/aRarity)
 	..()
 	rarity = aRarity
@@ -103,7 +108,7 @@
 	desc = "Silk woven from a unknown scout... Can be used to upgrade your armor.  \n\
 		Looks like it is from the simple variety of silk. \n\
 		When attached to armor it increases BLACK resistance by 5 and decreases RED by 5."
-	added_armor = new(black = 5, red = -5)
+	added_armor = list(BLACK_DAMAGE = 5, RED_DAMAGE = -5)
 	merge_type = /obj/item/stack/sheet/silk/indigo_simple
 	icon = 'icons/obj/carnival_silk.dmi'
 	icon_state = "simple_indigo_silk"
@@ -113,7 +118,7 @@
 	desc = "Silk woven from a sweeper... Can be used to upgrade your armor. \n\
 		Looks like it is from the advanced variety of silk. \n\
 		When attached to armor it increases BLACK resistance by 10 and decreases RED by 10."
-	added_armor = new(black = 10, red = -10)
+	added_armor = list(BLACK_DAMAGE = 10, RED_DAMAGE = -10)
 	merge_type = /obj/item/stack/sheet/silk/indigo_advanced
 	icon = 'icons/obj/carnival_silk.dmi'
 	icon_state = "advanced_indigo_silk"
@@ -123,7 +128,7 @@
 	desc = "Silk woven from a sweeper commander... Can be used to upgrade your armor. \n\
 		Looks like it is from the elegant variety of silk. \n\
 		When attached to armor it increases BLACK resistance by 15 and decreases RED by 15."
-	added_armor = new(black = 15, red = -15)
+	added_armor = list(BLACK_DAMAGE = 15, RED_DAMAGE = -15)
 	merge_type = /obj/item/stack/sheet/silk/indigo_elegant
 	icon = 'icons/obj/carnival_silk.dmi'
 	icon_state = "elegant_indigo_silk"
@@ -133,7 +138,7 @@
 	desc = "Silk woven from a (REDACTED)... Can be used to upgrade your armor. \n\
 		Looks like it is from the masterpiece variety of silk. \n\
 		When attached to armor it increases BLACK resistance by 20 and decreases RED by 20."
-	added_armor = new(black = 20, red = -20)
+	added_armor = list(BLACK_DAMAGE = 20, RED_DAMAGE = -20)
 	merge_type = /obj/item/stack/sheet/silk/indigo_masterpiece
 	icon = 'icons/obj/carnival_silk.dmi'
 	icon_state = "masterpiece_indigo_silk"
@@ -144,7 +149,7 @@
 	desc = "Silk woven from a spear bot... Can be used to upgrade your armor.  \n\
 		Looks like it is from the simple variety of silk. \n\
 		When attached to armor it increases RED resistance by 5 and decreases BLACK by 5."
-	added_armor = new(red = 5, black = -5)
+	added_armor = list(RED_DAMAGE = 5, BLACK_DAMAGE = -5)
 	merge_type = /obj/item/stack/sheet/silk/green_simple
 	icon = 'icons/obj/carnival_silk.dmi'
 	icon_state = "simple_green_silk"
@@ -154,7 +159,7 @@
 	desc = "Silk woven from a gun bot... Can be used to upgrade your armor. \n\
 		Looks like it is from the advanced variety of silk. \n\
 		When attached to armor it increases RED resistance by 10 and decreases BLACK by 10."
-	added_armor = new(red = 10, black = -10)
+	added_armor = list(RED_DAMAGE = 10, BLACK_DAMAGE = -10)
 	merge_type = /obj/item/stack/sheet/silk/green_advanced
 	icon = 'icons/obj/carnival_silk.dmi'
 	icon_state = "advanced_green_silk"
@@ -164,7 +169,7 @@
 	desc = "Silk woven from a factory... Can be used to upgrade your armor. \n\
 		Looks like it is from the elegant variety of silk. \n\
 		When attached to armor it increases RED resistance by 15 and decreases BLACK by 15."
-	added_armor = new(red = 15, black = -15)
+	added_armor = list(RED_DAMAGE = 15, BLACK_DAMAGE = -15)
 	merge_type = /obj/item/stack/sheet/silk/green_elegant
 	icon = 'icons/obj/carnival_silk.dmi'
 	icon_state = "elegant_green_silk"
@@ -174,7 +179,7 @@
 	desc = "Silk woven from a (REDACTED)... Can be used to upgrade your armor. \n\
 		Looks like it is from the masterpiece variety of silk. \n\
 		When attached to armor it increases RED resistance by 20 and decreases BLACK by 20."
-	added_armor = new(red = 20, black = -20)
+	added_armor = list(RED_DAMAGE = 20, BLACK_DAMAGE = -20)
 	merge_type = /obj/item/stack/sheet/silk/green_masterpiece
 	icon = 'icons/obj/carnival_silk.dmi'
 	icon_state = "masterpiece_green_silk"
@@ -185,7 +190,7 @@
 	desc = "Silk woven from a gene corp remnant... Can be used to upgrade your armor. \n\
 		Looks like it is from the simple variety of silk.\n\
 		When attached to armor it increases RED resistance by 5 and decreases WHITE by 5."
-	added_armor = new(red = 5, white = -5)
+	added_armor = list(RED_DAMAGE = 5, WHITE_DAMAGE = -5)
 	merge_type = /obj/item/stack/sheet/silk/steel_simple
 	icon = 'icons/obj/carnival_silk.dmi'
 	icon_state = "simple_steel_silk"
@@ -195,7 +200,7 @@
 	desc = "Silk woven from a gene corp corporal... Can be used to upgrade your armor. \n\
 		Looks like it is from the advanced variety of silk. \n\
 		When attached to armor it increases RED resistance by 10 and decrease WHITE by 10."
-	added_armor = new(red = 10, white = -10)
+	added_armor = list(RED_DAMAGE = 10, WHITE_DAMAGE = -10)
 	merge_type = /obj/item/stack/sheet/silk/steel_advanced
 	icon = 'icons/obj/carnival_silk.dmi'
 	icon_state = "advanced_steel_silk"
@@ -205,7 +210,7 @@
 	desc = "Silk woven from a gene corp commander... Can be used to upgrade your armor. \n\
 		Looks like it is from the elegant variety of silk. \n\
 		When attached to armor it increases RED resistance by 15 and decrease WHITE by 15."
-	added_armor = new(red = 15, white = -15)
+	added_armor = list(RED_DAMAGE = 15, WHITE_DAMAGE = -15)
 	merge_type = /obj/item/stack/sheet/silk/steel_elegant
 	icon = 'icons/obj/carnival_silk.dmi'
 	icon_state = "elegant_steel_silk"
@@ -215,7 +220,7 @@
 	desc = "Silk woven from a (REDACTED)... Can be used to upgrade your armor. \n\
 		Looks like it is from the masterpiece variety of silk. \n\
 		When attached to armor it increases RED resistance by 20 and decrease WHITE by 20."
-	added_armor = new(red = 20, white = -20)
+	added_armor = list(RED_DAMAGE = 20, WHITE_DAMAGE = -20)
 	merge_type = /obj/item/stack/sheet/silk/steel_masterpiece
 	icon = 'icons/obj/carnival_silk.dmi'
 	icon_state = "masterpiece_steel_silk"
@@ -226,7 +231,7 @@
 	desc = "Silk woven from a carnivores worm... Can be used to upgrade your armor. \n\
 		Looks like it is from the simple variety of silk. \n\
 		When attached to armor it decrease WHITE resistance by 5 and increases BLACK by 5."
-	added_armor = new(white = -5, black = 5)
+	added_armor = list(WHITE_DAMAGE = -5, BLACK_DAMAGE = 5)
 	merge_type = /obj/item/stack/sheet/silk/amber_simple
 	icon = 'icons/obj/carnival_silk.dmi'
 	icon_state = "simple_amber_silk"
@@ -236,7 +241,7 @@
 	desc = "Silk woven from a ??? Can be used to upgrade your armor. \n\
 		Looks like it is from the advanced variety of silk.\n\
 		When attached to armor it decrease WHITE resistance by 10 and increases BLACK by 10."
-	added_armor = new(white = -10, black = 10)
+	added_armor = list(WHITE_DAMAGE = -10, BLACK_DAMAGE = 10)
 	merge_type = /obj/item/stack/sheet/silk/amber_advanced
 	icon = 'icons/obj/carnival_silk.dmi'
 	icon_state = "advanced_amber_silk"
@@ -246,7 +251,7 @@
 	desc = "Silk woven from a bigger carnivores worm... Can be used to upgrade your armor. \n\
 		Looks like it is from the elegant variety of silk.\n\
 		When attached to armor it decrease WHITE resistance by 15 and increases BLACK by 15."
-	added_armor = new(white = -15, black = 15)
+	added_armor = list(WHITE_DAMAGE = -15, BLACK_DAMAGE = 15)
 	merge_type = /obj/item/stack/sheet/silk/amber_elegant
 	icon = 'icons/obj/carnival_silk.dmi'
 	icon_state = "elegant_amber_silk"
@@ -256,7 +261,7 @@
 	desc = "Silk woven from a (REDACTED)... Can be used to upgrade your armor. \n\
 		Looks like it is from the Masterpiece variety of silk.\n\
 		When attached to armor it decrease WHITE resistance by 20 and increases BLACK by 20."
-	added_armor = new(white = -20, black = 20)
+	added_armor = list(WHITE_DAMAGE = -20, BLACK_DAMAGE = 20)
 	merge_type = /obj/item/stack/sheet/silk/amber_masterpiece
 	icon = 'icons/obj/carnival_silk.dmi'
 	icon_state = "masterpiece_amber_silk"
@@ -267,7 +272,7 @@
 	desc = "Silk woven from a... Human? How horrific... Can be used to upgrade your armor. \n\
 		Looks like it is from the simple variety of silk. \n\
 		When attached to armor it increases PALE resistance by 5 and decreases RED and WHITE by 2.5."
-	added_armor = new(pale = 5, white = -2.5, red = -2.5)
+	added_armor = list(PALE_DAMAGE = 5, WHITE_DAMAGE = -2.5, RED_DAMAGE = -2.5)
 	merge_type = /obj/item/stack/sheet/silk/human_simple
 	icon = 'icons/obj/carnival_silk.dmi'
 	icon_state = "simple_human_silk"
@@ -277,7 +282,7 @@
 	desc = "Silk woven from a... Human? How horrific... Can be used to upgrade your armor. \n\
 		Looks like it is from the advanced variety of silk.\n\
 		When attached to armor it increases PALE resistance by 10 and decreases RED and WHITE by 5."
-	added_armor = new(pale = 10, white = -5, red = -5)
+	added_armor = list(PALE_DAMAGE = 10, WHITE_DAMAGE = -5, RED_DAMAGE = -5)
 	merge_type = /obj/item/stack/sheet/silk/human_advanced
 	icon = 'icons/obj/carnival_silk.dmi'
 	icon_state = "advanced_human_silk"
@@ -287,7 +292,7 @@
 	desc = "Silk woven from a... Human? How horrific... Can be used to upgrade your armor. \n\
 		Looks like it is from the elegant variety of silk.\n\
 		When attached to armor it increases PALE resistance by 15 and decreases RED and WHITE by 7.5."
-	added_armor = new(pale = 15, white = -7.5, red = -7.5)
+	added_armor = list(PALE_DAMAGE = 15, WHITE_DAMAGE = -7.5, RED_DAMAGE = -7.5)
 	merge_type = /obj/item/stack/sheet/silk/human_elegant
 	icon = 'icons/obj/carnival_silk.dmi'
 	icon_state = "elegant_human_silk"
@@ -297,7 +302,7 @@
 	desc = "Silk woven from a... Human? How horrific... Can be used to upgrade your armor. \n\
 		Looks like it is from the masterpiece variety of silk. The best of the best.\n\
 		When attached to armor it increases PALE resistance by 20 and decreases RED and WHITE by 10."
-	added_armor = new(pale = 20, white = -10, red = -10)
+	added_armor = list(PALE_DAMAGE = 20, WHITE_DAMAGE = -10, RED_DAMAGE = -10)
 	merge_type = /obj/item/stack/sheet/silk/human_masterpiece
 	icon = 'icons/obj/carnival_silk.dmi'
 	icon_state = "masterpiece_human_silk"
@@ -308,7 +313,7 @@
 	desc = "Silk woven from a Resurgence Clan Scout... Can be used to upgrade your armor. \n\
 		Looks like it is from the simple variety of silk. \n\
 		When attached to armor it increases RED resistance by 2.5 and BLACK resistance by 2.5, But decreases WHITE by 5."
-	added_armor = new(red = 2.5, black = 2.5, white = -5)
+	added_armor = list(RED_DAMAGE = 2.5, BLACK_DAMAGE = 2.5, WHITE_DAMAGE = -5)
 	merge_type = /obj/item/stack/sheet/silk/azure_simple
 	icon = 'icons/obj/carnival_silk.dmi'
 	icon_state = "simple_azure_silk"
@@ -318,7 +323,7 @@
 	desc = "Silk woven from a Resurgence Clan Defender... Can be used to upgrade your armor. \n\
 		Looks like it is from the advanced variety of silk.\n\
 		When attached to armor it increases RED resistance by 5 and BLACK resistance by 5, But decreases WHITE by 10."
-	added_armor = new(red = 5, black = 5, white = -10)
+	added_armor = list(RED_DAMAGE = 5, BLACK_DAMAGE = 5, WHITE_DAMAGE = -10)
 	merge_type = /obj/item/stack/sheet/silk/azure_advanced
 	icon = 'icons/obj/carnival_silk.dmi'
 	icon_state = "advanced_azure_silk"
@@ -328,7 +333,7 @@
 	desc = "Silk woven from a Resurgence Clan... Can be used to upgrade your armor. \n\
 		Looks like it is from the elegant variety of silk.\n\
 		When attached to armor it increases RED resistance by 7.5 and BLACK resistance by 7.5, But decreases WHITE by 15."
-	added_armor = new(red = 7.5, black = 7.5, white = -15)
+	added_armor = list(RED_DAMAGE = 7.5, BLACK_DAMAGE = 7.5, WHITE_DAMAGE = -15)
 	merge_type = /obj/item/stack/sheet/silk/azure_elegant
 	icon = 'icons/obj/carnival_silk.dmi'
 	icon_state = "elegant_azure_silk"
@@ -338,7 +343,7 @@
 	desc = "Silk woven from a Resurgence Clan... Can be used to upgrade your armor. \n\
 		Looks like it is from the masterpiece variety of silk. The best of the best.\n\
 		When attached to armor it increases RED resistance by 10 and BLACK resistance by 10, But decreases WHITE by 20."
-	added_armor = new(red = 10, black = 10, white = -20)
+	added_armor = list(RED_DAMAGE = 10, BLACK_DAMAGE = 10, WHITE_DAMAGE = -20)
 	merge_type = /obj/item/stack/sheet/silk/azure_masterpiece
 	icon = 'icons/obj/carnival_silk.dmi'
 	icon_state = "masterpiece_azure_silk"
@@ -349,7 +354,7 @@
 	desc = "Silk woven from a ???... Can be used to upgrade your armor. \n\
 		Looks like it is from the simple variety of silk. \n\
 		When attached to armor it decreases RED resistance by 2.5 and BLACK resistance by 2.5, But increases WHITE by 5."
-	added_armor = new(red = -2.5, black = -2.5, white = 5)
+	added_armor = list(RED_DAMAGE = -2.5, BLACK_DAMAGE = -2.5, WHITE_DAMAGE = 5)
 	merge_type = /obj/item/stack/sheet/silk/shrimple_simple
 	icon = 'icons/obj/carnival_silk.dmi'
 	icon_state = "simple_shrimple_silk"
@@ -359,7 +364,7 @@
 	desc = "Silk woven from a ???... Can be used to upgrade your armor. \n\
 		Looks like it is from the advanced variety of silk. \n\
 		When attached to armor it decreases RED resistance by 5 and BLACK resistance by 5, But increases WHITE by 10."
-	added_armor = new(red = -5, black = -5, white = 10)
+	added_armor = list(RED_DAMAGE = -5, BLACK_DAMAGE = -5, WHITE_DAMAGE = 10)
 	merge_type = /obj/item/stack/sheet/silk/shrimple_advanced
 	icon = 'icons/obj/carnival_silk.dmi'
 	icon_state = "advanced_shrimple_silk"
@@ -369,7 +374,7 @@
 	desc = "Silk woven from a ???... Can be used to upgrade your armor. \n\
 		Looks like it is from the elegant variety of silk. \n\
 		When attached to armor it decreases RED resistance by 7.5 and BLACK resistance by 7.5, But increases WHITE by 15."
-	added_armor = new(red = -7.5, black = -7.5, white = 15)
+	added_armor = list(RED_DAMAGE = -7.5, BLACK_DAMAGE = -7.5, WHITE_DAMAGE = 15)
 	merge_type = /obj/item/stack/sheet/silk/shrimple_elegant
 	icon = 'icons/obj/carnival_silk.dmi'
 	icon_state = "elegant_shrimple_silk"
@@ -379,7 +384,7 @@
 	desc = "Silk woven from a ???... Can be used to upgrade your armor. \n\
 		Looks like it is from the masterpiece variety of silk. \n\
 		When attached to armor it decreases RED resistance by 10 and BLACK resistance by 10, But increases WHITE by 20."
-	added_armor = new(red = -10, black = -10, white = 20)
+	added_armor = list(RED_DAMAGE = -10, BLACK_DAMAGE = -10, WHITE_DAMAGE = 20)
 	merge_type = /obj/item/stack/sheet/silk/shrimple_masterpiece
 	icon = 'icons/obj/carnival_silk.dmi'
 	icon_state = "masterpiece_shrimple_silk"
@@ -391,7 +396,7 @@
 	desc = "Silk woven from a ???... Can be used to upgrade your armor. \n\
 		Looks like it is from the simple variety of silk. \n\
 		When attached to armor it increases WHITE resistance by 5, But decreases BLACK by 5."
-	added_armor = new(black = -5, white = 5)
+	added_armor = list(BLACK_DAMAGE = -5, WHITE_DAMAGE = 5)
 	merge_type = /obj/item/stack/sheet/silk/violet_simple
 	icon = 'icons/obj/carnival_silk.dmi'
 	icon_state = "simple_violet_silk"
@@ -401,7 +406,7 @@
 	desc = "Silk woven from a ???... Can be used to upgrade your armor. \n\
 		Looks like it is from the advanced variety of silk. \n\
 		When attached to armor it increases WHITE resistance by 10, But decreases BLACK by 10."
-	added_armor = new(black = -10, white = 10)
+	added_armor = list(BLACK_DAMAGE = -10, WHITE_DAMAGE = 10)
 	merge_type = /obj/item/stack/sheet/silk/violet_advanced
 	icon = 'icons/obj/carnival_silk.dmi'
 	icon_state = "advanced_violet_silk"
@@ -411,7 +416,7 @@
 	desc = "Silk woven from a ???... Can be used to upgrade your armor. \n\
 		Looks like it is from the elegant variety of silk. \n\
 		When attached to armor it increases WHITE resistance by 15, But decreases BLACK by 15."
-	added_armor = new(black = -15, white = 15)
+	added_armor = list(BLACK_DAMAGE = -15, WHITE_DAMAGE = 15)
 	merge_type = /obj/item/stack/sheet/silk/violet_elegant
 	icon = 'icons/obj/carnival_silk.dmi'
 	icon_state = "elegant_violet_silk"
@@ -421,7 +426,7 @@
 	desc = "Silk woven from a ???... Can be used to upgrade your armor. \n\
 		Looks like it is from the masterpiece variety of silk. \n\
 		When attached to armor it increases WHITE resistance by 20, But decreases BLACK by 20."
-	added_armor = new(black = -20, white = 20)
+	added_armor = list(BLACK_DAMAGE = -20, WHITE_DAMAGE = 20)
 	merge_type = /obj/item/stack/sheet/silk/violet_masterpiece
 	icon = 'icons/obj/carnival_silk.dmi'
 	icon_state = "masterpiece_violet_silk"
@@ -432,7 +437,7 @@
 	desc = "Silk woven from a ???... Can be used to upgrade your armor. \n\
 		Looks like it is from the simple variety of silk. \n\
 		When attached to armor it increases WHITE resistance by 5, But decreases RED by 5."
-	added_armor = new(red = -5, white = 5)
+	added_armor = list(RED_DAMAGE = -5, WHITE_DAMAGE = 5)
 	merge_type = /obj/item/stack/sheet/silk/crimson_simple
 	icon = 'icons/obj/carnival_silk.dmi'
 	icon_state = "simple_crimson_silk"
@@ -442,7 +447,7 @@
 	desc = "Silk woven from a ???... Can be used to upgrade your armor. \n\
 		Looks like it is from the advanced variety of silk. \n\
 		When attached to armor it increases WHITE resistance by 10, But decreases RED by 10."
-	added_armor = new(red = -10, white = 10)
+	added_armor = list(RED_DAMAGE = -10, WHITE_DAMAGE = 10)
 	merge_type = /obj/item/stack/sheet/silk/crimson_advanced
 	icon = 'icons/obj/carnival_silk.dmi'
 	icon_state = "advanced_crimson_silk"
@@ -452,7 +457,7 @@
 	desc = "Silk woven from a ???... Can be used to upgrade your armor. \n\
 		Looks like it is from the elegant variety of silk. \n\
 		When attached to armor it increases WHITE resistance by 15, But decreases RED by 15."
-	added_armor = new(red = -15, white = 15)
+	added_armor = list(RED_DAMAGE = -15, WHITE_DAMAGE = 15)
 	merge_type = /obj/item/stack/sheet/silk/crimson_elegant
 	icon = 'icons/obj/carnival_silk.dmi'
 	icon_state = "elegant_crimson_silk"
@@ -462,7 +467,7 @@
 	desc = "Silk woven from a ???... Can be used to upgrade your armor. \n\
 		Looks like it is from the masterpiece variety of silk. \n\
 		When attached to armor it increases WHITE resistance by 20, But decreases RED by 20."
-	added_armor = new(red = -20, white = 20)
+	added_armor = list(RED_DAMAGE = -20, WHITE_DAMAGE = 20)
 	merge_type = /obj/item/stack/sheet/silk/crimson_masterpiece
 	icon = 'icons/obj/carnival_silk.dmi'
 	icon_state = "masterpiece_crimson_silk"

--- a/code/modules/clothing/suits/ego_gear/aleph.dm
+++ b/code/modules/clothing/suits/ego_gear/aleph.dm
@@ -334,36 +334,36 @@ Any attempt to code risk class armor will result in a 10 day Github ban.*/
 	var/warning_message
 	switch(stored_season) //Hopefully someday someone finds a more efficient way to change armor values
 		if("spring")
-			src.armor = new(red = 60, white = 80, black = 40, pale = 60, fire = 30)	//240
+			src.armor = getArmor(red = 60, white = 80, black = 40, pale = 60, fire = 30)	//240
 			if(stored_season != current_season) //Our drip is out of season
-				src.armor = new(red = 50, white = 80, black = 40, pale = 50, fire = 30)	//220
+				src.armor = getArmor(red = 50, white = 80, black = 40, pale = 50, fire = 30)	//220
 				weakened = TRUE
 				if(current_season == "fall")
-					src.armor = new(red = 50, white = 70, black = 30, pale = 50, fire = 30)	//200
+					src.armor = getArmor(red = 50, white = 70, black = 30, pale = 50, fire = 30)	//200
 					warning_message = "Fall has come, the leaves on your armor wither and die."
 		if("summer")
-			src.armor = new(red = 80, white = 40, black = 60, pale = 60, fire = 70)
+			src.armor = getArmor(red = 80, white = 40, black = 60, pale = 60, fire = 70)
 			if(stored_season != current_season) //Our drip is out of season
-				src.armor = new(red = 80, white = 40, black = 50, pale = 50, fire = 70)
+				src.armor = getArmor(red = 80, white = 40, black = 50, pale = 50, fire = 70)
 				weakened = TRUE
 				if(current_season == "winter")
-					src.armor = new(red = 70, white = 30, black = 50, pale = 50, fire = 70)
+					src.armor = getArmor(red = 70, white = 30, black = 50, pale = 50, fire = 70)
 					warning_message = "Winter is here. Your armor reacts, becoming stiff and brittle."
 		if("fall")
-			src.armor = new(red = 40, white = 60, black = 80, pale = 60, fire = 70)
+			src.armor = getArmor(red = 40, white = 60, black = 80, pale = 60, fire = 70)
 			if(stored_season != current_season) //Our drip is out of season
-				src.armor = new(red = 40, white = 50, black = 80, pale = 50, fire = 70)
+				src.armor = getArmor(red = 40, white = 50, black = 80, pale = 50, fire = 70)
 				weakened = TRUE
 				if(current_season == "spring")
-					src.armor = new(red = 30, white = 50, black = 70, pale = 50, fire = 70)
+					src.armor = getArmor(red = 30, white = 50, black = 70, pale = 50, fire = 70)
 					warning_message = "The arrival of spring weakens your armor further."
 		if("winter")
-			src.armor = new(red = 40, white = 60, black = 60, pale = 80, fire = 10)
+			src.armor = getArmor(red = 40, white = 60, black = 60, pale = 80, fire = 10)
 			if(stored_season != current_season) //Our drip is out of season
-				src.armor = new(red = 40, white = 50, black = 50, pale = 80, fire = 10)
+				src.armor = getArmor(red = 40, white = 50, black = 50, pale = 80, fire = 10)
 				weakened = TRUE
 				if(current_season == "summer")
-					src.armor = new(red = 30, white = 50, black = 50, pale = 70, fire = 0)
+					src.armor = getArmor(red = 30, white = 50, black = 50, pale = 70, fire = 0)
 					warning_message = "The summer heat is melting your armor."
 
 	if(current_holder && (weakened == TRUE))

--- a/code/modules/clothing/suits/ego_gear/ordeal.dm
+++ b/code/modules/clothing/suits/ego_gear/ordeal.dm
@@ -116,16 +116,16 @@
 	desc = damage_list[current_damage][1]
 	switch(current_damage)
 		if("red")
-			src.armor = new(red = 80, white = 60, black = 0, pale = 60)
+			src.armor = getArmor(red = 80, white = 60, black = 0, pale = 60)
 			playsound(get_turf(src), 'sound/effects/ordeals/violet/midnight_red_attack.ogg', 50, FALSE, 32)
 		if("white")
-			src.armor = new(red = 60, white = 80, black = 60, pale = 0)
+			src.armor = getArmor(red = 60, white = 80, black = 60, pale = 0)
 			playsound(get_turf(src), 'sound/effects/ordeals/violet/midnight_white_attack.ogg', 50, FALSE, 32)
 		if("black")
-			src.armor = new(red = 0, white = 60, black = 80, pale = 60)
+			src.armor = getArmor(red = 0, white = 60, black = 80, pale = 60)
 			playsound(get_turf(src), 'sound/effects/ordeals/violet/midnight_black_attack1.ogg', 50, FALSE, 32)
 		if("pale")
-			src.armor = new(red = 60, white = 0, black = 60, pale = 80)
+			src.armor = getArmor(red = 60, white = 0, black = 60, pale = 80)
 			playsound(get_turf(src), 'sound/effects/ordeals/violet/midnight_pale_attack.ogg', 50, FALSE, 32)
 
 // Radial menu


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
setRating proc on armor datums was pushing red armor into melee, white into bullet and so on, due to the inconsistent way the color damage types were added. I moved the color types to the start of the arglist the same way mob damage coeffs are already done.
Armor datums should not be manually created or modified as they use some kinda caching system to share the same datum instances based on armor tag, so I replaced all the places where they were created with getArmor instead.
The way silks modified armor was occasionally directly modifying armor datums, so I rewrote it to avoid potential armor pitfalls.
Additionally silks now wont downgrade armor to the MAX_ARMOR when the original armor was already better(80 + 5 wont become 40 anymore).
Made the new armor text a bit more readable.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Should fix some potential jank and makes silk application a bit better.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Silk wont downgrade armor unintentionally.
tweak: Made new armor message after silk application more readable.
code: Moved color damage parameters to the start of armor datum arglist for all armor procs.
code: replaced armor datum initializations with getArmor calls.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
