### PR TITLE
Expands Central Command in District4

### DIFF
--- a/ModularTegustation/tegu_items/enkephalin_rush/enkr_mobs.dm
+++ b/ModularTegustation/tegu_items/enkephalin_rush/enkr_mobs.dm
@@ -229,7 +229,7 @@
 	maxHealth = 600
 	health = 600
 	ranged = TRUE
-	ranged_cooldown_time = 5 SECONDS
+	ranged_cooldown_time = 10 SECONDS
 	rapid = 50
 	rapid_fire_delay = 0.4
 	projectilesound = 'sound/weapons/gun/smg/shot.ogg'
@@ -242,6 +242,13 @@
 	attack_sound = 'sound/weapons/fixer/generic/gen1.ogg'
 	damage_coeff = list(RED_DAMAGE = 1, WHITE_DAMAGE = 1, BLACK_DAMAGE = 0.6, PALE_DAMAGE = 0.6)
 	butcher_results = list(/obj/item/food/meat/slab/corroded = 1)
+
+
+/mob/living/simple_animal/hostile/ordeal/tsa_corrosion/AttackingTarget(atom/attacked_target)
+	if(ranged && ranged_cooldown <= world.time)
+		OpenFire(attacked_target)
+		return
+	..()
 
 //Projectiles
 /obj/item/ammo_casing/caseless/bigspread

--- a/_maps/map_files/Enkephalin_Rush/district_4.dmm
+++ b/_maps/map_files/Enkephalin_Rush/district_4.dmm
@@ -5,6 +5,12 @@
 	},
 /turf/open/floor/distortion/another_day,
 /area/city/backstreets_room)
+"ab" = (
+/obj/structure/sign/poster/lobotomycorp/random{
+	pixel_y = -32
+	},
+/turf/open/floor/plating/rust,
+/area/facility_hallway/command)
 "ac" = (
 /obj/structure/railing{
 	dir = 1
@@ -53,6 +59,9 @@
 /area/city/outskirts)
 "al" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/siding/yellow{
+	dir = 1
+	},
 /turf/open/floor/wood,
 /area/department_main/command)
 "am" = (
@@ -83,13 +92,17 @@
 /area/department_main/control)
 "as" = (
 /turf/closed/mineral/random/facility,
-/area/facility_hallway/control)
+/area/maintenance/disposal)
 "at" = (
 /obj/structure/fluff/bus/dense{
 	icon_state = "fronttire"
 	},
 /turf/open/floor/wood,
 /area/city/house)
+"au" = (
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/closed/mineral/random/facility/briah,
+/area/facility_hallway/command)
 "ax" = (
 /obj/machinery/light{
 	dir = 8
@@ -105,6 +118,10 @@
 	},
 /turf/open/floor/plating/grass,
 /area/department_main/command)
+"aA" = (
+/obj/structure/disposalpipe/segment,
+/turf/closed/indestructible/reinforced/old,
+/area/maintenance/disposal)
 "aC" = (
 /mob/living/simple_animal/hostile/humanoid/rat/zippy,
 /obj/effect/decal/cleanable/dirt,
@@ -363,7 +380,7 @@
 	baseturfs = /turf/open/floor/plating/asteroid;
 	name = "rocky rubble"
 	},
-/area/facility_hallway/control)
+/area/maintenance/disposal)
 "bx" = (
 /obj/structure/sign/directions/evac{
 	pixel_y = -32
@@ -567,11 +584,11 @@
 /turf/closed/indestructible/reinforced/old,
 /area/department_main/command)
 "cf" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/plaque{
 	alpha = 230;
 	icon_state = "LC12"
 	},
+/obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating,
 /area/department_main/command)
 "cg" = (
@@ -604,32 +621,16 @@
 	},
 /turf/open/floor/plating/asteroid,
 /area/surface_ruins/underground)
-"cl" = (
-/obj/structure/rack,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/reagent_containers/spray/chemsprayer/janitor,
-/obj/item/reagent_containers/spray/chemsprayer/janitor,
-/obj/item/reagent_containers/spray/chemsprayer/janitor,
-/obj/item/reagent_containers/spray/chemsprayer/janitor,
-/obj/item/reagent_containers/spray/chemsprayer/janitor,
-/obj/item/reagent_containers/spray/chemsprayer/janitor,
-/obj/item/reagent_containers/spray/chemsprayer/janitor,
-/obj/item/reagent_containers/spray/chemsprayer/janitor,
-/obj/item/reagent_containers/spray/chemsprayer/janitor,
-/obj/item/reagent_containers/spray/chemsprayer/janitor,
-/obj/item/reagent_containers/spray/chemsprayer/janitor,
-/obj/item/reagent_containers/spray/chemsprayer/janitor,
-/obj/item/storage/box/lights/tubes,
-/obj/item/storage/box/lights/mixed,
-/obj/item/mop/advanced,
-/turf/open/floor/plasteel/dark,
-/area/facility_hallway/welfare)
 "cm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
 /area/city)
+"cn" = (
+/obj/item/ego_weapon/contempt,
+/turf/closed/mineral/random/facility/briah,
+/area/facility_hallway/command)
 "co" = (
 /obj/structure/sign/poster/lobotomycorp/random{
 	pixel_y = -32
@@ -695,14 +696,6 @@
 /obj/machinery/telecomms/server/presets/security,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/city/outskirts)
-"cy" = (
-/obj/structure/sink/kitchen{
-	pixel_y = 14
-	},
-/obj/item/reagent_containers/glass/bucket,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark,
-/area/facility_hallway/welfare)
 "cz" = (
 /obj/machinery/light{
 	dir = 8
@@ -739,19 +732,6 @@
 	},
 /turf/open/floor/plating/rust,
 /area/facility_hallway/command)
-"cI" = (
-/obj/structure/sign/departments/command{
-	pixel_y = 32
-	},
-/obj/machinery/light/broken{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/yellow{
-	dir = 5
-	},
-/obj/effect/decal/cleanable/glass,
-/turf/open/floor/plating/rust,
-/area/facility_hallway/command)
 "cJ" = (
 /obj/effect/turf_decal/siding/purple{
 	dir = 10
@@ -774,6 +754,14 @@
 "cO" = (
 /turf/open/floor/circuit/green,
 /area/facility_hallway/control)
+"cP" = (
+/obj/item/kirbyplants/photosynthetic,
+/turf/open/floor/wood,
+/area/department_main/command)
+"cQ" = (
+/obj/structure/toolabnormality/shelter/entrance,
+/turf/open/floor/plasteel/dark,
+/area/facility_hallway/command)
 "cR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/broken,
@@ -824,10 +812,10 @@
 /turf/closed/indestructible/rock,
 /area/facility_hallway/command)
 "da" = (
-/obj/effect/turf_decal/siding/yellow{
-	dir = 8
-	},
 /obj/structure/fluff/hedge,
+/obj/effect/turf_decal/siding/yellow{
+	dir = 10
+	},
 /turf/open/floor/carpet/royalblue,
 /area/department_main/command)
 "db" = (
@@ -903,7 +891,6 @@
 /turf/open/floor/distortion/another_day,
 /area/city/backstreets_room)
 "dr" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/plaque{
 	alpha = 230;
 	icon_state = "LC15"
@@ -1098,6 +1085,14 @@
 	},
 /turf/open/floor/plating/grass,
 /area/city)
+"dY" = (
+/obj/structure/rack,
+/obj/item/instrument/recorder,
+/obj/item/instrument/saxophone,
+/obj/item/instrument/trombone,
+/obj/item/instrument/trumpet,
+/turf/open/floor/wood,
+/area/department_main/command)
 "dZ" = (
 /obj/structure/sign/poster/contraband/lusty_xenomorph,
 /turf/closed/indestructible/reinforced/old,
@@ -1149,6 +1144,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/rust,
 /area/facility_hallway/command)
+"ej" = (
+/obj/structure/chair/comfy/teal{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/department_main/command)
 "ek" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -1228,13 +1229,6 @@
 	},
 /turf/open/floor/plating/rust,
 /area/facility_hallway/command)
-"ez" = (
-/obj/effect/turf_decal/siding/yellow{
-	dir = 9
-	},
-/obj/item/toy/plush/yuri,
-/turf/open/floor/plasteel/dark,
-/area/facility_hallway/command)
 "eB" = (
 /turf/open/floor/plasteel/dark,
 /area/city)
@@ -1259,6 +1253,16 @@
 /obj/broken_regenerator,
 /turf/open/floor/carpet/red,
 /area/department_main/discipline)
+"eI" = (
+/obj/effect/turf_decal/siding/yellow{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/glass,
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/turf/open/floor/plating/rust,
+/area/facility_hallway/command)
 "eJ" = (
 /turf/closed/mineral/random/facility/abnormality{
 	risk_level = 2
@@ -1271,12 +1275,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/mine/hydroponics)
-"eL" = (
-/obj/structure/closet/crate/trashcart,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/dark,
-/area/facility_hallway/welfare)
 "eM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
@@ -1459,7 +1457,7 @@
 "fn" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/mineral/random/facility,
-/area/facility_hallway/control)
+/area/maintenance/disposal)
 "fo" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/mineral/random/facility/briah,
@@ -1544,13 +1542,6 @@
 /obj/machinery/light/broken,
 /turf/closed/mineral/random/facility/briah,
 /area/department_main/records)
-"fB" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/mopbucket,
-/obj/item/mop,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark,
-/area/facility_hallway/welfare)
 "fC" = (
 /obj/effect/turf_decal/siding/blue/corner{
 	dir = 4
@@ -1585,15 +1576,6 @@
 /obj/machinery/computer/security/wooden_tv,
 /turf/open/floor/carpet,
 /area/surface_ruins/underground)
-"fI" = (
-/obj/effect/turf_decal/siding/yellow{
-	dir = 9
-	},
-/obj/structure/sign/departments/command{
-	pixel_x = -32
-	},
-/turf/closed/mineral/random/facility/briah,
-/area/facility_hallway/command)
 "fJ" = (
 /obj/effect/turf_decal/siding/blue{
 	dir = 1
@@ -1624,10 +1606,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/city/shop)
-"fM" = (
-/obj/structure/sign/poster/official/cleanliness,
-/turf/closed/indestructible/reinforced/old,
-/area/facility_hallway/welfare)
 "fN" = (
 /obj/structure/sign/poster/lobotomycorp/clerk_lives_matter,
 /turf/closed/indestructible/reinforced,
@@ -1898,6 +1876,10 @@
 /obj/item/stack/sheet/plastic/fifty,
 /turf/open/floor/pod,
 /area/city/shop)
+"ha" = (
+/obj/item/toy/plush/lisa,
+/turf/open/floor/plating/rust,
+/area/department_main/command)
 "hb" = (
 /obj/structure/sign/poster/contraband/space_up,
 /turf/closed/indestructible/reinforced/old,
@@ -2108,6 +2090,17 @@
 	},
 /turf/closed/mineral/random/facility/atzliuth,
 /area/facility_hallway/welfare)
+"hM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bodycontainer/crematorium{
+	id = "trainingfurnace"
+	},
+/obj/machinery/button/crematorium{
+	id = "trainingfurnace";
+	pixel_x = 31
+	},
+/turf/open/floor/plasteel/dark,
+/area/maintenance/disposal)
 "hN" = (
 /obj/effect/turf_decal/siding/green{
 	dir = 6
@@ -2171,12 +2164,11 @@
 /turf/closed/mineral/random/facility,
 /area/department_main/information)
 "hX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/conveyor/inverted{
-	id = "welfaregarbage"
+/obj/machinery/door/airlock/vault{
+	name = "Backwards Clock containment zone"
 	},
-/turf/open/floor/plating,
-/area/facility_hallway/welfare)
+/turf/open/floor/plasteel/dark,
+/area/facility_hallway/command)
 "hY" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -2223,15 +2215,6 @@
 "il" = (
 /turf/closed/mineral/random/facility/briah,
 /area/facility_hallway/information)
-"im" = (
-/obj/effect/turf_decal/siding/yellow{
-	dir = 5
-	},
-/obj/structure/sign/departments/command{
-	pixel_x = 32
-	},
-/turf/open/floor/plating/rust,
-/area/facility_hallway/command)
 "in" = (
 /obj/machinery/facility_holomap{
 	dir = 0;
@@ -2318,6 +2301,12 @@
 	},
 /turf/open/floor/plating/rust,
 /area/facility_hallway/discipline)
+"iD" = (
+/obj/structure/closet/crate/trashcart,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/dark,
+/area/maintenance/disposal)
 "iE" = (
 /obj/machinery/computer/med_data{
 	dir = 1
@@ -2413,6 +2402,13 @@
 	},
 /turf/open/floor/plating,
 /area/facility_hallway/training)
+"iT" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/chair/comfy/teal{
+	dir = 8
+	},
+/turf/closed/mineral/random/facility/briah,
+/area/department_main/command)
 "iU" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/dark,
@@ -2425,7 +2421,7 @@
 	},
 /obj/machinery/recycler,
 /turf/open/floor/plating,
-/area/facility_hallway/control)
+/area/maintenance/disposal)
 "iX" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -2521,6 +2517,12 @@
 /obj/effect/spawner/lootdrop/cigbutt,
 /turf/open/floor/plating/rust,
 /area/city/backstreets_alley)
+"ju" = (
+/obj/effect/turf_decal/siding/yellow{
+	dir = 6
+	},
+/turf/closed/mineral/random/facility/briah,
+/area/department_main/command)
 "jv" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 7
@@ -2634,11 +2636,6 @@
 /obj/item/storage/belt/utility,
 /turf/open/floor/pod,
 /area/city/shop)
-"jM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/rawpe,
-/turf/open/floor/plasteel/dark,
-/area/facility_hallway/welfare)
 "jN" = (
 /obj/machinery/camera/autoname{
 	dir = 9
@@ -2659,14 +2656,6 @@
 	},
 /turf/open/floor/carpet,
 /area/surface_ruins/underground)
-"jP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "welfaregarbage"
-	},
-/turf/open/floor/plating,
-/area/facility_hallway/welfare)
 "jQ" = (
 /obj/structure/mirror{
 	pixel_y = 32
@@ -2765,17 +2754,6 @@
 /obj/machinery/telecomms/server/presets/common,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/city/outskirts)
-"kj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/bodycontainer/crematorium{
-	id = "trainingfurnace"
-	},
-/obj/machinery/button/crematorium{
-	id = "trainingfurnace";
-	pixel_x = 31
-	},
-/turf/open/floor/plasteel/dark,
-/area/facility_hallway/welfare)
 "kk" = (
 /obj/structure/rack,
 /obj/item/storage/firstaid/toxin,
@@ -2845,6 +2823,15 @@
 	},
 /turf/open/floor/plating,
 /area/department_main/control)
+"kv" = (
+/obj/structure/sign/painting/library{
+	pixel_y = -32
+	},
+/obj/structure/chair/comfy/teal{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/department_main/command)
 "kw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -2995,9 +2982,6 @@
 /obj/item/clothing/suit/armor/ego_gear/teth/wishing_cairn,
 /turf/closed/mineral/random/facility/briah,
 /area/department_main/extraction)
-"kV" = (
-/turf/closed/indestructible/rock,
-/area/facility_hallway/welfare)
 "kX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/trunk{
@@ -3059,7 +3043,7 @@
 /turf/closed/mineral/random/facility/abnormality{
 	risk_level = 2
 	},
-/area/facility_hallway/control)
+/area/maintenance/disposal)
 "lj" = (
 /obj/machinery/door/airlock/medical{
 	name = "medbay"
@@ -3121,14 +3105,6 @@
 	},
 /turf/open/floor/plating/rust,
 /area/department_main/safety)
-"ls" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/conveyor/inverted{
-	dir = 10;
-	id = "welfaregarbage"
-	},
-/turf/open/floor/plating,
-/area/facility_hallway/welfare)
 "lt" = (
 /obj/effect/turf_decal/siding/yellow{
 	dir = 9
@@ -3160,6 +3136,14 @@
 /obj/effect/mob_spawn/human/thumb,
 /turf/open/floor/plasteel/grimy,
 /area/city/backstreets_room)
+"ly" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/conveyor/inverted{
+	dir = 10;
+	id = "welfaregarbage"
+	},
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "lz" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/emergency,
@@ -3183,6 +3167,10 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/carpet/donk,
 /area/city/backstreets_alley)
+"lG" = (
+/obj/structure/sign/poster/official/cleanliness,
+/turf/closed/indestructible/reinforced/old,
+/area/maintenance/disposal)
 "lH" = (
 /obj/structure/toilet{
 	pixel_y = 15
@@ -3202,6 +3190,10 @@
 	},
 /turf/open/floor/wood,
 /area/department_main/manager)
+"lK" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/closed/indestructible/rock,
+/area/facility_hallway/command)
 "lL" = (
 /obj/machinery/light{
 	dir = 8
@@ -3340,7 +3332,7 @@
 	},
 /obj/item/toy/plush/fumo,
 /turf/open/floor/plasteel/dark,
-/area/facility_hallway/control)
+/area/maintenance/disposal)
 "ml" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/siding/yellow,
@@ -3451,6 +3443,12 @@
 	},
 /turf/closed/mineral/random/facility/briah,
 /area/department_main/records)
+"mD" = (
+/obj/effect/turf_decal/siding/yellow{
+	dir = 8
+	},
+/turf/open/floor/plating/rust,
+/area/department_main/command)
 "mF" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
@@ -3605,7 +3603,7 @@
 	baseturfs = /turf/open/floor/plating/asteroid;
 	name = "rocky rubble"
 	},
-/area/facility_hallway/control)
+/area/maintenance/disposal)
 "np" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/extraction_belt,
@@ -3658,6 +3656,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/city)
+"nz" = (
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/plating/rust,
+/area/facility_hallway/command)
 "nA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mob_spawn/human/clerk,
@@ -3711,14 +3713,6 @@
 	},
 /turf/open/floor/plating/rust,
 /area/facility_hallway/safety)
-"nJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/trunk,
-/obj/structure/disposaloutlet{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/facility_hallway/welfare)
 "nK" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -3732,10 +3726,6 @@
 	},
 /turf/open/floor/plating/grass,
 /area/city)
-"nP" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark,
-/area/facility_hallway/welfare)
 "nQ" = (
 /obj/effect/turf_decal/siding/yellow{
 	dir = 10
@@ -3748,6 +3738,9 @@
 "nS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/siding/yellow,
+/obj/effect/turf_decal/plaque{
+	icon_state = "LC29"
+	},
 /turf/open/floor/wood,
 /area/department_main/command)
 "nT" = (
@@ -3827,6 +3820,12 @@
 	},
 /turf/open/water/deep,
 /area/city)
+"oh" = (
+/obj/structure/chair/comfy/teal{
+	dir = 4
+	},
+/turf/closed/mineral/random/facility/briah,
+/area/department_main/command)
 "oi" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Central Command Department"
@@ -3891,6 +3890,12 @@
 /obj/effect/spawner/lootdrop/maint_drugs,
 /turf/open/floor/carpet/donk,
 /area/city/backstreets_alley)
+"or" = (
+/obj/machinery/camera/autoname{
+	dir = 4
+	},
+/turf/closed/mineral/random/facility/briah,
+/area/facility_hallway/command)
 "os" = (
 /obj/machinery/door/airlock/wood{
 	name = "arcade"
@@ -3913,26 +3918,13 @@
 /obj/effect/decal/cleanable/garbage,
 /turf/open/floor/plating/rust,
 /area/city/backstreets_alley)
-"ov" = (
-/obj/structure/sign/departments/command{
-	pixel_y = 32
-	},
-/obj/machinery/light/broken{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/yellow{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/glass,
-/turf/closed/mineral/random/facility/briah,
-/area/facility_hallway/command)
 "ox" = (
 /obj/machinery/button/crematorium{
 	id = "trainingfurnace";
 	pixel_x = 31
 	},
 /turf/closed/indestructible/reinforced/old,
-/area/facility_hallway/control)
+/area/maintenance/disposal)
 "oy" = (
 /obj/effect/turf_decal/siding/red{
 	dir = 1
@@ -3954,11 +3946,11 @@
 /turf/closed/mineral/random/facility/briah,
 /area/department_main/extraction)
 "oA" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/plaque{
 	alpha = 230;
 	icon_state = "LC19"
 	},
+/obj/effect/decal/cleanable/glass,
 /turf/open/floor/wood,
 /area/department_main/command)
 "oB" = (
@@ -4307,11 +4299,11 @@
 /turf/open/floor/plating/rust,
 /area/department_main/training)
 "pF" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/plaque{
 	alpha = 230;
 	icon_state = "LC14"
 	},
+/obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating,
 /area/department_main/command)
 "pG" = (
@@ -4374,6 +4366,20 @@
 	},
 /turf/open/floor/wood,
 /area/department_main/manager)
+"pQ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/vending/lobotomyarmband,
+/turf/open/floor/plating/rust,
+/area/department_main/command)
+"pR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/siding/yellow{
+	dir = 10
+	},
+/turf/open/floor/plating/rust,
+/area/department_main/command)
 "pT" = (
 /obj/machinery/light/broken{
 	dir = 1
@@ -4427,6 +4433,7 @@
 	alpha = 230;
 	icon_state = "LC21"
 	},
+/obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating/rust,
 /area/department_main/command)
 "qc" = (
@@ -4453,6 +4460,16 @@
 /obj/effect/turf_decal/siding/wood/corner,
 /turf/open/floor/grass,
 /area/surface_ruins/underground)
+"qg" = (
+/obj/structure/disposalpipe/junction/flip{
+	dir = 2
+	},
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plating/rust,
+/area/department_main/command)
 "qj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/siding/blue,
@@ -4611,7 +4628,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/maint_drugs,
 /turf/closed/mineral/random/facility,
-/area/facility_hallway/control)
+/area/maintenance/disposal)
 "qO" = (
 /turf/open/floor/carpet/orange,
 /area/department_main/training)
@@ -4755,6 +4772,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/city/shop)
+"rw" = (
+/obj/effect/decal/cleanable/crayon{
+	icon_state = "!"
+	},
+/turf/open/floor/plating/rust,
+/area/department_main/training)
 "rx" = (
 /obj/effect/decal/cleanable/crayon{
 	icon_state = "s"
@@ -4919,7 +4942,20 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/facility_hallway/control)
+/area/maintenance/disposal)
+"sg" = (
+/obj/structure/rack,
+/obj/item/ego_weapon/ranged/clerk,
+/obj/item/ego_weapon/ranged/clerk,
+/obj/item/ego_weapon/ranged/clerk,
+/obj/item/clothing/suit/armor/vest/alt,
+/obj/item/clothing/suit/armor/vest/alt,
+/obj/item/clothing/suit/armor/vest/alt,
+/obj/structure/sign/poster/lobotomycorp/random{
+	pixel_x = -32
+	},
+/turf/open/floor/wood,
+/area/department_main/command)
 "si" = (
 /obj/effect/turf_decal/siding/red{
 	dir = 8
@@ -4953,9 +4989,9 @@
 /area/city)
 "sm" = (
 /obj/effect/turf_decal/plaque{
-	icon_state = "LC30"
+	icon_state = "LC31"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/siding/yellow,
 /turf/open/floor/wood,
 /area/department_main/command)
 "sn" = (
@@ -5009,16 +5045,8 @@
 /turf/closed/mineral/random/facility,
 /area/facility_hallway/training)
 "sA" = (
-/obj/structure/table/wood/fancy/blue,
-/obj/machinery/newscaster{
-	pixel_y = -32
-	},
-/obj/item/flashlight/lamp/green{
-	pixel_x = -5;
-	pixel_y = 10
-	},
-/turf/open/floor/plating/rust,
-/area/department_main/command)
+/turf/open/floor/plasteel/dark,
+/area/facility_hallway/command)
 "sB" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/indestructible/reinforced/old,
@@ -5164,6 +5192,17 @@
 /obj/structure/sign/warning/nosmoking/circle,
 /turf/closed/indestructible/reinforced/old,
 /area/department_main/safety)
+"ta" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/carpet/royalblue,
+/area/department_main/command)
+"tb" = (
+/obj/effect/turf_decal/siding/yellow{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating/rust,
+/area/department_main/command)
 "tc" = (
 /obj/structure/table/reinforced,
 /obj/structure/disposalpipe/segment{
@@ -5174,6 +5213,16 @@
 /obj/item/storage/crayons,
 /turf/open/floor/plasteel/grimy,
 /area/city/shop)
+"td" = (
+/obj/effect/turf_decal/siding/yellow{
+	dir = 1
+	},
+/turf/closed/mineral/random/facility/briah,
+/area/department_main/command)
+"tf" = (
+/obj/effect/turf_decal/siding/yellow,
+/turf/open/floor/carpet/royalblue,
+/area/department_main/command)
 "th" = (
 /obj/machinery/accounting,
 /obj/structure/table/reinforced,
@@ -5208,6 +5257,10 @@
 	},
 /turf/open/floor/plating,
 /area/facility_hallway/welfare)
+"to" = (
+/obj/structure/sign/poster/ripped,
+/turf/closed/indestructible/reinforced/old,
+/area/maintenance/disposal)
 "tp" = (
 /obj/broken_regenerator,
 /turf/closed/mineral/random/facility/briah,
@@ -5224,6 +5277,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/facility_hallway/safety)
+"tt" = (
+/obj/effect/spawner/lootdrop/maintenance,
+/mob/living/simple_animal/hostile/ordeal/tsa_corrosion,
+/turf/open/floor/plating/rust,
+/area/facility_hallway/command)
 "tu" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -5259,6 +5317,12 @@
 	},
 /turf/open/floor/plating,
 /area/facility_hallway/training)
