### PR TITLE
Fixes fake shuttle call announcement on shuttle purchase

### DIFF
--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -336,6 +336,9 @@ SUBSYSTEM_DEF(shuttle)
 			callShuttle = FALSE
 			break
 
+	if(SSmaptype.maptype in SSmaptype.lc_maps || SSmaptype.maptype == "lcorp_city" || SSmaptype.maptype == "city")
+		callShuttle = FALSE
+
 	if(callShuttle)
 		if(EMERGENCY_IDLE_OR_RECALLED)
 			emergency.request(null, set_coefficient = 2.5)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Attempting to purchase a shuttle called the autoEvac() proc in subsystem/shuttle.dm. This proc's intended purpose seems to be to be called on the destruction of a comms console or AI (from actual base SS13), and then it checks to see if any other communications consoles or AIs are alive - if there aren't, it sends an emergency shuttle request.

I do not know why autoEvac() gets called by purchasing the shuttle. I also don't know why the shuttle request from autoEvac() doesn't actually call the shuttle.

This PR only adds a check to see if we're on an LC13 map, Corp City or City of Light, and prevents the shuttle from being requested by this proc if that is the case.

I have tested this on Facility Alpha and on City of Light and it seems to work fine. I didn't test it on Corp City because I can't find it in the list of maps on my local server for some reason.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

People will stop getting confused by purchasing a shuttle and thinking it automatically calls evac.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Purchasing a shuttle no longer creates a shuttle called message
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
