### PR TITLE
Fixes Courage (sword)

### DIFF
--- a/ModularTegustation/ego_weapons/melee/he.dm
+++ b/ModularTegustation/ego_weapons/melee/he.dm
@@ -413,7 +413,7 @@
 							FORTITUDE_ATTRIBUTE = 40
 							)
 
-/obj/item/ego_weapon/courage/attack(mob/living/M, mob/living/user)
+/obj/item/ego_weapon/mini/courage/attack(mob/living/M, mob/living/user)
 	if(!CanUseEgo(user))
 		return
 	var/friend_count = 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

When Courage was changed from a regular ego_weapon to a ego_weapon/mini, its attack() override's path wasn't changed with it, thus it was broken and didn't actually gain a force boost per nearby allies (it always had 10 force).

PR fixes the issue by fixing the attack() override's path.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It's a bugfix.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Fixes Courage (sword) ego weapon ally scaling
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
