### PR TITLE
Update activators.dm

### DIFF
--- a/ModularTegustation/sigsystem/activators.dm
+++ b/ModularTegustation/sigsystem/activators.dm
@@ -103,6 +103,9 @@
 	PingLocation()
 
 /obj/structure/closet/crate/sigsystem/togglelock(mob/living/user, silent)
+	if(user)
+		return
+
 	if(locked)
 		locked = FALSE
 		playsound(src,'sound/machines/boltsup.ogg',30,FALSE,3)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Locked Sigsystem Chests can no longer be opened by hand solely requiring a sigsystem pulse to unlock them.

## Changelog
:cl:
fix: Sigsystem chests are now no longer unlockable by humans.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
