### PR TITLE
Discord EGO wielded DPS "rebalancing", minor fixes

### DIFF
--- a/ModularTegustation/ego_weapons/melee/waw.dm
+++ b/ModularTegustation/ego_weapons/melee/waw.dm
@@ -1309,37 +1309,21 @@
 				L.throw_at(throw_target, rand(1, 2), whack_speed, user)
 	spin_reset()
 
-/obj/item/ego_weapon/discord
+/obj/item/ego_weapon/wield/discord
 	name = "discord"
-	desc = "The existance of evil proves the existance of good, just as light proves the existance of darkness."
-	special = "This weapon can be two-handed, and attacks thrice in rapid succession when doing so.\n Attacks with this weapon will heal a nearby ally using Assonance."
+	desc = "The existence of evil proves the existence of good, just as light proves the existence of darkness."
+	special = "This weapon attacks thrice in rapid succession when being wielded.\nAttacks with this weapon will heal a nearby ally using Assonance."
 	icon_state = "discord"
-	force = 28
+	force = 30
+	wielded_force = 27
 	attack_speed = 0.8
+	wielded_attack_speed = 0.8
 	attribute_requirements = list(
 							FORTITUDE_ATTRIBUTE = 80
 							)
 	damtype = BLACK_DAMAGE
-	var/wielded = FALSE
 
-/obj/item/ego_weapon/discord/Initialize()
-	. = ..()
-	RegisterSignal(src, COMSIG_TWOHANDED_WIELD, PROC_REF(OnWield))
-	RegisterSignal(src, COMSIG_TWOHANDED_UNWIELD, PROC_REF(on_unwield))
-
-/obj/item/ego_weapon/discord/ComponentInitialize()
-	. = ..()
-	AddComponent(/datum/component/two_handed, force_unwielded=30, force_wielded=20)
-
-/obj/item/ego_weapon/discord/proc/OnWield(obj/item/source, mob/user)
-	SIGNAL_HANDLER
-	wielded = TRUE
-
-/obj/item/ego_weapon/discord/proc/on_unwield(obj/item/source, mob/user)
-	SIGNAL_HANDLER
-	wielded = FALSE
-
-/obj/item/ego_weapon/discord/attack(mob/living/target, mob/living/carbon/human/user)
+/obj/item/ego_weapon/wield/discord/attack(mob/living/target, mob/living/carbon/human/user)
 	if(!..())
 		return FALSE
 	if(!ishostile(target))
@@ -1349,11 +1333,11 @@
 	Harmony(user)
 	if(!wielded)
 		return
-	user.changeNext_move(CLICK_CD_MELEE*attack_speed*2.5)
+	user.changeNext_move(CLICK_CD_MELEE*wielded_attack_speed*2.5)
 	for(var/i = 1 to 2)
 		addtimer(CALLBACK(src, PROC_REF(MultiSwing), target, user), CLICK_CD_MELEE * 0.6 * i)
 
-/obj/item/ego_weapon/discord/proc/MultiSwing(mob/living/target, mob/living/carbon/human/user)
+/obj/item/ego_weapon/wield/discord/proc/MultiSwing(mob/living/target, mob/living/carbon/human/user)
 	if(get_dist(target, user) > 1)
 		return
 	if(src != user.get_active_held_item())
@@ -1364,10 +1348,9 @@
 	playsound(loc, hitsound, get_clamped_volume(), TRUE, extrarange = stealthy_audio ? SILENCED_SOUND_EXTRARANGE : -1, falloff_distance = 0)
 	user.do_attack_animation(target)
 	target.attacked_by(src, user)
-
 	log_combat(user, target, pick(attack_verb_continuous), src.name, "(INTENT: [uppertext(user.a_intent)]) (DAMTYPE: [uppertext(damtype)])")
 
-/obj/item/ego_weapon/discord/proc/Harmony(mob/living/carbon/human/user)
+/obj/item/ego_weapon/wield/discord/proc/Harmony(mob/living/carbon/human/user)
 	var/heal_amount = 5
 	if(wielded)
 		heal_amount = 4

--- a/ModularTegustation/ego_weapons/ranged/ego_bullets/waw.dm
+++ b/ModularTegustation/ego_weapons/ranged/ego_bullets/waw.dm
@@ -212,8 +212,8 @@
 	if(H.stat == DEAD || H.status_flags & GODMODE)
 		return
 	for(var/mob/living/carbon/human/Yin in view(7, H))
