### PR TITLE
Fixes Drifting Fox works

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/he/drifting_fox.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/drifting_fox.dm
@@ -91,19 +91,25 @@
 		However, if the umbrellas are broken you will lose 5% for each umbrella broken.<br></b>")
 
 /mob/living/simple_animal/hostile/abnormality/drifting_fox/funpet(mob/petter)
-	pet += petter
+	pet |= petter
 	return ..()
+
+/mob/living/simple_animal/hostile/abnormality/drifting_fox/AttemptWork(mob/living/carbon/human/user, work_type)
+	if(user in pet)
+		if(work_type == ABNORMALITY_WORK_ATTACHMENT)
+			to_chat(user, span_notice("The abnormality seems to like this type of work more than usual!"))
+		else
+			to_chat(user, span_warning("The abnormality does not seem happy with your choice of work."))
+	. = ..()
 
 /mob/living/simple_animal/hostile/abnormality/drifting_fox/WorkChance(mob/living/carbon/human/user, chance, work_type)
 	if(user in pet)
 		if(work_type == ABNORMALITY_WORK_ATTACHMENT)
 			chance += 30
-			pet -= user
-			to_chat(user, span_notice("The abnormality seems to like this type of work more than usual!"))
 		else
 			chance -= 10
-			to_chat(user, span_warning("The abnormality does not seem happy with your choice of work."))
 		return chance
+	. = ..()
 
 /mob/living/simple_animal/hostile/abnormality/drifting_fox/PostWorkEffect(mob/living/carbon/human/user, work_type, pe, work_time)
 	if(user in pet)


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Couple issues here:
- It originally removed you from the petting list every time it tried to calculate work chances. This included opening the Work Console, so if you pet the fox and then opened the console, it'd count as you not having pet it
- You could be added to the petting list several times. As in, if you pet it 10 times, you'd get put in the list 10 times. Funnily enough this helped counteract that previous bug
- It sent the "This abnormality seems to like..." message every time it calculated work chances
- Most important issue: It was missing a . = ..() in WorkChance(). It had a return value if you pet the fox, which would take the normal chances and add 30% for Attachment or remove 10% for anything else. The problem is, if you didn't pet it, there was no return, so it returned... probably NULL by default, which ended up using abysmal work rates, to the point that original Instinct or Insight (45 or 40 respectively) WITH the -10 subtraction from petting it and doing an incorrect work type, ended up being MORE than the chance you got from the buggy code. This ended up in players ALWAYS petting the fox even for Instinct and Insight because otherwise it would actually just go 0/18 PE and breach and kill them.

Everything has been fixed in my testing. Fox works will now be as such: 
- 45% Instinct, down to 35% if you pet it
- 40% Insight, down to 30% if you pet it
- 15%/20%/25%/30%/35% Attachment, with +30% added if you pet it 
- 15% Repression, down to 5% if you pet it

I have not touched the balance per se, but de facto Fox is going to become a much better trainer so it may warrant nerfs. Or not, barely anyone takes it anyway.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Drifting Fox won't be broken

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Drifting Fox abnormality works now handle petting properly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
