### PR TITLE
CoL Update: Killing Multitools/Door Hacking

### DIFF
--- a/_maps/map_files/Event/city.dmm
+++ b/_maps/map_files/Event/city.dmm
@@ -6422,16 +6422,6 @@
 /obj/item/clothing/suit/apron,
 /turf/open/indestructible/white,
 /area/city/shop)
-"Ur" = (
-/obj/structure/delivery_door{
-	density = 1;
-	desc = "A mailbox for this house.";
-	icon = 'icons/obj/votebox.dmi';
-	icon_state = "votebox_maint";
-	name = "mail box"
-	},
-/turf/closed/indestructible/reinforced,
-/area/space)
 "Us" = (
 /obj/structure/chair/office/light,
 /turf/open/floor/plasteel/white,
@@ -40627,7 +40617,7 @@ Gz
 wX
 zA
 It
-Ur
+xO
 Hz
 Hz
 lV

--- a/_maps/map_files/Event/city.dmm
+++ b/_maps/map_files/Event/city.dmm
@@ -4873,7 +4873,6 @@
 /turf/open/indestructible/white,
 /area/city/shop)
 "Jy" = (
-/obj/item/storage/toolbox/mechanical,
 /obj/structure/closet,
 /obj/item/ego_weapon/city/district23,
 /obj/machinery/light/small,

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -112,6 +112,7 @@
 	var/air_tight = FALSE	//TRUE means density will be set as soon as the door begins to close
 	var/prying_so_hard = FALSE
 	var/whitelist_door	//Whistlist stuff
+	var/hackable = FALSE	//If FALSE, tools cannot be used to hack into the airlock's wires
 
 	flags_1 = RAD_PROTECT_CONTENTS_1 | RAD_NO_CONTAMINATE_1
 	rad_insulation = RAD_MEDIUM_INSULATION
@@ -758,6 +759,9 @@
 				visible_message("<span class='danger'>[user] headbutts the airlock. Good thing [user.p_theyre()] wearing a helmet.</span>")
 
 /obj/machinery/door/airlock/attempt_wire_interaction(mob/user)
+	if(!hackable)
+		to_chat(user, "<span class='warning'>This airlock's internal systems are inaccessible!</span>")
+		return WIRE_INTERACTION_FAIL
 	if(security_level)
 		to_chat(user, "<span class='warning'>Wires are protected!</span>")
 		return WIRE_INTERACTION_FAIL
@@ -925,6 +929,10 @@
 			return
 
 		if(whitelist_door)		//Whitelist doors kill you if you fucking open them. Crispy clerk.
+			return
+
+		if(!hackable && !panel_open)
+			to_chat(user, "<span class='warning'>This airlock's maintenance panel cannot be accessed!</span>")
 			return
 
 		panel_open = !panel_open

--- a/code/game/objects/items/devices/multitool.dm
+++ b/code/game/objects/items/devices/multitool.dm
@@ -33,6 +33,12 @@
 	var/obj/machinery/buffer // simple machine buffer for device linkage
 	var/mode = 0
 
+/obj/item/multitool/Initialize()
+	. = ..()
+	if(SSmaptype.maptype in SSmaptype.citymaps)
+		qdel(src)
+		return INITIALIZE_HINT_QDEL
+
 /obj/item/multitool/examine(mob/user)
 	. = ..()
 	. += span_notice("Its buffer [buffer ? "contains [buffer]." : "is empty."]")

--- a/code/game/objects/items/devices/multitool.dm
+++ b/code/game/objects/items/devices/multitool.dm
@@ -32,12 +32,14 @@
 	usesound = 'sound/weapons/empty.ogg'
 	var/obj/machinery/buffer // simple machine buffer for device linkage
 	var/mode = 0
+	var/city_break = TRUE
 
 /obj/item/multitool/Initialize()
 	. = ..()
-	if(SSmaptype.maptype in SSmaptype.citymaps)
-		qdel(src)
-		return INITIALIZE_HINT_QDEL
+	if(city_break)
+		if(SSmaptype.maptype in SSmaptype.citymaps)
+			qdel(src)
+			return INITIALIZE_HINT_QDEL
 
 /obj/item/multitool/examine(mob/user)
 	. = ..()
@@ -47,6 +49,8 @@
 	user.visible_message(span_suicide("[user] puts the [src] to [user.p_their()] chest. It looks like [user.p_theyre()] trying to pulse [user.p_their()] heart off!"))
 	return OXYLOSS//theres a reason it wasn't recommended by doctors
 
+/obj/item/multitool/admin
+	city_break = FALSE
 
 // Syndicate device disguised as a multitool; it will turn red when an AI camera is nearby.
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes all multitools delete themselves in city modes, (Also adds an admin multitool which doesn't remove itself). Also, adds a toggle to all doors, which makes them unhackable by default.

## Why It's Good For The Game

Multi-tools can be used to break doors, and in the current state, doors are used in CoL; they will be impossible to fix without admin help. So, making them hackable by default should fix the problem.

## Changelog
:cl:
tweak: tweaked doors to be unhackable
balance: removed multitools from city modes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
