### PR TITLE
Actually enables Sirocco

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/teth/sirocco.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/sirocco.dm
@@ -37,7 +37,7 @@
 		/datum/ego_datum/armor/desert,
 	)
 	gift_type = /datum/ego_gifts/desert
-	abnormality_origin = ABNORMALITY_ORIGIN_COMMUNITY
+	abnormality_origin = ABNORMALITY_ORIGIN_ORIGINAL
 
 	observation_prompt = "Why is everyone here such a bore? <br>Why doesn't anyone want to play with me? <br>\
 		A young girl's voice cries out from somewhere within the storm. <br>\


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I'm like 90% certain that Sirocco has been unpickable for the last month because the origin was community and most of the gamemodes don't select community abnos. So. You know. Heeheehoohoo.
It got turned into a main mode abnormality so that's an issue.
That or I'm completely wrong and somehow no one has voted for it ever in over a month. Which I think is statistically unlikely.

## Why It's Good For The Game

Having the abno actually pickable is, you know, good.

## Changelog
:cl:
fix: enables Sirocco
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