+"tz" = (
+/obj/structure/sign/departments/command{
+	pixel_y = 32
+	},
+/turf/open/floor/plating/rust,
+/area/department_main/command)
 "tA" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Information Department"
@@ -5300,6 +5364,15 @@
 	},
 /turf/open/floor/plating,
 /area/facility_hallway/safety)
+"tL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/recycler,
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "welfaregarbage"
+	},
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "tM" = (
 /obj/machinery/light/broken{
 	dir = 4
@@ -5314,7 +5387,7 @@
 	name = "disposal conveyor"
 	},
 /turf/closed/mineral/random/facility,
-/area/facility_hallway/control)
+/area/maintenance/disposal)
 "tO" = (
 /obj/structure/fans/tiny,
 /obj/structure/barricade/wooden,
@@ -5338,6 +5411,13 @@
 /obj/item/stack/sheet/glass/fifty,
 /turf/open/floor/pod,
 /area/city/shop)
+"tR" = (
+/obj/effect/turf_decal/siding/yellow{
+	dir = 9
+	},
+/obj/item/toy/plush/carmen,
+/turf/open/floor/plasteel/dark,
+/area/facility_hallway/command)
 "tS" = (
 /obj/effect/turf_decal/siding/yellow/corner{
 	dir = 4
@@ -5412,6 +5492,7 @@
 	alpha = 230;
 	icon_state = "LC23"
 	},
+/obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating,
 /area/department_main/command)
 "uf" = (
@@ -5500,6 +5581,12 @@
 /obj/effect/spawner/lootdrop/cigbutt,
 /turf/open/floor/plating/rust,
 /area/city/backstreets_alley)
+"uy" = (
+/obj/effect/turf_decal/siding/yellow{
+	dir = 9
+	},
+/turf/open/floor/carpet/royalblue,
+/area/department_main/command)
 "uz" = (
 /turf/closed/mineral/random/facility/briah,
 /area/department_main/extraction)
@@ -5678,6 +5765,9 @@
 /obj/structure/sign/departments/safety,
 /turf/closed/indestructible/reinforced/old,
 /area/department_main/safety)
+"vc" = (
+/turf/closed/indestructible/rock,
+/area/maintenance/disposal)
 "ve" = (
 /obj/effect/turf_decal/siding/yellow{
 	dir = 10
@@ -5805,16 +5895,32 @@
 	},
 /turf/closed/indestructible/reinforced,
 /area/city/house)
+"vy" = (
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/plating/rust,
+/area/facility_hallway/command)
 "vA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/broken,
 /obj/effect/decal/cleanable/glass,
 /turf/closed/mineral/random/facility/atzliuth,
 /area/department_main/welfare)
+"vB" = (
+/obj/structure/sign/departments/custodian{
+	pixel_y = -32
+	},
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "vC" = (
 /obj/structure/sign/warning/enginesafety,
 /turf/closed/indestructible/wood,
 /area/surface_ruins/underground)
+"vD" = (
+/obj/effect/turf_decal/siding/yellow{
+	dir = 10
+	},
+/turf/closed/mineral/random/facility/briah,
+/area/department_main/command)
 "vE" = (
 /obj/effect/mob_spawn/human/fixer/tieoffice,
 /turf/open/floor/wood,
@@ -5854,6 +5960,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/city/shop)
+"vL" = (
+/obj/effect/turf_decal/siding/yellow/corner,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/carpet/royalblue,
+/area/department_main/command)
 "vM" = (
 /obj/structure/rack,
 /obj/machinery/light/broken,
@@ -6022,9 +6133,6 @@
 /turf/open/floor/carpet/royalblue,
 /area/department_main/command)
 "wq" = (
-/obj/structure/sign/departments/command{
-	pixel_x = -32
-	},
 /obj/item/kirbyplants{
 	icon_state = "plant-18"
 	},
@@ -6249,6 +6357,13 @@
 	},
 /turf/closed/mineral/random/facility/briah,
 /area/facility_hallway/command)
+"xd" = (
+/obj/machinery/light/broken,
+/obj/effect/decal/cleanable/glass,
+/obj/structure/table/wood/fancy/blue,
+/obj/item/broken_bottle,
+/turf/open/floor/plating/rust,
+/area/department_main/command)
 "xe" = (
 /obj/effect/decal/cleanable/blood/footprints{
 	dir = 1
@@ -6263,6 +6378,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/water/deep,
 /area/city)
+"xh" = (
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/wood,
+/area/department_main/command)
 "xj" = (
 /obj/effect/spawner/lootdrop/maint_drugs,
 /turf/open/floor/plasteel/dark,
@@ -6402,6 +6524,12 @@
 	},
 /turf/closed/mineral/random/facility,
 /area/department_main/control)
+"xH" = (
+/obj/structure/chair/comfy/teal{
+	dir = 8
+	},
+/turf/open/floor/plating/rust,
+/area/department_main/command)
 "xI" = (
 /obj/structure/sign/departments/welfare,
 /turf/closed/indestructible/reinforced/old,
@@ -6474,6 +6602,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/rust,
 /area/facility_hallway/discipline)
+"xX" = (
+/obj/effect/turf_decal/siding/red{
+	dir = 1
+	},
+/obj/structure/table/glass,
+/obj/item/storage/belt/ego,
+/obj/item/storage/belt/ego,
+/obj/item/storage/belt/ego,
+/obj/effect/turf_decal/plaque{
+	icon_state = "LC31"
+	},
+/turf/open/floor/carpet,
+/area/facility_hallway/control)
 "xY" = (
 /obj/structure/table/wood/fancy/blue,
 /obj/structure/sign/ordealmonitor{
@@ -6681,12 +6822,6 @@
 	},
 /turf/closed/mineral/random/facility/briah,
 /area/department_main/records)
-"yQ" = (
-/obj/effect/turf_decal/siding/yellow{
-	dir = 8
-	},
-/turf/closed/indestructible/reinforced/old,
-/area/department_main/command)
 "yS" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/indestructible/reinforced/old,
@@ -6849,13 +6984,11 @@
 /area/department_main/safety)
 "zw" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/conveyor_switch/oneway{
-	dir = 4;
-	id = "welfaregarbage";
-	name = "disposal conveyor"
+/obj/effect/turf_decal/siding/yellow{
+	dir = 9
 	},
-/turf/open/floor/plasteel/dark,
-/area/facility_hallway/welfare)
+/turf/open/floor/plating/rust,
+/area/department_main/command)
 "zx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -6887,6 +7020,12 @@
 	},
 /turf/closed/mineral/random/facility,
 /area/department_main/information)
+"zC" = (
+/obj/effect/turf_decal/siding/yellow/corner{
+	dir = 8
+	},
+/turf/closed/mineral/random/facility/briah,
+/area/department_main/command)
 "zD" = (
 /turf/open/floor/plasteel/dark,
 /area/city/shop)
@@ -6962,7 +7101,7 @@
 	},
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating,
-/area/facility_hallway/control)
+/area/maintenance/disposal)
 "zR" = (
 /obj/structure/chair/office,
 /turf/open/floor/carpet/red,
@@ -7119,6 +7258,13 @@
 	},
 /turf/open/floor/plating/rust,
 /area/department_main/training)
+"Ap" = (
+/obj/structure/rack,
+/obj/item/instrument/banjo,
+/obj/item/instrument/eguitar,
+/obj/item/instrument/guitar,
+/turf/open/floor/wood,
+/area/department_main/command)
 "Ar" = (
 /obj/machinery/light/broken{
 	dir = 4
@@ -7195,6 +7341,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/closed/indestructible/opshuttle,
 /area/city/shop)
+"AE" = (
+/turf/closed/mineral/random/facility/abnormality{
+	risk_level = 3
+	},
+/area/department_main/command)
 "AF" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
@@ -7217,20 +7368,11 @@
 	baseturfs = /turf/open/floor/plating/asteroid;
 	name = "rocky rubble"
 	},
-/area/facility_hallway/control)
+/area/maintenance/disposal)
 "AG" = (
 /obj/machinery/computer/extraction_cargo,
 /turf/open/floor/pod,
 /area/city/shop)
-"AH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/recycler,
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "welfaregarbage"
-	},
-/turf/open/floor/plating,
-/area/facility_hallway/welfare)
 "AI" = (
 /obj/effect/turf_decal/siding/yellow,
 /obj/effect/decal/cleanable/dirt,
@@ -7331,6 +7473,13 @@
 /obj/structure/closet/crate,
 /turf/open/floor/plasteel/dark,
 /area/city/shop)
+"Bf" = (
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/glass,
+/turf/closed/mineral/random/facility/briah,
+/area/facility_hallway/command)
 "Bg" = (
 /obj/machinery/door/airlock/wood{
 	name = "forward base"
@@ -7378,6 +7527,16 @@
 	},
 /turf/closed/indestructible/reinforced,
 /area/city)
+"Bp" = (
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/yellow{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/glass,
+/turf/closed/mineral/random/facility/briah,
+/area/facility_hallway/command)
 "Bq" = (
 /obj/effect/landmark/abnospawn/enkephalin_rush/waw,
 /turf/open/floor/plating/rust,
@@ -7412,6 +7571,10 @@
 /obj/structure/chair/sofa/corp/left,
 /turf/open/floor/plasteel/dark,
 /area/city)
+"Bu" = (
+/obj/machinery/vending/coffee,
+/turf/open/floor/wood,
+/area/department_main/command)
 "Bw" = (
 /obj/effect/turf_decal/siding/yellow,
 /obj/effect/turf_decal/siding/yellow{
@@ -7459,7 +7622,7 @@
 /turf/open/floor/plating,
 /area/department_main/safety)
 "BE" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/glass,
 /obj/effect/turf_decal/plaque{
 	alpha = 230;
 	icon_state = "LC17"
@@ -7487,12 +7650,6 @@
 	},
 /turf/open/floor/carpet/red,
 /area/facility_hallway/control)
-"BK" = (
-/obj/effect/turf_decal/siding/yellow{
-	dir = 4
-	},
-/turf/closed/indestructible/reinforced/old,
-/area/department_main/command)
 "BM" = (
 /obj/machinery/camera/autoname,
 /obj/effect/turf_decal/siding/yellow{
@@ -7626,6 +7783,12 @@
 /obj/structure/toolabnormality/touch,
 /turf/closed/mineral/random/facility/briah,
 /area/department_main/records)
+"Cm" = (
+/obj/machinery/camera/autoname{
+	dir = 9
+	},
+/turf/open/floor/plating/rust,
+/area/facility_hallway/command)
 "Cn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/trunk{
@@ -7824,7 +7987,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/mineral/random/facility,
-/area/facility_hallway/control)
+/area/maintenance/disposal)
 "Dc" = (
 /obj/structure/sign/poster/ripped,
 /turf/closed/indestructible/reinforced/old,
@@ -8119,6 +8282,13 @@
 	},
 /turf/open/floor/plating,
 /area/department_main/discipline)
