### PR TITLE
Fixes Plushie Extractor

### DIFF
--- a/ModularTegustation/tegu_items/_belt.dm
+++ b/ModularTegustation/tegu_items/_belt.dm
@@ -20,7 +20,7 @@
 		/obj/item/deepscanner,
 		/obj/item/safety_kit,
 		/obj/item/clerkbot_gadget,
-		/obj/item/device/Plushie_Extractor,
+		/obj/item/device/plushie_extractor,
 		/obj/item/reagent_containers/hypospray/emais,
 		/obj/item/forcefield_projector
 		))

--- a/ModularTegustation/tegu_items/gadgets/unpowered.dm
+++ b/ModularTegustation/tegu_items/gadgets/unpowered.dm
@@ -830,7 +830,7 @@
 	else
 		. += span_notice("It is currently recharging.")
 /// I'm unsure if this is necessary, but just to be safe, I want to delete the timer when the object is destroyed.
-/obj/item/device/plushie_extractor/Destroy()
+/obj/item/device/plushie_extractor/Destroy(force)
 	deltimer(charge_timer)
 	charge_timer = null
 	return ..()

--- a/ModularTegustation/tegu_items/gadgets/unpowered.dm
+++ b/ModularTegustation/tegu_items/gadgets/unpowered.dm
@@ -750,52 +750,93 @@
 	to_chat(user, span_nicegreen("You extract [target]'s gift!"))
 	qdel(src)
 
-/obj/item/device/Plushie_Extractor
+/obj/item/device/plushie_extractor
 	name = "Plushie Extractor"
-	desc = "A device used for extracting plush versions of the abnormalities."
+	desc = "A device used for extracting plush versions of the abnormalities.\nThe extraction recharge period for this model lasts three minutes."
 	icon = 'icons/obj/device.dmi'
 	icon_state = "plushie_extractor"
 
-	var/static/abno_plushies = list()
-
+// Previous implementation of this item was bugged and didn't work, and was also designed slightly differently.
+// Old version added the user's ckey into a list. What did it do with their ckey? I don't know. I don't think it did anything, actually.
+// This version just works on a timer-based charge system. You use it on an abno, get their plushie, and then it recharges for three minutes, and then you can use it again.
+// Theoretically this means you can farm infinite plushies, given enough time. Well, you could already do that, but this device is an easier way to do it.
+	/// This variable determines whether the extractor is charged or not.
+	var/charged = TRUE
+	/// This variable holds the timer for the recharge, so we can delete it in case the object is destroyed somehow.
+	var/charge_timer
+	/// This variable represents how long the device will have to recharge for after use.
+	var/recharge_duration = 3 MINUTES
+	/// This list is a conversion table for abnormalities to abnormality plushies. If you wanna add an abnormality plushie, please also add it to this table.
 	var/static/list/output = list(
+		// ZAYIN
+
         // TETH
 	/mob/living/simple_animal/hostile/abnormality/scorched_girl = /obj/item/toy/plush/scorched,
 
-		//ZAYIN
-
-
-		//HE
+		// HE
 	/mob/living/simple_animal/hostile/abnormality/pinocchio = /obj/item/toy/plush/pinocchio,
 
-		//WAW
+		// WAW
 	/mob/living/simple_animal/hostile/abnormality/big_bird = /obj/item/toy/plush/bigbird,
 	/mob/living/simple_animal/hostile/abnormality/wrath_servant = /obj/item/toy/plush/sow,
 	/mob/living/simple_animal/hostile/abnormality/greed_king = /obj/item/toy/plush/kog,
 	/mob/living/simple_animal/hostile/abnormality/despair_knight = /obj/item/toy/plush/kod,
 	/mob/living/simple_animal/hostile/abnormality/big_wolf = /obj/item/toy/plush/big_bad_wolf,
 	/mob/living/simple_animal/hostile/abnormality/hatred_queen = /obj/item/toy/plush/qoh,
-		//ALEPH
+
+		// ALEPH
 	/mob/living/simple_animal/hostile/abnormality/melting_love = /obj/item/toy/plush/melt,
 	/mob/living/simple_animal/hostile/abnormality/mountain = /obj/item/toy/plush/mosb,
 	/mob/living/simple_animal/hostile/abnormality/nihil = /obj/item/toy/plush/nihil,
 
     )
 
-/obj/item/device/Plushie_Extractor/attack(mob/living/simple_animal/hostile/abnormality/I, mob/living/carbon/human/user)
+/obj/item/device/plushie_extractor/attack(mob/living/simple_animal/hostile/abnormality/I, mob/living/carbon/human/user)
 	. = ..()
 	if(!ishuman(user))
 		return
-	if(istype(I))
+	if(!istype(I))
 		return
