### PR TITLE
Removes EXP from the Adventure Console

### DIFF
--- a/ModularTegustation/lc13_obj/_adventure_console/adventure_layout.dm
+++ b/ModularTegustation/lc13_obj/_adventure_console/adventure_layout.dm
@@ -115,7 +115,6 @@
 		new /datum/data/extraction_cargo("TOY SWORD",	/obj/item/toy/waterballoon,			10) = 1,
 		new /datum/data/extraction_cargo("CAT TOY",	/obj/item/toy/cattoy,					15) = 1,
 		new /datum/data/extraction_cargo("PLUSH OF A FRIEND",/obj/item/toy/plush/binah,		15) = 1,
-		new /datum/data/extraction_cargo("UNMARKED CRATE",/obj/structure/lootcrate,			20) = 1,
 		new /datum/data/extraction_cargo("HOURGLASS",	/obj/item/hourglass,				25) = 1,
 		new /datum/data/extraction_cargo("CAT",	/mob/living/simple_animal/pet/cat,			50) = 1,
 		new /datum/data/extraction_cargo("CAK",	/mob/living/simple_animal/pet/cat/cak,		100) = 1,
@@ -126,7 +125,7 @@
 		new /datum/data/extraction_cargo("A GRENADE",				/obj/effect/spawner/lootdrop/grenade,	3) = 1,
 		new /datum/data/extraction_cargo("SOME AHN",				/obj/item/stack/spacecash/c500,			5) = 1,
 		new /datum/data/extraction_cargo("POSITIVE ENKEPHALIN",		/obj/item/rawpe,						10) = 1,
-		new /datum/data/extraction_cargo("EXPERIENCE",				/obj/item/attribute_increase/small,		15) = 1,
+		new /datum/data/extraction_cargo("UNMARKED CRATE",			/obj/structure/lootcrate,				15) = 1,
 	)
 
 	var/list/exchange_upgrade_list = list(


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
## This is a high-importance Pull Request as Senior staff has deemed it necessary to merge ASAP.
## This PR involves minimal code and has been confirmed to cause no issues.

## About The Pull Request
This PR removes the EXP ampules from the adventure console.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This was originally a test; that players abused to get absurd amounts of EXP very quickly.
This makes it such that players can no longer get EXP from said console.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Removed EXP Ampules from the adventure console.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
