### PR TITLE
adds abno sutures

### DIFF
--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -234,7 +234,7 @@
 	if (istype(M, /mob/living/simple_animal/hostile/abnormality))
 		try_heal(M, user)
 	else
-		to_chat(user, "span_warning("You can't use [src] on [M]!"))
+		to_chat(user, "span_warning("You can't use [src] on [M]!")")
 
 /obj/item/stack/medical/suture/emergency
 	name = "emergency suture"

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -234,7 +234,7 @@
 	if (istype(M, /mob/living/simple_animal/hostile/abnormality))
 		try_heal(M, user)
 	else
-		to_chat(user, "span_warning("You can't use [src] on [M]!")")
+		to_chat(user, span_warning("You can't use [src] on [M]!"))
 
 /obj/item/stack/medical/suture/emergency
 	name = "emergency suture"

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -219,6 +219,23 @@
 	grind_results = list(/datum/reagent/medicine/spaceacillin = 2)
 	merge_type = /obj/item/stack/medical/suture
 
+/obj/item/stack/medical/suture/abno
+	name = "abno suture"
+	desc = "sutures used to heal abno wounds."
+	heal_brute = 100
+	amount = 1
+	max_amount = 1
+	merge_type = /obj/item/stack/medical/suture/abno
+
+/obj/item/stack/medical/suture/abno/use()
+	return
+
+/obj/item/stack/medical/suture/abno/attack(mob/living/M, mob/user)
+	if (istype(M, /mob/living/simple_animal/hostile/abnormality))
+		try_heal(M, user)
+	else
+		to_chat(user, "span_warning("You can't use [src] on [M]!"))
+
 /obj/item/stack/medical/suture/emergency
 	name = "emergency suture"
 	desc = "A value pack of cheap sutures, not very good at repairing damage, but still decent at stopping bleeding."

--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -125,6 +125,7 @@
 		/obj/item/healthanalyzer = 1,
 		/obj/item/stack/medical/gauze/twelve = 1,
 		/obj/item/stack/medical/suture = 2,
+		/obj/item/stack/medical/suture/abno = 1,
 		/obj/item/stack/medical/mesh = 2,
 		/obj/item/reagent_containers/hypospray/medipen = 1,
 		/obj/item/surgical_drapes = 1,


### PR DESCRIPTION
## About The Pull Request

adds abno sutures that exclusively heal abnos for a large amount without being consumed

## Why It's Good For The Game

for use in lcl where abnos are often injured permanently as normal sutures are expensive, allows people to be more forceful without accidentally killing an abno thats been at low hp for a long while

## Changelog
:cl:
add: Added abno sutures
/:cl: