### PR TITLE
Amber Dawn Infestation

### DIFF
--- a/code/game/objects/items/food/meat.dm
+++ b/code/game/objects/items/food/meat.dm
@@ -912,7 +912,7 @@
 	name = "perfect meat"
 	desc = "An awful jiggling chunk of meat cut from the hide of a worm. It tastes foul and has the texture of spoiled jelly."
 	icon_state = "wormmeat"
-	food_reagents = list(/datum/reagent/consumable/nutriment/protein = 4, /datum/reagent/yuck = 5)
+	food_reagents = list(/datum/reagent/consumable/nutriment/protein = 4, /datum/reagent/yuck = 5, /datum/reagent/amber = 5)
 	tastes = list("slime" = 1, "jelly" = 1)
 	foodtypes = MEAT | RAW | TOXIC | GROSS
 

--- a/code/modules/mob/living/simple_animal/hostile/ordeal/amber.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/amber.dm
@@ -33,6 +33,7 @@
 	var/burrowing = FALSE
 
 	var/can_burrow_solo = TRUE // False for amber dawns spawned by dusks that are still alive
+	var/can_infect = TRUE // False for the hungriest one. Maybe also set this to false for dusk spawn if it ever becomes an issue.
 
 /mob/living/simple_animal/hostile/ordeal/amber_bug/Initialize()
 	. = ..()
@@ -40,6 +41,8 @@
 	pixel_x = base_pixel_x
 	base_pixel_y = rand(-6,6)
 	pixel_y = base_pixel_y
+	if(SSmaptype.maptype in SSmaptype.citymaps)
+		can_infect = FALSE //We want to avoid unecessary corpse gibbing and amber proliferation for cityspawn.
 	if(LAZYLEN(butcher_results)) //// It burrows in on spawn, spawned ones shouldn't
 		addtimer(CALLBACK(src, PROC_REF(BurrowOut), get_turf(src)))
 	if(SSmaptype == "lcorp_city")
@@ -98,6 +101,15 @@
 			for(var/obj/machinery/door/D in T.contents)
 				if(D.density)
 					return
+			if(ishuman(attacked_target) && can_infect)
+				var/mob/living/carbon/human/H = attacked_target
+				var/parasite_slot = H.getorganslot(ORGAN_SLOT_PARASITE_EGG)
+				if(H.stat != CONSCIOUS && !parasite_slot) //Only infect people in crit/dead and that don't have a parasite of some kind already.
+					var/obj/item/organ/amber_bug/amber_parasite = new(H)
+					amber_parasite.ordeal_reference = ordeal_reference
+					playsound(get_turf(src), 'sound/effects/ordeals/amber/dawn_dig_in.ogg', 25, 1)
+					to_chat(H, span_danger("The bug is eating its way inside your chest!"))
+					qdel(src)
 			forceMove(T)
 			SLEEP_CHECK_DEATH(2)
 
@@ -146,7 +158,7 @@
 	burrow_cooldown = world.time + burrow_cooldown_time
 	burrowing = FALSE
 
-//Amber dawn spawned from dusk
+//Amber dawn spawned from dusk and hungriest one.
 /mob/living/simple_animal/hostile/ordeal/amber_bug/spawned
 	can_burrow_solo = FALSE
 	butcher_results = list()
@@ -168,6 +180,178 @@
 		bug_mommy.spawned_mobs -= src
 	bug_mommy = null
 	return ..()