-		var/obj/item/ego_weapon/discord/D = Yin.get_active_held_item()
-		if(istype(D, /obj/item/ego_weapon/discord))
+		var/obj/item/ego_weapon/wield/discord/D = Yin.get_active_held_item()
+		if(istype(D, /obj/item/ego_weapon/wield/discord))
 			if(!D.CanUseEgo(Yin))
 				continue
 			Yin.adjustBruteLoss(-10)

--- a/code/datums/abnormality/_ego_datum/waw.dm
+++ b/code/datums/abnormality/_ego_datum/waw.dm
@@ -351,7 +351,7 @@
 	cost = 50
 
 /datum/ego_datum/weapon/discord
-	item_path = /obj/item/ego_weapon/discord
+	item_path = /obj/item/ego_weapon/wield/discord
 	cost = 50
 
 // Little Red Riding Hood Mercenary - Crimson Scar & Crimson Claw


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
"Rebalancing" is in quotes because it seems to me that the previous state was an oversight.

Discord, the weapon, in the current Master branch (6th of June 2025), has one-handed DPS of **42** and wielded DPS of **36**. (Justice not included in these measurements. Can slightly vary depending on the time you use on your test dummy, but these are the most consistent numbers for 20s testing.)

These numbers are relatively low compared to other WAW weapons, which can be explained by their Harmony special feature (healing Assonance weapon users on hit, and being healed by theirs too). However the most glaring issue here is... why wield the weapon if it lowers your DPS?

I have not chosen to rework the weapon or anything of the sort, even if I would like to do that. All this PR does is:
- Fixed really minor typo in the description because it bothered me and I couldn't justify not correcting it
- Discord will no longer have 3 different damage values, only 2. Before it started at 28 force, went down to 20 if you wielded it, and then went up to 30 if you unwielded it. Now it only has a wielded and unwielded value.
- Discord is now a subtype of /ego_weapon/wield/ instead of just /ego_weapon/. It previously implemented its own code for wielding, now it just uses the same framework as Ochre Sheet and Dark Carnival. Yes I remembered to change the datum too, and the reference in Yang's weapon.
- Discord wielded force **20->27**. This results in the following DPS numbers (Justice 0): 

One handed: **42dps**
Wielded: **48.6dps**



<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Justifying this change:
This is in line with other WAW weapons, though I did not find any document outlining intended DPS so I had to go test on a dummy for a while. From what I see, weapons with helpful gimmicks have lower DPS, and weapons with gimmicks you have to play around have higher DPS. Discord is a weapon with a hard to achieve conditional (you need to talk Agents into actually taking both Yin and Yang, then you need two people to be using Discord and Assonance weapons respectively which is a tough ask honestly), so I think this DPS is reasonable for it. Other numbers from my testing for comparison:
- SSWT (minorly negative gimmick - combo delay, no support aspect) **60dps**
- Oppression (minorly negative gimmick - have to correctly time empowering it, no support aspect) around **52dps**
- Totalitarianism (negative gimmick - have to wind up each strike by standing still to achieve full potential, no support aspect) around **61dps**, **32dps** if you do not play around the gimmick
- Blind Rage (kind of negative gimmick, has really good AOE but it hits structures and other Agents, no support aspect) somewhere in the range of **60-70dps** due to DOT variance, has AOE
- Dipsia (positive gimmick, lifesteal) **40dps**
- Amrita (spear with self stun, has AOE) **36dps** single target, **44dps** AOE spam
- Sunyata (normal beatstick with AOE you can simultaneously do) **40dps** single target, **66.7dps** if you also spam AOE
- Diffraction (no gimmicks) **42dps**, which seems kind of low honestly
- Abyssal Route (combo system that can be good for AOE or bad if it gets you into trouble) **39.4**dps

Considering all these numbers and their particular quirks, I think 48.6dps for wielding Discord is a very fair number. And if it isn't, just edit the wielded force I guess.

The weapon is rarely used as it is, so I think throwing it a bone isn't unreasonable. It was one of my favourite weapons in LobCorp because of how cool it looked, and it's a shame to see it get overshadowed by other weapons really hard.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Discord EGO weapon now a subtype of /ego_weapon/wield/.
balance: Discord EGO weapon wielded DPS increased.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
