### PR TITLE
Makes The Playables Trait Auto Give Comms to Abnormalities

### DIFF
--- a/ModularTegustation/misc_procs.dm
+++ b/ModularTegustation/misc_procs.dm
@@ -36,6 +36,16 @@
 	message_admins(span_adminnotice("[possessing_player.key] has possessed [abnormality.name]."))
 	log_admin("[possessing_player.key] has possessed [abnormality.name].")
 
+	if(SSlobotomy_corp.chosen_trait == FACILITY_TRAIT_PLAYABLES) //Most convenient way I could think of off the top of my head.
+		if(LAZYLEN(SSlobotomy_corp.all_abnormality_datums))
+			for(var/datum/abnormality/A in SSlobotomy_corp.all_abnormality_datums)
+				if(A.abno_radio)
+					continue
+				if(isnull(A.current))
+					A.abno_radio = TRUE
+					continue
+				A.current.AbnoRadio()
+
 	abnormality.key = possessing_player.key
 	abnormality.client?.init_verbs()
 	qdel(possessing_player)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
What the title says.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Almost all the maps for the main mode lack station bounced radios, so this can work as a subsitute.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Made Playables Round Trait auto give comms
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
