### PR TITLE
Cargo Console fix

### DIFF
--- a/code/game/machinery/computer/extraction_cargo.dm
+++ b/code/game/machinery/computer/extraction_cargo.dm
@@ -168,7 +168,8 @@
 			//So we have to adjust the available boxes down but adjust the goal boxes up. Why?
 			//Adjusting the available boxes adjusts the goal. This is just the best way to do it
 			SSlobotomy_corp.AdjustAvailableBoxes(-1 * product_datum.cost)
-			SSlobotomy_corp.AdjustGoalBoxes(product_datum.cost)
+			if(!SSlobotomy_corp.goal_reached)	//Okay, funny bug, if you have your goal eached and add goal boxes, then it adds to available boxes.
+				SSlobotomy_corp.AdjustGoalBoxes(product_datum.cost)		//Normal
 			playsound(get_turf(src), 'sound/machines/terminal_prompt_confirm.ogg', 50, TRUE)
 			updateUsrDialog()
 			return TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
You can no longer get infinite cargo PE.

> How I made it take from available boxes and not goal boxes, is that I removed available boxes, and added goal boxes.
> 
> The problem was that once the goal is reached, goal boxes add to available boxes
> So I would subtract 500 PE and then try to add 500 PE to the goal to Zero out the goal 
> but what that does AFTER quota is reached
> is subtracts 500 PE and then adds 500 PE to the available boxes


## Changelog
:cl:
fix: fixed infinite Cargo PE
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
