### PR TITLE
Adds chance alt refinery to rotation

### DIFF
--- a/ModularTegustation/tegu_items/refinery/alt_refinery/_refiner.dm
+++ b/ModularTegustation/tegu_items/refinery/alt_refinery/_refiner.dm
@@ -73,6 +73,7 @@ GLOBAL_LIST_INIT(unspawned_refiners, list(
 	/obj/structure/altrefiner/quick,
 	/obj/structure/altrefiner/timed,
 	/obj/structure/altrefiner/weapon,
+	/obj/structure/altrefiner/chance,
 ))
 
 /obj/effect/landmark/refinerspawn

--- a/ModularTegustation/tegu_items/refinery/alt_refinery/chance.dm
+++ b/ModularTegustation/tegu_items/refinery/alt_refinery/chance.dm
@@ -1,6 +1,6 @@
 /obj/structure/altrefiner/chance
 	name = "Chance Refinery"
-	desc = "A machine used by the Extraction Officer to coinflip for a PE box. Costs 25 cargo PE."
+	desc = "A machine used by the Extraction Officer to coinflip for a refined PE box. Costs 25 cargo PE."
 	icon_state = "dominator-purple"
 	extraction_cost = 25
 


### PR DESCRIPTION
Adds the chance alt refinery to rotation.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
"Kirie. Why isn't this in rotation?"
"IDK. Make a PR?"
"Ok"
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Adds a "chance" alt refinery that was created god knows when but was never added to rotation.
Also fixed the description that made our first thought go "Is this dispensing just a regular PE box or a refined one?".
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Adds the chance alt refinery to rotation.
fix: Fixed the description to avoid misunderstanding.
:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