+"Ea" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/vending/lobotomyuniform,
+/turf/open/floor/plating/rust,
+/area/department_main/command)
 "Ec" = (
 /obj/effect/turf_decal/siding/yellow{
 	dir = 10
@@ -8305,6 +8475,12 @@
 /obj/machinery/cryopod,
 /turf/open/floor/wood,
 /area/city/house)
+"EO" = (
+/obj/effect/turf_decal/siding/yellow/corner{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/department_main/command)
 "EP" = (
 /obj/structure/disposalpipe/junction/flip{
 	dir = 4
@@ -8325,6 +8501,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/suit/armor/ego_gear/zayin/dragon_staff,
 /obj/item/ego_weapon/support/dragon_staff,
+/obj/item/ego_weapon/ranged/fellbullet,
+/obj/item/clothing/suit/armor/ego_gear/he/fellbullet,
 /turf/closed/mineral/random/facility/briah,
 /area/department_main/extraction)
 "ES" = (
@@ -8391,6 +8569,10 @@
 	},
 /turf/closed/indestructible/reinforced/old,
 /area/department_main/safety)
+"Fb" = (
+/obj/item/kirbyplants/photosynthetic,
+/turf/open/floor/plating/rust,
+/area/department_main/command)
 "Fc" = (
 /obj/machinery/camera/autoname,
 /obj/effect/turf_decal/siding/yellow{
@@ -8458,6 +8640,15 @@
 /obj/machinery/mineral/unloading_machine,
 /turf/open/floor/plating/ashplanet/rocky,
 /area/city)
+"Fs" = (
+/obj/structure/sign/painting/library{
+	pixel_y = -32
+	},
+/obj/structure/chair/comfy/teal{
+	dir = 4
+	},
+/turf/open/floor/plating/rust,
+/area/department_main/command)
 "Ft" = (
 /obj/effect/turf_decal/siding/yellow/end{
 	dir = 4
@@ -8470,6 +8661,10 @@
 /obj/item/toy/plush/kog,
 /turf/open/floor/wood,
 /area/city/shop)
+"Fv" = (
+/obj/machinery/vending/cigarette,
+/turf/open/floor/plating/rust,
+/area/department_main/command)
 "Fw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -8480,7 +8675,6 @@
 /turf/open/floor/plating/rust,
 /area/department_main/training)
 "Fy" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/plaque{
 	alpha = 230;
 	icon_state = "LC10"
@@ -8533,6 +8727,10 @@
 /obj/effect/turf_decal/plaque{
 	alpha = 230;
 	icon_state = "LC13"
+	},
+/obj/effect/decal/cleanable/glass,
+/obj/effect/turf_decal/siding/yellow/corner{
+	dir = 4
 	},
 /turf/open/floor/plating/rust,
 /area/department_main/command)
@@ -8595,6 +8793,10 @@
 /obj/effect/spawner/structure/window/plasma/reinforced/plastitanium,
 /turf/open/floor/plating,
 /area/department_main/extraction)
+"Gc" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/maintenance/disposal)
 "Ge" = (
 /obj/item/rawpe,
 /obj/item/rawpe,
@@ -8669,10 +8871,6 @@
 /obj/effect/turf_decal/siding/yellow,
 /turf/open/floor/plating/rust,
 /area/facility_hallway/command)
-"Gu" = (
-/obj/structure/disposalpipe/segment,
-/turf/closed/indestructible/reinforced/old,
-/area/facility_hallway/welfare)
 "Gv" = (
 /obj/effect/turf_decal/siding/red{
 	dir = 4
@@ -8705,6 +8903,12 @@
 /obj/effect/turf_decal/tile/brown,
 /turf/open/floor/plasteel/white,
 /area/city/shop)
+"GA" = (
+/obj/structure/chair/comfy/teal{
+	dir = 4
+	},
+/turf/open/floor/plating/rust,
+/area/department_main/command)
 "GB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -8733,12 +8937,22 @@
 	},
 /turf/open/floor/plating/rust,
 /area/facility_hallway/discipline)
+"GF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/conveyor/inverted{
+	id = "welfaregarbage"
+	},
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "GG" = (
 /obj/effect/turf_decal/siding/yellow{
 	dir = 4
 	},
 /turf/closed/mineral/random/facility,
 /area/department_main/control)
+"GH" = (
+/turf/closed/indestructible/reinforced,
+/area/maintenance/disposal)
 "GI" = (
 /obj/effect/turf_decal/siding/green{
 	dir = 9
@@ -8831,6 +9045,16 @@
 /obj/structure/sign/departments/discipline,
 /turf/closed/indestructible/reinforced/old,
 /area/facility_hallway/discipline)
+"GX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/broken,
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "welfaregarbage"
+	},
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "GY" = (
 /obj/effect/turf_decal/siding/yellow/corner{
 	dir = 4
@@ -8881,48 +9105,6 @@
 	risk_level = 5
 	},
 /area/facility_hallway/discipline)
-"Hf" = (
-/obj/structure/rack,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/storage/bag/trash/bluespace,
-/obj/item/storage/bag/trash/bluespace,
-/obj/item/storage/bag/trash/bluespace,
-/obj/item/storage/bag/trash/bluespace,
-/obj/item/storage/bag/trash/bluespace,
-/obj/item/storage/bag/trash/bluespace,
-/obj/item/storage/bag/trash/bluespace,
-/obj/item/storage/bag/trash/bluespace,
-/obj/item/pushbroom,
-/obj/item/pushbroom,
-/obj/item/pushbroom,
-/obj/item/pushbroom,
-/obj/item/pushbroom,
-/obj/item/pushbroom,
-/obj/item/pushbroom,
-/obj/item/pushbroom,
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_x = 5;
-	pixel_y = -1
-	},
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_x = 5;
-	pixel_y = -1
-	},
-/obj/item/soap,
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_x = 5;
-	pixel_y = -1
-	},
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_x = 5;
-	pixel_y = -1
-	},
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_x = 5;
-	pixel_y = -1
-	},
-/turf/open/floor/plasteel/dark,
-/area/facility_hallway/welfare)
 "Hg" = (
 /obj/effect/turf_decal/siding/blue/corner{
 	dir = 4
@@ -8997,9 +9179,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/facility/dark,
 /area/department_main/discipline)
-"Hv" = (
-/turf/closed/indestructible/reinforced,
-/area/facility_hallway/welfare)
 "Hx" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/hypospray/medipen/salacid,
@@ -9086,12 +9265,6 @@
 	},
 /turf/open/floor/plating/ashplanet/rocky,
 /area/city/backstreets_alley)
-"HO" = (
-/obj/structure/sign/departments/command{
-	pixel_x = -32
-	},
-/turf/open/floor/plating/rust,
-/area/department_main/command)
 "HP" = (
 /obj/effect/turf_decal/siding/yellow,
 /obj/machinery/light/broken,
@@ -9103,6 +9276,7 @@
 	alpha = 230;
 	icon_state = "LC26"
 	},
+/obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating/rust,
 /area/department_main/command)
 "HR" = (
@@ -9157,6 +9331,9 @@
 /area/facility_hallway/training)
 "Ib" = (
 /obj/effect/turf_decal/siding/yellow,
+/obj/effect/turf_decal/plaque{
+	icon_state = "LC33"
+	},
 /turf/open/floor/plating,
 /area/department_main/command)
 "Ic" = (
@@ -9209,6 +9386,12 @@
 /obj/structure/closet/crate/freezer/surplus_limbs,
 /turf/open/floor/plating,
 /area/department_main/safety)
+"Ih" = (
+/obj/structure/fans/tiny,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/hatch,
+/turf/open/floor/plasteel/elevatorshaft,
+/area/maintenance/disposal)
 "Ii" = (
 /obj/effect/turf_decal/siding/red{
 	dir = 4
@@ -9240,6 +9423,7 @@
 	alpha = 230;
 	icon_state = "LC5"
 	},
+/obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating,
 /area/department_main/command)
 "Iq" = (
@@ -9354,6 +9538,13 @@
 /obj/item/toy/plush/hod,
 /turf/closed/mineral/random/facility,
 /area/facility_hallway/training)
+"IN" = (
+/obj/effect/turf_decal/siding/yellow{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/carpet/royalblue,
+/area/department_main/command)
 "IO" = (
 /obj/effect/spawner/lootdrop/garbage_spawner,
 /obj/effect/turf_decal/siding/brown,
@@ -9397,6 +9588,12 @@
 	},
 /turf/open/floor/carpet/orange,
 /area/department_main/training)
+"IW" = (
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/turf/open/floor/plating/rust,
+/area/facility_hallway/command)
 "IX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/siding/blue/corner{
@@ -9497,12 +9694,19 @@
 "Js" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/facility_holomap,
+/obj/effect/turf_decal/siding/yellow{
+	dir = 1
+	},
 /turf/open/floor/plating/rust,
 /area/department_main/command)
 "Jt" = (
 /obj/structure/table/wood/fancy/blue,
 /obj/machinery/light/built,
 /obj/effect/decal/cleanable/glass,
+/obj/item/flashlight/lamp/green{
+	pixel_x = -5;
+	pixel_y = 10
+	},
 /turf/open/floor/plating,
 /area/department_main/command)
 "Ju" = (
@@ -9511,15 +9715,6 @@
 	},
 /turf/open/floor/carpet/orange,
 /area/department_main/training)
-"Jv" = (
-/obj/structure/sign/departments/command{
-	pixel_x = 32
-	},
-/obj/item/kirbyplants{
-	icon_state = "plant-18"
-	},
-/turf/open/floor/carpet/royalblue,
-/area/department_main/command)
 "Jy" = (
 /obj/effect/turf_decal/plaque{
 	alpha = 230;
@@ -9579,6 +9774,7 @@
 	alpha = 230;
 	icon_state = "LC25"
 	},
+/obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating/rust,
 /area/department_main/command)
 "JI" = (
@@ -9603,6 +9799,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/mineral/random/facility/atzliuth,
 /area/facility_hallway/discipline)
+"JM" = (
+/obj/structure/table/wood/fancy/blue,
+/obj/item/broken_bottle,
+/turf/open/floor/plating/rust,
+/area/department_main/command)
 "JP" = (
 /obj/effect/turf_decal/box/white,
 /obj/machinery/light/broken,
@@ -9698,6 +9899,13 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/shelter,
 /area/facility_hallway/command)
+"Ke" = (
+/obj/machinery/light/broken,
+/obj/effect/decal/cleanable/glass,
+/obj/structure/table/wood/fancy/blue,
+/obj/item/broken_bottle,
+/turf/closed/mineral/random/facility/briah,
+/area/department_main/command)
 "Kf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -9803,7 +10011,7 @@
 	},
 /obj/item/reagent_containers/glass/bucket,
 /turf/closed/mineral/random/facility,
-/area/facility_hallway/control)
+/area/maintenance/disposal)
 "KC" = (
 /turf/open/floor/plasteel/grimy,
 /area/city/backstreets_room)
@@ -9937,6 +10145,14 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plasteel,
 /area/department_main/discipline)
+"Lb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "welfaregarbage"
+	},
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "Lc" = (
 /obj/machinery/light/broken,
 /obj/effect/decal/cleanable/dirt,
@@ -10050,6 +10266,26 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating/rust,
 /area/facility_hallway/command)
+"Lv" = (
+/obj/structure/rack,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/spray/chemsprayer/janitor,
+/obj/item/reagent_containers/spray/chemsprayer/janitor,
+/obj/item/reagent_containers/spray/chemsprayer/janitor,
+/obj/item/reagent_containers/spray/chemsprayer/janitor,
+/obj/item/reagent_containers/spray/chemsprayer/janitor,
+/obj/item/reagent_containers/spray/chemsprayer/janitor,
+/obj/item/reagent_containers/spray/chemsprayer/janitor,
+/obj/item/reagent_containers/spray/chemsprayer/janitor,
+/obj/item/reagent_containers/spray/chemsprayer/janitor,
+/obj/item/reagent_containers/spray/chemsprayer/janitor,
+/obj/item/reagent_containers/spray/chemsprayer/janitor,
+/obj/item/reagent_containers/spray/chemsprayer/janitor,
+/obj/item/storage/box/lights/tubes,
+/obj/item/storage/box/lights/mixed,
+/obj/item/mop/advanced,
+/turf/open/floor/plasteel/dark,
+/area/maintenance/disposal)
 "Lw" = (
 /obj/machinery/telecomms/server/presets/command,
 /turf/open/floor/circuit/telecomms/mainframe,
@@ -10126,7 +10362,7 @@
 	pixel_y = -1
 	},
 /turf/closed/mineral/random/facility,
-/area/facility_hallway/control)
+/area/maintenance/disposal)
 "LF" = (
 /obj/item/papercutter,
 /obj/structure/table_frame/wood,
@@ -10141,7 +10377,7 @@
 	id = "trainingfurnace"
 	},
 /turf/open/floor/plasteel/dark,
-/area/facility_hallway/control)
+/area/maintenance/disposal)
 "LI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -10242,6 +10478,12 @@
 "LX" = (
 /turf/closed/indestructible/reinforced/old,
 /area/department_main/information)
