### PR TITLE
Adds Variant Sweepers to City of Light

### DIFF
--- a/ModularTegustation/tegu_items/associations/cityspawners.dm
+++ b/ModularTegustation/tegu_items/associations/cityspawners.dm
@@ -95,7 +95,7 @@ GLOBAL_VAR_INIT(city_east_enemies, FALSE)
 			spawning = /mob/living/simple_animal/hostile/ordeal/indigo_noon
 			if(prob(30))
 				spawning = /mob/living/simple_animal/hostile/ordeal/indigo_dawn
-			else if(prob(25))
+			else if(prob(23))
 				spawning = pick(/mob/living/simple_animal/hostile/ordeal/indigo_noon/lanky, /mob/living/simple_animal/hostile/ordeal/indigo_noon/chunky)
 
 		if("bots")
@@ -138,7 +138,7 @@ GLOBAL_VAR_INIT(city_east_enemies, FALSE)
 			spawning = /mob/living/simple_animal/hostile/ordeal/indigo_noon
 			if(prob(30))
 				spawning = /mob/living/simple_animal/hostile/ordeal/indigo_dawn
-			else if(prob(25))
+			else if(prob(23))
 				spawning = pick(/mob/living/simple_animal/hostile/ordeal/indigo_noon/lanky, /mob/living/simple_animal/hostile/ordeal/indigo_noon/chunky)
 
 		if("bots")
@@ -181,7 +181,7 @@ GLOBAL_VAR_INIT(city_east_enemies, FALSE)
 			spawning = /mob/living/simple_animal/hostile/ordeal/indigo_noon
 			if(prob(30))
 				spawning = /mob/living/simple_animal/hostile/ordeal/indigo_dawn
-			else if(prob(25))
+			else if(prob(23))
 				spawning = pick(/mob/living/simple_animal/hostile/ordeal/indigo_noon/lanky, /mob/living/simple_animal/hostile/ordeal/indigo_noon/chunky)
 
 		if("bots")

--- a/ModularTegustation/tegu_items/associations/cityspawners.dm
+++ b/ModularTegustation/tegu_items/associations/cityspawners.dm
@@ -95,6 +95,8 @@ GLOBAL_VAR_INIT(city_east_enemies, FALSE)
 			spawning = /mob/living/simple_animal/hostile/ordeal/indigo_noon
 			if(prob(30))
 				spawning = /mob/living/simple_animal/hostile/ordeal/indigo_dawn
+			else if(prob(25))
+				spawning = pick(/mob/living/simple_animal/hostile/ordeal/indigo_noon/lanky, /mob/living/simple_animal/hostile/ordeal/indigo_noon/chunky)
 
 		if("bots")
 			spawning = /mob/living/simple_animal/hostile/ordeal/green_bot
@@ -136,6 +138,8 @@ GLOBAL_VAR_INIT(city_east_enemies, FALSE)
 			spawning = /mob/living/simple_animal/hostile/ordeal/indigo_noon
 			if(prob(30))
 				spawning = /mob/living/simple_animal/hostile/ordeal/indigo_dawn
+			else if(prob(25))
+				spawning = pick(/mob/living/simple_animal/hostile/ordeal/indigo_noon/lanky, /mob/living/simple_animal/hostile/ordeal/indigo_noon/chunky)
 
 		if("bots")
 			spawning = /mob/living/simple_animal/hostile/ordeal/green_bot
@@ -177,6 +181,8 @@ GLOBAL_VAR_INIT(city_east_enemies, FALSE)
 			spawning = /mob/living/simple_animal/hostile/ordeal/indigo_noon
 			if(prob(30))
 				spawning = /mob/living/simple_animal/hostile/ordeal/indigo_dawn
+			else if(prob(25))
+				spawning = pick(/mob/living/simple_animal/hostile/ordeal/indigo_noon/lanky, /mob/living/simple_animal/hostile/ordeal/indigo_noon/chunky)
 
 		if("bots")
 			spawning = /mob/living/simple_animal/hostile/ordeal/green_bot

--- a/code/modules/mob/living/simple_animal/hostile/ordeal/indigo/noon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/indigo/noon.dm
@@ -178,7 +178,7 @@
 	attack_sound = 'sound/effects/ordeals/indigo/stab_2.ogg'
 
 	/// COL Rebalancing
-	if(SSmaptype.maptype == "city")
+	if(SSmaptype.maptype in SSmaptype.citymaps)
 		move_to_delay = 2.9
 		movespeed = move_to_delay
 		dash_cooldown_time += 3 SECONDS
@@ -405,7 +405,7 @@
 	attack_sound = 'sound/effects/ordeals/indigo/stab_1.ogg'
 
 	/// COL Rebalancing
-	if(SSmaptype.maptype == "city")
+	if(SSmaptype.maptype in SSmaptype.citymaps)
 		maxHealth = 625
 		health = 625
 		extract_fuel_cooldown_time += 2 SECONDS

--- a/code/modules/mob/living/simple_animal/hostile/ordeal/indigo/noon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/indigo/noon.dm
@@ -26,17 +26,6 @@
 
 /mob/living/simple_animal/hostile/ordeal/indigo_noon/Initialize()
 	. = ..()
-	/// If we're on COL, some of the Indigo Noons that spawn on it have a chance to become variant sweepers at random.
-	/// If you want this behaviour on another gamemode, feel free to append an OR onto the conditional I suppose but be careful to rebalance them for it.
-	/// As for that parent_type check, the variant sweepers are subtypes and thus inherit this behaviour on initialize. I don't want a spawned Lanky Sweeper to accidentally
-	/// reroll into a Chunky, for example. It'd just be weird jank.
-	if(SSmaptype.maptype == "city" && parent_type == /mob/living/simple_animal/hostile/ordeal)
-		if(prob(23))
-			var/selected_type = pick(/mob/living/simple_animal/hostile/ordeal/indigo_noon/chunky, /mob/living/simple_animal/hostile/ordeal/indigo_noon/lanky)
-			new selected_type(loc)
-			qdel(src)
-			return
-
 	attack_sound = "sound/effects/ordeals/indigo/stab_[pick(1,2)].ogg"
 	icon_living = "sweeper_[pick(1,2)]"
 	icon_state = icon_living


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Any normal Indigo Noon has a small chance to turn into one of the Indigo Noon subtypes at random whenever it is spawned. Only happens on City of Light.

If you don't know what the Indigo Noon subtypes are, they are Lanky and Chunky Sweepers with special abilities recently added in PR #2936.

They have their stats rebalanced for City of Light gameplay, primarily the Chunky one receives some nerfs. They shouldn't give players too much trouble, as long as they remember to deal with their abilities appropiately.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Variety! Sweepers are normally boring statstick mobs that don't even have their gimmick of devouring things on City since it is disabled.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Sweeper subtypes can now appear in City of Light.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
