### PR TITLE
City L-Corp Update: Amber Fix

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/ordeal/amber.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/amber.dm
@@ -42,6 +42,8 @@
 	pixel_y = base_pixel_y
 	if(LAZYLEN(butcher_results)) //// It burrows in on spawn, spawned ones shouldn't
 		addtimer(CALLBACK(src, PROC_REF(BurrowOut), get_turf(src)))
+	if(SSmaptype == "lcorp_city")
+		can_burrow_solo = FALSE
 
 /mob/living/simple_animal/hostile/ordeal/amber_bug/death(gibbed)
 	alpha = 255
@@ -239,6 +241,8 @@
 	soundloop = new(list(src), TRUE)
 	if(LAZYLEN(butcher_results))
 		addtimer(CALLBACK(src, PROC_REF(BurrowOut), get_turf(src)))
+	if(SSmaptype == "lcorp_city")
+		can_burrow = FALSE
 
 /mob/living/simple_animal/hostile/ordeal/amber_dusk/OnDirChange(atom/thing, dir, newdir)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR updates the amber ordeal to become unable to burrow in the "lcorp_city" map.

## Why It's Good For The Game

Please, we don't want any more midnight levels or amber ordeals at round start.

## Changelog
:cl:
fix: fixed amber ordeal on "lcorp_city" map.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