+
+//A variation of the amber dawn that will eat corpses to grow stronger.
+/mob/living/simple_animal/hostile/ordeal/amber_bug/hungriest_one
+	name = "Hungriest One"
+	desc = "This one looks like it'll eat anything that moves."
+	maxHealth = 150
+	health = 150
+	melee_damage_lower = 9
+	melee_damage_upper = 12
+	color = "#a51f08"
+	can_infect = FALSE
+	stat_attack = DEAD
+	can_burrow_solo = FALSE
+	var/feeding_count = 0
+	var/max_feeding_count = 10
+
+	//Variables dictating wow many stats the bug will get per kill. (Decimals are % based on total health)
+	var/scaling_damage = 3
+	var/scaling_max_health = 0.2
+	var/scaling_healing = 0.2
+	var/spawn_on_kill = 3
+	var/count_per_kill = 1
+	var/size_per_kill = 1.1
+
+/mob/living/simple_animal/hostile/ordeal/amber_bug/hungriest_one/Initialize()
+	. = ..()
+	faction = list() //Removes all original allegiances of the bug on spawn. It's everyone's problem now.
+
+/mob/living/simple_animal/hostile/ordeal/amber_bug/hungriest_one/AttackingTarget(atom/attacked_target)
+	. = ..()
+	if(!. || !isliving(attacked_target))
+		return
+
+	var/mob/living/meal = attacked_target
+	if(istype(attacked_target, /mob/living/simple_animal/hostile/ordeal/amber_bug))
+		meal.adjustBruteLoss(200) //Should one shot every bug, but not other hugriest one.
+		visible_message(span_warning("[meal] is torn to shred by [src]!"))
+
+	if(meal.stat != DEAD)
+		return
+
+	var/turf/T = get_turf(src)
+	if(ishuman(meal))
+		for(var/i = 0, i < spawn_on_kill, i++)
+			new /mob/living/simple_animal/hostile/ordeal/amber_bug/spawned(T) //Every corpse is worth as much feeding count, but human ones lets it spawn more bugs to eat.
+
+			adjustBruteLoss(-maxHealth*0.5)
+	feeding_count += count_per_kill
+
+	if(feeding_count >= max_feeding_count)
+		gib()
+		var/max_spawn = clamp(length(GLOB.clients) * 4, 1, 15)
+		var/amber_list
+		var/bug_spawned = 0
+		if(ordeal_reference)
+			amber_list = ordeal_reference.ordeal_mobs
+		for(var/i = 0, i < 15, i++)
+			if(length(bug_spawned) > max_spawn || length(amber_list) > 50)
+				return
+			new /mob/living/simple_animal/hostile/ordeal/amber_bug/spawned(T) //TODO: make it evolve into a unique dusk that spawns more or something. Right now it just makes a lot of small bugs.
+			bug_spawned++
+	else
+		setMaxHealth(maxHealth* (1 + scaling_max_health)) //Exponential growth. It should be stopped by the eventual feeding count cap.
+		adjustBruteLoss(-maxHealth*scaling_healing)
+		melee_damage_lower += scaling_damage
+		melee_damage_upper += scaling_damage //Should go up to 40~ damage total before it explodes.
+
+		transform = transform.Scale(size_per_kill, size_per_kill)
+
+	meal.gib()
+
+/* DAWN AMBER ORGAN */
+/obj/item/organ/amber_bug
+	name = "hungry mass"
+	zone = BODY_ZONE_CHEST
+	slot = ORGAN_SLOT_PARASITE_EGG
+	icon_state = "tonguetied"
+	color = "gold"
+	var/physical_symptoms = FALSE
+	var/feeding_stage = 0
+	var/max_feeding_stage = 3
+	var/feeding_duration
+	var/total_bug_spawned = 0
+	var/cured = FALSE
+	var/datum/ordeal/ordeal_reference
+
+	var/feeding_interval = 1.5 MINUTES
+	var/spawn_amount = 2 //How many extra bugs spawn per feeding stage.
+
+/obj/item/organ/amber_bug/Initialize()
+	. = ..()
+	if(ishuman(loc))
+		feeding_duration = world.time + (feeding_interval)
+		Insert(loc)
+
+/obj/item/organ/amber_bug/on_find(mob/living/finder)
+	. = ..()
+	to_chat(finder, span_warning("You find something eating [owner]'s insides!"))
+
+/obj/item/organ/amber_bug/Remove(mob/living/carbon/human/M, special = 0)
+	if(M && !cured)
+		visible_message(span_warning("A bug leaps out of [M]!"))
+		SpawnBug(1)
+	. = ..()
+
+/obj/item/organ/amber_bug/on_life()
+	. = ..()
+	growProcess()
+
+/obj/item/organ/amber_bug/on_death()
+	. = ..()
+	growProcess() //Keeps eating even if they're dead.
+
+/obj/item/organ/amber_bug/proc/SpawnBug(bug_spawned)
+	var/max_spawn_amount = max_feeding_stage + spawn_amount
+	var/max_spawn = clamp(length(GLOB.clients) * 5, 2, max_spawn_amount) //Has a much higher cap per player than dusk at 5 bugs per client, due to the circumstances of spawn being rarer and longer.
+	var/list/amber_list
+	if(ordeal_reference)
+		amber_list = ordeal_reference.ordeal_mobs
+
+	var/turf/T = get_turf(owner)
+
+	for(var/i = 0, i < spawn_amount, i++)
+		var/mob/living/simple_animal/hostile/ordeal/amber_bug/bug = new(T)
+		total_bug_spawned++
+		if(length(total_bug_spawned) > max_spawn || length(amber_list) > 50)
+			if(owner.stat == DEAD)
+				owner.gib()
+			qdel(src)
+			return
+
+		if(ordeal_reference)
+			bug.ordeal_reference = ordeal_reference
+			ordeal_reference.ordeal_mobs += bug
+
+/obj/item/organ/amber_bug/proc/growProcess()
+	if(!src || QDELETED(src))
+		return //Here to fix a bug where it'd spawn two worms for some reason.
+
+	if(!owner)
+		qdel(src)
+		return
+
+	var/mob/living/carbon/human/H = owner
+	var/turf/T = get_turf(H)
+
+	if(H?.reagents?.has_reagent(/datum/reagent/amber)) //The 'cure' is amber bug meat.
+		to_chat(H, span_warning("The bug, tricked into eating the meat of its own kind, finds its way out of your body!"))
+		var/mob/living/simple_animal/hostile/ordeal/amber_bug/hungriest_one/bug = new(T)
+		if(ordeal_reference)
+			bug.ordeal_reference = ordeal_reference
+			ordeal_reference.ordeal_mobs += bug
+		cured = TRUE
+		qdel(src)
+		return
+
+	if(world.time <= feeding_duration)
+		return
+
+	var/bug_spawned = feeding_stage + 2 //Should go 3,4,5 bugs then explode, for a total of 12 bugs per body over 4.5 minutes.
+	feeding_duration = world.time + (feeding_interval)
+	feeding_stage++
+	H.apply_damage(feeding_stage * 10, RED_DAMAGE, null, H.run_armor_check(null, RED_DAMAGE), spread_damage = TRUE)
+	visible_message(span_danger("[feeding_stage] bugs eat their way out of [H]'s body!"))
+	playsound(get_turf(src), 'sound/effects/ordeals/amber/dawn_dig_out.ogg', 25, 1)
+	if(H.stat != DEAD)
+		H.emote("scream")
+	SpawnBug(bug_spawned)
+	if(feeding_stage >= max_feeding_stage)
+		if(H.stat == DEAD)
+			H.gib()
+		qdel(src)
 
 // Amber dusk
 /mob/living/simple_animal/hostile/ordeal/amber_dusk

