### PR TITLE
Slight adjustments to the game's pace

### DIFF
--- a/ModularTegustation/lc13_obj/lc13_computers/abnormality_work.dm
+++ b/ModularTegustation/lc13_obj/lc13_computers/abnormality_work.dm
@@ -226,7 +226,7 @@
 		work_chance -= 10
 	if(was_melting == MELTDOWN_CYAN)
 		work_chance -= 20
-	var/work_speed = 2 SECONDS / (1 + ((get_modified_attribute_level(user, TEMPERANCE_ATTRIBUTE) + datum_reference.understanding) / 100))
+	var/work_speed = 1.5 SECONDS / (1 + ((get_modified_attribute_level(user, TEMPERANCE_ATTRIBUTE) + datum_reference.understanding) / 100))
 	switch(work_bonus)
 		if(EXTRACTION_KEY)
 			if (GetFacilityUpgradeValue(UPGRADE_EXTRACTION_1))

--- a/code/__HELPERS/lobotomy_corp.dm
+++ b/code/__HELPERS/lobotomy_corp.dm
@@ -12,13 +12,15 @@
 				continue
 		. += H
 
-/// Returns amount of available agents that can work (Also Suppression Agents if suppressioncount = TRUE)
-/proc/AvailableAgentCount(suppressioncount = FALSE)
+/// Returns amount of available agents that can work
+/proc/AvailableAgentCount()
 	. = 0
-	for(var/mob/living/carbon/human/H in AllLivingAgents(suppressioncount))
+	for(var/mob/living/carbon/human/H in AllLivingAgents(FALSE))
 		if(!H.client)
 			continue
 		if(!H.mind)
+			continue
+		if(!is_station_level(H.z))
 			continue
 		. += 1
 

--- a/code/controllers/subsystem/abnormality_queue.dm
+++ b/code/controllers/subsystem/abnormality_queue.dm
@@ -35,7 +35,7 @@ SUBSYSTEM_DEF(abnormality_queue)
 	/// World time at which new abnormality will be spawned
 	var/next_abno_spawn = INFINITY
 	/// Wait time for next abno spawn; This time is further affected by amount of abnos in facility
-	var/next_abno_spawn_time = 5.5 MINUTES
+	var/next_abno_spawn_time = 4 MINUTES
 	/// Tracks if the current pick is forced
 	var/fucked_it_lets_rolled = FALSE
 	/// Due to Managers not passing the Litmus Test, divine approval is now necessary for red roll
@@ -68,7 +68,7 @@ SUBSYSTEM_DEF(abnormality_queue)
 /datum/controller/subsystem/abnormality_queue/proc/SpawnAbno()
 	// Earlier in the game, abnormalities will spawn faster and then slow down a bit
 	previous_abno_spawn = world.time
-	next_abno_spawn = world.time + next_abno_spawn_time + ((min(16, spawned_abnos) - 6) * 9) SECONDS
+	next_abno_spawn = world.time + next_abno_spawn_time + ((min(16, spawned_abnos) - 6) * 6) SECONDS
 
 	if(!length(GLOB.abnormality_room_spawners))
 		return

--- a/code/controllers/subsystem/abnormality_queue.dm
+++ b/code/controllers/subsystem/abnormality_queue.dm
@@ -68,7 +68,7 @@ SUBSYSTEM_DEF(abnormality_queue)
 /datum/controller/subsystem/abnormality_queue/proc/SpawnAbno()
 	// Earlier in the game, abnormalities will spawn faster and then slow down a bit
 	previous_abno_spawn = world.time
-	next_abno_spawn = world.time + next_abno_spawn_time + ((min(16, spawned_abnos) - 6) * 6) SECONDS
+	next_abno_spawn = world.time + next_abno_spawn_time + ((min(16, spawned_abnos) - round(rooms_start * 0.5)) * 8) SECONDS
 
 	if(!length(GLOB.abnormality_room_spawners))
 		return

--- a/code/controllers/subsystem/abnormality_queue.dm
+++ b/code/controllers/subsystem/abnormality_queue.dm
@@ -68,7 +68,7 @@ SUBSYSTEM_DEF(abnormality_queue)
 /datum/controller/subsystem/abnormality_queue/proc/SpawnAbno()
 	// Earlier in the game, abnormalities will spawn faster and then slow down a bit
 	previous_abno_spawn = world.time
