### PR TITLE
Replaces mentions of "City" faction with "Hostile"

### DIFF
--- a/ModularTegustation/tegu_mobs/lc13_blood_fiend.dm
+++ b/ModularTegustation/tegu_mobs/lc13_blood_fiend.dm
@@ -234,7 +234,7 @@
 	ChangeResistances(list(RED_DAMAGE = 0.3, WHITE_DAMAGE = 0.3, BLACK_DAMAGE = 0.3, PALE_DAMAGE = 0.3))
 	blood_target = target
 	blood_target.apply_status_effect(/datum/status_effect/bloodhold)
-	blood_target.faction += "city"
+	blood_target.faction += "hostile"
 	can_act = FALSE
 	var/list/dirs_to_land = shuffle(list(NORTH, SOUTH, EAST, WEST, NORTHEAST, NORTHWEST, SOUTHEAST, SOUTHWEST))
 	var/list/dir_overlays = list()
@@ -278,7 +278,7 @@
 	for (var/i in 1 to 3)
 		blood_target.cut_overlay(dir_overlays[i])
 		if (stat == DEAD)
-			blood_target.faction -= "city"
+			blood_target.faction -= "hostile"
 			continue
 		animate(src, alpha = 1,pixel_x = 16, pixel_z = 0, time = 0.1 SECONDS)
 		src.pixel_x = 16
@@ -295,7 +295,7 @@
 			say("ROT AWAY!!!")
 		Dash(blood_target)
 		sleep(0.25 SECONDS)
-	blood_target.faction -= "city"
+	blood_target.faction -= "hostile"
 	if (!cutter_hit)
 		var/mutable_appearance/colored_overlay = mutable_appearance(icon, "small_stagger", layer + 0.1)
 		add_overlay(colored_overlay)

--- a/code/modules/mob/living/simple_animal/friendly/npc.dm
+++ b/code/modules/mob/living/simple_animal/friendly/npc.dm
@@ -8,7 +8,7 @@
 	icon_state = "priest_wings_closed"
 	icon_living = "priest_wings_closed"
 	icon_dead = "none"
-	faction = list("city", "hostile")
+	faction = list("hostile")
 	turns_per_move = 1
 	maxHealth = 10000
 	health = 10000

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -241,7 +241,7 @@
 	//LC13 Check. If it's the citymap, they all gain a faction
 	if(SSmaptype.maptype in SSmaptype.citymaps)
 		if(city_faction)
-			faction += "city"
+			faction += "hostile"
 	if(occupied_tiles_down > 0 || occupied_tiles_up > 0 || occupied_tiles_left > 0 || occupied_tiles_right > 0)
 		occupied_tiles_left_current = occupied_tiles_left
 		occupied_tiles_right_current = occupied_tiles_right


### PR DESCRIPTION
## About The Pull Request
Let me explain to you my viewpoint.
The city faction was created as a nebulous unified faction for all hostile creatures in the city since they would fight eachother when in close proximity.
The hostile faction was created as a nebulous unified faction for all hostile creatures in lavaland and everywhere else since they would fight eachother when in close proximity.

This irritation came about because RCE had a NEW nebulous unified faction called "enemy" which has no purpose in its existence other than to later be corrected by future coders who see the redundancy. I tire of redundancy.

## Why It's Good For The Game
Reduces the amount of redundant code we have. If there is going to be "city", "hostile", and "enemy" and they have no interaction with eachother other than making the definition of default faction difficult to put into a static variable then i personally see it as a hinderance.

## Changelog
:cl:
tweak: Replaced "city" faction with nebulous "hostile"
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