+"LY" = (
+/obj/effect/turf_decal/siding/yellow{
+	dir = 1
+	},
+/turf/open/floor/carpet/royalblue,
+/area/department_main/command)
 "LZ" = (
 /obj/structure/sign/departments/control,
 /turf/closed/indestructible/reinforced/old,
@@ -10253,16 +10495,6 @@
 	},
 /turf/open/floor/plating/rust,
 /area/facility_hallway/information)
-"Mb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/broken,
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "welfaregarbage"
-	},
-/obj/effect/decal/cleanable/glass,
-/turf/open/floor/plating,
-/area/facility_hallway/welfare)
 "Mc" = (
 /obj/structure/fluff/bus/dense{
 	icon_state = "reartire"
@@ -10305,6 +10537,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/city/shop)
+"Mi" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel/dark,
+/area/facility_hallway/command)
 "Mj" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plasteel/dark,
@@ -10314,12 +10550,19 @@
 	icon_state = "LC30"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/siding/yellow,
 /turf/open/floor/plating,
 /area/department_main/command)
 "Mm" = (
 /obj/structure/chair/stool/bar,
 /turf/open/floor/wood,
 /area/city/shop)
+"Mn" = (
+/obj/effect/turf_decal/siding/yellow{
+	dir = 4
+	},
+/turf/open/floor/carpet/royalblue,
+/area/department_main/command)
 "Mo" = (
 /obj/effect/turf_decal/siding/red{
 	dir = 1
@@ -10374,6 +10617,12 @@
 /obj/machinery/computer,
 /turf/open/floor/plasteel,
 /area/city/backstreets_room)
+"Mz" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/department_main/command)
 "MA" = (
 /obj/structure/sign/poster/official/help_others{
 	pixel_y = -32
@@ -10381,6 +10630,9 @@
 /obj/effect/turf_decal/siding/yellow,
 /turf/closed/mineral/random/facility/briah,
 /area/facility_hallway/command)
+"MB" = (
+/turf/closed/indestructible/reinforced/old,
+/area/maintenance/disposal)
 "MC" = (
 /obj/effect/turf_decal/siding/yellow,
 /obj/effect/decal/cleanable/dirt,
@@ -10461,6 +10713,7 @@
 	alpha = 230;
 	icon_state = "LC18"
 	},
+/obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating,
 /area/department_main/command)
 "MR" = (
@@ -10530,6 +10783,10 @@
 /obj/effect/landmark/delayed/xeno_spawn,
 /turf/open/floor/plating/rust,
 /area/facility_hallway/training)
+"Nh" = (
+/obj/machinery/camera/autoname,
+/turf/open/floor/plasteel/dark,
+/area/facility_hallway/command)
 "Ni" = (
 /obj/effect/landmark/toolspawn,
 /turf/closed/mineral/random/facility{
@@ -10551,6 +10808,10 @@
 	alpha = 230;
 	icon_state = "LC4"
 	},
+/obj/effect/decal/cleanable/glass,
+/obj/effect/turf_decal/siding/yellow{
+	dir = 8
+	},
 /turf/open/floor/wood,
 /area/department_main/command)
 "Nm" = (
@@ -10569,6 +10830,12 @@
 /obj/item/toy/plush/yesod,
 /turf/closed/mineral/random/facility/briah,
 /area/department_main/extraction)
+"Np" = (
+/obj/effect/turf_decal/siding/yellow{
+	dir = 10
+	},
+/turf/open/floor/plating/rust,
+/area/department_main/command)
 "Nr" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -10597,6 +10864,7 @@
 	alpha = 230;
 	icon_state = "LC11"
 	},
+/obj/effect/decal/cleanable/glass,
 /turf/open/floor/wood,
 /area/department_main/command)
 "Nw" = (
@@ -10620,6 +10888,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/rust,
 /area/facility_hallway/discipline)
+"NB" = (
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating/rust,
+/area/facility_hallway/command)
 "NC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/siding/yellow{
@@ -10636,13 +10908,6 @@
 	},
 /turf/closed/mineral/random/facility,
 /area/department_main/information)
-"NE" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/effect/turf_decal/siding/brown{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/facility_hallway/welfare)
 "NG" = (
 /obj/structure/rack,
 /obj/item/melee/classic_baton,
@@ -10678,6 +10943,10 @@
 /obj/item/rawpe,
 /turf/open/floor/carpet/royalblue,
 /area/department_main/welfare)
+"NK" = (
+/obj/item/kirbyplants/photosynthetic,
+/turf/closed/mineral/random/facility/briah,
+/area/department_main/command)
 "NL" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/fence{
@@ -10761,11 +11030,18 @@
 /obj/effect/turf_decal/siding/green,
 /turf/closed/mineral/random/facility,
 /area/facility_hallway/safety)
+"Oc" = (
+/obj/structure/toolabnormality/clock,
+/turf/open/floor/plasteel/dark,
+/area/facility_hallway/command)
 "Od" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/plaque{
 	alpha = 230;
 	icon_state = "LC8"
+	},
+/obj/effect/turf_decal/siding/yellow{
+	dir = 4
 	},
 /turf/open/floor/plating/rust,
 /area/department_main/command)
@@ -10836,6 +11112,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/mineral/random/facility/atzliuth,
 /area/facility_hallway/discipline)
+"Or" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/mopbucket,
+/obj/item/mop,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/maintenance/disposal)
 "Os" = (
 /obj/machinery/jukebox{
 	req_access = list()
@@ -10871,12 +11154,6 @@
 /obj/item/food/carpmeat,
 /turf/open/floor/plasteel/freezer,
 /area/city/shop)
-"Ov" = (
-/obj/effect/turf_decal/siding/yellow{
-	dir = 4
-	},
-/turf/open/floor/plating/rust,
-/area/department_main/command)
 "Ow" = (
 /obj/machinery/light/small/broken,
 /obj/effect/decal/cleanable/dirt,
@@ -10887,6 +11164,17 @@
 /obj/structure/sign/poster/ripped,
 /turf/closed/indestructible/reinforced/old,
 /area/facility_hallway/command)
+"Oy" = (
+/obj/structure/rack,
+/obj/item/storage/belt/ego,
+/obj/item/storage/belt/ego,
+/obj/item/storage/belt/ego,
+/obj/item/storage/belt/ego,
+/obj/structure/sign/poster/lobotomycorp/random{
+	pixel_x = 32
+	},
+/turf/open/floor/wood,
+/area/department_main/command)
 "Oz" = (
 /obj/machinery/smartfridge/food,
 /obj/structure/disposalpipe/segment,
@@ -10928,6 +11216,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/mineral/random/facility/briah,
 /area/facility_hallway/command)
+"OK" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/turf_decal/siding/brown{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "OL" = (
 /obj/effect/turf_decal/siding/green{
 	dir = 10
@@ -11013,6 +11308,12 @@
 /obj/effect/landmark/start,
 /turf/open/floor/plating,
 /area/department_main/training)
+"Pb" = (
+/obj/effect/turf_decal/siding/yellow{
+	dir = 1
+	},
+/turf/open/floor/plating/rust,
+/area/department_main/command)
 "Pc" = (
 /obj/structure/rack,
 /obj/item/refiner_filter/green,
@@ -11052,7 +11353,7 @@
 	dir = 5
 	},
 /turf/closed/indestructible/reinforced/old,
-/area/facility_hallway/control)
+/area/maintenance/disposal)
 "Pk" = (
 /obj/effect/turf_decal/siding/blue{
 	dir = 4
@@ -11090,12 +11391,6 @@
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/plasteel,
 /area/city/backstreets_room)
-"Pt" = (
-/obj/structure/sign/departments/custodian{
-	pixel_y = -32
-	},
-/turf/open/floor/plating,
-/area/facility_hallway/welfare)
 "Pv" = (
 /turf/closed/indestructible/syndicate,
 /area/city/outskirts)
@@ -11113,7 +11408,7 @@
 	id = "controlgarbage"
 	},
 /turf/open/floor/plating,
-/area/facility_hallway/control)
+/area/maintenance/disposal)
 "PA" = (
 /obj/machinery/newscaster{
 	pixel_y = 32
@@ -11147,6 +11442,12 @@
 /obj/structure/fluff/hedge,
 /turf/open/floor/carpet/royalblue,
 /area/department_main/command)
+"PE" = (
+/turf/closed/mineral/random/facility{
+	baseturfs = /turf/open/floor/plating/asteroid;
+	name = "rocky rubble"
+	},
+/area/maintenance/disposal)
 "PF" = (
 /obj/structure/table/glass,
 /obj/item/documents,
@@ -11209,6 +11510,15 @@
 /obj/machinery/telecomms/relay/preset/telecomms,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/city/outskirts)
+"PQ" = (
+/obj/effect/turf_decal/siding/yellow{
+	dir = 4
+	},
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/turf/closed/mineral/random/facility/briah,
+/area/facility_hallway/command)
 "PR" = (
 /obj/structure/sign/poster/lobotomycorp/clerk_lives_matter,
 /turf/closed/indestructible/reinforced/old,
@@ -11284,6 +11594,14 @@
 "Qe" = (
 /turf/open/floor/plating/rust,
 /area/facility_hallway/information)
+"Qf" = (
+/obj/effect/decal/cleanable/glass,
+/obj/effect/turf_decal/plaque{
+	alpha = 230;
+	icon_state = "LC28"
+	},
+/turf/open/floor/plating,
+/area/department_main/command)
 "Qg" = (
 /obj/effect/turf_decal/siding/yellow{
 	dir = 6
@@ -11365,7 +11683,7 @@
 /obj/effect/turf_decal/bot,
 /obj/item/lightreplacer,
 /turf/closed/mineral/random/facility,
-/area/facility_hallway/control)
+/area/maintenance/disposal)
 "Qy" = (
 /obj/effect/turf_decal/siding/purple,
 /obj/effect/turf_decal/siding/purple{
@@ -11446,6 +11764,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/rust,
 /area/facility_hallway/command)
+"QQ" = (
+/obj/effect/turf_decal/siding/yellow{
+	dir = 5
+	},
+/turf/open/floor/plating/rust,
+/area/department_main/command)
 "QR" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
@@ -11558,6 +11882,12 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating/rust,
 /area/facility_hallway/discipline)
+"Ri" = (
+/obj/machinery/door/airlock/highsecurity{
+	name = "Central Command Department"
+	},
+/turf/open/floor/plating/rust,
+/area/department_main/command)
 "Rk" = (
 /obj/effect/turf_decal/siding/yellow{
 	dir = 6
@@ -11579,15 +11909,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/closed/indestructible/reinforced,
 /area/city/shop)
-"Rn" = (
-/obj/effect/turf_decal/siding/yellow{
-	dir = 10
-	},
-/obj/structure/sign/departments/command{
-	pixel_x = -32
-	},
-/turf/open/floor/plating/rust,
-/area/facility_hallway/command)
 "Rp" = (
 /turf/closed/indestructible/riveted,
 /area/city)
@@ -11668,6 +11989,48 @@
 	},
 /turf/closed/indestructible/opshuttle,
 /area/city/shop)
+"RL" = (
+/obj/structure/rack,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/bag/trash/bluespace,
+/obj/item/storage/bag/trash/bluespace,
+/obj/item/storage/bag/trash/bluespace,
+/obj/item/storage/bag/trash/bluespace,
+/obj/item/storage/bag/trash/bluespace,
+/obj/item/storage/bag/trash/bluespace,
+/obj/item/storage/bag/trash/bluespace,
+/obj/item/storage/bag/trash/bluespace,
+/obj/item/pushbroom,
+/obj/item/pushbroom,
+/obj/item/pushbroom,
+/obj/item/pushbroom,
+/obj/item/pushbroom,
+/obj/item/pushbroom,
+/obj/item/pushbroom,
+/obj/item/pushbroom,
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = 5;
+	pixel_y = -1
+	},
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = 5;
+	pixel_y = -1
+	},
+/obj/item/soap,
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = 5;
+	pixel_y = -1
+	},
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = 5;
+	pixel_y = -1
+	},
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = 5;
+	pixel_y = -1
+	},
+/turf/open/floor/plasteel/dark,
+/area/maintenance/disposal)
 "RM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -11737,6 +12100,13 @@
 /obj/effect/mob_spawn/human/fixer/tieoffice,
 /turf/open/floor/plasteel,
 /area/city/backstreets_room)
+"RY" = (
+/obj/effect/turf_decal/siding/yellow{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/carpet/royalblue,
+/area/department_main/command)
 "Sb" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/ordeal/thunderbird_corrosion,
@@ -11819,15 +12189,6 @@
 /obj/machinery/newscaster,
 /turf/closed/indestructible/reinforced/old,
 /area/department_main/welfare)
