### PR TITLE
LCL Hostile Faction fix

### DIFF
--- a/ModularTegustation/tegu_items/limbus_labs/!other_overwrites.dm
+++ b/ModularTegustation/tegu_items/limbus_labs/!other_overwrites.dm
@@ -28,14 +28,8 @@
 /mob/living/simple_animal/hostile/abnormality/Initialize()
 	. = ..()
 	if(SSmaptype.maptype == "limbus_labs")
-		vision_range = 7
+		vision_range = 3
 		aggro_vision_range = 7
-
-/mob/living/simple_animal/hostile/abnormality/BreachEffect()
-	. = ..()
-	if(SSmaptype.maptype == "limbus_labs")
-		if(!client)
-			faction = list("hostile")
 
 /mob/living/simple_animal/hostile/abnormality/Login()
 	. = ..()

--- a/ModularTegustation/tegu_items/limbus_labs/!other_overwrites.dm
+++ b/ModularTegustation/tegu_items/limbus_labs/!other_overwrites.dm
@@ -31,6 +31,12 @@
 		vision_range = 7
 		aggro_vision_range = 7
 
+/mob/living/simple_animal/hostile/abnormality/BreachEffect()
+	. = ..()
+	if(SSmaptype.maptype == "limbus_labs")
+		if(!client)
+			faction = list("hostile")
+
 /mob/living/simple_animal/hostile/abnormality/Login()
 	. = ..()
 	if(SSmaptype.maptype == "limbus_labs")

--- a/code/game/gamemodes/management/event/combat.dm
+++ b/code/game/gamemodes/management/event/combat.dm
@@ -29,7 +29,11 @@ GLOBAL_VAR_INIT(wcorp_enemy_faction, "") //decides which faction WCorp will be u
 		var/obj/effect/proc_holder/spell/targeted/night_vision/bloodspell = new
 		A.AddSpell(bloodspell)
 		if(!(SSmaptype.maptype in SSmaptype.citymaps))
-			if(!A.client)
+			if(SSmaptype.maptype == "limbus_labs")
+				if(!A.client)
+					A.faction += "hostile"
+
+			else
 				A.faction += "hostile"
 
 	if(SSmaptype.maptype in SSmaptype.autoend)

--- a/code/game/gamemodes/management/event/combat.dm
+++ b/code/game/gamemodes/management/event/combat.dm
@@ -29,9 +29,8 @@ GLOBAL_VAR_INIT(wcorp_enemy_faction, "") //decides which faction WCorp will be u
 		var/obj/effect/proc_holder/spell/targeted/night_vision/bloodspell = new
 		A.AddSpell(bloodspell)
 		if(!(SSmaptype.maptype in SSmaptype.citymaps))
-			if(SSmaptype.maptype == "limbus_labs")
-				return
-			A.faction += "hostile"
+			if(!A.client)
+				A.faction += "hostile"
 
 	if(SSmaptype.maptype in SSmaptype.autoend)
 		switch(SSmaptype.maptype)

--- a/code/game/gamemodes/management/event/combat.dm
+++ b/code/game/gamemodes/management/event/combat.dm
@@ -29,6 +29,8 @@ GLOBAL_VAR_INIT(wcorp_enemy_faction, "") //decides which faction WCorp will be u
 		var/obj/effect/proc_holder/spell/targeted/night_vision/bloodspell = new
 		A.AddSpell(bloodspell)
 		if(!(SSmaptype.maptype in SSmaptype.citymaps))
+			if(SSmaptype.maptype == "limbus_labs")
+				return
 			A.faction += "hostile"
 
 	if(SSmaptype.maptype in SSmaptype.autoend)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
LCL abnos are given unique factions so their AoEs can hit each other to engage in PvP. However if a player possesses a abno before the round starts the faction changes will apply THEN the abno will have the Hostile Faction applied meaning its AoE still wont hurt other abnos with the hostile faction, this PR makes the hostile faction only be applied if theres no client, this solves the issue as LCL has multipled faction overrides applied to the player from logins, logouts and initialize
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Abnormalities which only had AoE attacks got killed one-sidedly by abnormalities with melee attacks which closed off RP opportunities, this avoids that.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: lowered AI vision range to 3 (aggro vision range is still 7)
fix: fixed LCL abnos getting the wrong faction if the player joins too early
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
