### PR TITLE
makes chance refinary less op

### DIFF
--- a/ModularTegustation/tegu_items/refinery/alt_refinery/chance.dm
+++ b/ModularTegustation/tegu_items/refinery/alt_refinery/chance.dm
@@ -3,7 +3,7 @@
 	desc = "A machine used by the Extraction Officer to coinflip for a refined PE box. Costs 40 cargo PE."
 	icon_state = "dominator-purple"
 	extraction_cost = 40
-	reset_time = 20 SECONDS
+	var reset_time = 20 SECONDS
 	var ready = TRUE
 
 /obj/structure/altrefiner/chance/examine(mob/user)

--- a/ModularTegustation/tegu_items/refinery/alt_refinery/chance.dm
+++ b/ModularTegustation/tegu_items/refinery/alt_refinery/chance.dm
@@ -3,8 +3,8 @@
 	desc = "A machine used by the Extraction Officer to coinflip for a refined PE box. Costs 40 cargo PE."
 	icon_state = "dominator-purple"
 	extraction_cost = 40
-	var reset_time = 20 SECONDS
-	var ready = TRUE
+	var/reset_time = 20 SECONDS
+	var/ready = TRUE
 
 /obj/structure/altrefiner/chance/examine(mob/user)
 	. = ..()

--- a/ModularTegustation/tegu_items/refinery/alt_refinery/chance.dm
+++ b/ModularTegustation/tegu_items/refinery/alt_refinery/chance.dm
@@ -1,17 +1,25 @@
 /obj/structure/altrefiner/chance
 	name = "Chance Refinery"
-	desc = "A machine used by the Extraction Officer to coinflip for a refined PE box. Costs 25 cargo PE."
+	desc = "A machine used by the Extraction Officer to coinflip for a refined PE box. Costs 40 cargo PE."
 	icon_state = "dominator-purple"
-	extraction_cost = 25
+	extraction_cost = 40
+	reset_time = 20 SECONDS
+	var ready = TRUE
 
 /obj/structure/altrefiner/chance/examine(mob/user)
 	. = ..()
 	if (GetFacilityUpgradeValue(UPGRADE_EXTRACTION_1))
 		. += span_notice( "This machine seems to be upgraded, increasing its chance to 75%.")
 
+/obj/structure/altrefiner/chance/proc/reset()
+	ready = TRUE
+
 /obj/structure/altrefiner/chance/attack_hand(mob/living/carbon/M)
 	. = ..()
 	if(!.)
+		return
+	if(!ready)
+		to_chat(M, span_warning("The refinery is still processing. Please wait."))
 		return
 	var/success_chance = 50
 	if (GetFacilityUpgradeValue(UPGRADE_EXTRACTION_1))
@@ -23,3 +31,6 @@
 	else
 		playsound(get_turf(src), 'sound/machines/terminal_prompt_deny.ogg', 50, TRUE)
 		to_chat(M, span_warning("Refining failure. Please try again."))
+	ready = FALSE
+
+	addtimer(CALLBACK(src, PROC_REF(reset)), reset_time)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

nerfs chance refinery since its currently able to buy refined boxes for the same price as a raw on 0cd

## Why It's Good For The Game

chance refinery is op

## Changelog
:cl:
balance: chance refinery costs 40pe
balance: chance refinery has a 20s cooldown
/:cl: