### PR TITLE
Ghosts are now capable of spotting midround job openings (CoL)

### DIFF
--- a/code/controllers/subsystem/city_events.dm
+++ b/code/controllers/subsystem/city_events.dm
@@ -143,18 +143,22 @@ SUBSYSTEM_DEF(cityevents)
 	for(var/datum/job/processing in SSjob.occupations)
 		if(jobpicked <= 2)
 			if(istype(processing, /datum/job/scavenger))
+				deadchat_broadcast("A Rat job slot has just opened, respawn to play as one.", message_type=DEADCHAT_ANNOUNCEMENT)
 				processing.total_positions +=1
 
 		if(jobpicked == 3)
 			if(istype(processing, /datum/job/associateroaming))
+				deadchat_broadcast("A Roaming association job slot has just opened, respawn to play as one.", message_type=DEADCHAT_ANNOUNCEMENT)
 				processing.total_positions +=1
 
 		if(jobpicked == 4)
 			if(istype(processing, /datum/job/roamingsalsu))
+				deadchat_broadcast("A Blade Lineage Salsu job slot has just opened, respawn to play as one.", message_type=DEADCHAT_ANNOUNCEMENT)
 				processing.total_positions += 1
 
 		if(jobpicked == 5)
 			if(istype(processing, /datum/job/butcher))
+				deadchat_broadcast("A Backstreets Butcher job slot has just opened, respawn to play as one.", message_type=DEADCHAT_ANNOUNCEMENT)
 				processing.total_positions += 1
 
 /datum/controller/subsystem/cityevents/proc/Boss()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Notifies dchat if a midround job slot opens via CoL events
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Ghosts never notice midrounds opening as they silently open in the main menu while ghosts will not have access to this information without respawning
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Adds a notif for CoL ghosts of midround job slots opening
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
