### PR TITLE
Transfervar fix

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/_abnormality.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_abnormality.dm
@@ -371,17 +371,17 @@
 	return A
 
 /* Transfers a var to the datum to be used later
-The variable's index needs to be a non-numerical value.*/
-/mob/living/simple_animal/hostile/abnormality/proc/TransferVar(index, value)
+The variable's key needs to be non-numerical.*/
+/mob/living/simple_animal/hostile/abnormality/proc/TransferVar(key, value)
 	if(isnull(datum_reference))
 		return
-	LAZYSET(datum_reference.transferable_var, index, value)
+	LAZYSET(datum_reference.transferable_var, key, value)
 
 // Access an item in the "transferable_var" list of the abnormality's datum
-/mob/living/simple_animal/hostile/abnormality/proc/RememberVar(index)
+/mob/living/simple_animal/hostile/abnormality/proc/RememberVar(key)
 	if(isnull(datum_reference))
 		return
-	return LAZYACCESS(datum_reference.transferable_var, index)
+	return LAZYACCESS(datum_reference.transferable_var, key)
 
 // Modifiers for work chance
 /mob/living/simple_animal/hostile/abnormality/proc/WorkChance(mob/living/carbon/human/user, chance, work_type)

--- a/code/modules/mob/living/simple_animal/abnormality/_abnormality.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_abnormality.dm
@@ -370,11 +370,12 @@
 	datum_reference.connected_structures[A] = list(x_offset, y_offset)
 	return A
 
-// transfers a var to the datum to be used later
+/* Transfers a var to the datum to be used later
+The variable's index needs to be a non-numerical value.*/
 /mob/living/simple_animal/hostile/abnormality/proc/TransferVar(index, value)
 	if(isnull(datum_reference))
 		return
-	LAZYSET(datum_reference.transferable_var, value, index)
+	LAZYSET(datum_reference.transferable_var, index, value)
 
 // Access an item in the "transferable_var" list of the abnormality's datum
 /mob/living/simple_animal/hostile/abnormality/proc/RememberVar(index)

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/nothing_there.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/nothing_there.dm
@@ -138,7 +138,7 @@
 	breachloop = new(list(src), FALSE)
 
 /mob/living/simple_animal/hostile/abnormality/nothing_there/Destroy()
-	TransferVar(1, heard_words)
+	TransferVar("mimicry", heard_words)
 	QDEL_NULL(soundloop)
 	QDEL_NULL(heartbeat)
 	QDEL_NULL(disguiseloop)
@@ -147,7 +147,7 @@
 
 /mob/living/simple_animal/hostile/abnormality/nothing_there/PostSpawn()
 	. = ..()
-	var/list/old_heard = RememberVar(1)
+	var/list/old_heard = RememberVar("mimicry")
 	if(islist(old_heard) && LAZYLEN(old_heard))
 		heard_words = old_heard
 	soundloop.start() // We only play the ambience if we're spawned in containment

--- a/code/modules/mob/living/simple_animal/abnormality/teth/beauty_beast.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/beauty_beast.dm
@@ -48,7 +48,7 @@
 //it needs to use PostSpawn or we can't get the datum of beauty
 /mob/living/simple_animal/hostile/abnormality/beauty/PostSpawn()
 	. = ..()
-	var/cursed = RememberVar(1)
+	var/cursed = RememberVar("cursed")
 	if(!cursed)
 		return
 	for(var/mob/dead/observer/O in GLOB.player_list) //we grab the last person that died to beauty and yeet them in there
@@ -57,7 +57,7 @@
 			src.ckey = cursed
 			to_chat(src, span_userdanger("You begin to have hundreds of eyes burst from your mouth, while a pair of horns expel from your eye sockets, adorning themselves with flowers. Now the Beast, you forever search for someone to lift your curse."))
 			to_chat(src, span_notice("(If you wish to leave this body you can simply ghost with the ooc tab > ghost, there is no consequence for doing so.)"))
-			TransferVar(1, null) //we reset the cursed just in case
+			TransferVar("cursed", null) //we reset the cursed just in case
 			return
 
 /mob/living/simple_animal/hostile/abnormality/beauty/death(gibbed)
@@ -73,7 +73,7 @@
 			icon_state = "beauty_injured"
 
 		else if (!(GODMODE in user.status_flags))//If you already did repression, die.
-			TransferVar(1, user.ckey)
+			TransferVar("cursed", user.ckey)
 			user.gib()
 			death()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The TransferVar proc had the index and the value variable switched, so your "value" became the index of the list and viceversa (ironically, the current implementations of this proc worked only because of this oversight)
This fixes that and adds a bit of comment that makes clear that the index cannot be a numerical value.

## Why It's Good For The Game

Fixing a proc that has been bugged for quite some time is good (Also I need this for a rework I am doing, so win-win).

## Changelog
:cl:
fix: TransferVar proc now works as intended.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
