### PR TITLE
Nerfs L Corp Disciplinary Gear

### DIFF
--- a/ModularTegustation/tegu_items/disciplinary/_disciplinary.dm
+++ b/ModularTegustation/tegu_items/disciplinary/_disciplinary.dm
@@ -10,7 +10,7 @@
 	var/base_damage = 30 //Base damage of the tier
 	var/tier = 1 //used to figure out gun damage
 	//Armor stats
-	var/red_bonus = 20 //50 from the base of 20 in red, so 70
+	var/red_bonus = 10 //40 from the base of 20 in red, so 60
 	var/white_bonus = 10
 	var/black_bonus = 10
 	var/pale_bonus = 10

--- a/ModularTegustation/tegu_items/disciplinary/egoshards.dm
+++ b/ModularTegustation/tegu_items/disciplinary/egoshards.dm
@@ -31,7 +31,7 @@
 	name = "white egoshard"
 	icon_state = "egoshard_w"
 	damage_type = WHITE_DAMAGE
-	red_bonus = 0 //100 from the base of 20 in red, so 120
+	red_bonus = 0 //90 from the base of 20 in red, so 110
 	white_bonus = 50
 	black_bonus = 20
 	pale_bonus = 20
@@ -40,7 +40,7 @@
 	name = "black egoshard"
 	icon_state = "egoshard_b"
 	damage_type = BLACK_DAMAGE
-	red_bonus = 0 //100 from the base of 20 in red, so 120
+	red_bonus = 0 //90 from the base of 20 in red, so 110
 	white_bonus = 20
 	black_bonus = 50
 	pale_bonus = 20

--- a/ModularTegustation/tegu_items/disciplinary/egoshards.dm
+++ b/ModularTegustation/tegu_items/disciplinary/egoshards.dm
@@ -3,7 +3,7 @@
 	icon_state = "egoshard_w"
 	damage_type = WHITE_DAMAGE
 	red_bonus = -10
-	white_bonus = 40
+	white_bonus = 30
 	black_bonus = 10
 	pale_bonus = 10
 
@@ -13,7 +13,7 @@
 	damage_type = BLACK_DAMAGE
 	red_bonus = -10
 	white_bonus = 10
-	black_bonus = 40
+	black_bonus = 30
 	pale_bonus = 10
 
 /obj/item/egoshard/bad
@@ -22,7 +22,7 @@
 	tier = 2
 	base_damage = 40
 	stat_requirement = 80
-	red_bonus = 40 //100 from the base of 20 in red, so 120
+	red_bonus = 30 //90 from the base of 20 in red, so 110
 	white_bonus = 20
 	black_bonus = 20
 	pale_bonus = 20
@@ -32,7 +32,7 @@
 	icon_state = "egoshard_w"
 	damage_type = WHITE_DAMAGE
 	red_bonus = 0 //100 from the base of 20 in red, so 120
-	white_bonus = 60
+	white_bonus = 50
 	black_bonus = 20
 	pale_bonus = 20
 
@@ -42,86 +42,86 @@
 	damage_type = BLACK_DAMAGE
 	red_bonus = 0 //100 from the base of 20 in red, so 120
 	white_bonus = 20
-	black_bonus = 60
+	black_bonus = 50
 	pale_bonus = 20
 
 /obj/item/egoshard/good
 	name = "red egoshard"
 	desc = "A decently sized egoshard."
 	tier = 3
-	base_damage = 60
+	base_damage = 50
 	stat_requirement = 100
-	red_bonus = 50 //160 from the base of 20 in red, so 180
+	red_bonus = 40 //140 from the base of 20 in red, so 160
 	white_bonus = 30
-	black_bonus = 40
+	black_bonus = 30
 	pale_bonus = 40
 
 /obj/item/egoshard/good/white
 	name = "white egoshard"
 	icon_state = "egoshard_w"
 	damage_type = WHITE_DAMAGE
-	red_bonus = 20 //160 from the base of 20 in red, so 180
-	white_bonus = 70
+	red_bonus = 20 //140 from the base of 20 in red, so 160
+	white_bonus = 60
 	black_bonus = 30
-	pale_bonus = 40
+	pale_bonus = 30
 
 /obj/item/egoshard/good/black
 	name = "black egoshard"
 	icon_state = "egoshard_b"
 	damage_type = BLACK_DAMAGE
-	red_bonus = 20 //160 from the base of 20 in red, so 180
+	red_bonus = 10 //140 from the base of 20 in red, so 160
 	white_bonus = 40
-	black_bonus = 70
+	black_bonus = 60
 	pale_bonus = 30
 
 /obj/item/egoshard/good/pale
 	name = "pale egoshard"
 	icon_state = "egoshard_p"
 	damage_type = PALE_DAMAGE
-	base_damage = 45
-	red_bonus = 20 //160 from the base of 20 in red, so 180
+	base_damage = 37
+	red_bonus = 10 //140 from the base of 20 in red, so 160
 	white_bonus = 30
 	black_bonus = 40
-	pale_bonus = 70
+	pale_bonus = 60
 
 /obj/item/egoshard/great
 	name = "flawless red egoshard"
 	desc = "A pretty egoshard."
 	tier = 4
-	base_damage = 80
+	base_damage = 75
 	stat_requirement = 120
-	red_bonus = 60 //220 from the base of 20 in red, so 240
-	white_bonus = 60
-	black_bonus = 40
-	pale_bonus = 60
+	red_bonus = 50 //180 from the base of 20 in red, so 200
+	white_bonus = 50
+	black_bonus = 30
+	pale_bonus = 50
 
 /obj/item/egoshard/great/white
 	name = "flawless white egoshard"
 	icon_state = "egoshard_w"
 	damage_type = WHITE_DAMAGE
-	red_bonus = 20 //220 from the base of 20 in red, so 240
-	white_bonus = 80
-	black_bonus = 60
-	pale_bonus = 60
+	red_bonus = 10 //180 from the base of 20 in red, so 200
+	white_bonus = 70
+	black_bonus = 50
+	pale_bonus = 50
 
 /obj/item/egoshard/great/black
 	name = "flawless black egoshard"
 	icon_state = "egoshard_b"
 	damage_type = BLACK_DAMAGE
-	red_bonus = 20 //220 from the base of 20 in red, so 240
-	white_bonus = 60
-	black_bonus = 80
-	pale_bonus = 60
+	red_bonus = 10 //180 from the base of 20 in red, so 200
+	white_bonus = 70
+	black_bonus = 50
+	pale_bonus = 50
 
 /obj/item/egoshard/great/pale
 	name = "flawless pale egoshard"
 	icon_state = "egoshard_p"
 	damage_type = PALE_DAMAGE
-	base_damage = 60
-	red_bonus = 20 //220 from the base of 20 in red, so 240
-	white_bonus = 60
-	black_bonus = 60
-	pale_bonus = 80
+	base_damage = 55
+	red_bonus = 10 //180 from the base of 20 in red, so 200
+	white_bonus = 50
+	black_bonus = 50
+	pale_bonus = 70
 
 //These exist, but I'm not sure where I would put ALEPH++ tier egoshards in terms of loot
 /obj/item/egoshard/excellent


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Nerfs the EGO shard armor along with the strong EGO shard damage.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
L Corp Disciplinary Gear as is is either about as good as the other city gear or better. When you get something that remains conistent between rounds, it shouldn't be as strong as the other options. And not only that, but agents use some of the disciplinary armor since the armor gave the same resistance as EGO as the highest risk level in the facility that Agents can train to, so this trivializes abnormality selection as a result.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: rebalanced L Corp Disc Gear
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
