### PR TITLE
Fixes blind obsession runtimes and "sticky" slowdown

### DIFF
--- a/ModularTegustation/ego_weapons/melee/waw.dm
+++ b/ModularTegustation/ego_weapons/melee/waw.dm
@@ -1901,8 +1901,11 @@
 	. = ..()
 	if(!user)
 		return
-	current_holder = user
-	RegisterSignal(current_holder, COMSIG_MOVABLE_MOVED, PROC_REF(UserMoved))
+	if(slot != ITEM_SLOT_HANDS) //Clean up our slowdown and whatnot if we're storing the anchor somewhere on our person
+		dropped(user)
+	else
+		current_holder = user //If it's going into our hands, then we wanna register the signal and register as the holder
+		RegisterSignal(current_holder, COMSIG_MOVABLE_MOVED, PROC_REF(UserMoved))
 
 //Destroy setup
 /obj/item/ego_weapon/blind_obsession/Destroy(mob/user)
@@ -1921,7 +1924,8 @@
 	if(!user)
 		return
 	speed_slowdown = 0
-	UnregisterSignal(current_holder, COMSIG_MOVABLE_MOVED)
+	if(current_holder) //This check wouldn't need to exist but P Corp items call dropped() when we remove an item from them, and it will runtime if we don't check here
+		UnregisterSignal(current_holder, COMSIG_MOVABLE_MOVED)
 	if(!thrown)
 		PowerReset(user)
 	current_holder = null


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR fixes two runtimes related to Blind Obsession and also prevents the empowered slowdown from "sticking" when it is holstered.

Behaviour on master branch:
- Blind Obsession runtimes when it is holstered into your belt or EGO suit storage, because it is calling equipped() while already having its related signal registered by equipped() having been called when it was picked up. This causes a runtime from overriding an existing signal
- Blind Obsession runtimes when it is taken out of a P Corp storage item, probably also similar items like it. This is because removing an item from those storages calls dropped() on it, which unregisters a signal that wasn't registered already
- Blind Obsession applies a slowdown when it is empowered, this slowdown goes away if you either drop it, throw it or it times out. But if you holster it the slowdown remains until its timer runs out.

All three seem to be fixed from my testing. It is probably not super clean to call dropped() when holstering something, but I figure if the storage component can do it then it shouldn't be too bad here

## Why It's Good For The Game
It is very important that we take good care of our throwing weapons because they are the best and most important and coolest weapons in the game. Also less pointless runtimes might make it easier for staff to find actually important exceptions
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixed runtimes and slowdown issue relating to blind obsession E.G.O. weapon
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
