### PR TITLE
City Update: Ruined Town Adjustments

### DIFF
--- a/_maps/Quests/ruined_town.dmm
+++ b/_maps/Quests/ruined_town.dmm
@@ -143,10 +143,13 @@
 "aX" = (
 /obj/structure/table_frame/wood,
 /obj/item/food/breadslice/moldy,
+/obj/effect/decal/cleanable/blood/footprints,
 /turf/open/floor/wood,
 /area/city/shop)
 "aZ" = (
-/obj/structure/spider/cocoon,
+/obj/structure/spider/cocoon{
+	resistance_flags = 64
+	},
 /obj/effect/landmark/npc_reveal_sensor{
 	sensor_id = "ambush";
 	cooldown_duration = 6000
@@ -276,7 +279,10 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/ego_weapon/city/fixergreatsword,
-/obj/item/stack/spacecash/c100,
+/obj/structure/lootcrate/money{
+	lootlist = list(/obj/item/stack/spacecash/c200);
+	rareloot = list(/obj/item/stack/spacecash/c200)
+	},
 /turf/open/floor/wood,
 /area/city)
 "cm" = (
@@ -527,6 +533,18 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/keycard/office,
 /obj/effect/mob_spawn/human/corpse/russian,
+/mob/living/simple_animal/hostile/mutant_clown{
+	name = "'Mother?'";
+	icon_state = "glutton";
+	base_pixel_x = -16;
+	pixel_x = -16;
+	scream_damage = 40;
+	maxHealth = 1000;
+	melee_damage_lower = 40;
+	melee_damage_upper = 40;
+	color = "#f194f2";
+	return_to_origin = 1
+	},
 /turf/open/indestructible/necropolis,
 /area/city/shop)
 "dD" = (
@@ -751,7 +769,10 @@
 	},
 /obj/effect/spawner/lootdrop/garbage_spawner,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/lootcrate/money,
+/obj/structure/lootcrate/money{
+	lootlist = list(/obj/item/stack/spacecash/c200);
+	rareloot = list(/obj/item/stack/spacecash/c200)
+	},
 /turf/open/floor/plating/rust,
 /area/city/house)
 "eO" = (
@@ -793,7 +814,10 @@
 	},
 /obj/item/modular_computer/laptop/preset/fixer,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/lootcrate/money,
+/obj/structure/lootcrate/money{
+	lootlist = list(/obj/item/stack/spacecash/c200);
+	rareloot = list(/obj/item/stack/spacecash/c200)
+	},
 /turf/open/floor/plating/rust,
 /area/city/house)
 "fa" = (
@@ -980,6 +1004,7 @@
 	color = "#875300"
 	},
 /obj/effect/decal/cleanable/cobweb,
+/obj/item/stack/spacecash/c500,
 /turf/open/floor/wood,
 /area/city/fixers)
 "fZ" = (
@@ -1248,7 +1273,6 @@
 /turf/open/floor/plating,
 /area/city/fixers)
 "if" = (
-/obj/structure/lootcrate/hana,
 /obj/structure/barricade/meatbags,
 /obj/structure/lootcrate/hana,
 /turf/open/indestructible/necropolis,
@@ -1362,6 +1386,10 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/ego_weapon/city/rats/knife,
 /obj/item/food/breadslice/moldy,
+/obj/structure/lootcrate/money{
+	lootlist = list(/obj/item/stack/spacecash/c200);
+	rareloot = list(/obj/item/stack/spacecash/c200)
+	},
 /turf/open/floor/wood,
 /area/city)
 "iR" = (
@@ -1379,7 +1407,9 @@
 /area/city)
 "iS" = (
 /obj/structure/spider/stickyweb,
-/obj/structure/spider/cocoon,
+/obj/structure/spider/cocoon{
+	resistance_flags = 64
+	},
 /obj/effect/landmark/npc_reveal_spawn{
 	mobtype = /mob/living/simple_animal/hostile/poison/giant_spider;
 	sensor_id = "ambush"
@@ -1705,7 +1735,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/ego_weapon/city/rats/knife,
 /obj/item/food/breadslice/moldy,
-/obj/item/stack/spacecash/c100,
 /turf/open/floor/wood,
 /area/city)
 "lo" = (
@@ -1845,7 +1874,10 @@
 "mm" = (
 /obj/structure/table_frame/wood,
 /obj/item/flashlight/lamp,
-/obj/structure/lootcrate/money,
+/obj/structure/lootcrate/money{
+	lootlist = list(/obj/item/stack/spacecash/c200);
+	rareloot = list(/obj/item/stack/spacecash/c200)
+	},
 /obj/effect/decal/cleanable/glitter/pink,
 /turf/open/indestructible/necropolis,
 /area/city)
@@ -2093,7 +2125,10 @@
 /turf/open/floor/wood,
 /area/city)
 "nV" = (
-/obj/structure/lootcrate/money,
+/obj/structure/lootcrate/money{
+	lootlist = list(/obj/item/stack/spacecash/c200);
+	rareloot = list(/obj/item/stack/spacecash/c200)
+	},
 /turf/open/indestructible/necropolis,
 /area/city)
 "nX" = (
@@ -2365,7 +2400,10 @@
 	},
 /obj/effect/mob_spawn/human/corpse/charredskeleton,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/lootcrate/money,
+/obj/structure/lootcrate/money{
+	lootlist = list(/obj/item/stack/spacecash/c200);
+	rareloot = list(/obj/item/stack/spacecash/c200)
+	},
 /turf/open/floor/plating/rust,
 /area/city/house)
 "pT" = (
@@ -2391,9 +2429,22 @@
 /obj/structure/table/reinforced{
 	color = "#875300"
 	},
-/obj/structure/lootcrate/hana,
-/obj/structure/lootcrate/hana,
-/obj/structure/lootcrate/hana,
+/obj/structure/lootcrate/seven{
+	rareloot = list(/obj/item/clothing/suit/armor/ego_gear/city/devyat_suit, /obj/item/ego_weapon/city/devyat_trunk);
+	lootlist = list(/obj/item/clothing/suit/armor/ego_gear/city/devyat_suit/weak);
+	veryrareloot = list(/obj/item/ego_weapon/city/devyat_trunk/demo);
+	name = "Devyat Association Crate";
+	desc = "A crate recieved from devyat association. Open with a Crowbar.";
+	color = "#017821"
+	},
+/obj/structure/lootcrate/seven{
+	rareloot = list(/obj/item/clothing/suit/armor/ego_gear/city/devyat_suit, /obj/item/ego_weapon/city/devyat_trunk);
+	lootlist = list(/obj/item/clothing/suit/armor/ego_gear/city/devyat_suit/weak);
+	veryrareloot = list(/obj/item/ego_weapon/city/devyat_trunk/demo);
+	name = "Devyat Association Crate";
+	desc = "A crate recieved from devyat association. Open with a Crowbar.";
+	color = "#017821"
+	},
 /turf/open/floor/wood,
 /area/city)
 "qc" = (
@@ -2409,7 +2460,9 @@
 /turf/open/floor/plating/rust,
 /area/city/shop)
 "qg" = (
-/obj/structure/spider/cocoon,
+/obj/structure/spider/cocoon{
+	resistance_flags = 64
+	},
 /obj/effect/landmark/npc_reveal_sensor{
 	sensor_id = "ambush";
 	cooldown_duration = 6000
@@ -2451,7 +2504,9 @@
 	mobtype = /mob/living/simple_animal/hostile/poison/giant_spider;
 	sensor_id = "ambush"
 	},
-/obj/structure/spider/cocoon,
+/obj/structure/spider/cocoon{
+	resistance_flags = 64
+	},
 /turf/open/floor/plating/rust,
 /area/city/house)
 "qv" = (
@@ -2520,7 +2575,6 @@
 	color = "#875300"
 	},
 /obj/item/fish_feed,
-/obj/structure/lootcrate/money,
 /turf/open/floor/wood,
 /area/city/house)
 "qN" = (
@@ -2649,7 +2703,10 @@
 /obj/item/flashlight/lamp,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/lootcrate/money,
+/obj/structure/lootcrate/money{
+	lootlist = list(/obj/item/stack/spacecash/c200);
+	rareloot = list(/obj/item/stack/spacecash/c200)
+	},
 /turf/open/floor/plating/rust,
 /area/city/house)
 "rp" = (
@@ -2683,14 +2740,21 @@
 /turf/open/floor/plating/rust,
 /area/city/fixers)
 "rA" = (
-/obj/structure/spider/stickyweb,
-/obj/effect/landmark/npc_reveal_spawn{
-	mobtype = /mob/living/simple_animal/hostile/poison/giant_spider;
-	sensor_id = "ambush"
+/obj/effect/decal/cleanable/greenglow{
+	light_color = "#ff0037";
+	color = "#ff0037"
 	},
-/obj/structure/spider/cocoon,
-/turf/open/floor/plating/rust,
-/area/city/house)
+/obj/structure/lootcrate/money{
+	lootlist = list(/obj/item/stack/spacecash/c200);
+	rareloot = list(/obj/item/stack/spacecash/c200)
+	},
+/obj/structure/lootcrate/money{
+	lootlist = list(/obj/item/stack/spacecash/c200);
+	rareloot = list(/obj/item/stack/spacecash/c200)
+	},
+/obj/item/stack/spacecash/c500,
+/turf/open/indestructible/necropolis,
+/area/city)
 "rF" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table/reinforced{
@@ -2810,6 +2874,7 @@
 /obj/machinery/door/airlock/wood{
 	name = "The Bistro"
 	},
+/obj/effect/decal/cleanable/blood/footprints,
 /turf/open/floor/wood,
 /area/city/shop)
 "st" = (
@@ -3142,7 +3207,9 @@
 /area/city/fixers)
 "ui" = (
 /obj/structure/spider/stickyweb,
-/obj/structure/spider/cocoon,
+/obj/structure/spider/cocoon{
+	resistance_flags = 64
+	},
 /obj/effect/landmark/npc_reveal_spawn{
 	mobtype = /mob/living/simple_animal/hostile/poison/giant_spider;
 	sensor_id = "ambush"
@@ -3244,7 +3311,10 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/ego_weapon/city/fixerblade,
-/obj/item/stack/spacecash/c100,
+/obj/structure/lootcrate/money{
+	lootlist = list(/obj/item/stack/spacecash/c200);
+	rareloot = list(/obj/item/stack/spacecash/c200)
+	},
 /turf/open/floor/wood,
 /area/city)
 "uI" = (
@@ -3329,21 +3399,6 @@
 	dir = 1
 	},
 /turf/open/floor/wood,
-/area/city/shop)
-"vi" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/mob/living/simple_animal/hostile/mutant_clown{
-	name = "'Mother?'";
-	icon_state = "glutton";
-	base_pixel_x = -16;
-	pixel_x = -16;
-	scream_damage = 40;
-	maxHealth = 1000;
-	melee_damage_lower = 40;
-	melee_damage_upper = 40;
-	color = "#f194f2"
-	},
-/turf/open/indestructible/necropolis,
 /area/city/shop)
 "vj" = (
 /obj/machinery/light/small,
@@ -3872,7 +3927,10 @@
 /obj/structure/bed/maint,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/maintenance,
-/obj/structure/lootcrate/money,
+/obj/structure/lootcrate/money{
+	lootlist = list(/obj/item/stack/spacecash/c200);
+	rareloot = list(/obj/item/stack/spacecash/c200)
+	},
 /turf/open/floor/wood,
 /area/city/house)
 "yF" = (
@@ -3933,6 +3991,10 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/cobweb,
 /obj/item/ego_weapon/city/fixerblade,
+/obj/structure/lootcrate/money{
+	lootlist = list(/obj/item/stack/spacecash/c200);
+	rareloot = list(/obj/item/stack/spacecash/c200)
+	},
 /turf/open/floor/wood,
 /area/city)
 "yQ" = (
@@ -4099,7 +4161,10 @@
 /obj/structure/bed/maint,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/maintenance,
-/obj/structure/lootcrate/money,
+/obj/structure/lootcrate/money{
+	lootlist = list(/obj/item/stack/spacecash/c200);
+	rareloot = list(/obj/item/stack/spacecash/c200)
+	},
 /obj/item/food/cheesewedge,
 /turf/open/floor/wood{
 	icon_state = "wood-broken"
@@ -4224,7 +4289,10 @@
 "AD" = (
 /obj/structure/table_frame/wood,
 /obj/item/flashlight/lamp,
-/obj/structure/lootcrate/money,
+/obj/structure/lootcrate/money{
+	lootlist = list(/obj/item/stack/spacecash/c200);
+	rareloot = list(/obj/item/stack/spacecash/c200)
+	},
 /turf/open/floor/plating/rust,
 /area/city/house)
 "AI" = (
@@ -4579,7 +4647,10 @@
 /obj/structure/table_frame/wood,
 /obj/item/flashlight/lamp,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/lootcrate/money,
+/obj/structure/lootcrate/money{
+	lootlist = list(/obj/item/stack/spacecash/c200);
+	rareloot = list(/obj/item/stack/spacecash/c200)
+	},
 /turf/open/floor/wood,
 /area/city/house)
 "DG" = (
@@ -4719,7 +4790,10 @@
 /area/city/house)
 "EC" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
-/obj/structure/lootcrate/money,
+/obj/structure/lootcrate/money{
+	lootlist = list(/obj/item/stack/spacecash/c200);
+	rareloot = list(/obj/item/stack/spacecash/c200)
+	},
 /obj/structure/table/reinforced{
 	color = "#875300"
 	},
@@ -5524,7 +5598,10 @@
 /area/city/shop)
 "JQ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/lootcrate/money,
+/obj/structure/lootcrate/money{
+	lootlist = list(/obj/item/stack/spacecash/c200);
+	rareloot = list(/obj/item/stack/spacecash/c200)
+	},
 /obj/item/food/cheesewheel,
 /turf/open/floor/wood,
 /area/city/house)
@@ -5691,21 +5768,11 @@
 /turf/open/floor/plating/rust,
 /area/city/fixers)
 "KW" = (
-/obj/structure/toilet{
-	dir = 4;
-	color = "#875300"
+/obj/effect/decal/cleanable/blood/footprints,
+/turf/open/floor/wood{
+	icon_state = "wood-broken"
 	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/spider/stickyweb,
-/obj/structure/spider/cocoon,
-/obj/effect/landmark/npc_reveal_sensor{
-	sensor_id = "ambush";
-	cooldown_duration = 6000
-	},
-/turf/open/floor/plating/rust,
-/area/city/house)
+/area/city/shop)
 "KZ" = (
 /turf/closed/mineral/ash_rock,
 /area/city)
@@ -5735,8 +5802,6 @@
 	color = "#875300"
 	},
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/lootcrate/hana,
-/obj/structure/lootcrate/hana,
 /obj/structure/lootcrate/hana,
 /obj/structure/lootcrate/hana,
 /turf/open/indestructible/necropolis,
@@ -5985,7 +6050,10 @@
 /obj/item/modular_computer/laptop/preset/fixer,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/sand,
-/obj/structure/lootcrate/money,
+/obj/structure/lootcrate/money{
+	lootlist = list(/obj/item/stack/spacecash/c200);
+	rareloot = list(/obj/item/stack/spacecash/c200)
+	},
 /turf/open/floor/plating/rust,
 /area/city/house)
 "MR" = (
@@ -6083,10 +6151,9 @@
 /turf/open/floor/plating/rust,
 /area/city/house)
 "ND" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/regalrat,
-/turf/open/floor/wood,
-/area/city/house)
+/obj/effect/decal/cleanable/blood/gibs/up,
+/turf/open/floor/plating/asteroid,
+/area/city)
 "NH" = (
 /obj/structure/fluff/bus/dense{
 	icon_state = "frontwallbottom"
@@ -6463,13 +6530,9 @@
 /turf/open/floor/plating/rust,
 /area/city)
 "PZ" = (
-/obj/structure/table/reinforced{
-	color = "#875300"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/lootcrate/money,
-/turf/open/floor/plating/rust,
-/area/city/house)
+/obj/effect/decal/cleanable/blood/footprints,
+/turf/open/floor/plating/asteroid,
+/area/city)
 "Qc" = (
 /mob/living/simple_animal/mouse/brown{
 	faction = list("neutral")
@@ -6711,19 +6774,6 @@
 	},
 /turf/open/indestructible/necropolis,
 /area/city/backstreets_room)
-"RN" = (
-/obj/structure/sink/kitchen{
-	dir = 4;
-	pixel_x = -11
-	},
-/obj/structure/spider/stickyweb,
-/obj/structure/spider/cocoon,
-/obj/effect/landmark/npc_reveal_sensor{
-	sensor_id = "ambush";
-	cooldown_duration = 6000
-	},
-/turf/open/floor/plating/rust,
-/area/city/house)
 "RP" = (
 /obj/structure/table_frame,
 /obj/item/reagent_containers/glass/bottle/formaldehyde,
@@ -6785,10 +6835,8 @@
 /turf/open/floor/wood,
 /area/city/shop)
 "Se" = (
-/obj/structure/meatfloor,
-/obj/structure/lootcrate/hana,
 /obj/structure/barricade/meatbags,
-/obj/structure/lootcrate/hana,
+/obj/effect/landmark/cratespawn/corpo,
 /turf/open/indestructible/necropolis,
 /area/city)
 "Sf" = (
@@ -6900,7 +6948,10 @@
 /obj/structure/table/reinforced{
 	color = "#875300"
 	},
-/obj/structure/lootcrate/money,
+/obj/structure/lootcrate/money{
+	lootlist = list(/obj/item/stack/spacecash/c200);
+	rareloot = list(/obj/item/stack/spacecash/c200)
+	},
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plating/rust,
 /area/city/house)
@@ -7007,7 +7058,6 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 10
 	},
-/obj/structure/lootcrate/money,
 /obj/effect/decal/cleanable/greenglow{
 	light_color = "#ff0037";
 	color = "#ff0037"
@@ -7135,7 +7185,10 @@
 /obj/item/reagent_containers/glass/bottle/nutrient,
 /obj/item/reagent_containers/glass/bottle/nutrient,
 /obj/item/reagent_containers/glass/bottle/nutrient,
-/obj/structure/lootcrate/money,
+/obj/structure/lootcrate/money{
+	lootlist = list(/obj/item/stack/spacecash/c200);
+	rareloot = list(/obj/item/stack/spacecash/c200)
+	},
 /turf/open/floor/wood,
 /area/city/house)
 "TZ" = (
@@ -7145,23 +7198,6 @@
 /obj/effect/spawner/lootdrop/garbage_spawner,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood,
-/area/city/house)
-"Ub" = (
-/obj/structure/sink{
-	pixel_y = 16;
-	color = "#875300"
-	},
-/obj/structure/mirror{
-	pixel_x = -1;
-	pixel_y = 34
-	},
-/obj/structure/spider/cocoon,
-/obj/structure/spider/stickyweb,
-/obj/effect/landmark/npc_reveal_sensor{
-	sensor_id = "ambush";
-	cooldown_duration = 6000
-	},
-/turf/open/floor/plating/rust,
 /area/city/house)
 "Ud" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -7324,7 +7360,10 @@
 /obj/structure/table_frame/wood,
 /obj/item/poster/random_contraband,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/lootcrate/money,
