### PR TITLE
Adds ego assimilation

### DIFF
--- a/code/_globalvars/abnormalities.dm
+++ b/code/_globalvars/abnormalities.dm
@@ -1,0 +1,2 @@
+//tool abno reference for fetching ego
+GLOBAL_VAR(wishwell)

--- a/code/modules/clothing/suits/ego_gear/realized.dm
+++ b/code/modules/clothing/suits/ego_gear/realized.dm
@@ -495,6 +495,7 @@ No Ability	250
 	icon_state = "farmwatch"
 	armor = list(RED_DAMAGE = 70, WHITE_DAMAGE = 70, BLACK_DAMAGE = 40, PALE_DAMAGE = 60)
 	hat = /obj/item/clothing/head/ego_hat/farmwatch_hat
+	realized_ability = /obj/effect/proc_holder/ability/ego_assimilation/farmwatch
 
 /obj/item/clothing/head/ego_hat/farmwatch_hat
 	name = "farmwatch"
@@ -506,6 +507,7 @@ No Ability	250
 	desc = "I've always wished to be a bud. Soon to bloom, bearing a scent within."
 	icon_state = "spicebush"
 	armor = list(RED_DAMAGE = 40, WHITE_DAMAGE = 70, BLACK_DAMAGE = 70, PALE_DAMAGE = 60)
+	realized_ability = /obj/effect/proc_holder/ability/ego_assimilation/spicebush
 
 /obj/item/clothing/suit/armor/ego_gear/realization/desperation
 	name = "Scorching Desperation"
@@ -519,3 +521,4 @@ No Ability	250
 	desc = "We must find the Pallid Whale! Look alive, men! Spring! Roar!"
 	icon_state = "gasharpoon"
 	armor = list(RED_DAMAGE = 60, WHITE_DAMAGE = 70, BLACK_DAMAGE = 20, PALE_DAMAGE = 80)//230, required for the corresponding weapon abilities
+	realized_ability = /obj/effect/proc_holder/ability/ego_assimilation/gasharpoon

--- a/code/modules/mob/living/simple_animal/abnormality/_tools/zayin/wishwell.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_tools/zayin/wishwell.dm
@@ -182,6 +182,8 @@
 //This proc removes the need to copypaste every single armor and weapon into a list.
 /obj/structure/toolabnormality/wishwell/Initialize()
 	. = ..()
+	if(!GLOB.wishwell)
+		GLOB.wishwell = src
 
 	//Sorts them into their lists
 	for(var/path in subtypesof(/datum/ego_datum))

--- a/code/modules/spells/ability_types/realized.dm
+++ b/code/modules/spells/ability_types/realized.dm
@@ -1,3 +1,66 @@
+/* E.G.O assimilation */
+/obj/effect/proc_holder/ability/ego_assimilation
+	name = "E.G.O assimilation"
+	desc = "Convert an ALEPH E.G.O into a weapon comptaible with your suit. Can only be used once."
+	action_icon = 'icons/obj/ego_weapons.dmi'
+	action_icon_state = ""
+	base_icon_state = "template"
+	var/target_type = /obj/item/ego_weapon/mimicry
+	var/obj/structure/toolabnormality/wishwell/linked_structure
+
+/obj/effect/proc_holder/ability/ego_assimilation/Perform(atom/target, user)
+	..()
+	target = FindItems(user)//take the return value of the FindItems() proc here
+	if(!target)
+		to_chat(user, span_notice("There are no E.G.O weapons nearby."))
+		return
+	if(!istype(target, /obj/item/ego_weapon))
+		to_chat(user, span_notice("That is not an E.G.O weapon."))
+		return
+	if(!linked_structure)//Refer to wishing well for a list of all ALEPH E.G.O
+		linked_structure = GLOB.wishwell
+		if(!linked_structure)
+			to_chat(user, span_notice("This ability is currently unavailable."))
+			return
+	if(target.type in linked_structure.alephitem)//"alephitem" is a list
+		new target_type(get_turf(target))
+		qdel(target)
+		DeleteAbility(user)//Deletes the ability and removes it from the ego suit
+		return
+	to_chat(user, span_notice("Target's risk level is too low."))
+
+/obj/effect/proc_holder/ability/ego_assimilation/proc/FindItems(user)
+	var/list/stufflist = list()
+	var/obj/item/ego_weapon/chosen_ego
+	for(var/obj/item/ego_weapon/i in view(2, user))
+		stufflist += i
+	chosen_ego = input(user, "Which E.G.O will you assimilate?") as null|anything in stufflist
+	if(!chosen_ego)
+		return
+	return chosen_ego
+
+/obj/effect/proc_holder/ability/ego_assimilation/proc/DeleteAbility(mob/living/carbon/human/user)
+	var/obj/item/clothing/suit/armor/ego_gear/realization/mysuit = user.get_item_by_slot(ITEM_SLOT_OCLOTHING)
+	if(!istype(mysuit))
+		return
+	mysuit.realized_ability = null//sets it to a null value
+	qdel(src)
+
+/obj/effect/proc_holder/ability/ego_assimilation/farmwatch
+	base_icon_state = "farmwatch"
+	action_icon_state = "farmwatch"
+	target_type = /obj/item/ego_weapon/farmwatch
+
+/obj/effect/proc_holder/ability/ego_assimilation/spicebush
+	base_icon_state = "spicebush"
+	action_icon_state = "spicebush"
+	target_type = /obj/item/ego_weapon/spicebush
+
+/obj/effect/proc_holder/ability/ego_assimilation/gasharpoon
+	base_icon_state = "gasharpoon"
+	action_icon_state = "gasharpoon"
+	target_type = /obj/item/ego_weapon/shield/gasharpoon
+
 /* Fragment of the Universe - One with the Universe */
 /obj/effect/proc_holder/ability/universe_song
 	name = "Song of the Universe"

--- a/lobotomy-corp13.dme
+++ b/lobotomy-corp13.dme
@@ -218,6 +218,7 @@
 #include "code\__HELPERS\sorts\InsertSort.dm"
 #include "code\__HELPERS\sorts\MergeSort.dm"
 #include "code\__HELPERS\sorts\TimSort.dm"
+#include "code\_globalvars\abnormalities.dm"
 #include "code\_globalvars\bitfields.dm"
 #include "code\_globalvars\configuration.dm"
 #include "code\_globalvars\game_modes.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a feature to certain realized E.G.O (specifically the "Effloresced" E.G.O seen in limbus company) that allows them to create their corresponding weapon by sacrificing any ALEPH weapon. This ability can only be used once per suit.

Additionally, wishing well now creates a global reference to itself, so that its lists can be fetched without calling world.contents

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

I had intended to add this feature a long time ago, specifically for gasharpoon. At the time, my understanding of general BYOND code was inadequate and I was frustrated by my slow progress.

Code optimization is good for the game. The wishing well changes will be expanded in a separate PR.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added a new realized ability
code: realized abilities added to gasharpoon, farmwatch and spicebush. Wishing well now creates a reference to itself as a global variable
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
