### PR TITLE
Those of the Blade Lineage will now endure their wounds to ensure they hit a lethal strike

### DIFF
--- a/ModularTegustation/ego_weapons/melee/non_abnormality/syndicate.dm
+++ b/ModularTegustation/ego_weapons/melee/non_abnormality/syndicate.dm
@@ -79,7 +79,8 @@
 /obj/item/ego_weapon/city/bladelineage
 	name = "blade lineage katana"
 	desc = "A blade that is standard among blade lineage."
-	special = "Use this weapon in hand to immobilize yourself for 3 seconds and deal 5x damage on the next attack within 5 seconds."
+	special = "Use this weapon in hand to immobilize yourself for 3 seconds and deal 5x damage on the next attack within 5 seconds. \
+	This weapon allows you to resist differing levels of lethal damage while using it's active ability when worn with it's corresponding armor."
 	icon_state = "blade_lineage"
 	inhand_icon_state = "blade_lineage"
 	force = 46

--- a/ModularTegustation/ego_weapons/melee/non_abnormality/syndicate.dm
+++ b/ModularTegustation/ego_weapons/melee/non_abnormality/syndicate.dm
@@ -112,9 +112,28 @@
 	to_chat(user, span_userdanger("Yield my flesh."))
 	force*=multiplier
 
+	var/obj/item/clothing/suit/armor/ego_gear/city/blade_lineage_salsu/S = user.get_item_by_slot(ITEM_SLOT_OCLOTHING)
+	var/obj/item/clothing/suit/armor/ego_gear/city/blade_lineage_cutthroat/C = user.get_item_by_slot(ITEM_SLOT_OCLOTHING)
+	var/obj/item/clothing/suit/armor/ego_gear/city/blade_lineage_admin/R = user.get_item_by_slot(ITEM_SLOT_OCLOTHING)
+
+	if(istype(S))
+		ADD_TRAIT(user, TRAIT_NOSOFTCRIT, "unrelenting")
+
+	if(istype(C))
+		ADD_TRAIT(user, TRAIT_NOHARDCRIT, "unrelenting")
+		ADD_TRAIT(user, TRAIT_NOSOFTCRIT, "unrelenting")
+
+	if(istype(R))
+		ADD_TRAIT(user, TRAIT_NODEATH, "unrelenting")
+		ADD_TRAIT(user, TRAIT_NOHARDCRIT, "unrelenting")
+		ADD_TRAIT(user, TRAIT_NOSOFTCRIT, "unrelenting")
+
 	addtimer(CALLBACK(src, PROC_REF(Return), user), 5 SECONDS)
 
 /obj/item/ego_weapon/city/bladelineage/attack(mob/living/target, mob/living/carbon/human/user)
+	REMOVE_TRAIT(user, TRAIT_NODEATH, "unrelenting")
+	REMOVE_TRAIT(user, TRAIT_NOHARDCRIT, "unrelenting")
+	REMOVE_TRAIT(user, TRAIT_NOSOFTCRIT, "unrelenting")
 	..()
 	if(force != initial(force))
 		to_chat(user, span_userdanger("To claim their bones."))
@@ -124,3 +143,6 @@
 	force = initial(force)
 	ready = TRUE
 	to_chat(user, span_notice("Your blade is ready."))
+	REMOVE_TRAIT(user, TRAIT_NODEATH, "unrelenting")
+	REMOVE_TRAIT(user, TRAIT_NOHARDCRIT, "unrelenting")
+	REMOVE_TRAIT(user, TRAIT_NOSOFTCRIT, "unrelenting")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
When the Blade Lineage Katana is used with Blade Lineage robes it will allow the players to resist lethal damage for the duration of the Yield my flesh. Salsu robes allowing the player to survive softcrit, Cutthroat robes allowing the player to survive hardcrit and ronin robes allowing the player to survive death.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
adds more to a weapon/armor set which doesnt work well in the current enviroment of ai changes, so even if the player dies while using the weapon they will still guarantee some damage. Note that the Ronin armor is also in the 5% chance loot pool of the Syndicate Crate sharing space with Thumb and Index gear reducing its drop chance to 0.625% (allas color gear has a 1% chance)
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: gave BL katana the nosoftcrit trait for salsu robes, the nohardcrit trait for cutthroat robes, the nodeath trait for ronin robes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