-
+	/// If we don't have a plushie in our conversion table for the abnormality we just hit:
+	if(!ispath(output[I.type], /obj/item/toy/plush))
+		to_chat(user, span_notice("Unfortunately, [I] has not been approved for extraction into a marketable plushie. Please contact the Lobotomy Corporation Marketing and Public Relations Department if you believe a marketable plush of [I] could be used to improve the Wing's image."))
+		playsound(src, 'sound/machines/buzz-two.ogg', 25)
+		return
+	/// If the device isn't charged:
+	if(!charged)
+		to_chat(user, span_notice("This device hasn't finished recharging. Excessive plushification could endanger operations. Please wait until the recharge has finished."))
+		playsound(src, 'sound/machines/buzz-sigh.ogg', 25)
+		return
+	/// If we made it to this point, then we have an entry in our table and the device is charged. Begin a brief windup:
 	var/atom/item_out = output[I.type]
 	to_chat(user, span_notice("The device is slowly processing [I] into [initial(item_out.name)]..."))
-	if(!do_after(user, 5 SECONDS))
+	if(!do_after(user, 5 SECONDS, interaction_key = "plushie_extraction", max_interact_count = 1))
 		return
 
-	abno_plushies |= user.ckey
+	/// If we made it here then the extraction process should be successful.
+	charged = FALSE
 	var/atom/new_item = new item_out(get_turf(user))
 	user.put_in_hands(new_item)
 	to_chat(user, span_nicegreen("You retrieve [new_item] from the [src]!"))
-	playsound(get_turf(src), 'sound/items/timer.ogg', 50, TRUE)
+	playsound(get_turf(src), 'sound/machines/ping.ogg', 50, TRUE)
+	/// Begin the recharge.
+	charge_timer = addtimer(CALLBACK(src, PROC_REF(Recharge)), recharge_duration, TIMER_STOPPABLE)
+
+/// Small little addition onto the description to be able to tell whether the device is charged or not.
+/obj/item/device/plushie_extractor/examine(mob/user)
+	. = ..()
+	if(charged)
+		. += span_nicegreen("It is currently charged.")
+	else
+		. += span_notice("It is currently recharging.")
+/// I'm unsure if this is necessary, but just to be safe, I want to delete the timer when the object is destroyed.
+/obj/item/device/plushie_extractor/Destroy()
+	deltimer(charge_timer)
+	charge_timer = null
+	. = ..()
+
+/obj/item/device/plushie_extractor/proc/Recharge()
+	if(!charged)
+		charged = TRUE
+		playsound(get_turf(src), 'sound/machines/chime.ogg', 35, TRUE, 4)
+		audible_message(span_info("The [src.name] finishes recharging."))

--- a/ModularTegustation/tegu_items/gadgets/unpowered.dm
+++ b/ModularTegustation/tegu_items/gadgets/unpowered.dm
@@ -833,7 +833,7 @@
 /obj/item/device/plushie_extractor/Destroy()
 	deltimer(charge_timer)
 	charge_timer = null
-	. = ..()
+	return ..()
 
 /obj/item/device/plushie_extractor/proc/Recharge()
 	if(!charged)

--- a/ModularTegustation/tegu_items/refinery/crates/corporation.dm
+++ b/ModularTegustation/tegu_items/refinery/crates/corporation.dm
@@ -31,7 +31,7 @@
 		/obj/item/trait_injector/clerk_fear_immunity_injector,
 		/obj/item/trait_injector/officer_upgrade_injector,
 		/obj/item/ego_gift_extractor,
-		/obj/item/device/Plushie_Extractor,
+		/obj/item/device/plushie_extractor,
 	)
 
 //K Corporation

--- a/ModularTegustation/tegu_items/representative/research/lcorp.dm
+++ b/ModularTegustation/tegu_items/representative/research/lcorp.dm
@@ -160,7 +160,7 @@ GLOBAL_LIST_EMPTY(lcorp_upgrades)
 /datum/data/lc13research/plushie_extractor/ResearchEffect(obj/structure/representative_console/requester)
 	if(repeat_cooldown > world.time)
 		return
-	new /obj/item/device/Plushie_Extractor(get_turf(requester))
+	new /obj/item/device/plushie_extractor(get_turf(requester))
 	requester.visible_message(span_notice("The [requester] lights up as it teleports in the Extractor."))
 	repeat_cooldown = world.time + (10 SECONDS)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes the already-existing Plushie Extractor. Also refactors it from "obj/item/device/Plushie_Extractor" to "/obj/item/device/plushie_extractor" (removed uppercase from path since I'm pretty sure that doesn't fly). I also changed all of its references in corporation.dm, lcorp.dm and _belt.dm.

It's not quite as simple as that, I also changed it slightly.
The previous version of this item kept a static list variable to which it added the ckey of the user who used it. It never used this list of ckeys for any check, so I have no way of knowing what it was actually meant to do.

Now, we probably don't want to let people print 500 plushies in 1 minute, so the restriction I went with was a simple timer to recharge the item. Judging from the fact it's in a file called "unpowered.dm", battery charge isn't meant to be used here, so I just put it on a 3 minute timer after every use. Other than that, there are no restrictions on its usage. If the abnormality you use this on has a corresponding plushie mapped to it in the "output" static list, and the device is charged, you will be able to make a plushie out of it. Further restrictions can be added if deemed necessary, but like, it's just plushies, I don't think it's needed.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
One of the rarest items in the L Corp input should be actually functional. Waste of PE/a crate otherwise.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixed plushie extractor.
refactor: Changed item path of plushie extractor.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
