### PR TITLE
Added False Throne and Tiara armours to the Wishing Well

### DIFF
--- a/code/datums/abnormality/_ego_datum/waw.dm
+++ b/code/datums/abnormality/_ego_datum/waw.dm
@@ -516,3 +516,15 @@
 /datum/ego_datum/armor/heaven
 	item_path = /obj/item/clothing/suit/armor/ego_gear/waw/heaven
 	cost = 50
+
+// Adult Who Tells Lies - False Throne
+// This Abnormality also does not exist, yet. Though I think it has a decent chance of being added before Burrowing Heaven...
+/datum/ego_datum/armor/throne
+	item_path = /obj/item/clothing/suit/armor/ego_gear/waw/throne
+	cost = 50
+
+// Unknown Little Prince Aberration - Tiara
+// This will probably never have an Abnormality attached to it...? Still, shouldn't let the sprite go to waste, so into the Well it goes.
+/datum/ego_datum/armor/tiara
+	item_path = /obj/item/clothing/suit/armor/ego_gear/waw/tiara
+	cost = 50


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
False Throne and Tiara EGO armours added to the Wishing Well loot pool.

False Throne is EGO from the Adult Who Tells Lies, who does not exist in LC13 at the moment. Tiara is apparently EGO based on a Little Prince aberration we don't know anything of. Neither of these are getting their corresponding abnos anytime soon, so why not add them to the Well?

Only other loose, non-special EGO missing a datum is the Contempt Awe weapon but it currently has a datum included in someone else's PR at the moment so I won't add it here to avoid conflicts.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The sprites look cool, more armour variety.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: False Throne and Tiara armour EGO datums added
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
