### PR TITLE
Ordeals nolonger count Ghosts

### DIFF
--- a/code/modules/ordeals/_ordealtypes.dm
+++ b/code/modules/ordeals/_ordealtypes.dm
@@ -29,8 +29,8 @@
 
 /datum/ordeal/simplespawn/Run()
 	..()
-	var/place_player_mod = round(GLOB.clients.len * place_player_multiplicator) // Ten players add a new spot
-	var/spawn_player_mod = round(GLOB.clients.len * spawn_player_multiplicator)
+	var/place_player_mod = round(length(AllLivingAgents(TRUE)) * place_player_multiplicator) // Ten players add a new spot
+	var/spawn_player_mod = round(length(AllLivingAgents(TRUE)) * spawn_player_multiplicator)
 	if(!LAZYLEN(GLOB.xeno_spawn))
 		message_admins("No xeno spawns found when spawning in ordeal!")
 		return
@@ -82,8 +82,8 @@
 	if(!LAZYLEN(GLOB.xeno_spawn))
 		message_admins("No xeno spawns found when spawning in ordeal!")
 		return
-	var/boss_player_mod = round(GLOB.clients.len * boss_player_multiplicator)
-	var/grunt_player_mod = round(GLOB.clients.len * grunt_player_multiplicator)
+	var/boss_player_mod = round(length(AllLivingAgents(TRUE)) * boss_player_multiplicator)
+	var/grunt_player_mod = round(length(AllLivingAgents(TRUE)) * grunt_player_multiplicator)
 	var/list/available_locs = GLOB.xeno_spawn.Copy()
 	for(var/i = 1 to round(boss_amount + boss_player_mod))
 		var/turf/T = pick(available_locs)

--- a/code/modules/ordeals/brown_ordeals.dm
+++ b/code/modules/ordeals/brown_ordeals.dm
@@ -25,8 +25,8 @@
 
 /datum/ordeal/brown_dawn/Run() // So basically we want to spawn a crap ton of enemies - Identical to simplespawn, but one type per group
 	..()
-	var/place_player_mod = round(GLOB.clients.len * place_player_multiplicator) // Ten players add a new spot
-	var/spawn_player_mod = round(GLOB.clients.len * spawn_player_multiplicator)
+	var/place_player_mod = round(length(AllLivingAgents(TRUE)) * place_player_multiplicator) // Ten players add a new spot
+	var/spawn_player_mod = round(length(AllLivingAgents(TRUE)) * spawn_player_multiplicator)
 	if(!LAZYLEN(GLOB.xeno_spawn))
 		message_admins("No xeno spawns found when spawning in ordeal!")
 		return

--- a/code/modules/ordeals/gold_ordeals.dm
+++ b/code/modules/ordeals/gold_ordeals.dm
@@ -26,8 +26,8 @@
 	if(!LAZYLEN(GLOB.xeno_spawn))
 		message_admins("No xeno spawns found when spawning in ordeal!")
 		return
-	var/boss_player_mod = round(GLOB.clients.len * boss_player_multiplicator)
-	var/grunt_player_mod = round(GLOB.clients.len * grunt_player_multiplicator)
+	var/boss_player_mod = round(length(AllLivingAgents(TRUE)) * boss_player_multiplicator)
+	var/grunt_player_mod = round(length(AllLivingAgents(TRUE)) * grunt_player_multiplicator)
 	var/list/available_locs = GLOB.xeno_spawn.Copy()
 
 	for(var/i = 1 to round(boss_amount + boss_player_mod)) // Run the usual simplecommander code
@@ -71,8 +71,8 @@
 	if(!LAZYLEN(GLOB.xeno_spawn))
 		message_admins("No xeno spawns found when spawning in ordeal!")
 		return
-	var/boss_player_mod = round(GLOB.clients.len * boss_player_multiplicator)
-	var/grunt_player_mod = round(GLOB.clients.len * grunt_player_multiplicator)
+	var/boss_player_mod = round(length(AllLivingAgents(TRUE)) * boss_player_multiplicator)
+	var/grunt_player_mod = round(length(AllLivingAgents(TRUE)) * grunt_player_multiplicator)
 	var/list/available_locs = GLOB.xeno_spawn.Copy()
 	for(var/i = 1 to round(roamer_amount + boss_player_mod)) // we spawn single roamers using boss slots as a base
 		var/turf/T = pick(available_locs)
@@ -150,8 +150,8 @@
 	if(!LAZYLEN(GLOB.xeno_spawn))
 		message_admins("No xeno spawns found when spawning in ordeal!")
 		return
-	var/boss_player_mod = round(GLOB.clients.len * boss_player_multiplicator)
-	var/grunt_player_mod = round(GLOB.clients.len * grunt_player_multiplicator)
+	var/boss_player_mod = round(length(AllLivingAgents(TRUE)) * boss_player_multiplicator)
+	var/grunt_player_mod = round(length(AllLivingAgents(TRUE)) * grunt_player_multiplicator)
 	var/list/available_locs = GLOB.xeno_spawn.Copy()
 
 	for(var/i = 1 to round(boss_amount + boss_player_mod))


### PR DESCRIPTION
## About The Pull Request

This changes how Ordeals count Players, Now excluding Ghosts and non-agent staff. This may be buggy and require a few days of testing before being fully pushed.

## Why It's Good For The Game

Ghosts will nolonger cause ordeals in solo shifts to be unnecessarily overpowered, And allow casual gameplay to be actually casual instead of difficult.

## Changelog
:cl:
tweak: Ordeals nolonger count non-agent staff to ordeals (Likely needs testing)
fix: Ghosts no longer count to ordeals.
code: Changed GLOB.Clients in ordeal modules to AllLivingAgents,
/:cl:
