### PR TITLE
Magic Bullet/Pistol actually fires faster with the Armor now (among a couple things)

### DIFF
--- a/ModularTegustation/ego_weapons/ranged/waw.dm
+++ b/ModularTegustation/ego_weapons/ranged/waw.dm
@@ -107,7 +107,7 @@
 	if(istype(Z))
 		cached_multiplier = projectile_damage_multiplier
 		projectile_damage_multiplier *= 2.5
-		fire_delay = 15
+		fire_delay = 8
 	..()
 
 
@@ -298,11 +298,11 @@
 	desc = "All the power of magic bullet, in a smaller package."
 	icon_state = "magic_pistol"
 	inhand_icon_state = "magic_pistol"
-	special = "This weapon pierces all targets. This weapon fires faster with the matching armor"
+	special = "This weapon pierces most targets. This weapon fires and reloads faster with the matching armor"
 	force = 17
 	damtype = BLACK_DAMAGE
 	projectile_path = /obj/projectile/ego_bullet/ego_magicpistol
-	fire_delay = 6
+	fire_delay = 7
 	shotsleft = 7
 	reloadtime = 1.2 SECONDS
 	fire_sound = 'sound/abnormalities/freischutz/shoot.ogg'
@@ -319,11 +319,20 @@
 	var/obj/item/clothing/suit/armor/ego_gear/he/magicbullet/Y = myman.get_item_by_slot(ITEM_SLOT_OCLOTHING)
 	var/obj/item/clothing/suit/armor/ego_gear/realization/bigiron/Z = myman.get_item_by_slot(ITEM_SLOT_OCLOTHING)
 	if(istype(Y))
-		fire_delay = 8
+		fire_delay = 5
 	if(istype(Z))
 		cached_multiplier = projectile_damage_multiplier
 		projectile_damage_multiplier *= 2.5
-		fire_delay = 8
+		fire_delay = 5
+	..()
+
+/obj/item/ego_weapon/ranged/pistol/magic_pistol/reload_ego(mob/user)
+	var/mob/living/carbon/human/myman = user
+	var/obj/item/clothing/suit/armor/ego_gear/he/magicbullet/Y = myman.get_item_by_slot(ITEM_SLOT_OCLOTHING)
+	var/obj/item/clothing/suit/armor/ego_gear/realization/bigiron/Z = myman.get_item_by_slot(ITEM_SLOT_OCLOTHING)
+	reloadtime = initial(reloadtime)
+	if(istype(Y) || istype(Z))
+		reloadtime = 0.8 SECONDS
 	..()
 
 /obj/item/ego_weapon/ranged/pistol/laststop


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The Big Iron realization now speeds up Magic Bullet to the same fire-rate as the base armor (15 --> 8 fire_delay)
Magic Pistol now has a slightly slower base fire-rate (6 --> 7 fire_delay) but now actually benefits from both corresponding armors (8, yes it debuffed the base fire-rate before --> 5 fire_delay), so it's slightly faster than before if you are wearing the set.
Also Magic Pistol now gains a bit for reload speed if you are using the corresponding armors (1.2 seconds --> 0.8 seconds)

## Why It's Good For The Game

EGO set buffs should work and increase DPS significantly. Especially if they are realizations

## Changelog
:cl:
tweak: Added a buff to reload speed to magic pistol with the armor.
fix: fixed magic pistol and magic bullet fire-rate buff
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
