### PR TITLE
SpitePR | Cleanbot Shush

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/cleanbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/cleanbot.dm
@@ -252,9 +252,6 @@
 			if(prob(15)) // Wets floors and spawns foam randomly
 				UnarmedAttack(src)
 
-	else if(prob(5))
-		audible_message("[src] makes an excited beeping booping sound!")
-
 	if(ismob(target))
 		if(!(target in view(DEFAULT_SCAN_RANGE, src)))
 			target = null


### PR DESCRIPTION
Disables cleanbots making an annoying beeping noise that would spam chat if you were idle near it when it is doing nothing.

## About The Pull Request

Quite literally just removes the line of code that makes Cleanbots spam 'makes a beep-booping noise!' when idle.

## Why It's Good For The Game

Ever been afk and something happened and you wish you knew about but you were near a cleanbot that spams chat every second? No? Well this is just incase.

## Changelog
:cl:
del: Removes the annoying beepbooping.
code: Removed a elseif line.