### PR TITLE
Damage Type Shuffle Uniform RNG + abno resistances in abno docs

### DIFF
--- a/ModularTegustation/lc13_damage_type_shuffler.dm
+++ b/ModularTegustation/lc13_damage_type_shuffler.dm
@@ -22,34 +22,36 @@ GLOBAL_DATUM_INIT(damage_type_shuffler, /datum/damage_type_shuffler, new /datum/
 	ReshuffleAll()
 
 /datum/damage_type_shuffler/proc/Reshuffle(list/mapping)
-	var/list/sources = list(RED_DAMAGE, WHITE_DAMAGE, BLACK_DAMAGE, PALE_DAMAGE)
-	var/list/targets = list(RED_DAMAGE, WHITE_DAMAGE, BLACK_DAMAGE, PALE_DAMAGE)
-	for(var/i in 1 to 3)
-		MapNeverSelf(mapping, sources, targets)
-	MapAllowSelf(mapping, sources, targets)
+	//Hard coding these is the best way I could figure out to get a uniform distribution of mappings.
+	//all 17 possible mappings with up to 1 self mapped type.
+	var/static/list/all_mappings = list(
+		list(RED_DAMAGE = RED_DAMAGE, WHITE_DAMAGE = BLACK_DAMAGE, BLACK_DAMAGE = PALE_DAMAGE, PALE_DAMAGE = WHITE_DAMAGE),
+		list(RED_DAMAGE = RED_DAMAGE, WHITE_DAMAGE = PALE_DAMAGE, BLACK_DAMAGE = WHITE_DAMAGE, PALE_DAMAGE = BLACK_DAMAGE),
 
-/datum/damage_type_shuffler/proc/MapNeverSelf(list/mapping, list/sources, list/targets)
-	var/sources_string = "[sources]"
-	var/targets_string = "[targets]"
-	var/source = pick_n_take(sources)
-	var/target = pick(targets - source)
-	if(!source || !target)
-		stack_trace("damage shuffler/MapNeverSelf: failed to map from [sources_string] to [targets_string].")
-		return FALSE
-	targets -= target
-	mapping[source] = target
-	return TRUE
+		list(RED_DAMAGE = BLACK_DAMAGE, WHITE_DAMAGE = WHITE_DAMAGE, BLACK_DAMAGE = PALE_DAMAGE, PALE_DAMAGE = RED_DAMAGE),
+		list(RED_DAMAGE = PALE_DAMAGE, WHITE_DAMAGE = WHITE_DAMAGE, BLACK_DAMAGE = RED_DAMAGE, PALE_DAMAGE = BLACK_DAMAGE),
 
-/datum/damage_type_shuffler/proc/MapAllowSelf(list/mapping, list/sources, list/targets)
-	var/sources_string = "[sources]"
-	var/targets_string = "[targets]"
-	var/source = pick_n_take(sources)
-	var/target = pick_n_take(targets)
-	if(!source || !target)
-		stack_trace("damage shuffler/MapAllowSelf: failed to map from [sources_string] to [targets_string].")
-		return FALSE
-	mapping[source] = target
-	return TRUE
+		list(RED_DAMAGE = WHITE_DAMAGE, WHITE_DAMAGE = PALE_DAMAGE, BLACK_DAMAGE = BLACK_DAMAGE, PALE_DAMAGE = RED_DAMAGE),
+		list(RED_DAMAGE = PALE_DAMAGE, WHITE_DAMAGE = RED_DAMAGE, BLACK_DAMAGE = BLACK_DAMAGE, PALE_DAMAGE = WHITE_DAMAGE),
+
+		list(RED_DAMAGE = WHITE_DAMAGE, WHITE_DAMAGE = BLACK_DAMAGE, BLACK_DAMAGE = RED_DAMAGE, PALE_DAMAGE = PALE_DAMAGE),
+		list(RED_DAMAGE = BLACK_DAMAGE, WHITE_DAMAGE = RED_DAMAGE, BLACK_DAMAGE = WHITE_DAMAGE, PALE_DAMAGE = PALE_DAMAGE),
+
+		list(RED_DAMAGE = WHITE_DAMAGE, WHITE_DAMAGE = RED_DAMAGE, BLACK_DAMAGE = PALE_DAMAGE, PALE_DAMAGE = BLACK_DAMAGE),
+		list(RED_DAMAGE = WHITE_DAMAGE, WHITE_DAMAGE = BLACK_DAMAGE, BLACK_DAMAGE = PALE_DAMAGE, PALE_DAMAGE = RED_DAMAGE),
+		list(RED_DAMAGE = WHITE_DAMAGE, WHITE_DAMAGE = PALE_DAMAGE, BLACK_DAMAGE = RED_DAMAGE, PALE_DAMAGE = BLACK_DAMAGE),
+
+		list(RED_DAMAGE = BLACK_DAMAGE, WHITE_DAMAGE = RED_DAMAGE, BLACK_DAMAGE = PALE_DAMAGE, PALE_DAMAGE = WHITE_DAMAGE),
+		list(RED_DAMAGE = BLACK_DAMAGE, WHITE_DAMAGE = PALE_DAMAGE, BLACK_DAMAGE = RED_DAMAGE, PALE_DAMAGE = WHITE_DAMAGE),
+		list(RED_DAMAGE = BLACK_DAMAGE, WHITE_DAMAGE = PALE_DAMAGE, BLACK_DAMAGE = WHITE_DAMAGE, PALE_DAMAGE = RED_DAMAGE),
+
+		list(RED_DAMAGE = PALE_DAMAGE, WHITE_DAMAGE = RED_DAMAGE, BLACK_DAMAGE = WHITE_DAMAGE, PALE_DAMAGE = BLACK_DAMAGE),
+		list(RED_DAMAGE = PALE_DAMAGE, WHITE_DAMAGE = BLACK_DAMAGE, BLACK_DAMAGE = RED_DAMAGE, PALE_DAMAGE = WHITE_DAMAGE),
+		list(RED_DAMAGE = PALE_DAMAGE, WHITE_DAMAGE = BLACK_DAMAGE, BLACK_DAMAGE = WHITE_DAMAGE, PALE_DAMAGE = RED_DAMAGE),
+	)
+	var/list/picked_mapping = pick(all_mappings)
+	for(var/i in picked_mapping)
+		mapping[i] = picked_mapping[i]
 
 /datum/damage_type_shuffler/proc/ReshuffleAll()
 	Reshuffle(mapping_offense)

--- a/code/modules/paperwork/records/info/_info.dm
+++ b/code/modules/paperwork/records/info/_info.dm
@@ -102,7 +102,10 @@ For escape damage you will have to get creative and figure out how dangerous it 
 
 	info += "<h3><center>Breach Information</center></h3><br>"
 	if(isnull(abno_breach_damage_type))
-		abno_breach_damage_type = uppertext(initial(abno_type.melee_damage_type))
+		var/damage_type = initial(abno_type.melee_damage_type)
+		if(GLOB.damage_type_shuffler?.is_enabled && IsColorDamageType(damage_type))
+			damage_type = GLOB.damage_type_shuffler.mapping_offense[damage_type]
+		abno_breach_damage_type = uppertext(damage_type)
 	if(isnull(abno_breach_damage_count))
 		abno_breach_damage_count = SimpleDamageToText(initial(abno_type.melee_damage_upper) * initial(abno_type.rapid_melee))
 	info += "<h4>Escape Damage Type:</h4> [abno_breach_damage_type]<br>"
@@ -110,9 +113,12 @@ For escape damage you will have to get creative and figure out how dangerous it 
 
 	// Resistances
 	for(var/line in abno_resistances)
-		var/resist = abno_resistances[line]
+		var/damage_type = line
+		if(GLOB.damage_type_shuffler?.is_enabled && IsColorDamageType(line))
+			damage_type = GLOB.damage_type_shuffler.mapping_defense[line]
+		var/resist = abno_resistances[damage_type]
 		if(!resist)
-			resist = SimpleResistanceToText(GLOB.cached_abno_resistances[abno_type][line])
+			resist = SimpleResistanceToText(GLOB.cached_abno_resistances[abno_type][damage_type])
 		info += "<h4>[capitalize(line)] Resistance:</h4> [resist]<br>"
 
 /obj/item/paper/fluff/info/AltClick(mob/living/user, obj/item/I)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The mapping logic was causing a weird probability of picking certain mappings:
![2025-04-30 21_58_07-Window](https://github.com/user-attachments/assets/73cde632-58ba-47fb-b1c4-d5a4576dae01)
Half of the mappings were 5 times more likely to be chosen than the rest.
I couldnt figure out an algorithm to get a uniform distribution so I just manually defined each of the 17 mappings.
![2025-04-30 22_32_03-Window](https://github.com/user-attachments/assets/844cc597-e878-44cd-858c-1cffb6b539c2)
Now its about 5.9% for each mapping.
Also made abnormality records show remapped resistances and breach damage ( some customised info docs might not get converted but should work for most things).
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Should be less likely to get same mappings in a row.
Easier to see new resistances.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Changed the way damage type shuffle mappings were chosen to be more uniform.
tweak: Abnormality info docs should show remapped resistances and attack type.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