--- a/code/modules/reagents/chemistry/reagents/lc13_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/lc13_reagents.dm
@@ -81,3 +81,13 @@
 	name = "Concentrated Pale Toxin"
 	damage = 5
 	toxpwr = 0.5
+
+///I don't know if this is supposed to be here but whatever. Extracted from Amber ordeals meat, only serves to get the parasite out at the moment.
+/datum/reagent/amber
+	name = "Amber Extract"
+	description = "It tastes awful, yet you want more."
+	glass_name = "glass of Amber Extract"
+	glass_desc = "The liquid shifts with hunger."
+	color = "#5c462d"
+	taste_description = "starvation"
+	can_synth = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
What started as a simple attempt to buff amber dawns has grown a little bigger than I anticipated.

What does this PR do?
It makes amber dawns capable of infesting someone in critical condition. This person will proceed to spawn 3, 4 then 5 bugs over the course of 4.5 minutes out of their body, in which case the infection will stop. The spawning will continue even on the person's death, which should encourage people to destroy the body as soon as possible. Amber dawns spawned from the infection will count towards whatever ordeal is currently ongoing, but that will not stop new dawns from spawning after the ordeal is over if the infection is still active. Only humans can be infected, not monkeys, or abnos, or anything else.

Even if the person is saved from their critical condition, they will still have to survive those 4.5 minutes and the subsequent spawns from it. 

There is a way to stop the infection early, the first is to extract the parasite via surgery, the other method is to eat raw amber meat. This will spawn a buffed up version of an amber dawn, much stronger, harder to kill, and gets stronger with every kill. However, since this one tasted the flesh of its own kind, will now start attacking everything it finds, including other amber dawns. If it kills a human, it'll gib them to spawn more amber dawns that it'll immediately try to kill. At 10 kills of any kind, it'll explode into 30 amber dawns (which should require it to kill about 3 people first, assuming it doesn't find random bodies on the way.)

Ambers are incapable of infecting others during city spawn. The feature is somewhat unpolished and might need live testing to see what needs to be tweaked.

## Why It's Good For The Game

This is admittedly a lot of changes and complexity for dawns, that are supposed to be the simplest ordeals in the game, however I do believe it fits the theme and difficulty just fine. The dawns can only proliferate if they actually manage to get someone in crit, and the special dawn can only spawn if someone is actively fed amber meat, so it can't really happen on accident. This is supposed to give amber dawns the possibility of swarming out of control not due to a timer but to the amount of death in the facility, which is usually something entirely within the agent's control.

## Changelog
:cl:
add: Amber dawns can now infect people in critical condition.
add: The hungriest one will spawn if you eat amber meat while infected.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
