### PR TITLE
Damage Type Shuffle Pale Adjustment

### DIFF
--- a/ModularTegustation/ego_weapons/_ego_weapon.dm
+++ b/ModularTegustation/ego_weapons/_ego_weapon.dm
@@ -235,10 +235,6 @@
 	if(GLOB.damage_type_shuffler?.is_enabled && IsColorDamageType(damage_type))
 		var/datum/damage_type_shuffler/shuffler = GLOB.damage_type_shuffler
 		var/new_damage_type = shuffler.mapping_offense[damage_type]
-		if(new_damage_type == PALE_DAMAGE && damage_type != PALE_DAMAGE)
-			damage *= shuffler.pale_debuff
-		else if(new_damage_type != PALE_DAMAGE && damage_type == PALE_DAMAGE)
-			damage /= shuffler.pale_debuff
 		damage_type = new_damage_type
 	if(force_multiplier != 1)
 		return span_notice("It deals [round(damage * force_multiplier, 0.1)] [damage_type] damage. (+ [(force_multiplier - 1) * 100]%)")

--- a/ModularTegustation/ego_weapons/ranged/_ranged.dm
+++ b/ModularTegustation/ego_weapons/ranged/_ranged.dm
@@ -169,10 +169,6 @@
 	if(GLOB.damage_type_shuffler?.is_enabled && IsColorDamageType(damage_type))
 		var/datum/damage_type_shuffler/shuffler = GLOB.damage_type_shuffler
 		var/new_damage_type = shuffler.mapping_offense[damage_type]
-		if(new_damage_type == PALE_DAMAGE && damage_type != PALE_DAMAGE)
-			damage *= shuffler.pale_debuff
-		else if(new_damage_type != PALE_DAMAGE && damage_type == PALE_DAMAGE)
-			damage /= shuffler.pale_debuff
 		damage_type = new_damage_type
 	if(force_multiplier != 1)
 		return span_notice("It deals [round(damage * force_multiplier, 0.1)] [damage_type] damage in melee. (+ [(force_multiplier - 1) * 100]%)")
@@ -186,10 +182,6 @@
 	if(GLOB.damage_type_shuffler?.is_enabled && IsColorDamageType(damage_type))
 		var/datum/damage_type_shuffler/shuffler = GLOB.damage_type_shuffler
 		var/new_damage_type = shuffler.mapping_offense[damage_type]
-		if(new_damage_type == PALE_DAMAGE && damage_type != PALE_DAMAGE)
-			damage = round(last_projectile_damage * shuffler.pale_debuff, 0.1)
-		else if(new_damage_type != PALE_DAMAGE && damage_type == PALE_DAMAGE)
-			damage = round(last_projectile_damage / shuffler.pale_debuff, 0.1)
 		damage_type = new_damage_type
 	if(pellets > 1)	//for shotguns
 		return span_notice("Its bullets deal [damage] x [pellets] [damage_type] damage.[projectile_damage_multiplier != 1 ? " (+ [(projectile_damage_multiplier - 1) * 100]%)" : ""]")

--- a/code/datums/abnormality/_ego_datum/_ego_datum.dm
+++ b/code/datums/abnormality/_ego_datum/_ego_datum.dm
@@ -47,10 +47,6 @@ GLOBAL_LIST_EMPTY(ego_datums)
 		if(GLOB.damage_type_shuffler?.is_enabled && IsColorDamageType(bullet_damage_type))
 			var/datum/damage_type_shuffler/shuffler = GLOB.damage_type_shuffler
 			var/new_damage_type = shuffler.mapping_offense[bullet_damage_type]
-			if(new_damage_type == PALE_DAMAGE && bullet_damage_type != PALE_DAMAGE)
-				bullet_damage *= shuffler.pale_debuff
-			else if(new_damage_type != PALE_DAMAGE && bullet_damage_type == PALE_DAMAGE)
-				bullet_damage /= shuffler.pale_debuff
 			bullet_damage_type = new_damage_type
 		information["attribute_requirements"] = E.attribute_requirements.Copy()
 		information["attack_info"] = "Its bullets deal [bullet_damage] [bullet_damage_type] damage."
@@ -77,10 +73,6 @@ GLOBAL_LIST_EMPTY(ego_datums)
 	if(GLOB.damage_type_shuffler?.is_enabled && IsColorDamageType(damage_type))
 		var/datum/damage_type_shuffler/shuffler = GLOB.damage_type_shuffler
 		var/new_damage_type = shuffler.mapping_offense[damage_type]
-		if(new_damage_type == PALE_DAMAGE && damage_type != PALE_DAMAGE)
-			damage *= shuffler.pale_debuff
-		else if(new_damage_type != PALE_DAMAGE && damage_type == PALE_DAMAGE)
-			damage /= shuffler.pale_debuff
 		damage_type = new_damage_type
 	information["attack_info"] = "It deals [damage] [damage_type] damage."
 	information["throwforce"] = E.throwforce

--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -18,10 +18,6 @@
 	if(GLOB.damage_type_shuffler?.is_enabled && IsColorDamageType(damagetype))
 		var/datum/damage_type_shuffler/shuffler = GLOB.damage_type_shuffler
 		var new_damage_type = shuffler.mapping_offense[damagetype]
-		if(new_damage_type == PALE_DAMAGE && damagetype != PALE_DAMAGE)
-			damage *= shuffler.pale_debuff
-		else if(new_damage_type != PALE_DAMAGE && damagetype == PALE_DAMAGE)
-			damage /= shuffler.pale_debuff
 		damagetype = new_damage_type
 	var/signal_return = SEND_SIGNAL(src, COMSIG_MOB_APPLY_DAMGE, damage, damagetype, def_zone)
 	if(signal_return & COMPONENT_MOB_DENY_DAMAGE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Pale buff/debuff modifier will only apply to damage received by humans.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Should make pale weapons viable against mobs during damage type shuffle.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Damage Type Shuffle pale debuff modifier now only applies to damage taken by humans.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