-"Ss" = (
-/obj/effect/turf_decal/siding/yellow{
-	dir = 6
-	},
-/obj/structure/sign/departments/command{
-	pixel_x = 32
-	},
-/turf/closed/mineral/random/facility/briah,
-/area/facility_hallway/command)
 "St" = (
 /obj/structure/railing{
 	dir = 1
@@ -12006,6 +12367,13 @@
 	},
 /turf/open/floor/pod/light,
 /area/facility_hallway/manager)
+"SX" = (
+/obj/effect/turf_decal/siding/brown{
+	dir = 1
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "SY" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/dark,
@@ -12036,6 +12404,12 @@
 	},
 /turf/open/floor/plating/rust,
 /area/facility_hallway/safety)
+"Tf" = (
+/obj/machinery/door/airlock/vault{
+	name = "Shelter From The 27th Of March containment zone"
+	},
+/turf/open/floor/plasteel/dark,
+/area/facility_hallway/command)
 "Tg" = (
 /obj/item/reagent_containers/syringe,
 /obj/effect/decal/cleanable/dirt,
@@ -12071,6 +12445,16 @@
 /obj/item/pizzabox/meat,
 /turf/open/floor/plasteel/white,
 /area/city/shop)
+"Tn" = (
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/yellow{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plating/rust,
+/area/facility_hallway/command)
 "To" = (
 /obj/effect/turf_decal/siding/red,
 /obj/effect/decal/cleanable/dirt,
@@ -12086,6 +12470,11 @@
 /obj/machinery/door/airlock/vault,
 /turf/open/floor/plasteel,
 /area/city/backstreets_room)
+"Tt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/rawpe,
+/turf/open/floor/plasteel/dark,
+/area/maintenance/disposal)
 "Tu" = (
 /obj/machinery/camera/autoname,
 /obj/effect/decal/cleanable/dirt,
@@ -12094,6 +12483,13 @@
 	},
 /turf/closed/mineral/random/facility/atzliuth,
 /area/facility_hallway/discipline)
+"Tv" = (
+/obj/structure/rack,
+/obj/item/instrument/bikehorn,
+/obj/item/instrument/harmonica,
+/obj/item/instrument/violin,
+/turf/open/floor/wood,
+/area/department_main/command)
 "Tw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -12293,19 +12689,6 @@
 /obj/effect/turf_decal/siding/brown,
 /turf/open/floor/plating/rust,
 /area/facility_hallway/training)
-"TX" = (
-/obj/structure/sign/departments/command{
-	pixel_x = 32
-	},
-/turf/open/floor/plating/rust,
-/area/department_main/command)
-"TY" = (
-/obj/structure/table/wood/fancy/blue,
-/obj/effect/turf_decal/plaque{
-	icon_state = "LC29"
-	},
-/turf/open/floor/plating/rust,
-/area/department_main/command)
 "TZ" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "LC1"
@@ -12337,6 +12720,14 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating/rust,
 /area/facility_hallway/training)
+"Ue" = (
+/obj/item/kirbyplants/photosynthetic,
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/wood,
+/area/department_main/command)
 "Uf" = (
 /obj/effect/turf_decal/siding/blue/corner{
 	dir = 8
@@ -12370,6 +12761,9 @@
 	},
 /turf/open/floor/plating/grass,
 /area/city)
+"Ul" = (
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "Um" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating/rust,
@@ -12460,7 +12854,13 @@
 	dir = 4
 	},
 /turf/closed/indestructible/reinforced/old,
-/area/facility_hallway/control)
+/area/maintenance/disposal)
+"UH" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/closed/mineral/random/facility/briah,
+/area/department_main/command)
 "UI" = (
 /obj/effect/landmark/start,
 /obj/effect/turf_decal/siding/brown,
@@ -12501,6 +12901,7 @@
 	alpha = 230;
 	icon_state = "LC16"
 	},
+/obj/effect/decal/cleanable/glass,
 /turf/open/floor/wood,
 /area/department_main/command)
 "US" = (
@@ -12519,6 +12920,12 @@
 /obj/structure/sign/departments/control,
 /turf/closed/indestructible/reinforced/old,
 /area/department_main/control)
+"UW" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/closed/indestructible/reinforced/old,
+/area/maintenance/disposal)
 "UX" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -12574,6 +12981,13 @@
 /obj/effect/turf_decal/stripes/full,
 /turf/open/floor/plasteel/dark,
 /area/city)
+"Vj" = (
+/obj/effect/turf_decal/siding/yellow{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/carpet/royalblue,
+/area/department_main/command)
 "Vk" = (
 /obj/structure/chair/wood,
 /turf/open/floor/wood,
@@ -12621,6 +13035,12 @@
 	},
 /turf/closed/indestructible/reinforced/old,
 /area/department_main/welfare)
+"Vx" = (
+/obj/effect/turf_decal/siding/yellow{
+	dir = 8
+	},
+/turf/open/floor/carpet/royalblue,
+/area/department_main/command)
 "VA" = (
 /obj/machinery/computer/med_data{
 	dir = 8;
@@ -12694,10 +13114,10 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/city/outskirts)
 "VL" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/plaque{
 	icon_state = "LC3"
 	},
+/obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating,
 /area/department_main/command)
 "VQ" = (
@@ -12711,11 +13131,11 @@
 /turf/open/floor/plating/rust,
 /area/department_main/extraction)
 "VS" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/plaque{
 	alpha = 230;
 	icon_state = "LC7"
 	},
+/obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating,
 /area/department_main/command)
 "VT" = (
@@ -12788,7 +13208,7 @@
 	id = "controlgarbage"
 	},
 /turf/open/floor/plasteel/dark,
-/area/facility_hallway/control)
+/area/maintenance/disposal)
 "Wb" = (
 /obj/machinery/modular_computer/console/preset/research{
 	name = "information department console"
@@ -12844,9 +13264,15 @@
 /obj/item/clothing/accessory/armband/lobotomy/extraction,
 /obj/item/clothing/accessory/armband/lobotomy/extraction,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/ego_weapon/ranged/fellbullet,
 /turf/closed/mineral/random/facility/briah,
 /area/department_main/extraction)
+"Wm" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/closed/mineral/random/facility/briah,
+/area/department_main/command)
 "Wn" = (
 /obj/machinery/light/broken{
 	dir = 8
@@ -12855,11 +13281,33 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/facility/dark,
 /area/department_main/training)
+"Wo" = (
+/obj/effect/turf_decal/siding/yellow,
+/turf/open/floor/plating/rust,
+/area/department_main/command)
 "Wp" = (
 /obj/effect/turf_decal/siding/yellow/end{
 	dir = 8
 	},
 /turf/open/floor/plating/rust,
+/area/facility_hallway/command)
+"Wq" = (
+/obj/structure/sink/kitchen{
+	pixel_y = 14
+	},
+/obj/item/reagent_containers/glass/bucket,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/maintenance/disposal)
+"Wt" = (
+/obj/effect/turf_decal/siding/yellow{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/glass,
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/turf/closed/mineral/random/facility/briah,
 /area/facility_hallway/command)
 "Wu" = (
 /obj/effect/turf_decal/siding/yellow{
@@ -12870,6 +13318,15 @@
 "Ww" = (
 /turf/open/water/deep,
 /area/city)
+"Wx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/conveyor_switch/oneway{
+	dir = 4;
+	id = "welfaregarbage";
+	name = "disposal conveyor"
+	},
+/turf/open/floor/plasteel/dark,
+/area/maintenance/disposal)
 "Wy" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -12996,13 +13453,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/closed/mineral/random/facility/atzliuth,
 /area/department_main/discipline)
-"WU" = (
-/obj/effect/turf_decal/siding/brown{
-	dir = 1
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/facility_hallway/welfare)
 "WV" = (
 /turf/closed/mineral/random/facility/atzliuth,
 /area/facility_hallway/discipline)
@@ -13019,13 +13469,6 @@
 "WZ" = (
 /turf/open/floor/plating/ashplanet/rocky,
 /area/city/backstreets_alley)
-"Xa" = (
-/obj/effect/turf_decal/siding/yellow{
-	dir = 1
-	},
-/obj/item/toy/plush/lisa,
-/turf/closed/mineral/random/facility/briah,
-/area/facility_hallway/command)
 "Xb" = (
 /obj/effect/turf_decal/siding/yellow/corner,
 /turf/closed/mineral/random/facility,
@@ -13036,6 +13479,7 @@
 	alpha = 230;
 	icon_state = "LC27"
 	},
+/obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating/rust,
 /area/department_main/command)
 "Xf" = (
@@ -13061,6 +13505,13 @@
 	},
 /turf/open/floor/plating/rust,
 /area/facility_hallway/control)
+"Xj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/siding/yellow{
+	dir = 6
+	},
+/turf/open/floor/plating/rust,
+/area/department_main/command)
 "Xk" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/table_frame/wood,
@@ -13072,7 +13523,6 @@
 /turf/open/floor/carpet/orange,
 /area/department_main/training)
 "Xm" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/plaque{
 	alpha = 230;
 	icon_state = "LC22"
@@ -13087,12 +13537,13 @@
 	icon_state = "LC6"
 	},
 /obj/effect/landmark/delayed/department_center,
+/obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating,
 /area/department_main/command)
 "Xp" = (
 /obj/effect/spawner/lootdrop/maint_drugs,
 /turf/closed/mineral/random/facility,
-/area/facility_hallway/control)
+/area/maintenance/disposal)
 "Xq" = (
 /obj/structure/sign/poster/ripped,
 /obj/machinery/button/door/indestructible{
@@ -13124,6 +13575,7 @@
 /obj/effect/turf_decal/plaque{
 	icon_state = "LC31"
 	},
+/obj/effect/turf_decal/siding/yellow,
 /turf/open/floor/plating,
 /area/department_main/command)
 "Xw" = (
@@ -13269,6 +13721,11 @@
 /obj/effect/turf_decal/siding/blue,
 /turf/open/floor/facility/white,
 /area/city)
+"XU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/siding/yellow/corner,
+/turf/open/floor/wood,
+/area/department_main/command)
 "XV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/departments/training,
@@ -13284,6 +13741,14 @@
 /obj/structure/filingcabinet,
 /turf/open/floor/plating,
 /area/department_main/control)
+"XY" = (
+/obj/item/kirbyplants/photosynthetic,
+/obj/machinery/light/broken{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/wood,
+/area/department_main/command)
 "Yb" = (
 /obj/machinery/light,
 /obj/machinery/light,
@@ -13322,12 +13787,12 @@
 /obj/item/hemostat,
 /turf/open/floor/facility/white,
 /area/city)
-"Yg" = (
-/obj/structure/fans/tiny,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/hatch,
-/turf/open/floor/plasteel/elevatorshaft,
-/area/facility_hallway/welfare)
+"Yf" = (
+/obj/effect/turf_decal/plaque{
+	icon_state = "LC29"
+	},
+/turf/closed/mineral/random/facility/briah,
+/area/facility_hallway/command)
 "Yh" = (
 /obj/structure/sign/poster/contraband/fun_police,
 /turf/closed/indestructible/reinforced,
@@ -13390,10 +13855,10 @@
 /turf/open/floor/carpet/green,
 /area/department_main/safety)
 "Yq" = (
-/obj/effect/turf_decal/siding/yellow{
-	dir = 4
-	},
 /obj/structure/fluff/hedge,
+/obj/effect/turf_decal/siding/yellow{
+	dir = 6
+	},
 /turf/open/floor/plating,
 /area/department_main/command)
 "Yr" = (
@@ -13402,6 +13867,10 @@
 	},
 /turf/open/floor/plating/rust,
 /area/facility_hallway/welfare)