-	next_abno_spawn = world.time + next_abno_spawn_time + ((min(16, spawned_abnos) - round(rooms_start * 0.5)) * 8) SECONDS
+	next_abno_spawn = world.time + next_abno_spawn_time + ((min(16, spawned_abnos) - floor(rooms_start * 0.5)) * 8) SECONDS
 
 	if(!length(GLOB.abnormality_room_spawners))
 		return

--- a/code/controllers/subsystem/abnormality_queue.dm
+++ b/code/controllers/subsystem/abnormality_queue.dm
@@ -35,7 +35,7 @@ SUBSYSTEM_DEF(abnormality_queue)
 	/// World time at which new abnormality will be spawned
 	var/next_abno_spawn = INFINITY
 	/// Wait time for next abno spawn; This time is further affected by amount of abnos in facility
-	var/next_abno_spawn_time = 4 MINUTES
+	var/next_abno_spawn_time = 5 MINUTES
 	/// Tracks if the current pick is forced
 	var/fucked_it_lets_rolled = FALSE
 	/// Due to Managers not passing the Litmus Test, divine approval is now necessary for red roll

--- a/code/controllers/subsystem/abnormality_queue.dm
+++ b/code/controllers/subsystem/abnormality_queue.dm
@@ -35,7 +35,7 @@ SUBSYSTEM_DEF(abnormality_queue)
 	/// World time at which new abnormality will be spawned
 	var/next_abno_spawn = INFINITY
 	/// Wait time for next abno spawn; This time is further affected by amount of abnos in facility
-	var/next_abno_spawn_time = 6 MINUTES
+	var/next_abno_spawn_time = 5.5 MINUTES
 	/// Tracks if the current pick is forced
 	var/fucked_it_lets_rolled = FALSE
 	/// Due to Managers not passing the Litmus Test, divine approval is now necessary for red roll

--- a/code/controllers/subsystem/lobotomy_corp.dm
+++ b/code/controllers/subsystem/lobotomy_corp.dm
@@ -116,7 +116,7 @@ SUBSYSTEM_DEF(lobotomy_corp)
 
 /datum/controller/subsystem/lobotomy_corp/proc/SetGoal()
 	var/player_mod = length(GLOB.player_list) * 0.2
-	box_goal = clamp(round(7500 * player_mod), 3000, 36000)
+	box_goal = clamp(round(5000 * player_mod), 3000, 36000)
 
 	if(SSmaptype.maptype in SSmaptype.lc_maps)
 		//Here's the anouncement for the trait.
@@ -276,7 +276,7 @@ SUBSYSTEM_DEF(lobotomy_corp)
 	qliphoth_meter = 0
 	var/abno_amount = length(all_abnormality_datums)
 	var/player_count = AvailableAgentCount()
-	qliphoth_max = round((player_count > 1 ? 4 : 3) + round(player_count*1.35) + GLOB.Sephirahordealspeed + GetFacilityUpgradeValue(UPGRADE_MELTDOWN_INCREASE)) // Some extra help on non solo rounds
+	qliphoth_max = round((player_count > 1 ? 4 : 3) + player_count + GLOB.Sephirahordealspeed + GetFacilityUpgradeValue(UPGRADE_MELTDOWN_INCREASE)) // Some extra help on non solo rounds
 	qliphoth_state += 1
 	for(var/datum/abnormality/A in all_abnormality_datums)
 		if(istype(A.current))

--- a/code/controllers/subsystem/lobotomy_corp.dm
+++ b/code/controllers/subsystem/lobotomy_corp.dm
@@ -48,7 +48,7 @@ SUBSYSTEM_DEF(lobotomy_corp)
 	// What ordeal level is being rolled for
 	var/next_ordeal_level = 1
 	// Minimum time for each ordeal level to occur. If requirement is not met - normal meltdown will occur
-	var/list/ordeal_timelock = list(20 MINUTES, 40 MINUTES, 60 MINUTES, 90 MINUTES, 0, 0, 0, 0, 0)
+	var/list/ordeal_timelock = list(10 MINUTES, 20 MINUTES, 40 MINUTES, 60 MINUTES, 0, 0, 0, 0, 0)
 	// Datum of the chosen ordeal. It's stored so manager can know what's about to happen
 	var/datum/ordeal/next_ordeal = null
 	/// List of currently running ordeals
@@ -276,11 +276,7 @@ SUBSYSTEM_DEF(lobotomy_corp)
 	qliphoth_meter = 0
 	var/abno_amount = length(all_abnormality_datums)
 	var/player_count = AvailableAgentCount()
