### PR TITLE
L-Corp Rep "Clerk Training" upgrade made compatible with "Abno Blitz" station trait

### DIFF
--- a/ModularTegustation/tegu_items/representative/research/lcorp.dm
+++ b/ModularTegustation/tegu_items/representative/research/lcorp.dm
@@ -126,8 +126,13 @@ GLOBAL_LIST_EMPTY(lcorp_upgrades)
 /datum/data/lc13research/clerkbuff/ResearchEffect(obj/structure/representative_console/requester)
 	for(var/mob/living/carbon/human/H in GLOB.player_list)
 		if(H?.mind?.assigned_role in GLOB.service_positions)
-			H.set_attribute_limit(40)
-			H.adjust_all_attribute_levels(40)
+			if(SSmaptype.chosen_trait == FACILITY_TRAIT_ABNO_BLITZ)
+				H.set_attribute_limit(60)
+				H.adjust_all_attribute_levels(60)
+
+			else
+				H.set_attribute_limit(40)
+				H.adjust_all_attribute_levels(40)
 
 	GLOB.lcorp_upgrades += "Clerk Buff"
 	..()

--- a/code/modules/jobs/job_types/assistant.dm
+++ b/code/modules/jobs/job_types/assistant.dm
@@ -50,14 +50,20 @@ GLOBAL_LIST_EMPTY(spawned_clerks)
 	else	//Don't buff them if they can work jesus
 		outfit_owner.set_attribute_limit(130)
 
-	for(var/upgradecheck in GLOB.lcorp_upgrades)
-		if(upgradecheck == "Clerk Buff")
-			outfit_owner.set_attribute_limit(40)
-			outfit_owner.adjust_all_attribute_levels(40)
-
 	if(SSmaptype.chosen_trait == FACILITY_TRAIT_ABNO_BLITZ)
 		outfit_owner.set_attribute_limit(40)
 		outfit_owner.adjust_all_attribute_levels(40)
+
+
+	for(var/upgradecheck in GLOB.lcorp_upgrades)
+		if(upgradecheck == "Clerk Buff")
+			if(SSmaptype.chosen_trait == FACILITY_TRAIT_ABNO_BLITZ)
+				outfit_owner.set_attribute_limit(60)
+				outfit_owner.adjust_all_attribute_levels(60)
+
+			else
+				outfit_owner.set_attribute_limit(40)
+				outfit_owner.adjust_all_attribute_levels(40)
 
 	if(outfit_owner.ckey in GLOB.spawned_clerks)
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes the clerk upgrade take them to level 3, instead of level 2 on abno blitz.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Abno Blitz makes all clerks start with level 2, issue here is the LCorp Rep upgrade of 25 PE becomes useless as clerks are already level 2 for Abno Blitz which is a bad look for an already unpopular representative. This PR lets the L-Corp Rep remain viable within Abno Blitz.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: tweaked lcorp rep upgrade to make clerks level 3 on abno blitz
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