+"Ys" = (
+/obj/item/deepscanner,
+/turf/closed/mineral/random/facility/briah,
+/area/department_main/command)
 "Yt" = (
 /obj/effect/turf_decal/siding/yellow{
 	dir = 8
@@ -13483,6 +13952,13 @@
 "YD" = (
 /turf/open/floor/carpet/donk,
 /area/city/backstreets_alley)
+"YE" = (
+/obj/machinery/light/broken{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plating/rust,
+/area/facility_hallway/command)
 "YF" = (
 /obj/effect/turf_decal/siding/blue,
 /obj/effect/decal/cleanable/dirt,
@@ -13611,6 +14087,14 @@
 /obj/item/ego_weapon/support/dragon_staff,
 /turf/closed/mineral/random/facility,
 /area/department_main/control)
+"YZ" = (
+/obj/effect/turf_decal/siding/yellow,
+/turf/closed/mineral/random/facility/briah,
+/area/department_main/command)
+"Za" = (
+/obj/structure/sign/departments/command,
+/turf/closed/indestructible/reinforced/old,
+/area/department_main/command)
 "Zb" = (
 /obj/effect/turf_decal/siding/yellow{
 	dir = 8
@@ -13641,10 +14125,13 @@
 /turf/open/floor/carpet/green,
 /area/department_main/safety)
 "Ze" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/plaque{
 	alpha = 230;
 	icon_state = "LC9"
+	},
+/obj/effect/decal/cleanable/glass,
+/obj/effect/turf_decal/siding/yellow/corner{
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/department_main/command)
@@ -13724,6 +14211,13 @@
 "Zt" = (
 /turf/closed/wall/mineral/plastitanium,
 /area/facility_hallway/manager)
+"Zu" = (
+/obj/structure/rack,
+/obj/item/instrument/accordion,
+/obj/item/instrument/glockenspiel,
+/obj/item/instrument/piano_synth,
+/turf/open/floor/wood,
+/area/department_main/command)
 "Zv" = (
 /obj/machinery/vending/medical{
 	req_access = list()
@@ -47839,7 +48333,7 @@ mK
 Kb
 vH
 Ta
-Fx
+rw
 Ne
 ZL
 ZL
@@ -48619,11 +49113,11 @@ zW
 ZL
 CQ
 pC
-yO
-SQ
-SQ
-SQ
-yO
+vc
+MB
+MB
+MB
+vc
 ZL
 ZL
 ZL
@@ -48876,11 +49370,11 @@ zW
 ZL
 CQ
 pC
-sc
+PE
 no
 Qx
-SQ
-SQ
+MB
+MB
 ZL
 ZL
 ZL
@@ -49133,7 +49627,7 @@ zW
 ZL
 CQ
 CQ
-yO
+vc
 li
 tN
 sf
@@ -49390,7 +49884,7 @@ zW
 ZL
 ZL
 ZL
-yO
+vc
 AF
 qN
 zP
@@ -49645,13 +50139,13 @@ ZA
 ZA
 zW
 ZL
-SQ
-yO
-SQ
+MB
+vc
+MB
 LE
 qN
 Pz
-yF
+UW
 ZL
 ZL
 ZL
@@ -49902,13 +50396,13 @@ zW
 zW
 zW
 ZL
-SQ
-sc
+MB
+PE
 bw
 Da
 Xp
 Pz
-yF
+UW
 ZL
 ZL
 ZL
@@ -50159,13 +50653,13 @@ ZL
 ZL
 ZL
 ZL
-SQ
+MB
 as
 ox
 KB
 fn
 iV
-yF
+UW
 ZL
 ZL
 ZL
@@ -50416,13 +50910,13 @@ ZL
 ZL
 FO
 ZL
-SQ
+MB
 as
-SQ
+MB
 LH
 mk
 Wa
-yF
+UW
 ZL
 ZL
 ZL
@@ -52475,7 +52969,7 @@ Vh
 LN
 Am
 HS
-pk
+xX
 rZ
 RP
 Sc
@@ -62994,11 +63488,6 @@ ZL
 ZL
 ZL
 ZL
-kV
-LL
-LL
-LL
-LL
 ZL
 ZL
 ZL
@@ -63009,6 +63498,11 @@ ZL
 ZL
 ZL
 ZL
+vc
+MB
+MB
+MB
+MB
 ZL
 ZL
 ZL
@@ -63251,24 +63745,24 @@ ZL
 ZL
 ZL
 ZL
-kV
-NE
-fB
-eL
-Hv
-LL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+vc
+OK
+Or
+iD
+GH
+MB
 ML
 sL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
 ZL
 ZL
 ZL
@@ -63508,24 +64002,24 @@ ZL
 ZL
 ZL
 ZL
-kV
-NE
-cl
-zw
-nJ
-Gu
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+vc
+OK
+Lv
+Wx
+sf
+aA
 Qb
 Ms
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
 ZL
 ZL
 ZL
@@ -63765,24 +64259,24 @@ ZL
 ZL
 ZL
 ZL
-kV
-WU
-Hf
-nP
-Mb
-fM
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+vc
+SX
+RL
+Gc
+GX
+lG
 ZL
 Ms
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
 ZL
 ZL
 ZL
@@ -63997,20 +64491,6 @@ ZL
 ZL
 ZL
 ZL
-LL
-LL
-LL
-LL
-LL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
 ZL
 ZL
 ZL
@@ -64022,24 +64502,38 @@ ZL
 ZL
 ZL
 LL
-Dc
 LL
-cy
-jM
-jP
 LL
+LL
+LL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+MB
+to
+MB
+Wq
+Tt
+Lb
+MB
 ZL
 Ms
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
 ZL
 ZL
 ZL
@@ -64254,20 +64748,6 @@ UZ
 UZ
 UZ
 ZL
-LL
-YO
-YO
-YO
-LL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
 ZL
 ZL
 ZL
@@ -64280,11 +64760,35 @@ ZL
 ZL
 LL
 YO
-Yg
-jM
-jM
-AH
+YO
+YO
 LL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+MB
+Ul
+Ih
+Tt
+Tt
+tL
+MB
 ML
 Qb
 ZL
@@ -64303,16 +64807,6 @@ Dc
 LL
 LL
 LL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
 ZL
 ZL
 ZL
@@ -64511,6 +65005,16 @@ ey
 sW
 UZ
 ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
 LL
 YO
 YO
@@ -64535,13 +65039,13 @@ LL
 ZL
 ZL
 ZL
-LL
-YO
-LL
-kj
-hX
-ls
-LL
+MB
+Ul
+MB
+hM
+GF
+ly
+MB
 Ms
 LL
 LL
@@ -64560,16 +65064,6 @@ ud
 qA
 zc
 LL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
 ZL
 ZL
 ZL
@@ -64768,6 +65262,16 @@ NO
 Rf
 Ox
 ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
 LL
 YO
 YO
@@ -64792,13 +65296,13 @@ LL
 ZL
 ZL
 ZL
-LL
-Pt
-LL
-LL
-LL
-LL
-LL
+MB
+vB
+MB
+MB
+MB
+MB
+MB
 Ms
 LL
 YO
@@ -64817,16 +65321,6 @@ WI
 oo
 gW
 LL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
 ZL
 ZL
 ZL
@@ -65025,6 +65519,16 @@ Bq
 us
 UZ
 ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
 LL
 YO
 YO
@@ -65049,9 +65553,9 @@ LL
 ZL
 ZL
 ZL
-LL
-YO
-LL
+MB
+Ul
+MB
 ZL
 ZL
 ZL
@@ -65074,16 +65578,6 @@ MM
 qH
 gW
 LL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
 ZL
 ZL
 ZL
@@ -65281,6 +65775,16 @@ xO
 RH
 us
 UZ
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
 ZL
 LL
 YO
@@ -65504,16 +66008,6 @@ ZL
 ZL
 ZL
 ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
 "}
 (202,1,1) = {"
 ZL
@@ -65537,6 +66031,16 @@ UZ
 Gn
 bT
 us
+UZ
+ZL
+ZL
+ZL
+ZL
+ZL
+UZ
+UZ
+UZ
+UZ
 UZ
 ZL
 LL
@@ -65761,16 +66265,6 @@ ZL
 ZL
 ZL
 ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
 "}
 (203,1,1) = {"
 ZL
@@ -65794,6 +66288,16 @@ UZ
 Fc
 bT
 us
+UZ
+ZL
+ZL
+ZL
+ZL
+ZL
+UZ
+Nh
+sA
+sA
 UZ
 ZL
 ZL
@@ -66018,16 +66522,6 @@ ZL
 ZL
 ZL
 ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
 "}
 (204,1,1) = {"
 ZL
@@ -66051,6 +66545,16 @@ UZ
 xO
 bT
 UD
+UZ
+ZL
+ZL
+ZL
+ZL
+ZL
+UZ
+sA
+Oc
+Mi
 UZ
 ZL
 ZL
@@ -66275,16 +66779,6 @@ ZL
 ZL
 ZL
 ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
 "}
 (205,1,1) = {"
 ZL
@@ -66308,6 +66802,16 @@ UZ
 xO
 RH
 us
+UZ
+ZL
+ZL
+ZL
+ZL
+ZL
+UZ
+sA
+sA
+sA
 UZ
 UZ
 UZ
@@ -66532,16 +67036,6 @@ ZL
 ZL
 ZL
 ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
 "}
 (206,1,1) = {"
 ZL
@@ -66565,6 +67059,16 @@ Ox
 jw
 RH
 Rf
+UZ
+UZ
+UZ
+UZ
+UZ
+UZ
+UZ
+lK
+hX
+lK
 UZ
 iR
 iR
@@ -66789,16 +67293,6 @@ ZL
 ZL
 ZL
 ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
 "}
 (207,1,1) = {"
 ZL
@@ -66822,6 +67316,16 @@ FI
 xO
 RH
 Rf
+UZ
+vy
+RH
+bT
+or
+au
+bT
+bT
+RH
+RH
 UZ
 iR
 iR
@@ -67046,16 +67550,6 @@ ZL
 ZL
 ZL
 ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
 "}
 (208,1,1) = {"
 ZL
@@ -67079,6 +67573,16 @@ UZ
 xO
 bT
 us
+UZ
+YE
+RH
+bT
+NB
+NB
+RH
+bT
+au
+au
 UZ
 iR
 iR
@@ -67303,16 +67807,6 @@ ZL
 ZL
 ZL
 ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
 "}
 (209,1,1) = {"
 ZL
@@ -67336,6 +67830,16 @@ UZ
 Yk
 bT
 us
+UZ
+RH
+au
+NB
+tt
+RH
+IW
+RH
+NB
+RH
 UZ
 iR
 iR
@@ -67560,16 +68064,6 @@ ZL
 ZL
 ZL
 ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
 "}
 (210,1,1) = {"
 ZL
@@ -67594,6 +68088,16 @@ Yk
 bT
 Rf
 Oj
+bT
+bT
+ab
+ce
+ce
+ce
+Za
+Ri
+Za
+ce
 iR
 iR
 iR
@@ -67817,16 +68321,6 @@ ZL
 ZL
 ZL
 ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
 "}
 (211,1,1) = {"
 ZL
@@ -67851,6 +68345,16 @@ xO
 RH
 Rf
 UZ
+RH
+RH
+RH
+ce
+Zu
+Ap
+Ue
+WW
+cP
+ce
 UZ
 Ox
 UZ
@@ -68074,16 +68578,6 @@ ZL
 ZL
 ZL
 ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
 "}
 (212,1,1) = {"
 ZL
@@ -68108,7 +68602,17 @@ xO
 RH
 hw
 UZ
-Zb
+RH
+RH
+RH
+ce
+gD
+uy
+mD
+Np
+gD
+ce
+sH
 Zb
 Zb
 Zb
@@ -68331,16 +68835,6 @@ ZL
 ZL
 ZL
 ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
 "}
 (213,1,1) = {"
 ZL
@@ -68366,6 +68860,16 @@ RH
 cH
 oi
 RH
+bT
+RH
+ce
+gD
+td
+yG
+Wo
+ej
+ce
+Yk
 RH
 RH
 RH
@@ -68588,16 +69092,6 @@ ZL
 ZL
 ZL
 ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
 "}
 (214,1,1) = {"
 ZL
@@ -68618,15 +69112,25 @@ ZL
 ZL
 ZL
 UZ
-im
+JQ
 UM
-Ss
+Aj
 UZ
+RH
+bT
+RH
+ce
+Fv
+Pb
+yG
+tf
+JM
+ce
+JQ
 Hq
 Hq
-Hq
-SN
-SN
+Wt
+PQ
 Hq
 Aj
 UZ
@@ -68845,16 +69349,6 @@ ZL
 ZL
 ZL
 ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
 "}
 (215,1,1) = {"
 ZL
@@ -68875,12 +69369,22 @@ ZL
 ZL
 ZL
 ce
-ce
+Za
 Ks
+Za
 ce
 ce
 ce
 ce
+ce
+Bu
+Pb
+yG
+tf
+xH
+ce
+ce
+Ri
 ce
 ce
 UZ
@@ -69102,16 +69606,6 @@ ZL
 ZL
 ZL
 ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
 "}
 (216,1,1) = {"
 ZL
@@ -69134,11 +69628,21 @@ ce
 Uz
 wq
 ZO
-HO
+ZO
 CD
 xY
 Yz
 kO
+Za
+WW
+Pb
+gD
+tf
+ZO
+sg
+WW
+gD
+gD
 ce
 ZX
 nA
@@ -69359,16 +69863,6 @@ ZL
 ZL
 ZL
 ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
 "}
 (217,1,1) = {"
 ZL
@@ -69388,14 +69882,24 @@ aG
 UT
 wh
 da
-yQ
-yQ
-PB
+ce
+ce
+zw
 PB
 cV
 Yt
 gi
 ZM
+ce
+xh
+Pb
+gD
+zC
+mD
+Vx
+mD
+vD
+oh
 ce
 lH
 hu
@@ -69616,16 +70120,6 @@ ZL
 ZL
 ZL
 ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
 "}
 (218,1,1) = {"
 ZL
@@ -69645,7 +70139,7 @@ yg
 am
 kO
 fl
-Zx
+pR
 ce
 Js
 Zx
@@ -69653,6 +70147,16 @@ OT
 am
 dS
 eN
+ce
+WW
+Pb
+yG
+gD
+gD
+gD
+ZO
+YZ
+xd
 ce
 Zc
 iu
@@ -69873,16 +70377,6 @@ ZL
 ZL
 ZL
 ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
 "}
 (219,1,1) = {"
 ZL
@@ -69902,14 +70396,24 @@ Ui
 am
 am
 UP
-WW
+EO
 Nl
 Ze
 pF
 oA
 ZO
 nS
-TY
+ZO
+Ri
+ZO
+td
+gD
+ha
+gD
+gD
+tz
+Wo
+kv
 ce
 UZ
 PW
@@ -69936,23 +70440,13 @@ xO
 DA
 Aj
 Oj
-ez
+tR
 wK
 RC
 wK
 nG
 lQ
 Ms
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
 ZL
 ZL
 ZL
@@ -70168,7 +70662,17 @@ JH
 Mk
 yG
 ce
-ov
+ZO
+Pb
+gD
+gD
+gD
+gD
+ZO
+Wo
+cP
+Za
+Bp
 ip
 aP
 Ot
@@ -70387,16 +70891,6 @@ ZL
 ZL
 ZL
 ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
 "}
 (221,1,1) = {"
 ZL
@@ -70423,6 +70917,16 @@ UQ
 qb
 HQ
 Xv
+ZO
+FM
+WW
+Pb
+ZO
+AE
+gD
+gD
+ZO
+Wo
 ZO
 Ks
 GY
@@ -70644,16 +71148,6 @@ ZL
 ZL
 ZL
 ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
 "}
 (222,1,1) = {"
 ZL
@@ -70682,7 +71176,17 @@ Xd
 sm
 ZO
 ce
-cI
+ZO
+Pb
+gD
+gD
+ZO
+gD
+ZO
+tf
+Fb
+Za
+Tn
 SN
 SN
 OJ
@@ -70901,16 +71405,6 @@ ZL
 ZL
 ZL
 ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
 "}
 (223,1,1) = {"
 ZL
@@ -70930,14 +71424,24 @@ Th
 am
 am
 Rb
-al
+XU
 Od
 FL
 MQ
 ue
-kO
+Qf
 Ib
-sA
+ZO
+Ri
+ZO
+Pb
+gD
+ZO
+ZO
+ZO
+ZO
+tf
+Fs
 ce
 UZ
 Ox
@@ -71158,16 +71662,6 @@ ZL
 ZL
 ZL
 ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
 "}
 (224,1,1) = {"
 ZL
@@ -71187,7 +71681,7 @@ hm
 am
 kO
 am
-Zx
+Xj
 FM
 al
 Zx
@@ -71195,6 +71689,16 @@ OT
 Zx
 rL
 Jt
+ce
+ZO
+LY
+Ys
+yG
+yG
+ZO
+ZO
+YZ
+Ke
 ce
 vg
 vg
@@ -71415,16 +71919,6 @@ ZL
 ZL
 ZL
 ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
 "}
 (225,1,1) = {"
 ZL
@@ -71444,14 +71938,24 @@ wm
 PD
 tV
 Yq
-BK
-BK
-Ov
+ce
+ce
+QQ
 fe
 fe
 fe
 WD
 OQ
+uk
+qg
+Vj
+ta
+vL
+tb
+tb
+RY
+IN
+iT
 uk
 TI
 TI
@@ -71672,16 +72176,6 @@ ZL
 ZL
 ZL
 ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
 "}
 (226,1,1) = {"
 ZL
@@ -71702,13 +72196,23 @@ uU
 ce
 ce
 Uz
-Jv
+wq
 ZO
-TX
+ZO
 zZ
 pU
 lN
 Xu
+Za
+Mz
+Pb
+ZO
+tf
+ZO
+Oy
+WW
+ZO
+gD
 ce
 vg
 vg
@@ -71929,16 +72433,6 @@ ZL
 ZL
 ZL
 ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
 "}
 (227,1,1) = {"
 ZL
@@ -71959,12 +72453,22 @@ ZL
 ZL
 ZL
 ce
-ce
+Za
 GU
+Za
 ce
 ce
 ce
 ce
+ce
+Ea
+Pb
+ZO
+Wo
+GA
+ce
+ce
+Ri
 ce
 ce
 UZ
@@ -72186,16 +72690,6 @@ ZL
 ZL
 ZL
 ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
 "}
 (228,1,1) = {"
 ZL
@@ -72216,14 +72710,24 @@ ZL
 ZL
 ZL
 UZ
-fI
+pJ
 ip
-Rn
+Wu
 UZ
+RH
+RH
+RH
+ce
+pQ
+LY
+ZO
+Wo
+JM
+ce
 sH
 Zb
 Zb
-Zb
+eI
 jC
 Zb
 nQ
@@ -72443,16 +72947,6 @@ ZL
 ZL
 ZL
 ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
 "}
 (229,1,1) = {"
 ZL
@@ -72474,10 +72968,20 @@ ZL
 ZL
 wI
 Yk
-bT
+RH
 ST
 oi
-GY
+RH
+RH
+bT
+ce
+UH
+Pb
+ZO
+tf
+xH
+ce
+Yk
 RH
 RH
 RH
@@ -72700,16 +73204,6 @@ ZL
 ZL
 ZL
 ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
 "}
 (230,1,1) = {"
 ZL
@@ -72734,6 +73228,16 @@ Yk
 bT
 pK
 UZ
+RH
+Yf
+bT
+ce
+Wm
+QQ
+Mn
+ju
+gD
+ce
 QZ
 Hq
 SN
@@ -72957,16 +73461,6 @@ ZL
 ZL
 ZL
 ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
 "}
 (231,1,1) = {"
 ZL
@@ -72991,6 +73485,16 @@ xO
 RH
 Rf
 UZ
+RH
+RH
+RH
+ce
+Tv
+dY
+XY
+ZO
+NK
+ce
 UZ
 UZ
 UZ
@@ -73214,16 +73718,6 @@ ZL
 ZL
 ZL
 ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
 "}
 (232,1,1) = {"
 ZL
@@ -73248,6 +73742,16 @@ Gn
 bT
 Rf
 UZ
+bT
+RH
+ab
+ce
+ce
+ce
+Za
+Ri
+Za
+ce
 iR
 iR
 iR
@@ -73471,16 +73975,6 @@ ZL
 ZL
 ZL
 ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
 "}
 (233,1,1) = {"
 ZL
@@ -73501,9 +73995,19 @@ UZ
 UZ
 UZ
 UZ
-oF
+oc
 bT
-Rf
+us
+UZ
+au
+au
+NB
+RH
+YU
+Bf
+bT
+RH
+RH
 UZ
 iR
 iR
@@ -73728,16 +74232,6 @@ ZL
 ZL
 ZL
 ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
 "}
 (234,1,1) = {"
 ZL
@@ -73762,6 +74256,16 @@ xO
 RH
 Rf
 Ox
+YE
+bT
+au
+bT
+bT
+RH
+au
+au
+au
+UZ
 iR
 iR
 iR
@@ -73985,16 +74489,6 @@ ZL
 ZL
 ZL
 ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
 "}
 (235,1,1) = {"
 ZL
@@ -74015,9 +74509,19 @@ iR
 iR
 iR
 UZ
-Xa
-RH
+xO
+bT
 us
+UZ
+nz
+RH
+RH
+Cm
+RH
+au
+au
+bT
+cn
 UZ
 iR
 iR
@@ -74242,16 +74746,6 @@ ZL
 ZL
 ZL
 ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
 "}
 (236,1,1) = {"
 ZL
@@ -74275,6 +74769,16 @@ Ox
 xO
 RH
 pK
+UZ
+UZ
+UZ
+UZ
+UZ
+UZ
+UZ
+lK
+Tf
+lK
 UZ
 iR
 iR
@@ -74499,16 +75003,6 @@ ZL
 ZL
 ZL
 ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
 "}
 (237,1,1) = {"
 ZL
@@ -74532,6 +75026,16 @@ FI
 xO
 RH
 us
+UZ
+ZL
+ZL
+ZL
+ZL
+ZL
+UZ
+Nh
+sA
+sA
 UZ
 UZ
 UZ
@@ -74756,16 +75260,6 @@ ZL
 ZL
 ZL
 ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
 "}
 (238,1,1) = {"
 ZL
@@ -74787,8 +75281,18 @@ iR
 iR
 UZ
 Yk
-RH
+bT
 us
+UZ
+ZL
+ZL
+ZL
+ZL
+ZL
+UZ
+sA
+cQ
+Mi
 UZ
 ZL
 nt
@@ -75013,16 +75517,6 @@ ZL
 ZL
 ZL
 ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
 "}
 (239,1,1) = {"
 ZL
@@ -75046,6 +75540,16 @@ UZ
 Yk
 bT
 bF
+UZ
+ZL
+ZL
+ZL
+ZL
+ZL
+UZ
+sA
+sA
+sA
 UZ
 ZL
 nt
@@ -75270,16 +75774,6 @@ ZL
 ZL
 ZL
 ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
 "}
 (240,1,1) = {"
 ZL
@@ -75300,9 +75794,19 @@ iR
 iR
 iR
 UZ
-Yk
+xO
 RH
 us
+UZ
+ZL
+ZL
+ZL
+ZL
+ZL
+UZ
+UZ
+UZ
+UZ
 UZ
 ZL
 nt
@@ -75527,16 +76031,6 @@ ZL
 ZL
 ZL
 ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
 "}
 (241,1,1) = {"
 ZL
@@ -75561,6 +76055,16 @@ xO
 RH
 Rf
 UZ
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
 ZL
 nt
 qF
@@ -75784,16 +76288,6 @@ ZL
 ZL
 ZL
 ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
 "}
 (242,1,1) = {"
 ZL
@@ -75818,6 +76312,16 @@ oc
 JG
 Rf
 UZ
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
 ZL
 nt
 qF
@@ -76041,16 +76545,6 @@ ZL
 ZL
 ZL
 ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
 "}
 (243,1,1) = {"
 ZL
@@ -76075,6 +76569,16 @@ Yk
 Bq
 Rf
 Ox
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
 ZL
 nt
 qF
@@ -76298,16 +76802,6 @@ ZL
 ZL
 ZL
 ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
 "}
 (244,1,1) = {"
 ZL
@@ -76332,6 +76826,16 @@ JQ
 Hq
 Dv
 UZ
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
 ZL
 nt
 nt
@@ -76382,16 +76886,6 @@ Dq
 iz
 Ag
 nt
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
 ZL
 ZL
 ZL
@@ -76626,6 +77120,16 @@ ZL
 ZL
 ZL
 ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
+ZL
 nt
 jo
 nt
@@ -76639,16 +77143,6 @@ nt
 jo
 nt
 nt
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
-ZL
 ZL
 ZL
 ZL


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

What it says on the tin.

Also maps Shelter from the 27th of March and Backwards Clock into District4, at the Briah layer.

Corroded security agents can now fire at point blank, with their ranged cooldown doubled.

The eastern wing of CC now lacks an open route for the abnormality to path through.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

**Before:**
<img width="1335" height="1151" alt="image" src="https://github.com/user-attachments/assets/b78f512d-8047-4af1-bf10-109b5064be51" />

**After:**
<img width="1703" height="1249" alt="image" src="https://github.com/user-attachments/assets/5421165e-5251-4ba2-aded-5aad78c0a085" />

## Why It's Good For The Game

Approaching the briah layer is the most dangerous part of this map. Most players will have their attributes anywhere between 40 and 55 at this point, while potentially contending with three or more WAW-level abnormalities. This, combined with the confined area, made it excessively difficult for unprepared players. This PR expands the initial area that players can explore upon reaching the layer, without needing to trip too many mining events.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: mapping changes
balance: ER mob nerf
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
