### PR TITLE
Adventure Console Update V2.2 [DONE]

### DIFF
--- a/ModularTegustation/lc13_obj/_adventure_console/adventure_events/_event.dm
+++ b/ModularTegustation/lc13_obj/_adventure_console/adventure_events/_event.dm
@@ -197,3 +197,9 @@
 /datum/adventure_event/proc/RewardKey(key_identifier)
 	gamer.GiveKey(key_identifier)
 	temp_text += "[key_identifier] GAINED<br>"
+
+/datum/adventure_event/proc/AdjustDamageDice(newdice)
+	if(gamer.ChangeDice(newdice))
+		temp_text += "[newdice] WEAPON GAINED<br>"
+		return newdice
+	temp_text += "AdjustDamageDice ERROR<br>"

--- a/ModularTegustation/lc13_obj/_adventure_console/adventure_events/abnormality/zayin/we_can_change_anything.dm
+++ b/ModularTegustation/lc13_obj/_adventure_console/adventure_events/abnormality/zayin/we_can_change_anything.dm
@@ -11,7 +11,13 @@
 
 		"The machine spits you out.<br>\
 		You call back to the clinking outside of the machine, seeing<br>\
-		a pile of coins lie outside for you to take."
+		a pile of coins lie outside for you to take.",
+
+		"The machine spits you out.<br>\
+		Whats left of you splatters to the ground in a wet red pulp.<br>\
+		Your somehow functioning eye watch as your coins are collected <br>\
+		by a figure in a lab coat.<br>\
+		Your remains are disposed of before you awaken back on the path.",
 		)
 	var/machine_coins = 0
 
@@ -23,11 +29,15 @@
 			BUTTON_FORMAT(2, "ENTER THE MACHINE", M)
 			return
 		if(2)
-			BUTTON_FORMAT(2, "ENJOY THE MACHINE", M)
-			BUTTON_FORMAT(2, "ENJOY THE MACHINE", M)
-			BUTTON_FORMAT(3, "LEAVE THE MACHINE", M)
-			BUTTON_FORMAT(2, "ENJOY THE MACHINE", M)
-			BUTTON_FORMAT(2, "ENJOY THE MACHINE", M)
+			if(gamer.virtual_integrity > -5)
+				BUTTON_FORMAT(2, "ENJOY THE MACHINE", M)
+				BUTTON_FORMAT(2, "ENJOY THE MACHINE", M)
+				BUTTON_FORMAT(3, "LEAVE THE MACHINE", M)
+				BUTTON_FORMAT(2, "ENJOY THE MACHINE", M)
+				BUTTON_FORMAT(2, "ENJOY THE MACHINE", M)
+			else
+				BUTTON_FORMAT(4, "DIE", M)
+				return
 			AdjustHitPoint(-10)
 			machine_coins++
 			return

--- a/ModularTegustation/lc13_obj/_adventure_console/adventure_events/general/sinking_bell.dm
+++ b/ModularTegustation/lc13_obj/_adventure_console/adventure_events/general/sinking_bell.dm
@@ -44,6 +44,8 @@
 		The pressure of the water slowly fades as your broken body is pushed up to the water.<br>\
 		When you awaken your on the shore unharmed.<br>\
 		As you look back you see a metal container with two eyes slowly sink below the waves.",
+
+		"Your different now.",
 		)
 
 /datum/adventure_event/sinking_bell/EventChoiceFormat(obj/machinery/M, mob/living/carbon/human/H)
@@ -60,6 +62,7 @@
 			return
 		if(4)
 			AdjustHitPoint(-20)
+			AdjustStatNum(GLOOM_STAT,3)
 		if(5)
 			BUTTON_FORMAT(2, "SURRENDER TO THE PULL", M)
 			BUTTON_FORMAT(6, "REACH FOR THE BELL", M)
@@ -79,4 +82,12 @@
 		if(8)
 			BUTTON_FORMAT(9, "REST", M)
 			return
+		if(9)
+			AdjustStatNum(SLOTH_STAT,1)
+			. += "THIS EVENT HAS CHANGED YOU<br>"
+			BUTTON_FORMAT(10, "SWAP [gamer.virtual_damage] for 1d7 DAMAGE DICE?", M)
+			BUTTON_FORMAT(0, "CONTINUE", M)
+			return
+		if(10)
+			AdjustDamageDice("1d7")
 	return ..()

--- a/ModularTegustation/lc13_obj/_adventure_console/adventure_layout.dm
+++ b/ModularTegustation/lc13_obj/_adventure_console/adventure_layout.dm
@@ -1,5 +1,5 @@
 /**
- * ADVENTURE CONSOLE V2.1
+ * ADVENTURE CONSOLE V2.2
  * TEXT BASED ADVENTURES
  * Adventures that are mostly predefined paths.
  * This was difficult to finalize since i havent made a text based adventure before.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
A very small Adventure Console update.
Adds a new proc to events that allows events to change damage dice values.
Sinking Bell now has a weapon upgrade in it as a reward for your resolve.
We_can_change_anything now has a limit to the amount of damage you can convert into coins, with a punishment for using it too much.


## Changelog
:cl:
add: AdjustDamageDice proc to adventure console.
tweak: sinking_bell and we_can_change_anything adventure console events
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
