### PR TITLE
Updates wield subtype to allow forced dual-wielding

### DIFF
--- a/ModularTegustation/ego_weapons/melee/subtype/wielded.dm
+++ b/ModularTegustation/ego_weapons/melee/subtype/wielded.dm
@@ -14,11 +14,13 @@
 	var/wielded_anti_justice_multiplier = 1
 	//holder stuff and unwield stuff
 	var/mob/current_holder
+	var/two_hands_required = FALSE
 	var/should_unwield_cooldown = FALSE
 	var/unwield_time = 3 SECONDS
 	var/unwield_cooldown
 	//text
 	var/wield_stats = "This weapon can be two-handed."
+	var/forced_wield_stats = "This weapon requires both hands to be wielded."
 	var/wield_special = null
 
 /obj/item/ego_weapon/wield/Initialize()
@@ -28,11 +30,14 @@
 
 /obj/item/ego_weapon/wield/ComponentInitialize()
 	. = ..()
-	AddComponent(/datum/component/two_handed, force_unwielded=initial(force), force_wielded=wielded_force)
+	AddComponent(/datum/component/two_handed, force_unwielded=initial(force), force_wielded=wielded_force, require_twohands=two_hands_required)
 
 /obj/item/ego_weapon/wield/examine(mob/user)
 	. = ..()
-	. += span_notice(wield_stats)
+	if(two_hands_required)
+		. += span_notice(forced_wield_stats)
+	else
+		. += span_notice(wield_stats)
 	if(wield_special)
 		. += span_notice(wield_special)
 
@@ -61,8 +66,10 @@
 	current_holder = null
 
 /obj/item/ego_weapon/wield/attack_self(mob/user)
-	if (should_unwield_cooldown && unwield_cooldown > world.time)
-		to_chat(user, span_userdanger("You wielded [src] to recently!"))
+	if(two_hands_required)
+		return
+	if(should_unwield_cooldown && unwield_cooldown > world.time)
+		to_chat(user, span_userdanger("You wielded [src] too recently!"))
 		return
 	. = ..()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a variable to make a wield EGO weapon need two hands to be grabbed at all.

## Why It's Good For The Game

More possibilities (Also I need this for a rework I am doing, so win-win)

## Changelog
:cl:
tweak: wield subtype now allows for forced dual wielding
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