-	var/total_count = AvailableAgentCount(suppressioncount = TRUE)
-	var/suppression_modifier = 1
-	if(player_count != total_count)
-		suppression_modifier = 1.3
-	qliphoth_max = round((player_count > 1 ? 4 : 3) + player_count*1.5*suppression_modifier + GLOB.Sephirahordealspeed + GetFacilityUpgradeValue(UPGRADE_MELTDOWN_INCREASE)) // Some extra help on non solo rounds
+	qliphoth_max = round((player_count > 1 ? 4 : 3) + round(player_count*1.35) + GLOB.Sephirahordealspeed + GetFacilityUpgradeValue(UPGRADE_MELTDOWN_INCREASE)) // Some extra help on non solo rounds
 	qliphoth_state += 1
 	for(var/datum/abnormality/A in all_abnormality_datums)
 		if(istype(A.current))
@@ -358,7 +354,7 @@ SUBSYSTEM_DEF(lobotomy_corp)
 		return FALSE
 	next_ordeal = pick(available_ordeals)
 	all_ordeals[next_ordeal_level] -= next_ordeal
-	next_ordeal_time = max(3, qliphoth_state + next_ordeal.delay + (next_ordeal.random_delay ? rand(-1, 1) : 0))
+	next_ordeal_time = max(3, qliphoth_state + next_ordeal.delay)
 	next_ordeal_level += 1 // Increase difficulty!
 	for(var/obj/structure/sign/ordealmonitor/O in GLOB.lobotomy_devices)
 		O.update_icon()

--- a/code/controllers/subsystem/lobotomy_corp.dm
+++ b/code/controllers/subsystem/lobotomy_corp.dm
@@ -48,7 +48,7 @@ SUBSYSTEM_DEF(lobotomy_corp)
 	// What ordeal level is being rolled for
 	var/next_ordeal_level = 1
 	// Minimum time for each ordeal level to occur. If requirement is not met - normal meltdown will occur
-	var/list/ordeal_timelock = list(10 MINUTES, 20 MINUTES, 40 MINUTES, 60 MINUTES, 0, 0, 0, 0, 0)
+	var/list/ordeal_timelock = list(10 MINUTES, 25 MINUTES, 45 MINUTES, 60 MINUTES, 0, 0, 0, 0, 0)
 	// Datum of the chosen ordeal. It's stored so manager can know what's about to happen
 	var/datum/ordeal/next_ordeal = null
 	/// List of currently running ordeals

--- a/code/datums/facility_upgrade.dm
+++ b/code/datums/facility_upgrade.dm
@@ -239,6 +239,9 @@
 	max_value = 3
 	info = " - This upgrade inceases the amount of <b>Works</b> needed for a Qliphoth Meltdown by 1 per upgrade.<br> - This upgrade additionally increases the time limit of <b>Post Midnight Core Suppressions</b> by 20 Minutes per upgrade."
 
+/datum/facility_upgrade/meltdown_increase/CanUpgrade()
+	return FALSE
+
 /datum/facility_upgrade/meltdown_increase/Upgrade()
 	value = min(max_value, value + 1)
 	. = ..()

--- a/code/datums/facility_upgrade.dm
+++ b/code/datums/facility_upgrade.dm
@@ -239,9 +239,6 @@
 	max_value = 3
 	info = " - This upgrade inceases the amount of <b>Works</b> needed for a Qliphoth Meltdown by 1 per upgrade.<br> - This upgrade additionally increases the time limit of <b>Post Midnight Core Suppressions</b> by 20 Minutes per upgrade."
 
-/datum/facility_upgrade/meltdown_increase/CanUpgrade()
-	return FALSE
-
 /datum/facility_upgrade/meltdown_increase/Upgrade()
 	value = min(max_value, value + 1)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes meltdowns need less works, quota need less pe, and abno and ordeal arrival rates a lot faster like how it was 2 years ago
Also removes randomization from when ordeal can start and only agents(not eras) on the playing z level count for the works needed for meltdown. Agent work speed was also increased by 25%.
## Why It's Good For The Game

The pace of the game being way too slow to the point of making the game tiring to play. This problem becomes even worse in high pop where the increased scaling can lead to a sluggish game pace with a few modifiers caused from sephirah, eras, and the lob upgrade.

## Changelog
:cl:
tweak: tweaked a few values
balance: rebalanced abno arrival time, min ordeal time, work speed, and quota
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
