### PR TITLE
Damage Type Shuffle Adjustments

### DIFF
--- a/ModularTegustation/lc13_damage_type_shuffler.dm
+++ b/ModularTegustation/lc13_damage_type_shuffler.dm
@@ -15,7 +15,7 @@ GLOBAL_DATUM_INIT(damage_type_shuffler, /datum/damage_type_shuffler, new /datum/
 	var/list/mapping_defense = list(RED_DAMAGE = RED_DAMAGE, WHITE_DAMAGE = WHITE_DAMAGE, BLACK_DAMAGE = BLACK_DAMAGE, PALE_DAMAGE = PALE_DAMAGE)
 	///If a non pale damage type became pale then all new pale damage will be multiplied by this for a lil bit of balance.
 	///If pale damage turned into non pale damage it will be divided by this value.
-	var/pale_debuff = 0.75
+	var/pale_debuff = 0.55
 
 /datum/damage_type_shuffler/New()
 	. = ..()

--- a/code/controllers/subsystem/maptype.dm
+++ b/code/controllers/subsystem/maptype.dm
@@ -23,7 +23,7 @@ SUBSYSTEM_DEF(maptype)
 						FACILITY_TRAIT_MOBA_AGENTS = 10, 		//Agents pick a MOBA class
 						FACILITY_TRAIT_CRITICAL_HITS = 10,		//EGO can Critical hit.
 						FACILITY_TRAIT_DEPARTMENTAL_BUFFS = 10,	//Departmental Agent Buffs
-						FACILITY_TRAIT_DAMAGE_TYPE_SHUFFLE = 5, //Shuffles all lob corp color damage types randomly. Attack and armor damage types shuffled separately.
+						FACILITY_TRAIT_DAMAGE_TYPE_SHUFFLE = 2, //Shuffles all lob corp color damage types randomly. Attack and armor damage types shuffled separately.
 						FACILITY_TRAIT_ABNO_BLITZ = 3,			//The game is significantly Faster, starts after noon.
 
 						//Joke stuff is below, should all be low


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes the pale debuff multiplier 0.75 => 0.55 (buff would be 1.33 => 1.82).
Changes damage type shuffle weight 5 => 2.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Should make white night scary again.
Increased rarity for the station trait should make it less annoying.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Damage type shuffle station trait is more rare now (weight adjusted 5 => 2).
balance: Damage type shuffle pale debuff multiplier adjusted 0.75 => 0.55 (buff 1.33 => 1.82).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