+/obj/structure/lootcrate/money{
+	lootlist = list(/obj/item/stack/spacecash/c200);
+	rareloot = list(/obj/item/stack/spacecash/c200)
+	},
 /turf/open/indestructible/necropolis,
 /area/city)
 "UW" = (
@@ -7473,7 +7512,10 @@
 /obj/structure/table/reinforced{
 	color = "#875300"
 	},
-/obj/structure/lootcrate/money,
+/obj/structure/lootcrate/money{
+	lootlist = list(/obj/item/stack/spacecash/c200);
+	rareloot = list(/obj/item/stack/spacecash/c200)
+	},
 /turf/open/floor/plating/rust,
 /area/city/house)
 "VU" = (
@@ -7533,15 +7575,6 @@
 /mob/living/simple_animal/hostile/humanoid/rat/zippy/scavenger{
 	dir = 1
 	},
-/turf/open/floor/wood,
-/area/city)
-"Wu" = (
-/obj/structure/table/reinforced{
-	color = "#875300"
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/item/food/freshfish/rotten,
-/obj/item/stack/spacecash/c100,
 /turf/open/floor/wood,
 /area/city)
 "Wv" = (
@@ -7627,7 +7660,10 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/cobweb,
-/obj/structure/lootcrate/money,
+/obj/structure/lootcrate/money{
+	lootlist = list(/obj/item/stack/spacecash/c200);
+	rareloot = list(/obj/item/stack/spacecash/c200)
+	},
 /turf/open/floor/plating/rust,
 /area/city/house)
 "Xe" = (
@@ -8088,7 +8124,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/food/breadslice/moldy,
 /obj/item/food/breadslice/moldy,
-/obj/item/stack/spacecash/c100,
 /turf/open/floor/wood,
 /area/city)
 "ZI" = (
@@ -8283,8 +8318,8 @@ kC
 io
 Eh
 Se
-if
-if
+Se
+Se
 dI
 dI
 kC
@@ -8549,7 +8584,7 @@ kC
 oY
 oY
 kC
-if
+Se
 dI
 Eh
 Eh
@@ -8822,9 +8857,9 @@ kC
 kC
 Ux
 dI
-if
-if
-if
+Se
+Se
+Se
 Eh
 io
 kC
@@ -9328,7 +9363,7 @@ oY
 "}
 (14,1,1) = {"
 Vr
-Ux
+rA
 mM
 dI
 Eh
@@ -10526,7 +10561,7 @@ GK
 lX
 es
 oQ
-ND
+lX
 Dr
 Aa
 ew
@@ -12547,7 +12582,7 @@ Vr
 oY
 oY
 ej
-Wu
+nk
 MZ
 jV
 ej
@@ -13136,10 +13171,10 @@ Hj
 Hj
 ka
 ew
-KW
+Xg
 bP
 eO
-RN
+IX
 dn
 fo
 Su
@@ -13767,7 +13802,7 @@ ew
 ka
 ew
 Xg
-qr
+bP
 Ut
 IX
 yc
@@ -13856,7 +13891,7 @@ sa
 ew
 ka
 ew
-Ub
+za
 eO
 eO
 ui
@@ -14127,7 +14162,7 @@ bw
 ka
 ew
 xa
-rA
+eO
 eO
 eO
 aZ
@@ -14964,7 +14999,7 @@ bw
 ew
 qQ
 dp
-PZ
+wE
 NU
 oc
 op
@@ -15096,7 +15131,7 @@ Fx
 Ql
 HS
 Tb
-Hw
+KW
 Tb
 aX
 Tb
@@ -15189,10 +15224,10 @@ uU
 Fx
 cm
 He
-Hw
+KW
 ss
-bw
-bw
+PZ
+ND
 bw
 bw
 lx
@@ -16083,7 +16118,7 @@ oY
 oY
 nN
 wH
-vi
+kb
 dB
 TC
 ab
@@ -17276,7 +17311,7 @@ wY
 rH
 rH
 fk
-fd
+aq
 Vr
 bw
 Vr
@@ -18464,7 +18499,7 @@ ka
 ka
 ka
 vx
-vx
+ka
 bw
 xR
 Ei
@@ -18553,7 +18588,7 @@ ka
 bw
 bw
 ka
-vx
+ka
 ka
 ka
 ka

--- a/_maps/Quests/ruined_town.dmm
+++ b/_maps/Quests/ruined_town.dmm
@@ -3129,6 +3129,7 @@
 	mouse_opacity = 0;
 	alpha = 0
 	},
+/mob/living/simple_animal/hostile/netherworld/migo,
 /turf/open/floor/plating/asteroid/basalt/wasteland,
 /area/city)
 "tV" = (

--- a/code/modules/mob/living/simple_animal/friendly/eric_t.dm
+++ b/code/modules/mob/living/simple_animal/friendly/eric_t.dm
@@ -1,8 +1,8 @@
 /mob/living/simple_animal/hostile/ui_npc/eric_t
 	name = "Eric T."
 	desc = "A fancy looking fellow wearing a mask; they look relaxed right now."
-	health = 1000
-	maxHealth = 1000
+	health = 2500
+	maxHealth = 2500
 	typing_interval = 30
 	portrait = "erik_bloodfiend_zoom.PNG"
 	start_scene_id = "intro"
@@ -48,6 +48,9 @@
 
 	if(isnull(scene_manager.get_var(user, "player.is_worker")))
 		scene_manager.set_var(user, "player.is_worker", FALSE)
+
+	if(isnull(scene_manager.get_var(user, "player.collected_parcels")))
+		scene_manager.set_var(user, "player.collected_parcels", 0)
 
 	// Check if player has the briefcase
 	var/has_briefcase = briefcase_check(user)
@@ -244,6 +247,7 @@
 			),
 			"quest" = list(
 				"text" = "\[dialog.intro_quest_shown?About the Contract...:Any other jobs?\]",
+				"visibility_expression" = "player.collected_parcels>=6",
 				"default_scene" = "quest_1",
 				"transitions" = list(
 					list(
@@ -264,6 +268,9 @@
 		"actions" = list(
 			"..." = list(
 				"text" = "...",
+				"var_updates" = list(
+					"player.collected_parcels" = "{player.collected_parcels++}",
+				),
 				"default_scene" = "job"
 			)
 		)
@@ -765,7 +772,7 @@
 
 /mob/living/simple_animal/hostile/ui_npc/eric_t/proc/afterkill()
 	sleep(25)
-	manual_emote("Wipes their gloves clean...")
+	manual_emote("wipes their gloves clean...")
 	sleep(45)
 	say("Anyone else wants to bother me?")
 

--- a/code/modules/mob/living/simple_animal/friendly/nuke_leader.dm
+++ b/code/modules/mob/living/simple_animal/friendly/nuke_leader.dm
@@ -434,13 +434,33 @@
 			"text" = "I have sent out some scouts to make gas masks to traverse, you should be able to find them in the old butcher's restaurant.",
 			"actions" = list(
 				"..." = list(
-					"text" = "Thanks for giving directions.",
-					"default_scene" = "main_screen"
+					"text" = "...",
+					"default_scene" = "breifcase_11"
 				)
 			)
 		),
 
 		"breifcase_11" = list(
+			"text" = "Oh, one more thing of note. After some careful observations of those clowns, they appear to share some sort of connection with their 'Grandfather'.",
+			"actions" = list(
+				"..." = list(
+					"text" = "...",
+					"default_scene" = "breifcase_12"
+				)
+			)
+		),
+
+		"breifcase_12" = list(
+			"text" = "So, if you wish attempt to hunt down the 'Grandfather', I would recommend killing every single clown before hand. You would not want to be jumped by all of them.",
+			"actions" = list(
+				"..." = list(
+					"text" = "Thanks for the warning.",
+					"default_scene" = "breifcase_main"
+				)
+			)
+		),
+
+		"breifcase_main" = list(
 			"text" = "Hm... Got any updates on that?",
 			"actions" = list(
 				"..." = list(
@@ -481,7 +501,7 @@
 			"actions" = list(
 				"..." = list(
 					"text" = "...",
-					"default_scene" = "breifcase_11"
+					"default_scene" = "breifcase_main"
 				)
 			)
 		),


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR makes a few Adjustments to the ruined town quest, making it slightly less free to get loot by reducing the amount of lootcrates in trapped buildings, and making it so you need to be Grade 7 to be able to take the quest.

Along with that, a few devyat lootcrates have been added to the ruined map, which will guarantee dropping some devyat gear.

## Why It's Good For The Game

Makes the Ruined Town slightly more balanced by making gathering loot require more combat.

## Changelog
:cl:
tweak: tweaked the ruined town quest
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
