### PR TITLE
Achievement Update: Presenting Achievements [WORK IN PROGRESS]

### DIFF
--- a/ACHIEVEMENT_IDEAS.md
+++ b/ACHIEVEMENT_IDEAS.md
@@ -1,74 +1,73 @@
 # Achievement Ideas from Discord
 
 ## Collection/Farming Achievements
-- Obtain silk from mobs 120 times
-    - `code/modules/mob/living/simple_animal/abnormality/teth/spider_bud.dm`
-- Forge 50 weapons as a workshop attendant on City of Light
-    - `code/modules/jobs/job_types/city/workshop.dm`
-    - `ModularTegustation/tegu_items/workshop/_templates.dm`
-- Feed a plushie to Basilisoup
+- ✅ **IMPLEMENTED** - Obtain silk from mobs 120 times
+    - `code\game\objects\items\stacks\sheets\silk.dm`, make the silkweaver track the number of times it has been used.
+- ✅ **IMPLEMENTED** - Forge 50 weapons as a workshop attendant on City of Light
+    - `ModularTegustation\tegu_items\workshop\forging.dm`
+- ✅ **IMPLEMENTED** - Feed a plushie to Basilisoup
     - `code/modules/mob/living/simple_animal/abnormality/he/basilisoup.dm`
 - Collect the golden bough in ER
     - *Needs investigation for ER files*
-- Generate 100 PE from Spiderbud from a successful work
+- ❌ **TOO COMPLEX** - Generate 100 PE from Spiderbud from a successful work
     - `code/modules/mob/living/simple_animal/abnormality/teth/spider_bud.dm`
 
 ## City of Light Specific
-- Max out a workshop weapon in City of Light
+- ✅ **IMPLEMENTED** - Max out a workshop weapon in City of Light
     - `ModularTegustation/tegu_items/workshop/_templates.dm`
 - Trip on a landmine in one of the COL starter rooms
     - *Needs investigation for landmine/trap files*
 
 ## Medical/Infection
 - Cure Naked Nest infection without a cure
-    - `code/modules/mob/living/simple_animal/abnormality/waw/naked_nest.dm`
-- Cure Naked Nest infection with a cure
+    - *Needs investigation for surgery*
+- ✅ **IMPLEMENTED** - Cure Naked Nest infection with a cure
     - `code/modules/mob/living/simple_animal/abnormality/waw/naked_nest.dm`
 
 ## Abnormality Interactions
-- Free yourself from Nobody Is' chokehold
+- ✅ **IMPLEMENTED** - Free yourself from Nobody Is' chokehold
     - `code/modules/mob/living/simple_animal/abnormality/aleph/nobody_is.dm`
-- Save someone from the wolf yourself
+- ✅ **IMPLEMENTED** - Save someone from the wolf yourself
     - `code/modules/mob/living/simple_animal/abnormality/waw/big_wolf.dm`
-- Be saved by Red Hood after getting eaten by Wolf
+- ✅ **IMPLEMENTED** - Be saved by Red Hood after getting eaten by Wolf
     - `code/modules/mob/living/simple_animal/abnormality/waw/big_wolf.dm`
     - `code/modules/mob/living/simple_animal/abnormality/waw/red_riding_mercenary.dm`
-- Use Fell Bullet's shotgun interaction
-    - *Needs investigation for Fell Bullet files*
-- Experience the special interaction between SWA and a person with her EGO gift
-    - *Needs investigation for SWA files*
-- Breach Golden Apple with a Yuri plushie
+- ✅ **IMPLEMENTED** - Use Fell Bullet's shotgun interaction
+    - `ModularTegustation\ego_weapons\ranged\waw.dm`
+- ✅ **IMPLEMENTED** - Experience the special interaction between SWA and a person with her EGO gift
+    - `code\modules\mob\living\simple_animal\abnormality\waw\snow_whites_apple.dm`
+- ✅ **IMPLEMENTED** - Breach Golden Apple with a Yuri plushie
     - `code/modules/mob/living/simple_animal/abnormality/he/golden_false_apple.dm`
     - `code/game/objects/items/plushes.dm`
-- Hear Silent Orchestra's full performance
+- ✅ **IMPLEMENTED** - Hear Silent Orchestra's full performance
     - `code/modules/mob/living/simple_animal/abnormality/aleph/silent_orchestra.dm`
-- Activate Hammer of Light
+- ✅ **IMPLEMENTED** - Activate Hammer of Light
     - `code/modules/mob/living/simple_animal/abnormality/zayin/hammer_light.dm`
-- Survive a non-instinct/attachment work on Nothing There
+- ✅ **IMPLEMENTED** - Survive a non-instinct/attachment work on Nothing There
     - `code/modules/mob/living/simple_animal/abnormality/aleph/nothing_there.dm`
-- Die to Punishing Bird without having enraged it beforehand
+- ✅ **IMPLEMENTED** - Die to Punishing Bird without having enraged it beforehand
     - `code/modules/mob/living/simple_animal/abnormality/teth/punishing_bird.dm`
-- Kill WhiteNight by confessing to one sin
+- ✅ **IMPLEMENTED** - Kill WhiteNight by confessing to one sin
     - `code/modules/mob/living/simple_animal/abnormality/aleph/white_night.dm`
-- Kill WhiteNight with Hammer of Light
+- ✅ **IMPLEMENTED** - Kill WhiteNight with Hammer of Light
     - `code/modules/mob/living/simple_animal/abnormality/aleph/white_night.dm`
     - `code/modules/mob/living/simple_animal/abnormality/zayin/hammer_light.dm`
-- Rescue a friend/Be rescued from Snow Queen
+- ✅ **IMPLEMENTED** - Rescue a friend/Be rescued from Snow Queen
     - `code/modules/mob/living/simple_animal/abnormality/he/snow_queen.dm`
-- Trigger Snow Queen's ice encasement due to wearing Feather of Honour
+- ✅ **IMPLEMENTED** - Trigger Snow Queen's ice encasement due to wearing Feather of Honour
     - `code/modules/mob/living/simple_animal/abnormality/he/snow_queen.dm`
 
 ## Combat/Survival
 - Re-sane 8 agents in the same round
-    - `code/modules/sanity/sanity_mob.dm`
-- Have 5 abno kills as records officer
-    - `code/modules/jobs/job_types/records.dm`
+    - *Needs investigation for how to track re-sanes*
+- ❌ **TOO COMPLEX** - Have 5 abno kills as records officer
+    - `ModularTegustation\ego_weapons\_ego_weapon.dm`, just check the mind of the user, and give them a counter.
 - Beat midnight on B12
     - *Needs investigation for specific midnight files*
 - Beat Abno Blitz (Purple Rare achievement)
     - *Needs investigation for Abno Blitz game mode*
-- Get hit by hell train and survive
-    - `code/modules/mob/living/simple_animal/abnormality/waw/express_train_to_hell.dm`
+- ✅ **IMPLEMENTED** - Get hit by hell train and survive
+    - `code/modules/mob/living/simple_animal/abnormality/waw/express_train.dm`
 - Survive 20 minutes in Warp corp cleanup
     - *Needs investigation for Warp corp game mode*
 - Survive 10 minutes in Warp corp cleanup
@@ -76,126 +75,122 @@
 - Kill 8 x-corp monsters with a single grenade
     - *Needs investigation for X-corp monster files*
 - Land a naked parry on a pale pillar/pale fixer
-    - `code/modules/mob/living/simple_animal/hostile/moon_fixer.dm`
-- Trigger FAN five times on the same character
-    - *Needs investigation for FAN mechanic*
-- Repress Melting Love whilst having her blessing - and survive
+    - *Needs investigation for where this weapon is*
+- ✅ **IMPLEMENTED** - Trigger FAN five times on the same character
+    - `code\modules\mob\living\simple_animal\abnormality\he\fan.dm`
+- ✅ **IMPLEMENTED** - Repress Melting Love whilst having her blessing - and survive
     - `code/modules/mob/living/simple_animal/abnormality/aleph/melting_love.dm`
 
 ## Progression/Meta
-- Complete 50% of all achievements
+- Complete 50% of all achievements, only including LC13 and City achivements
     - `code/controllers/subsystem/achievements.dm`
 - Complete 100% of all achievements
     - `code/controllers/subsystem/achievements.dm`
 - Achieve enough playtime to get the Veteran Player's cloak
     - `code/modules/client/preferences.dm`
 - Play the maximum amount of hours as intern
-    - `code/modules/jobs/job_types/intern.dm`
+    - `code/modules/jobs/job_types/intern.dm`, 100 hours
 
 ## Equipment/Items
 - Have at least 2 tool abno ego weapons and 1 tool abno ego armour
     - `code/modules/mob/living/simple_animal/abnormality/_tools/`
 - Get a Level 5, 10, 15 and 20 fishing hat respectively
-    - *Needs investigation for fishing system*
+    - `ModularTegustation\fishing\code\fishing_items\fishing_hat.dm`
 - "Dumbass" - Hit yourself with boomerang weapon.
     - *Needs investigation for boomerang weapon files*
-- "This is my fixer OC, donut steel." - Have all color fixer weapons on you + Twilight suit.
-    - `ModularTegustation/ego_weapons/melee/non_abnormality/color_fixer.dm`
+- ❌ **TOO COMPLEX** - "This is my fixer OC, donut steel." - Have all color fixer weapons on you + Twilight suit.
+    - `ModularTegustation/ego_weapons/melee/non_abnormality/color_fixer.dm`, just check if the player is holding "/obj/item/ego_weapon/city/pt/slash, /obj/item/ego_weapon/black_silence_gloves, /obj/item/ego_weapon/mimicry/kali, /obj/item/ego_weapon/city/reverberation"
 
 ## Special/Easter Eggs
-- Say "uwu" on the radio achievement
-    - `code/modules/mob/living/say.dm`
-- See the Chaos Dunk (Call it "Slam Jam" - Red Rare)
-    - *Needs investigation for Chaos Dunk*
+- ✅ **IMPLEMENTED** - Say "uwu" on the radio achievement
+    - `code/modules/mob/living/say.dm`, `code\game\objects\items\devices\radio\radio.dm`
+- ✅ **IMPLEMENTED** - See the Chaos Dunk (Call it "Slam Jam" - Red Rare)
+    - `code\modules\holodeck\items.dm`, check the /obj/structure/holohoop object
 - Make an achievement for becoming a fatass with a hint on how to get rid of it
     - *Needs investigation for weight/fatness system*
-- Successfully hear and type 680 mhz codes 5 times in a row
-    - *Needs investigation for radio code system*
+- ✅ **IMPLEMENTED** - Successfully hear and type 680 mhz codes 5 times in a row
+    - `code\modules\mob\living\simple_animal\abnormality\he\KHz.dm`
 
 ## Boss Achievements
 - Defeat the Heart of Greed (second highest rarity)
     - *Needs investigation for Heart of Greed boss*
-- Yin and Yang: Realize either Harmony of Duality or Duality of Harmony
-    - *Needs investigation for Yin/Yang realization*
+- ✅ **IMPLEMENTED** - Yin and Yang: Realize either Harmony of Duality or Duality of Harmony
+    - `code\modules\mob\living\simple_animal\abnormality\_tools\zayin\realizer.dm`
 - Survive until extraction with Yin, Yang, ETTH & [fourth one]
     - *Needs investigation for extraction game mode*
 
 ## Realization Achievements
-- Realize Carmen/Benjamin from their respective plushies
-    - `code/game/objects/items/plushes.dm`
-- Realize Ayin from Paradise Lost's weapon
-    - *Needs investigation for Paradise Lost weapon*
+- ✅ **IMPLEMENTED** - Realize Carmen/Benjamin from their respective plushies
+    - `code\modules\mob\living\simple_animal\abnormality\_tools\zayin\realizer.dm`
+- ✅ **IMPLEMENTED** - Realize Ayin from Paradise Lost's weapon
+    - `code\modules\mob\living\simple_animal\abnormality\_tools\zayin\realizer.dm`
 
 ## Stat Achievements
-- Achieve a rating of equal or greater than 200 in one of the following virtues: Fortitude/Prudence/Temperance/Justice (gifts count)
+- ✅ **IMPLEMENTED** - Achieve a rating of equal or greater than 200 in one of the following virtues: Fortitude/Prudence/Temperance/Justice (gifts count)
     - `code/modules/mob/living/attributes.dm`
-- Achieve a rating of equal or greater than 200 in all of the virtues (gifts count)
+- ✅ **IMPLEMENTED** - Achieve a rating of equal or greater than 200 in all of the virtues (gifts count)
     - `code/modules/mob/living/attributes.dm`
 
 ## Round Events
-- Be in a round where Bald balds everyone in the facility
+- ✅ **IMPLEMENTED** - Be in a round where Bald balds everyone in the facility
     - `code/modules/mob/living/simple_animal/abnormality/zayin/bald.dm`
 
 ## Resource Management
-- Refine 100 PE boxes in the same round
-    - `code/game/objects/items/pe_box.dm`
+- ✅ **IMPLEMENTED** - Refine 100 PE boxes (now player-specific)
+    - `ModularTegustation\tegu_items\refinery\refinery.dm`
 
 ## Death Achievements
-- Get killed by friendly breach Queen of Hatred
-    - *Needs investigation for Queen of Hatred*
-- Die to Blubbering Toad
+- ✅ **IMPLEMENTED** - Get killed by friendly breach Queen of Hatred
+    - `code\modules\mob\living\simple_animal\abnormality\waw\hatred_queen.dm`
+- ✅ **IMPLEMENTED** - Die to Blubbering Toad
     - `code/modules/mob/living/simple_animal/abnormality/zayin/blubbering_toad.dm`
 - Get ??? by the cuckoospawn
     - *Needs investigation for Cuckoo Clock abnormality*
 
 ## Special/Illegal Actions
-- Make meth (description: "How?")
+- ✅ **IMPLEMENTED** - Make meth (description: "How?")
     - `code/modules/reagents/chemistry/recipes.dm`
-- Let Blubbering Toad out
+- ✅ **IMPLEMENTED** - Let Blubbering Toad out
     - `code/modules/mob/living/simple_animal/abnormality/zayin/blubbering_toad.dm`
 
 ## Core Suppression
-- Make beating each core's reward an achievement
-    - `code/modules/suppressions/command.dm`
-    - `code/modules/suppressions/control.dm`
-    - `code/modules/suppressions/extraction.dm`
-    - `code/modules/suppressions/information.dm`
-    - `code/modules/suppressions/records.dm`
-    - `code/modules/suppressions/safety.dm`
-    - `code/modules/suppressions/training.dm`
-    - `code/modules/suppressions/welfare.dm`
-- Burn a Binah plush
+- ✅ **IMPLEMENTED** - Make beating each core's reward an achievement
+    - `code/modules/suppressions/control.dm` - Malkuth
+    - `code/modules/suppressions/information.dm` - Yesod
+    - `code/modules/suppressions/training.dm` - Hod
+    - `code/modules/suppressions/safety.dm` - Netzach
+    - `code/modules/suppressions/command.dm` - Tiphereth
+    - `code/modules/suppressions/welfare.dm` - Chesed
+    - `code/modules/suppressions/records.dm` - Hokma
+    - `code/modules/suppressions/extraction.dm` - Binah
+    - Note: Gebura suppression not yet implemented in game
+- ✅ **IMPLEMENTED** - Burn a Binah plush
     - `code/game/objects/items/plushes.dm`
 
 ## Ordeal Achievements
 - Make one of each ordeal monster food items
     - `code/modules/ordeals/` (various ordeal files)
-- The other midnights
-    - `code/modules/ordeals/amber_ordeals.dm`
-    - `code/modules/ordeals/green_ordeals.dm`
-    - `code/modules/ordeals/violet_ordeals.dm`
-    - `code/modules/ordeals/white_ordeals.dm`
-- Kill WhiteNight during a pink midnight
+- ✅ **IMPLEMENTED** - Kill WhiteNight during a pink midnight
     - `code/modules/mob/living/simple_animal/abnormality/aleph/white_night.dm`
     - `code/modules/ordeals/pink_ordeals.dm`
 
 ## Combat Challenges
-- Make killing Claw hard
-    - `code/modules/mob/living/simple_animal/hostile/abnormality/white_night/claw.dm`
-- Damage PBird
+- ✅ **IMPLEMENTED** - Kill Claw (already exists as WhiteMidnight achievement)
+    - `ModularTegustation/tegu_mobs/the_claw.dm`
+- ✅ **IMPLEMENTED** - Damage PBird
     - `code/modules/mob/living/simple_animal/abnormality/teth/punishing_bird.dm`
-- Kill PBird (separate achievement)
+- ✅ **IMPLEMENTED** - Kill PBird (separate achievement)
     - `code/modules/mob/living/simple_animal/abnormality/teth/punishing_bird.dm`
-- Kill Distorted form
-    - `code/modules/mob/living/simple_animal/hostile/distortion/`
+- ✅ **IMPLEMENTED** - Kill Distorted form
+    - `code/modules/mob/living/simple_animal/abnormality/aleph/distortedform.dm`
 
 ## City Exploration
 - Get to the happy room in the city
     - *Needs investigation for city map files*
 
 ## Role-Specific
-- As a clerk role, use a weapon that isn't ZAYIN or TETH
-    - `code/modules/jobs/job_types/clerk.dm`
+- ✅ **IMPLEMENTED** - As a clerk role, use a weapon that isn't ZAYIN or TETH
+    - `ModularTegustation\ego_weapons\_ego_weapon.dm`, just check if the weapon has requirments, and if the mind is of a clerk
 
 ---
 *Note: More achievement ideas to be added. Files marked with "Needs investigation" require further searching to locate the appropriate implementation files.*

--- a/ACHIEVEMENT_IDEAS.md
+++ b/ACHIEVEMENT_IDEAS.md
@@ -1,0 +1,201 @@
+# Achievement Ideas from Discord
+
+## Collection/Farming Achievements
+- Obtain silk from mobs 120 times
+    - `code/modules/mob/living/simple_animal/abnormality/teth/spider_bud.dm`
+- Forge 50 weapons as a workshop attendant on City of Light
+    - `code/modules/jobs/job_types/city/workshop.dm`
+    - `ModularTegustation/tegu_items/workshop/_templates.dm`
+- Feed a plushie to Basilisoup
+    - `code/modules/mob/living/simple_animal/abnormality/he/basilisoup.dm`
+- Collect the golden bough in ER
+    - *Needs investigation for ER files*
+- Generate 100 PE from Spiderbud from a successful work
+    - `code/modules/mob/living/simple_animal/abnormality/teth/spider_bud.dm`
+
+## City of Light Specific
+- Max out a workshop weapon in City of Light
+    - `ModularTegustation/tegu_items/workshop/_templates.dm`
+- Trip on a landmine in one of the COL starter rooms
+    - *Needs investigation for landmine/trap files*
+
+## Medical/Infection
+- Cure Naked Nest infection without a cure
+    - `code/modules/mob/living/simple_animal/abnormality/waw/naked_nest.dm`
+- Cure Naked Nest infection with a cure
+    - `code/modules/mob/living/simple_animal/abnormality/waw/naked_nest.dm`
+
+## Abnormality Interactions
+- Free yourself from Nobody Is' chokehold
+    - `code/modules/mob/living/simple_animal/abnormality/aleph/nobody_is.dm`
+- Save someone from the wolf yourself
+    - `code/modules/mob/living/simple_animal/abnormality/waw/big_wolf.dm`
+- Be saved by Red Hood after getting eaten by Wolf
+    - `code/modules/mob/living/simple_animal/abnormality/waw/big_wolf.dm`
+    - `code/modules/mob/living/simple_animal/abnormality/waw/red_riding_mercenary.dm`
+- Use Fell Bullet's shotgun interaction
+    - *Needs investigation for Fell Bullet files*
+- Experience the special interaction between SWA and a person with her EGO gift
+    - *Needs investigation for SWA files*
+- Breach Golden Apple with a Yuri plushie
+    - `code/modules/mob/living/simple_animal/abnormality/he/golden_false_apple.dm`
+    - `code/game/objects/items/plushes.dm`
+- Hear Silent Orchestra's full performance
+    - `code/modules/mob/living/simple_animal/abnormality/aleph/silent_orchestra.dm`
+- Activate Hammer of Light
+    - `code/modules/mob/living/simple_animal/abnormality/zayin/hammer_light.dm`
+- Survive a non-instinct/attachment work on Nothing There
+    - `code/modules/mob/living/simple_animal/abnormality/aleph/nothing_there.dm`
+- Die to Punishing Bird without having enraged it beforehand
+    - `code/modules/mob/living/simple_animal/abnormality/teth/punishing_bird.dm`
+- Kill WhiteNight by confessing to one sin
+    - `code/modules/mob/living/simple_animal/abnormality/aleph/white_night.dm`
+- Kill WhiteNight with Hammer of Light
+    - `code/modules/mob/living/simple_animal/abnormality/aleph/white_night.dm`
+    - `code/modules/mob/living/simple_animal/abnormality/zayin/hammer_light.dm`
+- Rescue a friend/Be rescued from Snow Queen
+    - `code/modules/mob/living/simple_animal/abnormality/he/snow_queen.dm`
+- Trigger Snow Queen's ice encasement due to wearing Feather of Honour
+    - `code/modules/mob/living/simple_animal/abnormality/he/snow_queen.dm`
+
+## Combat/Survival
+- Re-sane 8 agents in the same round
+    - `code/modules/sanity/sanity_mob.dm`
+- Have 5 abno kills as records officer
+    - `code/modules/jobs/job_types/records.dm`
+- Beat midnight on B12
+    - *Needs investigation for specific midnight files*
+- Beat Abno Blitz (Purple Rare achievement)
+    - *Needs investigation for Abno Blitz game mode*
+- Get hit by hell train and survive
+    - `code/modules/mob/living/simple_animal/abnormality/waw/express_train_to_hell.dm`
+- Survive 20 minutes in Warp corp cleanup
+    - *Needs investigation for Warp corp game mode*
+- Survive 10 minutes in Warp corp cleanup
+    - *Needs investigation for Warp corp game mode*
+- Kill 8 x-corp monsters with a single grenade
+    - *Needs investigation for X-corp monster files*
+- Land a naked parry on a pale pillar/pale fixer
+    - `code/modules/mob/living/simple_animal/hostile/moon_fixer.dm`
+- Trigger FAN five times on the same character
+    - *Needs investigation for FAN mechanic*
+- Repress Melting Love whilst having her blessing - and survive
+    - `code/modules/mob/living/simple_animal/abnormality/aleph/melting_love.dm`
+
+## Progression/Meta
+- Complete 50% of all achievements
+    - `code/controllers/subsystem/achievements.dm`
+- Complete 100% of all achievements
+    - `code/controllers/subsystem/achievements.dm`
+- Achieve enough playtime to get the Veteran Player's cloak
+    - `code/modules/client/preferences.dm`
+- Play the maximum amount of hours as intern
+    - `code/modules/jobs/job_types/intern.dm`
+
+## Equipment/Items
+- Have at least 2 tool abno ego weapons and 1 tool abno ego armour
+    - `code/modules/mob/living/simple_animal/abnormality/_tools/`
+- Get a Level 5, 10, 15 and 20 fishing hat respectively
+    - *Needs investigation for fishing system*
+- "Dumbass" - Hit yourself with boomerang weapon.
+    - *Needs investigation for boomerang weapon files*
+- "This is my fixer OC, donut steel." - Have all color fixer weapons on you + Twilight suit.
+    - `ModularTegustation/ego_weapons/melee/non_abnormality/color_fixer.dm`
+
+## Special/Easter Eggs
+- Say "uwu" on the radio achievement
+    - `code/modules/mob/living/say.dm`
+- See the Chaos Dunk (Call it "Slam Jam" - Red Rare)
+    - *Needs investigation for Chaos Dunk*
+- Make an achievement for becoming a fatass with a hint on how to get rid of it
+    - *Needs investigation for weight/fatness system*
+- Successfully hear and type 680 mhz codes 5 times in a row
+    - *Needs investigation for radio code system*
+
+## Boss Achievements
+- Defeat the Heart of Greed (second highest rarity)
+    - *Needs investigation for Heart of Greed boss*
+- Yin and Yang: Realize either Harmony of Duality or Duality of Harmony
+    - *Needs investigation for Yin/Yang realization*
+- Survive until extraction with Yin, Yang, ETTH & [fourth one]
+    - *Needs investigation for extraction game mode*
+
+## Realization Achievements
+- Realize Carmen/Benjamin from their respective plushies
+    - `code/game/objects/items/plushes.dm`
+- Realize Ayin from Paradise Lost's weapon
+    - *Needs investigation for Paradise Lost weapon*
+
+## Stat Achievements
+- Achieve a rating of equal or greater than 200 in one of the following virtues: Fortitude/Prudence/Temperance/Justice (gifts count)
+    - `code/modules/mob/living/attributes.dm`
+- Achieve a rating of equal or greater than 200 in all of the virtues (gifts count)
+    - `code/modules/mob/living/attributes.dm`
+
+## Round Events
+- Be in a round where Bald balds everyone in the facility
+    - `code/modules/mob/living/simple_animal/abnormality/zayin/bald.dm`
+
+## Resource Management
+- Refine 100 PE boxes in the same round
+    - `code/game/objects/items/pe_box.dm`
+
+## Death Achievements
+- Get killed by friendly breach Queen of Hatred
+    - *Needs investigation for Queen of Hatred*
+- Die to Blubbering Toad
+    - `code/modules/mob/living/simple_animal/abnormality/zayin/blubbering_toad.dm`
+- Get ??? by the cuckoospawn
+    - *Needs investigation for Cuckoo Clock abnormality*
+
+## Special/Illegal Actions
+- Make meth (description: "How?")
+    - `code/modules/reagents/chemistry/recipes.dm`
+- Let Blubbering Toad out
+    - `code/modules/mob/living/simple_animal/abnormality/zayin/blubbering_toad.dm`
+
+## Core Suppression
+- Make beating each core's reward an achievement
+    - `code/modules/suppressions/command.dm`
+    - `code/modules/suppressions/control.dm`
+    - `code/modules/suppressions/extraction.dm`
+    - `code/modules/suppressions/information.dm`
+    - `code/modules/suppressions/records.dm`
+    - `code/modules/suppressions/safety.dm`
+    - `code/modules/suppressions/training.dm`
+    - `code/modules/suppressions/welfare.dm`
+- Burn a Binah plush
+    - `code/game/objects/items/plushes.dm`
+
+## Ordeal Achievements
+- Make one of each ordeal monster food items
+    - `code/modules/ordeals/` (various ordeal files)
+- The other midnights
+    - `code/modules/ordeals/amber_ordeals.dm`
+    - `code/modules/ordeals/green_ordeals.dm`
+    - `code/modules/ordeals/violet_ordeals.dm`
+    - `code/modules/ordeals/white_ordeals.dm`
+- Kill WhiteNight during a pink midnight
+    - `code/modules/mob/living/simple_animal/abnormality/aleph/white_night.dm`
+    - `code/modules/ordeals/pink_ordeals.dm`
+
+## Combat Challenges
+- Make killing Claw hard
+    - `code/modules/mob/living/simple_animal/hostile/abnormality/white_night/claw.dm`
+- Damage PBird
+    - `code/modules/mob/living/simple_animal/abnormality/teth/punishing_bird.dm`
+- Kill PBird (separate achievement)
+    - `code/modules/mob/living/simple_animal/abnormality/teth/punishing_bird.dm`
+- Kill Distorted form
+    - `code/modules/mob/living/simple_animal/hostile/distortion/`
+
+## City Exploration
+- Get to the happy room in the city
+    - *Needs investigation for city map files*
+
+## Role-Specific
+- As a clerk role, use a weapon that isn't ZAYIN or TETH
+    - `code/modules/jobs/job_types/clerk.dm`
+
+---
+*Note: More achievement ideas to be added. Files marked with "Needs investigation" require further searching to locate the appropriate implementation files.*

--- a/IMPLEMENTED_ACHIEVEMENTS.md
+++ b/IMPLEMENTED_ACHIEVEMENTS.md
@@ -4,172 +4,216 @@ This file lists all achievements implemented in this session, with space to add 
 
 ### Obtain silk from mobs 120 times
 **File:** `code/game/objects/items/stacks/sheets/silk.dm`  
-**Title:** 
+**Name:** the Legend of the Silksong, Will Make Fine SIlk?
+**Title:** the Legend of the Silksong
 
 ### Forge 50 weapons as a workshop attendant
-**File:** `ModularTegustation/tegu_items/workshop/_templates.dm`  
-**Title:** 
+**File:** `ModularTegustation/tegu_items/workshop/_templates.dm`
+**Name:** Respectable Workshop, Workshop Meister
+**Title:** a Workshop Meister
 
 ### Feed a plushie to Basilisoup
 **File:** `code/modules/mob/living/simple_animal/abnormality/he/basilisoup.dm`  
-**Title:** 
+**Name:** plushie cooking 1o1, Soup from a Plush
+**Title:** a Plushie Chef
 
 ### Refine 100 PE boxes
 **File:** `ModularTegustation/tegu_items/refinery/refinery.dm`  
-**Title:** 
+**Name:** Don't forget to do your dailies
+**Title:** Refina-Junkie
 
 ### Max out a workshop weapon
 **File:** `ModularTegustation/tegu_items/workshop/_templates.dm`  
-**Title:** 
+**Name:** Weapon of mass Fixer-ation, S-Class Workshop Meister
+**Title:** an S-Class Workshop Meister
 
 ### Cure Naked Nest infection with a cure
 **File:** `code/modules/mob/living/simple_animal/abnormality/waw/naked_nest.dm`  
-**Title:** 
+**Name:** Clothed Nest, Nakedly Unafraid
+**Title:** Nakedly Unafraid
 
 ### Free yourself from Nobody Is' chokehold
 **File:** `code/modules/mob/living/simple_animal/abnormality/aleph/nobody_is.dm`  
-**Title:** 
+**Name:** Reversal
+**Title:** a Reversal Expert
+
 
 ### Save someone from the wolf yourself
 **File:** `code/modules/mob/living/simple_animal/abnormality/waw/big_wolf.dm`  
-**Title:** 
+**Name:** Free the Pig, Wolf and the Seven Lambs
+**Title:** the Wolf and the Seven Lambs
 
 ### Be saved by Red Hood after getting eaten by Wolf
 **Files:** `code/modules/mob/living/simple_animal/abnormality/waw/big_wolf.dm`, `code/modules/mob/living/simple_animal/abnormality/waw/red_riding_mercenary.dm`  
-**Title:** 
+**Name:** In Sheep's Clothing
+**Title:** being In Sheep's Clothing
 
 ### Use Fell Bullet's shotgun interaction
 **File:** `ModularTegustation/ego_weapons/ranged/waw.dm`  
-**Title:** 
+**Name:** "Bullet drenched with blood of ally.", FireIShallFire
+**Title:** Memory Burner
 
 ### Experience SWA and EGO gift interaction
 **File:** `code/modules/mob/living/simple_animal/abnormality/waw/snow_whites_apple.dm`  
-**Title:** 
+**Name:** Abhorrent Admiration
+**Title:** an Abhorrent Admirer
 
 ### Breach Golden Apple with a Yuri plushie
 **Files:** `code/modules/mob/living/simple_animal/abnormality/he/golden_false_apple.dm`, `code/game/objects/items/plushes.dm`  
-**Title:** 
+**Name:** "remember about abno eggs, idiot!", Not again..!
+**Title:** saying Not Again!
 
 ### Hear Silent Orchestra's full performance
 **File:** `code/modules/mob/living/simple_animal/abnormality/aleph/silent_orchestra.dm`  
-**Title:** 
+**Name:** Curtains down for the performance of history, "Give applause to the song no one can hear, but all can listen to"
+**Title:** bringing Curtains Down
 
 ### Activate Hammer of Light
 **File:** `code/modules/mob/living/simple_animal/abnormality/zayin/hammer_light.dm`  
-**Title:** 
+**Name:** It gives you as much as it takes
+**Title:** giving as much as taking
 
 ### Survive a non-instinct/attachment work on Nothing There
 **File:** `code/modules/mob/living/simple_animal/abnormality/aleph/nothing_there.dm`  
-**Title:** 
+**Name:** Not so flattered
+**Title:** being Not So Flattered
 
 ### Die to Punishing Bird without enraging it
 **File:** `code/modules/mob/living/simple_animal/abnormality/teth/punishing_bird.dm`  
-**Title:** 
+**Name:** Lethal Birdpany, Misdeeds not allowed!
+**Title:** forbidding Misdeeds
 
 ### Kill WhiteNight by confessing to one sin
 **File:** `code/modules/mob/living/simple_animal/abnormality/aleph/white_night.dm`  
-**Title:** 
+**Name:** "Jesus is that you?", The 12th Apostle
+**Title:** the 12th Apostle
 
 ### Kill WhiteNight with Hammer of Light
 **Files:** `code/modules/mob/living/simple_animal/abnormality/aleph/white_night.dm`, `code/modules/mob/living/simple_animal/abnormality/zayin/hammer_light.dm`  
-**Title:** 
+**Name:** Divine Intervention
+**Title:** a Divine Intervener
 
 ### Rescue/Be rescued from Snow Queen
 **File:** `code/modules/mob/living/simple_animal/abnormality/he/snow_queen.dm`  
-**Title:** 
+**Name:** Gerda and Kai
+**Title:** being like Gerda and Kai
 
 ### Trigger Snow Queen's ice due to Feather of Honour
 **File:** `code/modules/mob/living/simple_animal/abnormality/he/snow_queen.dm`  
-**Title:** 
+**Name:** Frozen Honor
+**Title:** being Frozen with Honor
 
 ### Trigger FAN five times on the same character
 **File:** `code/modules/mob/living/simple_animal/abnormality/he/fan.dm`  
-**Title:** 
+**Name:** "Refreshing air for 199,99!"
+**Title:** selling Refreshing Air
 
 ### Get hit by hell train and survive
 **File:** `code/modules/mob/living/simple_animal/abnormality/waw/express_train.dm`  
-**Title:** 
+**Name:** Not my stop
+**Title:** saying Not My Stop
 
 ### Repress Melting Love with blessing and survive
 **File:** `code/modules/mob/living/simple_animal/abnormality/aleph/melting_love.dm`  
-**Title:** 
+**Name:** Begone Thot!
+**Title:** saying Begone Thot
 
 ### Say "uwu" on the radio
 **Files:** `code/modules/mob/living/say.dm`, `code/game/objects/items/devices/radio/radio.dm`  
-**Title:** 
+**Name:** "Illegal in 26 districts.", Don't teach NT strange things...
+**Title:** being Illegal in 26 Districts
 
 ### See the Chaos Dunk
 **File:** `code/modules/holodeck/items.dm`  
-**Title:** 
+**Name:** B-Ballnacht
+**Title:** witnessing B-Ballnacht
 
 ### Successfully type 680 mHz codes 5 times in a row
 **File:** `code/modules/mob/living/simple_animal/abnormality/he/KHz.dm`  
-**Title:** 
+**Name:** Charlie Alpha November Yankee Oscar Uniform Hotel Echo Alpha Romeo
+**Title:** a Radio Operator
 
 ### Yin and Yang realization
 **File:** `code/modules/mob/living/simple_animal/abnormality/_tools/zayin/realizer.dm`  
-**Title:** 
+**Name:** Duality
+**Title:** a Duality Master
 
 ### Realize Carmen/Benjamin from plushies
 **File:** `code/modules/mob/living/simple_animal/abnormality/_tools/zayin/realizer.dm`  
-**Title:** 
+**Name:** A friend from the past
+**Title:** a Friend from the Past
 
 ### Realize Ayin from Paradise Lost
 **File:** `code/modules/mob/living/simple_animal/abnormality/_tools/zayin/realizer.dm`  
-**Title:** 
+**Name:** One God
+**Title:** the One God
 
 ### Achieve 200+ in one virtue
 **File:** `code/datums/attributes/_attribute.dm`  
-**Title:** 
+**Name:** Virtuous
+**Title:** being Virtuous
 
 ### Achieve 200+ in all virtues
 **File:** `code/datums/attributes/_attribute.dm`  
-**Title:** 
+**Name:** Most Virtuous
+**Title:** the Most Virtuous
 
 ### Be in a round where Bald balds everyone
 **File:** `code/modules/mob/living/simple_animal/abnormality/zayin/bald.dm`  
-**Title:** 
+**Name:** Now We're Awesome
+**Title:** being Awesome Now
 
 ### Get killed by friendly Queen of Hatred
 **File:** `code/modules/mob/living/simple_animal/abnormality/waw/hatred_queen.dm`  
-**Title:** 
+**Name:** Villain of the day, Villain beware!!!
+**Title:** the Villain of the Day
 
 ### Die to Blubbering Toad
 **File:** `code/modules/mob/living/simple_animal/abnormality/zayin/blubbering_toad.dm`  
-**Title:** 
+**Name:** Just don't bother it...
+**Title:** knowing to Not Bother It
 
 ### Make meth
 **File:** `code/modules/reagents/chemistry/recipes/drugs.dm`  
-**Title:** 
+**Name:** Breaking Bong
+**Title:** a Breaking Bong Expert
 
 ### Let Blubbering Toad out
 **File:** `code/modules/mob/living/simple_animal/abnormality/zayin/blubbering_toad.dm`  
-**Title:** 
+**Name:** Gloomy, I said don't bother it!
+**Title:** being Gloomy
 
 ### Beat each core suppression
 **Files:** Various suppression files (Control, Information, Training, Safety, Command, Welfare, Records, Extraction)  
-**Title:** 
+**Name:** Road to Day 47
+**Title:** on the Road to Day 47
 
 ### Burn a Binah plush
 **File:** `code/game/objects/items/plushes.dm`  
-**Title:** 
+**Name:** Gebura approves
+**Title:** being Gebura Approved
 
 ### Kill WhiteNight during Pink Midnight
 **Files:** `code/modules/mob/living/simple_animal/abnormality/aleph/white_night.dm`, `code/modules/ordeals/misc_ordeals.dm`  
-**Title:** 
+**Name:** "DOOM, hell on facility.", A Night Everlasting
+**Title:** a Night Everlasting
 
 ### Damage Punishing Bird
 **File:** `code/modules/mob/living/simple_animal/abnormality/teth/punishing_bird.dm`  
-**Title:** 
+**Name:** SINNER!!!
+**Title:** a SINNER!!!
 
 ### Kill Punishing Bird
 **File:** `code/modules/mob/living/simple_animal/abnormality/teth/punishing_bird.dm`  
-**Title:** Punished Bird 
+**Name:** Punishment denied!
+**Title:** denying Punishment
 
 ### Kill Distorted Form
 **File:** `code/modules/mob/living/simple_animal/abnormality/aleph/distortedform.dm`  
-**Title:** 
+**Name:** Egoism
+**Title:** being Egoism Incarnate
 
 ### Clerk using non-ZAYIN/TETH weapon
 **File:** `ModularTegustation/ego_weapons/_ego_weapon.dm`  
-**Title:** 
+**Name:** Breaking the limits
+**Title:** a Limit Breaker

--- a/IMPLEMENTED_ACHIEVEMENTS.md
+++ b/IMPLEMENTED_ACHIEVEMENTS.md
@@ -1,0 +1,175 @@
+# Implemented Achievements
+
+This file lists all achievements implemented in this session, with space to add titles for the examine system. Titles should be something following the lines off... "Their specialization is [title]!"
+
+### Obtain silk from mobs 120 times
+**File:** `code/game/objects/items/stacks/sheets/silk.dm`  
+**Title:** 
+
+### Forge 50 weapons as a workshop attendant
+**File:** `ModularTegustation/tegu_items/workshop/_templates.dm`  
+**Title:** 
+
+### Feed a plushie to Basilisoup
+**File:** `code/modules/mob/living/simple_animal/abnormality/he/basilisoup.dm`  
+**Title:** 
+
+### Refine 100 PE boxes
+**File:** `ModularTegustation/tegu_items/refinery/refinery.dm`  
+**Title:** 
+
+### Max out a workshop weapon
+**File:** `ModularTegustation/tegu_items/workshop/_templates.dm`  
+**Title:** 
+
+### Cure Naked Nest infection with a cure
+**File:** `code/modules/mob/living/simple_animal/abnormality/waw/naked_nest.dm`  
+**Title:** 
+
+### Free yourself from Nobody Is' chokehold
+**File:** `code/modules/mob/living/simple_animal/abnormality/aleph/nobody_is.dm`  
+**Title:** 
+
+### Save someone from the wolf yourself
+**File:** `code/modules/mob/living/simple_animal/abnormality/waw/big_wolf.dm`  
+**Title:** 
+
+### Be saved by Red Hood after getting eaten by Wolf
+**Files:** `code/modules/mob/living/simple_animal/abnormality/waw/big_wolf.dm`, `code/modules/mob/living/simple_animal/abnormality/waw/red_riding_mercenary.dm`  
+**Title:** 
+
+### Use Fell Bullet's shotgun interaction
+**File:** `ModularTegustation/ego_weapons/ranged/waw.dm`  
+**Title:** 
+
+### Experience SWA and EGO gift interaction
+**File:** `code/modules/mob/living/simple_animal/abnormality/waw/snow_whites_apple.dm`  
+**Title:** 
+
+### Breach Golden Apple with a Yuri plushie
+**Files:** `code/modules/mob/living/simple_animal/abnormality/he/golden_false_apple.dm`, `code/game/objects/items/plushes.dm`  
+**Title:** 
+
+### Hear Silent Orchestra's full performance
+**File:** `code/modules/mob/living/simple_animal/abnormality/aleph/silent_orchestra.dm`  
+**Title:** 
+
+### Activate Hammer of Light
+**File:** `code/modules/mob/living/simple_animal/abnormality/zayin/hammer_light.dm`  
+**Title:** 
+
+### Survive a non-instinct/attachment work on Nothing There
+**File:** `code/modules/mob/living/simple_animal/abnormality/aleph/nothing_there.dm`  
+**Title:** 
+
+### Die to Punishing Bird without enraging it
+**File:** `code/modules/mob/living/simple_animal/abnormality/teth/punishing_bird.dm`  
+**Title:** 
+
+### Kill WhiteNight by confessing to one sin
+**File:** `code/modules/mob/living/simple_animal/abnormality/aleph/white_night.dm`  
+**Title:** 
+
+### Kill WhiteNight with Hammer of Light
+**Files:** `code/modules/mob/living/simple_animal/abnormality/aleph/white_night.dm`, `code/modules/mob/living/simple_animal/abnormality/zayin/hammer_light.dm`  
+**Title:** 
+
+### Rescue/Be rescued from Snow Queen
+**File:** `code/modules/mob/living/simple_animal/abnormality/he/snow_queen.dm`  
+**Title:** 
+
+### Trigger Snow Queen's ice due to Feather of Honour
+**File:** `code/modules/mob/living/simple_animal/abnormality/he/snow_queen.dm`  
+**Title:** 
+
+### Trigger FAN five times on the same character
+**File:** `code/modules/mob/living/simple_animal/abnormality/he/fan.dm`  
+**Title:** 
+
+### Get hit by hell train and survive
+**File:** `code/modules/mob/living/simple_animal/abnormality/waw/express_train.dm`  
+**Title:** 
+
+### Repress Melting Love with blessing and survive
+**File:** `code/modules/mob/living/simple_animal/abnormality/aleph/melting_love.dm`  
+**Title:** 
+
+### Say "uwu" on the radio
+**Files:** `code/modules/mob/living/say.dm`, `code/game/objects/items/devices/radio/radio.dm`  
+**Title:** 
+
+### See the Chaos Dunk
+**File:** `code/modules/holodeck/items.dm`  
+**Title:** 
+
+### Successfully type 680 mHz codes 5 times in a row
+**File:** `code/modules/mob/living/simple_animal/abnormality/he/KHz.dm`  
+**Title:** 
+
+### Yin and Yang realization
+**File:** `code/modules/mob/living/simple_animal/abnormality/_tools/zayin/realizer.dm`  
+**Title:** 
+
+### Realize Carmen/Benjamin from plushies
+**File:** `code/modules/mob/living/simple_animal/abnormality/_tools/zayin/realizer.dm`  
+**Title:** 
+
+### Realize Ayin from Paradise Lost
+**File:** `code/modules/mob/living/simple_animal/abnormality/_tools/zayin/realizer.dm`  
+**Title:** 
+
+### Achieve 200+ in one virtue
+**File:** `code/datums/attributes/_attribute.dm`  
+**Title:** 
+
+### Achieve 200+ in all virtues
+**File:** `code/datums/attributes/_attribute.dm`  
+**Title:** 
+
+### Be in a round where Bald balds everyone
+**File:** `code/modules/mob/living/simple_animal/abnormality/zayin/bald.dm`  
+**Title:** 
+
+### Get killed by friendly Queen of Hatred
+**File:** `code/modules/mob/living/simple_animal/abnormality/waw/hatred_queen.dm`  
+**Title:** 
+
+### Die to Blubbering Toad
+**File:** `code/modules/mob/living/simple_animal/abnormality/zayin/blubbering_toad.dm`  
+**Title:** 
+
+### Make meth
+**File:** `code/modules/reagents/chemistry/recipes/drugs.dm`  
+**Title:** 
+
+### Let Blubbering Toad out
+**File:** `code/modules/mob/living/simple_animal/abnormality/zayin/blubbering_toad.dm`  
+**Title:** 
+
+### Beat each core suppression
+**Files:** Various suppression files (Control, Information, Training, Safety, Command, Welfare, Records, Extraction)  
+**Title:** 
+
+### Burn a Binah plush
+**File:** `code/game/objects/items/plushes.dm`  
+**Title:** 
+
+### Kill WhiteNight during Pink Midnight
+**Files:** `code/modules/mob/living/simple_animal/abnormality/aleph/white_night.dm`, `code/modules/ordeals/misc_ordeals.dm`  
+**Title:** 
+
+### Damage Punishing Bird
+**File:** `code/modules/mob/living/simple_animal/abnormality/teth/punishing_bird.dm`  
+**Title:** 
+
+### Kill Punishing Bird
+**File:** `code/modules/mob/living/simple_animal/abnormality/teth/punishing_bird.dm`  
+**Title:** Punished Bird 
+
+### Kill Distorted Form
+**File:** `code/modules/mob/living/simple_animal/abnormality/aleph/distortedform.dm`  
+**Title:** 
+
+### Clerk using non-ZAYIN/TETH weapon
+**File:** `ModularTegustation/ego_weapons/_ego_weapon.dm`  
+**Title:** 

--- a/ModularTegustation/ego_weapons/_ego_weapon.dm
+++ b/ModularTegustation/ego_weapons/_ego_weapon.dm
@@ -218,6 +218,17 @@
 			return FALSE
 	if(!SpecialEgoCheck(H))
 		return FALSE
+
+	// Check for clerk achievement - if clerk is using a weapon with requirements (non-ZAYIN/TETH)
+	if(H.mind && H.mind.assigned_role == "Clerk")
+		var/has_requirements = FALSE
+		for(var/atr in attribute_requirements)
+			if(attribute_requirements[atr] > 0)
+				has_requirements = TRUE
+				break
+		if(has_requirements && H.client)
+			H.client.give_award(/datum/award/achievement/lc13/clerk_high_ego, H)
+
 	return TRUE
 
 /obj/item/ego_weapon/proc/SpecialEgoCheck(mob/living/carbon/human/H)

--- a/ModularTegustation/ego_weapons/ranged/waw.dm
+++ b/ModularTegustation/ego_weapons/ranged/waw.dm
@@ -799,6 +799,12 @@
 		return
 	SpinAnimation(speed = 2, loops = 1, segments = 3, parallel = TRUE)//the abno version should always spin
 	B.damage *= 2
+
+	// Award achievement for using Fell Bullet's shotgun interaction (portal shooting)
+	if(B.firer && ishuman(B.firer))
+		var/mob/living/carbon/human/shooter = B.firer
+		shooter.client?.give_award(/datum/award/achievement/lc13/fell_bullet, shooter)
+
 	var/turf/real_target = get_link_target_turf()
 	for(var/obj/effect/portal/fellbullet/P in real_target)
 		P.SpinAnimation(speed = 5, loops = 1, segments = 3, parallel = TRUE)

--- a/ModularTegustation/tegu_items/workshop/_templates.dm
+++ b/ModularTegustation/tegu_items/workshop/_templates.dm
@@ -69,6 +69,12 @@
 
 	active = TRUE
 
+	// Track weapon forging for achievement (workshop attendant only)
+	if(user && user.mind && user.mind.assigned_role == "Workshop Attendant")
+		user.mind.weapons_forged++
+		if(user.mind.weapons_forged >= 50)
+			user.client?.give_award(/datum/award/achievement/lc13/weapon_forger, user)
+
 	//Modify these
 	force *= mod.forcemod
 	true_force *= mod.forcemod
@@ -148,6 +154,11 @@
 		level_xp = weapon_lv * xp_per_level
 		force *= 1.1
 		true_force *= 1.1
+
+		// Award achievement for maxing out a workshop weapon
+		if(weapon_lv >= max_lv && ishuman(user))
+			var/mob/living/carbon/human/H = user
+			H.client?.give_award(/datum/award/achievement/lc13/workshop_max, H)
 
 //This only is used for fishing weapons
 /obj/item/ego_weapon/template/proc/CheckHoroscope()

--- a/code/__DEFINES/achievements.dm
+++ b/code/__DEFINES/achievements.dm
@@ -52,6 +52,118 @@
 #define MEDAL_RAT_LEADER_QUEST "Rat Leader Quest"
 #define MEDAL_CLAN_GENOCIDE "Clan Genocide"
 #define MEDAL_NUKE_RATS_GENOCIDE "Nuke Rats Genocide"
+#define MEDAL_DIE_TO_TOAD "Die to Blubbering Toad"
+#define MEDAL_FREE_TOAD "Freedom for Toad"
+#define MEDAL_DIE_TO_PBIRD "Small Beak Big Pain"
+#define MEDAL_ACTIVATE_HAMMER "Divine Intervention"
+#define MEDAL_DAMAGE_PBIRD "Dont Poke the Bird"
+
+// Collection/Farming Achievements
+#define MEDAL_SILK_COLLECTOR "Silk Collector"
+#define MEDAL_WEAPON_FORGER "Master Forger"
+#define MEDAL_PLUSHIE_FEEDER "Plushie Feeder"
+#define MEDAL_SPIDER_FARMER "Spider Farmer"
+#define MEDAL_PE_REFINER "PE Master"
+
+// Abnormality Interaction Achievements
+#define MEDAL_NOBODY_ESCAPE "Nobody's Escape"
+#define MEDAL_WOLF_SAVIOR "Wolf Savior"
+#define MEDAL_RED_HOOD_SAVED "Red Hood Rescue"
+#define MEDAL_GOLDEN_APPLE_BREACH "Golden Mischief"
+#define MEDAL_ORCHESTRA_LISTENER "Orchestra Audience"
+#define MEDAL_NOTHING_SURVIVOR "Nothing Survivor"
+#define MEDAL_ONE_SIN_CONFESSION "One Sin"
+#define MEDAL_HAMMER_KILL_WN "Hammer Justice"
+#define MEDAL_SNOW_QUEEN_RESCUE "Ice Breaker"
+#define MEDAL_SNOW_QUEEN_FROZEN "Honored Ice"
+#define MEDAL_MELTING_LOVE_SURVIVOR "Love Survivor"
+
+// Death Achievements
+#define MEDAL_QUEEN_HATRED_DEATH "Friendly Fire"
+#define MEDAL_CUCKOO_DEATH "Cuckoo Clock"
+
+// Combat Achievements
+#define MEDAL_RESANE_AGENTS "Mind Healer"
+#define MEDAL_RECORDS_KILLER "Record Breaker"
+#define MEDAL_MIDNIGHT_B12 "B12 Survivor"
+#define MEDAL_ABNO_BLITZ "Blitz Master"
+#define MEDAL_TRAIN_SURVIVOR "Train Dodger"
+#define MEDAL_WARP_20MIN "Warp Veteran"
+#define MEDAL_WARP_10MIN "Warp Survivor"
+#define MEDAL_XCORP_GRENADE "Grenade Master"
+#define MEDAL_NAKED_PARRY "Naked Parry"
+#define MEDAL_FAN_TRIGGER "FAN Master"
+#define MEDAL_KILL_PBIRD "Bird Killer"
+#define MEDAL_KILL_DISTORTED "Distortion Slayer"
+#define MEDAL_KILL_CLAW_HARD "Claw Crusher"
+
+// Boss Achievements
+#define MEDAL_HEART_OF_GREED "Greed Slayer"
+#define MEDAL_YIN_YANG "Duality Master"
+#define MEDAL_EXTRACTION_SURVIVOR "Extraction Expert"
+
+// Progression Achievements
+#define MEDAL_HALF_ACHIEVEMENTS "Halfway There"
+#define MEDAL_ALL_ACHIEVEMENTS "Completionist"
+#define MEDAL_VETERAN_CLOAK "Veteran"
+#define MEDAL_MAX_INTERN "Eternal Intern"
+
+// Equipment Achievements
+#define MEDAL_TOOL_COLLECTOR "Tool Master"
+#define MEDAL_FISHING_5 "Novice Fisher"
+#define MEDAL_FISHING_10 "Skilled Fisher"
+#define MEDAL_FISHING_15 "Expert Fisher"
+#define MEDAL_FISHING_20 "Master Fisher"
+#define MEDAL_BOOMERANG_SELF "Dumbass"
+#define MEDAL_COLOR_FIXER_SET "Fixer OC"
+
+// Special/Easter Eggs
+#define MEDAL_UWU_RADIO "UwU"
+#define MEDAL_CHAOS_DUNK "Slam Jam"
+#define MEDAL_FATASS "Fatass"
+#define MEDAL_RADIO_CODES "Radio Expert"
+
+// Realization Achievements
+#define MEDAL_REALIZE_CARMEN "Carmen Realized"
+#define MEDAL_REALIZE_BENJAMIN "Benjamin Realized"
+#define MEDAL_REALIZE_AYIN "Ayin Realized"
+
+// Stat Achievements
+#define MEDAL_VIRTUE_200_SINGLE "Virtuous"
+#define MEDAL_VIRTUE_200_ALL "Paragon"
+
+// Round Events
+#define MEDAL_BALD_NUKE "Bald Witness"
+
+// Core Suppression Individual Achievements
+#define MEDAL_SUPPRESS_MALKUTH "Malkuth Suppressed"
+#define MEDAL_SUPPRESS_YESOD "Yesod Suppressed"
+#define MEDAL_SUPPRESS_HOD "Hod Suppressed"
+#define MEDAL_SUPPRESS_NETZACH "Netzach Suppressed"
+#define MEDAL_SUPPRESS_TIPHERETH "Tiphereth Suppressed"
+#define MEDAL_SUPPRESS_CHESED "Chesed Suppressed"
+#define MEDAL_SUPPRESS_GEBURA "Gebura Suppressed"
+#define MEDAL_SUPPRESS_HOKMA "Hokma Suppressed"
+#define MEDAL_SUPPRESS_BINAH "Binah Suppressed"
+#define MEDAL_BURN_BINAH_PLUSH "Binah Burner"
+
+// Ordeal Achievements
+#define MEDAL_ORDEAL_FOOD "Ordeal Chef"
+#define MEDAL_PINK_WHITENIGHT "Pink Slayer"
+
+// City Achievements
+#define MEDAL_HAPPY_ROOM "Happy Explorer"
+#define MEDAL_WORKSHOP_MAX "Workshop Master"
+#define MEDAL_LANDMINE_TRIP "Trap Springer"
+#define MEDAL_GOLDEN_BOUGH "Bough Collector"
+
+// Role-Specific Achievements
+#define MEDAL_CLERK_WEAPON "Armed Clerk"
+
+// Miscellaneous Achievements
+#define MEDAL_MAKE_METH "How?"
+#define MEDAL_FELL_BULLET "Fell Bullet"
+#define MEDAL_SWA_INTERACTION "SWA Special"
 
 //Skill medal hub IDs
 #define MEDAL_LEGENDARY_MINER		"Legendary Miner"

--- a/code/__DEFINES/achievements.dm
+++ b/code/__DEFINES/achievements.dm
@@ -71,16 +71,21 @@
 #define MEDAL_RED_HOOD_SAVED "Red Hood Rescue"
 #define MEDAL_GOLDEN_APPLE_BREACH "Golden Mischief"
 #define MEDAL_ORCHESTRA_LISTENER "Orchestra Audience"
+#define MEDAL_HAMMER_ACTIVATE "Light Activated"
 #define MEDAL_NOTHING_SURVIVOR "Nothing Survivor"
+#define MEDAL_PUNISHING_BIRD_INNOCENT "Innocent Victim"
 #define MEDAL_ONE_SIN_CONFESSION "One Sin"
 #define MEDAL_HAMMER_KILL_WN "Hammer Justice"
 #define MEDAL_SNOW_QUEEN_RESCUE "Ice Breaker"
 #define MEDAL_SNOW_QUEEN_FROZEN "Honored Ice"
 #define MEDAL_MELTING_LOVE_SURVIVOR "Love Survivor"
+#define MEDAL_NAKED_NEST_CURE_WITHOUT "Natural Recovery"
+#define MEDAL_NAKED_NEST_CURE_WITH "Medical Treatment"
 
 // Death Achievements
 #define MEDAL_QUEEN_HATRED_DEATH "Friendly Fire"
 #define MEDAL_CUCKOO_DEATH "Cuckoo Clock"
+#define MEDAL_BLUBBERING_TOAD_DEATH "Toad Victim"
 
 // Combat Achievements
 #define MEDAL_RESANE_AGENTS "Mind Healer"
@@ -131,6 +136,15 @@
 // Stat Achievements
 #define MEDAL_VIRTUE_200_SINGLE "Virtuous"
 #define MEDAL_VIRTUE_200_ALL "Paragon"
+#define MEDAL_MELTING_LOVE_BLESSING_REPRESS "Tough Love"
+#define MEDAL_KILL_WN_PINK_MIDNIGHT "Twilight Slayer"
+#define MEDAL_MHZ_CODES "Radio Savant"
+#define MEDAL_FRIENDLY_QOH_KILL "Friendly Fire"
+#define MEDAL_BALD_ROUND "Bald is Awesome"
+#define MEDAL_CLERK_HIGH_EGO "Above My Pay Grade"
+#define MEDAL_CARMEN_BENJAMIN "Lost Companions"
+#define MEDAL_AYIN_REALIZED "Paradise Found"
+#define MEDAL_MAKE_METH "How"
 
 // Round Events
 #define MEDAL_BALD_NUKE "Bald Witness"
@@ -161,9 +175,9 @@
 #define MEDAL_CLERK_WEAPON "Armed Clerk"
 
 // Miscellaneous Achievements
-#define MEDAL_MAKE_METH "How?"
 #define MEDAL_FELL_BULLET "Fell Bullet"
 #define MEDAL_SWA_INTERACTION "SWA Special"
+#define MEDAL_BLUBBERING_TOAD_RELEASE "Toad Liberator"
 
 //Skill medal hub IDs
 #define MEDAL_LEGENDARY_MINER		"Legendary Miner"

--- a/code/datums/achievements/LC13_achievements.dm
+++ b/code/datums/achievements/LC13_achievements.dm
@@ -22,6 +22,7 @@
 	desc = "One of your characters survived a full shift as a L corp employee."
 	database_id = MEDAL_LCORPWORLD
 	icon = "lcorp"
+	difficulty = ACHIEVEMENT_EASY
 
 /datum/award/achievement/lc13/scorpworld
 	name = "A Shrimple Arrangement"
@@ -35,6 +36,7 @@
 	desc = "End the shift forever marked by the the monster of the Black Forest."
 	database_id = MEDAL_TWILIGHT
 	icon = "twilight"
+	difficulty = ACHIEVEMENT_HARD
 
 //LC13 Bosses
 /datum/award/achievement/lc13/white_night
@@ -42,30 +44,35 @@
 	desc = "Slay T-03-46 and prevent divine judgement."
 	database_id = BOSS_MEDAL_WHITENIGHT
 	icon = "whitenight"
+	difficulty = ACHIEVEMENT_HARD
 
 /datum/award/achievement/lc13/ambermidnight
 	name = "Eternal Meal"
 	desc = "Defend the facility from an insatiable swarm."
 	database_id = BOSS_MEDAL_AMBERMIDNIGHT
 	icon = "amber"
+	difficulty = ACHIEVEMENT_NORMAL
 
 /datum/award/achievement/lc13/greenmidnight
 	name = "Last Helix"
 	desc = "Save the facility from being cleansed."
 	database_id = BOSS_MEDAL_GREENMIDNIGHT
 	icon = "green"
+	difficulty = ACHIEVEMENT_NORMAL
 
 /datum/award/achievement/lc13/violetmidnight
 	name = "The God Delusion"
 	desc = "Defend the facility from an enigmatic force."
 	database_id = BOSS_MEDAL_VIOLETMIDNIGHT
 	icon = "violet"
+	difficulty = ACHIEVEMENT_NORMAL
 
 /datum/award/achievement/lc13/whitemidnight
 	name = "The Claw"
 	desc = "Relive the worst day of the founders life."
 	database_id = BOSS_MEDAL_WHITEMIDNIGHT
 	icon = "claw"
+	difficulty = ACHIEVEMENT_NORMAL
 
 //City achievements
 /datum/award/achievement/lc13/city

--- a/code/datums/achievements/LC13_achievements.dm
+++ b/code/datums/achievements/LC13_achievements.dm
@@ -137,3 +137,39 @@
 	desc = "You've eliminated all the rat scavengers."
 	database_id = MEDAL_NUKE_RATS_GENOCIDE
 	icon = "rats_genocide"
+
+//Abnormality interaction achievements
+/datum/award/achievement/lc13/die_to_toad
+	name = "Oops"
+	desc = "Die to Blubbering Toad."
+	database_id = MEDAL_DIE_TO_TOAD
+	icon = "blubbering_toad"
+	difficulty = ACHIEVEMENT_EASY
+
+/datum/award/achievement/lc13/free_toad
+	name = "Freedom for Toad"
+	desc = "Let Blubbering Toad out of containment."
+	database_id = MEDAL_FREE_TOAD
+	icon = "blubbering_toad"
+	difficulty = ACHIEVEMENT_EASY
+
+/datum/award/achievement/lc13/die_to_pbird
+	name = "Small Beak, Big Pain"
+	desc = "Die to Punishing Bird without enraging it."
+	database_id = MEDAL_DIE_TO_PBIRD
+	icon = "punishing_bird"
+	difficulty = ACHIEVEMENT_NORMAL
+
+/datum/award/achievement/lc13/activate_hammer
+	name = "Divine Intervention"
+	desc = "Activate the Hammer of Light."
+	database_id = MEDAL_ACTIVATE_HAMMER
+	icon = "hammer_light"
+	difficulty = ACHIEVEMENT_NORMAL
+
+/datum/award/achievement/lc13/damage_pbird
+	name = "Don't Poke the Bird"
+	desc = "Damage Punishing Bird and face the consequences."
+	database_id = MEDAL_DAMAGE_PBIRD
+	icon = "punishing_bird"
+	difficulty = ACHIEVEMENT_EASY

--- a/code/datums/achievements/LC13_achievements_extended.dm
+++ b/code/datums/achievements/LC13_achievements_extended.dm
@@ -1,0 +1,583 @@
+// Extended LC13 Achievements - Created from community suggestions
+
+//=================================
+// COLLECTION/FARMING ACHIEVEMENTS
+//=================================
+
+/datum/award/achievement/lc13/silk_collector
+	name = "Silk Collector"
+	desc = "Obtain silk from mobs 120 times."
+	database_id = MEDAL_SILK_COLLECTOR
+	icon = "spider_bud"
+	difficulty = ACHIEVEMENT_HARD
+
+/datum/award/achievement/lc13/weapon_forger
+	name = "Master Forger"
+	desc = "Forge 50 weapons as a workshop attendant on City of Light."
+	database_id = MEDAL_WEAPON_FORGER
+	icon = "workshop"
+	difficulty = ACHIEVEMENT_HARD
+
+/datum/award/achievement/lc13/plushie_feeder
+	name = "Plushie Feeder"
+	desc = "Feed a plushie to Basilisoup."
+	database_id = MEDAL_PLUSHIE_FEEDER
+	icon = "basilisoup"
+	difficulty = ACHIEVEMENT_EASY
+
+/datum/award/achievement/lc13/spider_farmer
+	name = "Spider Farmer"
+	desc = "Generate 100 PE from Spiderbud from a successful work."
+	database_id = MEDAL_SPIDER_FARMER
+	icon = "spider_bud"
+	difficulty = ACHIEVEMENT_NORMAL
+
+/datum/award/achievement/lc13/pe_refiner
+	name = "PE Master"
+	desc = "Refine 100 PE boxes in the same round."
+	database_id = MEDAL_PE_REFINER
+	icon = "pe_box"
+	difficulty = ACHIEVEMENT_NORMAL
+
+//=================================
+// ABNORMALITY INTERACTIONS
+//=================================
+
+/datum/award/achievement/lc13/nobody_escape
+	name = "Nobody's Escape"
+	desc = "Free yourself from Nobody Is' chokehold."
+	database_id = MEDAL_NOBODY_ESCAPE
+	icon = "nobody_is"
+	difficulty = ACHIEVEMENT_NORMAL
+
+/datum/award/achievement/lc13/wolf_savior
+	name = "Wolf Savior"
+	desc = "Save someone from the wolf yourself."
+	database_id = MEDAL_WOLF_SAVIOR
+	icon = "big_wolf"
+	difficulty = ACHIEVEMENT_NORMAL
+
+/datum/award/achievement/lc13/red_hood_saved
+	name = "Red Hood Rescue"
+	desc = "Be saved by Red Hood after getting eaten by Wolf."
+	database_id = MEDAL_RED_HOOD_SAVED
+	icon = "red_hood"
+	difficulty = ACHIEVEMENT_NORMAL
+
+/datum/award/achievement/lc13/golden_apple_breach
+	name = "'I didn’t want to die.'"
+	desc = "Breach Golden Apple with a Yuri plushie."
+	database_id = MEDAL_GOLDEN_APPLE_BREACH
+	icon = "golden_apple"
+	difficulty = ACHIEVEMENT_NORMAL
+
+/datum/award/achievement/lc13/orchestra_listener
+	name = "Orchestra Audience"
+	desc = "Hear Silent Orchestra's full performance."
+	database_id = MEDAL_ORCHESTRA_LISTENER
+	icon = "silent_orchestra"
+	difficulty = ACHIEVEMENT_NORMAL
+
+/datum/award/achievement/lc13/nothing_survivor
+	name = "Nothing Survivor"
+	desc = "Survive a non-instinct/attachment work on Nothing There."
+	database_id = MEDAL_NOTHING_SURVIVOR
+	icon = "nothing_there"
+	difficulty = ACHIEVEMENT_HARD
+
+/datum/award/achievement/lc13/one_sin_confession
+	name = "One Sin"
+	desc = "Kill WhiteNight by confessing to one sin."
+	database_id = MEDAL_ONE_SIN_CONFESSION
+	icon = "whitenight"
+	difficulty = ACHIEVEMENT_NORMAL
+
+/datum/award/achievement/lc13/hammer_kill_wn
+	name = "Hammer Justice"
+	desc = "Kill WhiteNight with Hammer of Light."
+	database_id = MEDAL_HAMMER_KILL_WN
+	icon = "whitenight"
+	difficulty = ACHIEVEMENT_HARD
+
+/datum/award/achievement/lc13/snow_queen_rescue
+	name = "Ice Breaker"
+	desc = "Rescue a friend/Be rescued from Snow Queen."
+	database_id = MEDAL_SNOW_QUEEN_RESCUE
+	icon = "snow_queen"
+	difficulty = ACHIEVEMENT_NORMAL
+
+/datum/award/achievement/lc13/snow_queen_frozen
+	name = "Honored Ice"
+	desc = "Trigger Snow Queen's ice encasement due to wearing Feather of Honour."
+	database_id = MEDAL_SNOW_QUEEN_FROZEN
+	icon = "snow_queen"
+	difficulty = ACHIEVEMENT_NORMAL
+
+/datum/award/achievement/lc13/melting_love_survivor
+	name = "Love Survivor"
+	desc = "Repress Melting Love whilst having her blessing - and survive."
+	database_id = MEDAL_MELTING_LOVE_SURVIVOR
+	icon = "melting_love"
+	difficulty = ACHIEVEMENT_VERYHARD
+
+//=================================
+// DEATH ACHIEVEMENTS
+//=================================
+
+/datum/award/achievement/lc13/queen_hatred_death
+	name = "Friendly Fire"
+	desc = "Get killed by friendly breach Queen of Hatred."
+	database_id = MEDAL_QUEEN_HATRED_DEATH
+	icon = "queen_hatred"
+	difficulty = ACHIEVEMENT_NORMAL
+
+/datum/award/achievement/lc13/cuckoo_death
+	name = "Cuckoo Clock"
+	desc = "Get ??? by the cuckoospawn."
+	database_id = MEDAL_CUCKOO_DEATH
+	icon = "cuckoo_clock"
+	difficulty = ACHIEVEMENT_NORMAL
+
+//=================================
+// COMBAT ACHIEVEMENTS
+//=================================
+
+/datum/award/achievement/lc13/resane_agents
+	name = "Mind Healer"
+	desc = "Re-sane 8 agents in the same round."
+	database_id = MEDAL_RESANE_AGENTS
+	icon = "sanity"
+	difficulty = ACHIEVEMENT_EASY
+
+/datum/award/achievement/lc13/records_killer
+	name = "Record Breaker"
+	desc = "Have 5 abno kills as records officer."
+	database_id = MEDAL_RECORDS_KILLER
+	icon = "records"
+	difficulty = ACHIEVEMENT_NORMAL
+
+/datum/award/achievement/lc13/midnight_b12
+	name = "B12 Survivor"
+	desc = "Beat midnight on B12."
+	database_id = MEDAL_MIDNIGHT_B12
+	icon = "midnight"
+	difficulty = ACHIEVEMENT_VERYHARD
+
+/datum/award/achievement/lc13/abno_blitz
+	name = "Blitz Master"
+	desc = "Beat Abno Blitz."
+	database_id = MEDAL_ABNO_BLITZ
+	icon = "abno_blitz"
+	difficulty = ACHIEVEMENT_VERYHARD
+
+/datum/award/achievement/lc13/train_survivor
+	name = "Train Dodger"
+	desc = "Get hit by hell train and survive."
+	database_id = MEDAL_TRAIN_SURVIVOR
+	icon = "express_train"
+	difficulty = ACHIEVEMENT_HARD
+
+/datum/award/achievement/lc13/warp_20min
+	name = "Warp Veteran"
+	desc = "Survive 20 minutes in Warp corp cleanup."
+	database_id = MEDAL_WARP_20MIN
+	icon = "warp_corp"
+	difficulty = ACHIEVEMENT_VERYHARD
+
+/datum/award/achievement/lc13/warp_10min
+	name = "Warp Survivor"
+	desc = "Survive 10 minutes in Warp corp cleanup."
+	database_id = MEDAL_WARP_10MIN
+	icon = "warp_corp"
+	difficulty = ACHIEVEMENT_HARD
+
+/datum/award/achievement/lc13/xcorp_grenade
+	name = "Grenade Master"
+	desc = "Kill 8 x-corp monsters with a single grenade."
+	database_id = MEDAL_XCORP_GRENADE
+	icon = "grenade"
+	difficulty = ACHIEVEMENT_HARD
+
+/datum/award/achievement/lc13/naked_parry
+	name = "Naked Parry"
+	desc = "Land a naked parry on a pale pillar/pale fixer."
+	database_id = MEDAL_NAKED_PARRY
+	icon = "parry"
+	difficulty = ACHIEVEMENT_HARD
+
+/datum/award/achievement/lc13/fan_trigger
+	name = "FAN Master"
+	desc = "Trigger FAN five times on the same character."
+	database_id = MEDAL_FAN_TRIGGER
+	icon = "fan"
+	difficulty = ACHIEVEMENT_NORMAL
+
+/datum/award/achievement/lc13/kill_pbird
+	name = "Bird Killer"
+	desc = "Kill Punishing Bird."
+	database_id = MEDAL_KILL_PBIRD
+	icon = "punishing_bird"
+	difficulty = ACHIEVEMENT_HARD
+
+/datum/award/achievement/lc13/kill_distorted
+	name = "Distortion Slayer"
+	desc = "Kill Distorted form."
+	database_id = MEDAL_KILL_DISTORTED
+	icon = "distortion"
+	difficulty = ACHIEVEMENT_HARD
+
+//=================================
+// BOSS ACHIEVEMENTS
+//=================================
+
+/datum/award/achievement/lc13/heart_of_greed
+	name = "Greed Slayer"
+	desc = "Defeat the Heart of Greed."
+	database_id = MEDAL_HEART_OF_GREED
+	icon = "heart_greed"
+	difficulty = ACHIEVEMENT_VERYHARD
+
+/datum/award/achievement/lc13/yin_yang
+	name = "Duality Master"
+	desc = "Realize either Harmony of Duality or Duality of Harmony."
+	database_id = MEDAL_YIN_YANG
+	icon = "yin_yang"
+	difficulty = ACHIEVEMENT_NORMAL
+
+/datum/award/achievement/lc13/extraction_survivor
+	name = "Extraction Expert"
+	desc = "Survive until extraction with Yin, Yang, ETTH & the fourth."
+	database_id = MEDAL_EXTRACTION_SURVIVOR
+	icon = "extraction"
+	difficulty = ACHIEVEMENT_HARD
+
+//=================================
+// PROGRESSION ACHIEVEMENTS
+//=================================
+
+/datum/award/achievement/lc13/half_achievements
+	name = "Halfway There"
+	desc = "Complete 50% of all achievements."
+	database_id = MEDAL_HALF_ACHIEVEMENTS
+	icon = "halfway"
+	difficulty = ACHIEVEMENT_HARD
+
+/datum/award/achievement/lc13/all_achievements
+	name = "Completionist"
+	desc = "Complete 100% of all achievements."
+	database_id = MEDAL_ALL_ACHIEVEMENTS
+	icon = "completionist"
+	difficulty = ACHIEVEMENT_HARDEST
+
+/datum/award/achievement/lc13/veteran_cloak
+	name = "Veteran"
+	desc = "Achieve enough playtime to get the Veteran Player's cloak."
+	database_id = MEDAL_VETERAN_CLOAK
+	icon = "veteran"
+	difficulty = ACHIEVEMENT_HARD
+
+/datum/award/achievement/lc13/max_intern
+	name = "Eternal Intern"
+	desc = "Play the maximum amount of hours as intern."
+	database_id = MEDAL_MAX_INTERN
+	icon = "intern"
+	difficulty = ACHIEVEMENT_NORMAL
+
+//=================================
+// EQUIPMENT ACHIEVEMENTS
+//=================================
+
+/datum/award/achievement/lc13/tool_collector
+	name = "Tool Master"
+	desc = "Have at least 2 tool abno ego weapons and 1 tool abno ego armour."
+	database_id = MEDAL_TOOL_COLLECTOR
+	icon = "tools"
+	difficulty = ACHIEVEMENT_NORMAL
+
+/datum/award/achievement/lc13/fishing_5
+	name = "Novice Fisher"
+	desc = "Get a Level 5 fishing hat."
+	database_id = MEDAL_FISHING_5
+	icon = "fishing"
+	difficulty = ACHIEVEMENT_EASY
+
+/datum/award/achievement/lc13/fishing_10
+	name = "Skilled Fisher"
+	desc = "Get a Level 10 fishing hat."
+	database_id = MEDAL_FISHING_10
+	icon = "fishing"
+	difficulty = ACHIEVEMENT_NORMAL
+
+/datum/award/achievement/lc13/fishing_15
+	name = "Expert Fisher"
+	desc = "Get a Level 15 fishing hat."
+	database_id = MEDAL_FISHING_15
+	icon = "fishing"
+	difficulty = ACHIEVEMENT_HARD
+
+/datum/award/achievement/lc13/fishing_20
+	name = "Master Fisher"
+	desc = "Get a Level 20 fishing hat."
+	database_id = MEDAL_FISHING_20
+	icon = "fishing"
+	difficulty = ACHIEVEMENT_HARD
+
+/datum/award/achievement/lc13/boomerang_self
+	name = "Dumbass"
+	desc = "Hit yourself with boomerang weapon."
+	database_id = MEDAL_BOOMERANG_SELF
+	icon = "boomerang"
+	difficulty = ACHIEVEMENT_EASY
+
+/datum/award/achievement/lc13/color_fixer_set
+	name = "This is my fixer OC, donut steel"
+	desc = "Have all color fixer weapons on you + Twilight suit."
+	database_id = MEDAL_COLOR_FIXER_SET
+	icon = "color_fixer"
+	difficulty = ACHIEVEMENT_VERYHARD
+
+//=================================
+// SPECIAL/EASTER EGGS
+//=================================
+
+/datum/award/achievement/lc13/uwu_radio
+	name = "UwU"
+	desc = "Say 'uwu' on the radio."
+	database_id = MEDAL_UWU_RADIO
+	icon = "uwu"
+	difficulty = ACHIEVEMENT_EASY
+
+/datum/award/achievement/lc13/chaos_dunk
+	name = "Slam Jam"
+	desc = "See the Chaos Dunk."
+	database_id = MEDAL_CHAOS_DUNK
+	icon = "chaos_dunk"
+	difficulty = ACHIEVEMENT_VERYHARD
+
+/datum/award/achievement/lc13/fatass
+	name = "Fatass"
+	desc = "Become a fatass."
+	database_id = MEDAL_FATASS
+	icon = "fatass"
+	difficulty = ACHIEVEMENT_NORMAL
+
+/datum/award/achievement/lc13/radio_codes
+	name = "Radio Expert"
+	desc = "Successfully hear and type 680 mhz codes 5 times in a row."
+	database_id = MEDAL_RADIO_CODES
+	icon = "radio"
+	difficulty = ACHIEVEMENT_NORMAL
+
+//=================================
+// REALIZATION ACHIEVEMENTS
+//=================================
+
+/datum/award/achievement/lc13/realize_carmen
+	name = "Carmen Realized"
+	desc = "Realize Carmen from her plushie."
+	database_id = MEDAL_REALIZE_CARMEN
+	icon = "carmen"
+	difficulty = ACHIEVEMENT_NORMAL
+
+/datum/award/achievement/lc13/realize_benjamin
+	name = "Benjamin Realized"
+	desc = "Realize Benjamin from his plushie."
+	database_id = MEDAL_REALIZE_BENJAMIN
+	icon = "benjamin"
+	difficulty = ACHIEVEMENT_NORMAL
+
+/datum/award/achievement/lc13/realize_ayin
+	name = "Ayin Realized"
+	desc = "Realize Ayin from Paradise Lost's weapon."
+	database_id = MEDAL_REALIZE_AYIN
+	icon = "ayin"
+	difficulty = ACHIEVEMENT_NORMAL
+
+//=================================
+// STAT ACHIEVEMENTS
+//=================================
+
+/datum/award/achievement/lc13/virtue_200_single
+	name = "Virtuous"
+	desc = "Achieve a rating of equal or greater than 200 in one virtue (gifts count)."
+	database_id = MEDAL_VIRTUE_200_SINGLE
+	icon = "virtue"
+	difficulty = ACHIEVEMENT_NORMAL
+
+/datum/award/achievement/lc13/virtue_200_all
+	name = "Paragon"
+	desc = "Achieve a rating of equal or greater than 200 in all virtues (gifts count)."
+	database_id = MEDAL_VIRTUE_200_ALL
+	icon = "paragon"
+	difficulty = ACHIEVEMENT_HARD
+
+//=================================
+// ROUND EVENTS
+//=================================
+
+/datum/award/achievement/lc13/bald_nuke
+	name = "Bald Witness"
+	desc = "Be in a round where Bald nukes the facility."
+	database_id = MEDAL_BALD_NUKE
+	icon = "bald"
+	difficulty = ACHIEVEMENT_NORMAL
+
+//=================================
+// CORE SUPPRESSION ACHIEVEMENTS
+//=================================
+
+/datum/award/achievement/lc13/suppress_malkuth
+	name = "Control Suppressed"
+	desc = "Complete Malkuth's core suppression."
+	database_id = MEDAL_SUPPRESS_MALKUTH
+	icon = "malkuth"
+	difficulty = ACHIEVEMENT_NORMAL
+
+/datum/award/achievement/lc13/suppress_yesod
+	name = "Information Suppressed"
+	desc = "Complete Yesod's core suppression."
+	database_id = MEDAL_SUPPRESS_YESOD
+	icon = "yesod"
+	difficulty = ACHIEVEMENT_NORMAL
+
+/datum/award/achievement/lc13/suppress_hod
+	name = "Training Suppressed"
+	desc = "Complete Hod's core suppression."
+	database_id = MEDAL_SUPPRESS_HOD
+	icon = "hod"
+	difficulty = ACHIEVEMENT_NORMAL
+
+/datum/award/achievement/lc13/suppress_netzach
+	name = "Safety Suppressed"
+	desc = "Complete Netzach's core suppression."
+	database_id = MEDAL_SUPPRESS_NETZACH
+	icon = "netzach"
+	difficulty = ACHIEVEMENT_NORMAL
+
+/datum/award/achievement/lc13/suppress_tiphereth
+	name = "Central Command Suppressed"
+	desc = "Complete Tiphereth's core suppression."
+	database_id = MEDAL_SUPPRESS_TIPHERETH
+	icon = "tiphereth"
+	difficulty = ACHIEVEMENT_NORMAL
+
+/datum/award/achievement/lc13/suppress_chesed
+	name = "Welfare Suppressed"
+	desc = "Complete Chesed's core suppression."
+	database_id = MEDAL_SUPPRESS_CHESED
+	icon = "chesed"
+	difficulty = ACHIEVEMENT_NORMAL
+
+/datum/award/achievement/lc13/suppress_gebura
+	name = "Disciplinary Suppressed"
+	desc = "Complete Gebura's core suppression."
+	database_id = MEDAL_SUPPRESS_GEBURA
+	icon = "gebura"
+	difficulty = ACHIEVEMENT_NORMAL
+
+/datum/award/achievement/lc13/suppress_hokma
+	name = "Records Suppressed"
+	desc = "Complete Hokma's core suppression."
+	database_id = MEDAL_SUPPRESS_HOKMA
+	icon = "hokma"
+	difficulty = ACHIEVEMENT_NORMAL
+
+/datum/award/achievement/lc13/suppress_binah
+	name = "Extraction Suppressed"
+	desc = "Complete Binah's core suppression."
+	database_id = MEDAL_SUPPRESS_BINAH
+	icon = "binah"
+	difficulty = ACHIEVEMENT_HARD
+
+/datum/award/achievement/lc13/burn_binah_plush
+	name = "Binah Burner"
+	desc = "Burn a Binah plush."
+	database_id = MEDAL_BURN_BINAH_PLUSH
+	icon = "binah"
+	difficulty = ACHIEVEMENT_EASY
+
+//=================================
+// ORDEAL ACHIEVEMENTS
+//=================================
+
+/datum/award/achievement/lc13/ordeal_food
+	name = "Ordeal Chef"
+	desc = "Make one of each ordeal monster food items."
+	database_id = MEDAL_ORDEAL_FOOD
+	icon = "ordeal_food"
+	difficulty = ACHIEVEMENT_EASY
+
+/datum/award/achievement/lc13/pink_whitenight
+	name = "Pink Slayer"
+	desc = "Kill WhiteNight during a pink midnight."
+	database_id = MEDAL_PINK_WHITENIGHT
+	icon = "pink_midnight"
+	difficulty = ACHIEVEMENT_VERYHARD
+
+//=================================
+// CITY ACHIEVEMENTS
+//=================================
+
+/datum/award/achievement/lc13/happy_room
+	name = "Happy Explorer"
+	desc = "Get to the happy room in the city."
+	database_id = MEDAL_HAPPY_ROOM
+	icon = "happy_room"
+	difficulty = ACHIEVEMENT_NORMAL
+
+/datum/award/achievement/lc13/workshop_max
+	name = "Workshop Master"
+	desc = "Max out a workshop weapon in City of Light."
+	database_id = MEDAL_WORKSHOP_MAX
+	icon = "workshop"
+	difficulty = ACHIEVEMENT_HARD
+
+/datum/award/achievement/lc13/landmine_trip
+	name = "Trap Springer"
+	desc = "Trip on a landmine in one of the COL starter rooms."
+	database_id = MEDAL_LANDMINE_TRIP
+	icon = "landmine"
+	difficulty = ACHIEVEMENT_EASY
+
+/datum/award/achievement/lc13/golden_bough
+	name = "Bough Collector"
+	desc = "Collect the golden bough in ER."
+	database_id = MEDAL_GOLDEN_BOUGH
+	icon = "golden_bough"
+	difficulty = ACHIEVEMENT_VERYHARD
+
+//=================================
+// ROLE-SPECIFIC ACHIEVEMENTS
+//=================================
+
+/datum/award/achievement/lc13/clerk_weapon
+	name = "Armed Clerk"
+	desc = "As a clerk role, use a weapon that isn't ZAYIN or TETH."
+	database_id = MEDAL_CLERK_WEAPON
+	icon = "clerk"
+	difficulty = ACHIEVEMENT_HARD
+
+//=================================
+// MISCELLANEOUS ACHIEVEMENTS
+//=================================
+
+/datum/award/achievement/lc13/make_meth
+	name = "How?"
+	desc = "Make meth."
+	database_id = MEDAL_MAKE_METH
+	icon = "chemistry"
+	difficulty = ACHIEVEMENT_HARDEST
+
+/datum/award/achievement/lc13/fell_bullet
+	name = "Fell Bullet"
+	desc = "Use Fell Bullet's shotgun for its intended use."
+	database_id = MEDAL_FELL_BULLET
+	icon = "fell_bullet"
+	difficulty = ACHIEVEMENT_NORMAL
+
+/datum/award/achievement/lc13/swa_interaction
+	name = "SWA Special"
+	desc = "Experience the special interaction between SWA and a person with her EGO gift."
+	database_id = MEDAL_SWA_INTERACTION
+	icon = "swa"
+	difficulty = ACHIEVEMENT_NORMAL

--- a/code/datums/achievements/LC13_achievements_extended.dm
+++ b/code/datums/achievements/LC13_achievements_extended.dm
@@ -5,21 +5,24 @@
 //=================================
 
 /datum/award/achievement/lc13/silk_collector
-	name = "Silk Collector"
+	name = "The Legend of the Silksong" // Alternative: "Will Make Fine Silk?"
+	title = "the Legend of the Silksong"
 	desc = "Obtain silk from mobs 120 times."
 	database_id = MEDAL_SILK_COLLECTOR
 	icon = "spider_bud"
 	difficulty = ACHIEVEMENT_HARD
 
 /datum/award/achievement/lc13/weapon_forger
-	name = "Master Forger"
+	name = "Workshop Meister" // Alternative: "Respectable Workshop"
+	title = "a Workshop Meister"
 	desc = "Forge 50 weapons as a workshop attendant on City of Light."
 	database_id = MEDAL_WEAPON_FORGER
 	icon = "workshop"
 	difficulty = ACHIEVEMENT_HARD
 
 /datum/award/achievement/lc13/plushie_feeder
-	name = "Plushie Feeder"
+	name = "Plushie Cooking 101" // Alternative: "Soup from a Plush"
+	title = "a Plushie Chef"
 	desc = "Feed a plushie to Basilisoup."
 	database_id = MEDAL_PLUSHIE_FEEDER
 	icon = "basilisoup"
@@ -280,7 +283,8 @@
 	difficulty = ACHIEVEMENT_VERYHARD
 
 /datum/award/achievement/lc13/yin_yang
-	name = "Duality Master"
+	name = "Duality"
+	title = "a Duality Master"
 	desc = "Realize either Harmony of Duality or Duality of Harmony."
 	database_id = MEDAL_YIN_YANG
 	icon = "yin_yang"
@@ -441,76 +445,87 @@
 
 /datum/award/achievement/lc13/virtue_200_single
 	name = "Virtuous"
+	title = "being Virtuous"
 	desc = "Achieve a rating of equal or greater than 200 in one virtue (gifts count)."
 	database_id = MEDAL_VIRTUE_200_SINGLE
 	icon = "virtue"
 	difficulty = ACHIEVEMENT_NORMAL
 
 /datum/award/achievement/lc13/virtue_200_all
-	name = "Paragon"
+	name = "Most Virtuous"
+	title = "the Most Virtuous"
 	desc = "Achieve a rating of equal or greater than 200 in all virtues (gifts count)."
 	database_id = MEDAL_VIRTUE_200_ALL
 	icon = "paragon"
 	difficulty = ACHIEVEMENT_HARD
 
 /datum/award/achievement/lc13/melting_love_blessing_repress
-	name = "Tough Love"
+	name = "Begone Thot!"
+	title = "saying Begone Thot"
 	desc = "Repress Melting Love whilst having her blessing - and survive."
 	database_id = MEDAL_MELTING_LOVE_BLESSING_REPRESS
 	icon = "melting_love_tough"
 	difficulty = ACHIEVEMENT_HARD
 
 /datum/award/achievement/lc13/kill_wn_pink_midnight
-	name = "Twilight Slayer"
+	name = "A Night Everlasting" // Alternative: "DOOM, Hell on Facility"
+	title = "a Night Everlasting"
 	desc = "Kill WhiteNight during a pink midnight."
 	database_id = MEDAL_KILL_WN_PINK_MIDNIGHT
 	icon = "twilight_slayer"
 	difficulty = ACHIEVEMENT_HARD
 
 /datum/award/achievement/lc13/mhz_codes
-	name = "Radio Savant"
+	name = "Charlie Alpha November Yankee Oscar Uniform Hotel Echo Alpha Romeo"
+	title = "a Radio Operator"
 	desc = "Successfully hear and type 680 mHz codes 5 times in a row."
 	database_id = MEDAL_MHZ_CODES
 	icon = "radio_savant"
 	difficulty = ACHIEVEMENT_HARD
 
 /datum/award/achievement/lc13/friendly_qoh_kill
-	name = "Friendly Fire"
+	name = "Villain of the Day" // Alternative: "Villain Beware!!!"
+	title = "the Villain of the Day"
 	desc = "Get killed by friendly breach Queen of Hatred."
 	database_id = MEDAL_FRIENDLY_QOH_KILL
 	icon = "friendly_fire"
 	difficulty = ACHIEVEMENT_HARD
 
 /datum/award/achievement/lc13/bald_round
-	name = "Bald is Awesome!"
+	name = "Now We're Awesome"
+	title = "being Awesome Now"
 	desc = "Be in a round where Bald balds everyone in the facility."
 	database_id = MEDAL_BALD_ROUND
 	icon = "bald_awesome"
 	difficulty = ACHIEVEMENT_NORMAL
 
 /datum/award/achievement/lc13/clerk_high_ego
-	name = "Above My Pay Grade"
+	name = "Breaking the Limits"
+	title = "a Limit Breaker"
 	desc = "As a clerk role, use a weapon that isn't ZAYIN or TETH."
 	database_id = MEDAL_CLERK_HIGH_EGO
 	icon = "clerk_high_ego"
 	difficulty = ACHIEVEMENT_NORMAL
 
 /datum/award/achievement/lc13/carmen_benjamin
-	name = "Lost Companions"
+	name = "A Friend from the Past"
+	title = "a Friend from the Past"
 	desc = "Realize Carmen/Benjamin from their respective plushies."
 	database_id = MEDAL_CARMEN_BENJAMIN
 	icon = "lost_companions"
 	difficulty = ACHIEVEMENT_EASY
 
 /datum/award/achievement/lc13/ayin_realized
-	name = "Paradise Found"
+	name = "One God"
+	title = "the One God"
 	desc = "Realize Ayin from Paradise Lost's weapon."
 	database_id = MEDAL_AYIN_REALIZED
 	icon = "paradise_found"
 	difficulty = ACHIEVEMENT_EASY
 
 /datum/award/achievement/lc13/make_meth
-	name = "How?"
+	name = "Breaking Bong"
+	title = "a Breaking Bong Expert"
 	desc = "Make meth."
 	database_id = MEDAL_MAKE_METH
 	icon = "how_meth"

--- a/code/datums/achievements/LC13_achievements_extended.dm
+++ b/code/datums/achievements/LC13_achievements_extended.dm
@@ -78,12 +78,26 @@
 	icon = "silent_orchestra"
 	difficulty = ACHIEVEMENT_NORMAL
 
+/datum/award/achievement/lc13/hammer_activate
+	name = "Light Activated"
+	desc = "Activate Hammer of Light."
+	database_id = MEDAL_HAMMER_ACTIVATE
+	icon = "hammer_light"
+	difficulty = ACHIEVEMENT_EASY
+
 /datum/award/achievement/lc13/nothing_survivor
 	name = "Nothing Survivor"
 	desc = "Survive a non-instinct/attachment work on Nothing There."
 	database_id = MEDAL_NOTHING_SURVIVOR
 	icon = "nothing_there"
 	difficulty = ACHIEVEMENT_HARD
+
+/datum/award/achievement/lc13/punishing_bird_innocent
+	name = "Innocent Victim"
+	desc = "Die to Punishing Bird without having enraged it beforehand."
+	database_id = MEDAL_PUNISHING_BIRD_INNOCENT
+	icon = "punishing_bird"
+	difficulty = ACHIEVEMENT_NORMAL
 
 /datum/award/achievement/lc13/one_sin_confession
 	name = "One Sin"
@@ -120,6 +134,20 @@
 	icon = "melting_love"
 	difficulty = ACHIEVEMENT_VERYHARD
 
+/datum/award/achievement/lc13/naked_nest_cure_without
+	name = "Natural Recovery"
+	desc = "Cure Naked Nest infection without a cure."
+	database_id = MEDAL_NAKED_NEST_CURE_WITHOUT
+	icon = "naked_nest"
+	difficulty = ACHIEVEMENT_HARD
+
+/datum/award/achievement/lc13/naked_nest_cure_with
+	name = "Medical Treatment"
+	desc = "Cure Naked Nest infection with a cure."
+	database_id = MEDAL_NAKED_NEST_CURE_WITH
+	icon = "naked_nest"
+	difficulty = ACHIEVEMENT_EASY
+
 //=================================
 // DEATH ACHIEVEMENTS
 //=================================
@@ -137,6 +165,13 @@
 	database_id = MEDAL_CUCKOO_DEATH
 	icon = "cuckoo_clock"
 	difficulty = ACHIEVEMENT_NORMAL
+
+/datum/award/achievement/lc13/blubbering_toad_death
+	name = "Toad Victim"
+	desc = "Die to Blubbering Toad."
+	database_id = MEDAL_BLUBBERING_TOAD_DEATH
+	icon = "blubbering_toad"
+	difficulty = ACHIEVEMENT_EASY
 
 //=================================
 // COMBAT ACHIEVEMENTS
@@ -212,8 +247,15 @@
 	icon = "fan"
 	difficulty = ACHIEVEMENT_NORMAL
 
+/datum/award/achievement/lc13/damage_pbird
+	name = "Bird Harmer"
+	desc = "Damage Punishing Bird."
+	database_id = MEDAL_DAMAGE_PBIRD
+	icon = "punishing_bird"
+	difficulty = ACHIEVEMENT_EASY
+
 /datum/award/achievement/lc13/kill_pbird
-	name = "Bird Killer"
+	name = "Punished Bird"
 	desc = "Kill Punishing Bird."
 	database_id = MEDAL_KILL_PBIRD
 	icon = "punishing_bird"
@@ -411,6 +453,69 @@
 	icon = "paragon"
 	difficulty = ACHIEVEMENT_HARD
 
+/datum/award/achievement/lc13/melting_love_blessing_repress
+	name = "Tough Love"
+	desc = "Repress Melting Love whilst having her blessing - and survive."
+	database_id = MEDAL_MELTING_LOVE_BLESSING_REPRESS
+	icon = "melting_love_tough"
+	difficulty = ACHIEVEMENT_HARD
+
+/datum/award/achievement/lc13/kill_wn_pink_midnight
+	name = "Twilight Slayer"
+	desc = "Kill WhiteNight during a pink midnight."
+	database_id = MEDAL_KILL_WN_PINK_MIDNIGHT
+	icon = "twilight_slayer"
+	difficulty = ACHIEVEMENT_HARD
+
+/datum/award/achievement/lc13/mhz_codes
+	name = "Radio Savant"
+	desc = "Successfully hear and type 680 mHz codes 5 times in a row."
+	database_id = MEDAL_MHZ_CODES
+	icon = "radio_savant"
+	difficulty = ACHIEVEMENT_HARD
+
+/datum/award/achievement/lc13/friendly_qoh_kill
+	name = "Friendly Fire"
+	desc = "Get killed by friendly breach Queen of Hatred."
+	database_id = MEDAL_FRIENDLY_QOH_KILL
+	icon = "friendly_fire"
+	difficulty = ACHIEVEMENT_HARD
+
+/datum/award/achievement/lc13/bald_round
+	name = "Bald is Awesome!"
+	desc = "Be in a round where Bald balds everyone in the facility."
+	database_id = MEDAL_BALD_ROUND
+	icon = "bald_awesome"
+	difficulty = ACHIEVEMENT_NORMAL
+
+/datum/award/achievement/lc13/clerk_high_ego
+	name = "Above My Pay Grade"
+	desc = "As a clerk role, use a weapon that isn't ZAYIN or TETH."
+	database_id = MEDAL_CLERK_HIGH_EGO
+	icon = "clerk_high_ego"
+	difficulty = ACHIEVEMENT_NORMAL
+
+/datum/award/achievement/lc13/carmen_benjamin
+	name = "Lost Companions"
+	desc = "Realize Carmen/Benjamin from their respective plushies."
+	database_id = MEDAL_CARMEN_BENJAMIN
+	icon = "lost_companions"
+	difficulty = ACHIEVEMENT_EASY
+
+/datum/award/achievement/lc13/ayin_realized
+	name = "Paradise Found"
+	desc = "Realize Ayin from Paradise Lost's weapon."
+	database_id = MEDAL_AYIN_REALIZED
+	icon = "paradise_found"
+	difficulty = ACHIEVEMENT_EASY
+
+/datum/award/achievement/lc13/make_meth
+	name = "How?"
+	desc = "Make meth."
+	database_id = MEDAL_MAKE_METH
+	icon = "how_meth"
+	difficulty = ACHIEVEMENT_HARDEST
+
 //=================================
 // ROUND EVENTS
 //=================================
@@ -581,3 +686,10 @@
 	database_id = MEDAL_SWA_INTERACTION
 	icon = "swa"
 	difficulty = ACHIEVEMENT_NORMAL
+
+/datum/award/achievement/lc13/blubbering_toad_release
+	name = "Toad Liberator"
+	desc = "Let Blubbering Toad out."
+	database_id = MEDAL_BLUBBERING_TOAD_RELEASE
+	icon = "blubbering_toad"
+	difficulty = ACHIEVEMENT_EASY

--- a/code/datums/achievements/_awards.dm
+++ b/code/datums/achievements/_awards.dm
@@ -67,7 +67,7 @@
 
 /// Difficulty levels for achievements
 #define ACHIEVEMENT_EASY "Easy"
-#define ACHIEVEMENT_NORMAL "Normal"  
+#define ACHIEVEMENT_NORMAL "Normal"
 #define ACHIEVEMENT_HARD "Hard"
 #define ACHIEVEMENT_VERYHARD "Very Hard"
 #define ACHIEVEMENT_HARDEST "Hardest"
@@ -77,6 +77,9 @@
 	desc = "Achievement for epic people"
 	/// Difficulty of this achievement
 	var/difficulty = ACHIEVEMENT_NORMAL
+	/// Title to display in examine text - should make sense in "Their specialization is [title]!"
+	/// If not set, falls back to using the achievement name
+	var/title
 
 /datum/award/achievement/get_metadata_row()
 	. = ..()

--- a/code/datums/achievements/_awards.dm
+++ b/code/datums/achievements/_awards.dm
@@ -65,9 +65,18 @@
 /datum/award/proc/on_unlock(mob/user)
 	return
 
+/// Difficulty levels for achievements
+#define ACHIEVEMENT_EASY "Easy"
+#define ACHIEVEMENT_NORMAL "Normal"  
+#define ACHIEVEMENT_HARD "Hard"
+#define ACHIEVEMENT_VERYHARD "Very Hard"
+#define ACHIEVEMENT_HARDEST "Hardest"
+
 ///Achievements are one-off awards for usually doing cool things.
 /datum/award/achievement
 	desc = "Achievement for epic people"
+	/// Difficulty of this achievement
+	var/difficulty = ACHIEVEMENT_NORMAL
 
 /datum/award/achievement/get_metadata_row()
 	. = ..()
@@ -79,6 +88,22 @@
 /datum/award/achievement/on_unlock(mob/user)
 	. = ..()
 	to_chat(user, span_greenannounce("<B>Achievement unlocked: [name]!</B>"))
+
+/// Returns the hex color associated with this achievement's difficulty
+/datum/award/achievement/proc/get_difficulty_color()
+	switch(difficulty)
+		if(ACHIEVEMENT_EASY)
+			return "#ADD8E6" // Pale blue
+		if(ACHIEVEMENT_NORMAL)
+			return "#00FF00" // Green
+		if(ACHIEVEMENT_HARD)
+			return "#FF0000" // Red
+		if(ACHIEVEMENT_VERYHARD)
+			return "#800080" // Purple
+		if(ACHIEVEMENT_HARDEST)
+			return "#FFA500" // Orange
+		else
+			return "#00FF00" // Default to green
 
 ///Scores are for leaderboarded things, such as killcount of a specific boss
 /datum/award/score

--- a/code/datums/attributes/_attribute.dm
+++ b/code/datums/attributes/_attribute.dm
@@ -47,6 +47,21 @@ GLOBAL_LIST_INIT(attribute_types, list(
 	return round(level) + initial_stat_value
 
 /datum/attribute/proc/on_update(mob/living/carbon/user)
+	// Check for virtue achievements
+	if(ishuman(user))
+		var/mob/living/carbon/human/H = user
+		if(get_modified_level() >= 200)
+			H.client?.give_award(/datum/award/achievement/lc13/virtue_200_single, H)
+
+			// Check if all virtues are 200+
+			var/all_200 = TRUE
+			for(var/attr_name in H.attributes)
+				var/datum/attribute/attr = H.attributes[attr_name]
+				if(attr.get_modified_level() < 200)
+					all_200 = FALSE
+					break
+			if(all_200)
+				H.client?.give_award(/datum/award/achievement/lc13/virtue_200_all, H)
 	return
 
 /datum/attribute/proc/adjust_level(mob/living/carbon/human/user, addition)

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -91,6 +91,19 @@
 	///Assoc list of key active addictions and value amount of cycles that it has been active.
 	var/list/active_addictions
 
+	/// Number of PE boxes refined by this player for achievement tracking
+	var/pe_boxes_refined = 0
+	/// Number of times silk has been obtained for achievement tracking
+	var/silk_harvested = 0
+	/// Number of weapons forged as workshop attendant
+	var/weapons_forged = 0
+	/// Number of abnormality kills as records officer
+	var/records_officer_kills = 0
+	/// Number of successful 680 mHz codes in a row
+	var/mhz_codes_streak = 0
+	/// Number of times FAN has been triggered on this character
+	var/fan_triggers = 0
+
 /datum/mind/New(_key)
 	key = _key
 	martial_art = default_martial_art

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -222,6 +222,11 @@
 		return
 	if(!M.IsVocal())
 		return
+
+	// Check for uwu achievement
+	if(ishuman(M) && findtext(lowertext(message), "uwu"))
+		var/mob/living/carbon/human/H = M
+		H.client?.give_award(/datum/award/achievement/lc13/uwu_radio, H)
 	if(LAZYLEN(radio_sounds)) //Sephora - Radios make small static sounds now.
 		var/sound_channel = SSsounds.random_available_channel()
 		var/radio_sound = pick(radio_sounds)

--- a/code/game/objects/items/plushes.dm
+++ b/code/game/objects/items/plushes.dm
@@ -407,6 +407,13 @@
 	icon_state = "binah"
 	gender = FEMALE
 
+/obj/item/toy/plush/binah/fire_act(exposed_temperature, exposed_volume)
+	. = ..()
+	// Award achievement for burning a Binah plush
+	for(var/mob/living/carbon/human/H in view(7, src))
+		if(H.stat != DEAD)
+			H.client?.give_award(/datum/award/achievement/lc13/burn_binah_plush, H)
+
 /obj/item/toy/plush/angela
 	name = "angela plushie"
 	desc = "A plushie depicting Lobotomy Corporation's AI."

--- a/code/game/objects/items/stacks/sheets/silk.dm
+++ b/code/game/objects/items/stacks/sheets/silk.dm
@@ -4,12 +4,22 @@
 #define RARITY_MASTERPIECE "Masterpiece"
 
 /datum/component/butchering/silkbutchering
+	var/mob/living/harvester = null
 
 /datum/component/butchering/silkbutchering/checkButchering(obj/item/source, mob/living/M, mob/living/user)
+	harvester = user
 	return M.silk_results || ishuman(M)
 
 /datum/component/butchering/silkbutchering/ButcherEffects(mob/living/meat)
 	var/turf/T = meat.drop_location()
+
+	// Track silk harvesting for achievement
+	if(ishuman(harvester) && harvester.mind)
+		var/mob/living/carbon/human/H = harvester
+		H.mind.silk_harvested++
+		if(H.mind.silk_harvested >= 120)
+			H.client?.give_award(/datum/award/achievement/lc13/silk_collector, H)
+
 	if(ishuman(meat))
 		// if(meat.client)
 		// 	meat.visible_message(span_notice("[meat]'s soul resists the silkweaver!"))

--- a/code/modules/admin/verbs/achievement_test.dm
+++ b/code/modules/admin/verbs/achievement_test.dm
@@ -1,0 +1,67 @@
+/client/proc/unlock_achievement_test()
+	set name = "Unlock Achievement (Test)"
+	set category = "Debug"
+	
+	if(!check_rights(R_DEBUG))
+		return
+	
+	var/list/all_achievements = list()
+	for(var/achievement_type in SSachievements.achievements)
+		var/datum/award/achievement/A = SSachievements.achievements[achievement_type]
+		if(!A.name)
+			continue
+		all_achievements[A.name] = achievement_type
+	
+	var/choice = input("Select an achievement to unlock:", "Achievement Test") as null|anything in all_achievements
+	if(!choice)
+		return
+	
+	var/achievement_type = all_achievements[choice]
+	player_details.achievements.unlock(achievement_type, mob)
+	to_chat(src, "<span class='adminnotice'>Unlocked achievement: [choice]</span>")
+
+/client/proc/reset_achievement_test()
+	set name = "Reset Achievement (Test)"
+	set category = "Debug"
+	
+	if(!check_rights(R_DEBUG))
+		return
+	
+	var/list/unlocked = list()
+	for(var/achievement_type in player_details.achievements.data)
+		if(!player_details.achievements.data[achievement_type])
+			continue
+		var/datum/award/achievement/A = SSachievements.achievements[achievement_type]
+		if(!A || !A.name)
+			continue
+		unlocked[A.name] = achievement_type
+	
+	if(!unlocked.len)
+		to_chat(src, "<span class='warning'>You have no unlocked achievements!</span>")
+		return
+	
+	var/choice = input("Select an achievement to reset:", "Achievement Reset") as null|anything in unlocked
+	if(!choice)
+		return
+	
+	var/achievement_type = unlocked[choice]
+	player_details.achievements.reset(achievement_type)
+	to_chat(src, "<span class='adminnotice'>Reset achievement: [choice]</span>")
+
+/client/proc/view_my_achievements()
+	set name = "View My Achievements"
+	set category = "Debug"
+	
+	if(!check_rights(R_DEBUG))
+		return
+	
+	var/list/output = list("<b>Your Achievements:</b>")
+	for(var/achievement_type in SSachievements.achievements)
+		var/datum/award/achievement/A = SSachievements.achievements[achievement_type]
+		if(!A.name)
+			continue
+		var/unlocked = player_details.achievements.data[achievement_type]
+		var/color = unlocked ? "#00FF00" : "#FF0000"
+		output += "<span style='color: [color]'>[A.name] ([A.difficulty]) - [unlocked ? "UNLOCKED" : "LOCKED"]</span>"
+	
+	to_chat(src, output.Join("<br>"))

--- a/code/modules/admin/verbs/achievement_test.dm
+++ b/code/modules/admin/verbs/achievement_test.dm
@@ -1,21 +1,21 @@
 /client/proc/unlock_achievement_test()
 	set name = "Unlock Achievement (Test)"
 	set category = "Debug"
-	
+
 	if(!check_rights(R_DEBUG))
 		return
-	
+
 	var/list/all_achievements = list()
 	for(var/achievement_type in SSachievements.achievements)
 		var/datum/award/achievement/A = SSachievements.achievements[achievement_type]
 		if(!A.name)
 			continue
 		all_achievements[A.name] = achievement_type
-	
+
 	var/choice = input("Select an achievement to unlock:", "Achievement Test") as null|anything in all_achievements
 	if(!choice)
 		return
-	
+
 	var/achievement_type = all_achievements[choice]
 	player_details.achievements.unlock(achievement_type, mob)
 	to_chat(src, "<span class='adminnotice'>Unlocked achievement: [choice]</span>")
@@ -23,10 +23,10 @@
 /client/proc/reset_achievement_test()
 	set name = "Reset Achievement (Test)"
 	set category = "Debug"
-	
+
 	if(!check_rights(R_DEBUG))
 		return
-	
+
 	var/list/unlocked = list()
 	for(var/achievement_type in player_details.achievements.data)
 		if(!player_details.achievements.data[achievement_type])
@@ -35,15 +35,15 @@
 		if(!A || !A.name)
 			continue
 		unlocked[A.name] = achievement_type
-	
+
 	if(!unlocked.len)
 		to_chat(src, "<span class='warning'>You have no unlocked achievements!</span>")
 		return
-	
+
 	var/choice = input("Select an achievement to reset:", "Achievement Reset") as null|anything in unlocked
 	if(!choice)
 		return
-	
+
 	var/achievement_type = unlocked[choice]
 	player_details.achievements.reset(achievement_type)
 	to_chat(src, "<span class='adminnotice'>Reset achievement: [choice]</span>")
@@ -51,10 +51,10 @@
 /client/proc/view_my_achievements()
 	set name = "View My Achievements"
 	set category = "Debug"
-	
+
 	if(!check_rights(R_DEBUG))
 		return
-	
+
 	var/list/output = list("<b>Your Achievements:</b>")
 	for(var/achievement_type in SSachievements.achievements)
 		var/datum/award/achievement/A = SSachievements.achievements[achievement_type]
@@ -63,5 +63,5 @@
 		var/unlocked = player_details.achievements.data[achievement_type]
 		var/color = unlocked ? "#00FF00" : "#FF0000"
 		output += "<span style='color: [color]'>[A.name] ([A.difficulty]) - [unlocked ? "UNLOCKED" : "LOCKED"]</span>"
-	
+
 	to_chat(src, output.Join("<br>"))

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -412,6 +412,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	READ_FILE(S["feature_moth_antennae"], features["moth_antennae"])
 	READ_FILE(S["feature_moth_markings"], features["moth_markings"])
 	READ_FILE(S["persistent_scars"] , persistent_scars)
+	READ_FILE(S["chosen_achievement"], chosen_achievement)
 	READ_FILE(S["alt_titles_preferences"], alt_titles_preferences)// Tegu edit - Alt job titles
 	if(!CONFIG_GET(flag/join_with_mutant_humans))
 		features["tail_human"] = "none"
@@ -587,6 +588,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	WRITE_FILE(S["feature_moth_antennae"]			, features["moth_antennae"])
 	WRITE_FILE(S["feature_moth_markings"]		, features["moth_markings"])
 	WRITE_FILE(S["persistent_scars"]			, persistent_scars)
+	WRITE_FILE(S["chosen_achievement"]		, chosen_achievement)
 
 	//Custom names
 	for(var/custom_name_id in GLOB.preferences_custom_names)

--- a/code/modules/holodeck/items.dm
+++ b/code/modules/holodeck/items.dm
@@ -144,6 +144,10 @@
 
 /obj/structure/holohoop/proc/ChaosDunk()
 	show_global_blurb(50, "Chaos Dunk")
+	// Award achievement to all players who witnessed the Chaos Dunk
+	for(var/mob/living/carbon/human/H in GLOB.player_list)
+		if(H.stat != DEAD && H.client)
+			H.client.give_award(/datum/award/achievement/lc13/chaos_dunk, H)
 	Explode()
 	Cinematic(CINEMATIC_CHAOS_DUNK, world)
 

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -19,6 +19,14 @@
 			obscure_examine = TRUE
 
 	. = list("<span class='info'>*---------*\nThis is <EM>[!obscure_name ? name : "Unknown"]</EM>!")
+	
+	// Achievement specialization display
+	if(client && client.prefs && client.prefs.chosen_achievement)
+		var/achievement_type = client.prefs.chosen_achievement
+		if(SSachievements.achievements[achievement_type])
+			var/datum/award/achievement/A = SSachievements.achievements[achievement_type]
+			var/color = A.get_difficulty_color()
+			. += "Their specialization is <span style='color: [color]'>[A.name]</span>!"
 
 	if(obscure_examine)
 		return list("<span class='warning'>You're struggling to make out any details...")

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -19,14 +19,15 @@
 			obscure_examine = TRUE
 
 	. = list("<span class='info'>*---------*\nThis is <EM>[!obscure_name ? name : "Unknown"]</EM>!")
-	
+
 	// Achievement specialization display
 	if(client && client.prefs && client.prefs.chosen_achievement)
 		var/achievement_type = client.prefs.chosen_achievement
 		if(SSachievements.achievements[achievement_type])
 			var/datum/award/achievement/A = SSachievements.achievements[achievement_type]
 			var/color = A.get_difficulty_color()
-			. += "Their specialization is <span style='color: [color]'>[A.name]</span>!"
+			var/display_text = A.title ? A.title : A.name
+			. += "Their specialization is <span style='color: [color]'>[display_text]</span>!"
 
 	if(obscure_examine)
 		return list("<span class='warning'>You're struggling to make out any details...")

--- a/code/modules/mob/living/simple_animal/abnormality/_tools/zayin/realizer.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_tools/zayin/realizer.dm
@@ -148,3 +148,15 @@
 	user.put_in_hands(new_item)
 	to_chat(user, span_nicegreen("You retrieve [new_item] from the [src]!"))
 	playsound(get_turf(src), 'sound/magic/clockwork/ratvar_attack.ogg', 50, TRUE)
+
+	// Award achievements for specific realizations
+	if(user.client)
+		// Yin Yang achievement
+		if(istype(new_item, /obj/item/clothing/suit/armor/ego_gear/realization/duality_yang) || istype(new_item, /obj/item/clothing/suit/armor/ego_gear/realization/duality_yin))
+			user.client.give_award(/datum/award/achievement/lc13/yin_yang, user)
+		// Carmen/Benjamin achievement from plushies
+		if(istype(new_item, /obj/item/toy/plush/carmen) || istype(new_item, /obj/item/toy/plush/benjamin))
+			user.client.give_award(/datum/award/achievement/lc13/carmen_benjamin, user)
+		// Ayin achievement from Paradise Lost
+		if(istype(new_item, /obj/item/toy/plush/ayin))
+			user.client.give_award(/datum/award/achievement/lc13/ayin_realized, user)

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/distortedform.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/distortedform.dm
@@ -334,6 +334,10 @@
 	sound_to_playing_players_on_level("sound/abnormalities/distortedform/screech2.ogg", 85, zlevel = z)
 
 /mob/living/simple_animal/hostile/abnormality/distortedform/death(gibbed)
+	// Award achievement for killing Distorted Form
+	for(var/mob/living/carbon/human/H in view(7, src))
+		if(H.stat != DEAD)
+			H.client?.give_award(/datum/award/achievement/lc13/kill_distorted, H)
 	if(changed)
 		ChangeForm()
 	can_act = FALSE

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/melting_love.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/melting_love.dm
@@ -229,6 +229,12 @@
 	if(work_type == ABNORMALITY_WORK_REPRESSION)
 		to_chat(gifted_human, span_userdanger("[src] didn't like that!"))
 		datum_reference.qliphoth_change(-1)
+		// Check if they survive the repression for achievement
+		addtimer(CALLBACK(src, PROC_REF(CheckSurvivalAchievement), user), 5 SECONDS)
+
+/mob/living/simple_animal/hostile/abnormality/melting_love/proc/CheckSurvivalAchievement(mob/living/carbon/human/user)
+	if(user && user.stat != DEAD && user.client)
+		user.client.give_award(/datum/award/achievement/lc13/melting_love_blessing_repress, user)
 
 /* Checking if bigslime is dead or not and apply a damage buff if yes */
 /mob/living/simple_animal/hostile/abnormality/melting_love/proc/SlimeDeath(datum/source, gibbed)

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/nobody_is.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/nobody_is.dm
@@ -294,6 +294,10 @@
 	if(grab_victim)
 		release_damage = clamp(release_damage + damage, 0, release_threshold)
 		if(release_damage >= release_threshold)
+			// Award achievement for escaping Nobody Is' chokehold
+			if(ishuman(grab_victim))
+				var/mob/living/carbon/human/H = grab_victim
+				H.client?.give_award(/datum/award/achievement/lc13/nobody_escape, H)
 			ReleaseGrab()
 	if(!oberon_mode)
 		last_heal_time = world.time + 10 SECONDS // Heal delayed when taking damage; Doubled because it was a little too quick.

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/nothing_there.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/nothing_there.dm
@@ -399,6 +399,9 @@
 
 /mob/living/simple_animal/hostile/abnormality/nothing_there/PostWorkEffect(mob/living/carbon/human/user, work_type, pe, work_time)
 	worker = null
+	// Award achievement for surviving non-instinct/attachment work
+	if(work_type != ABNORMALITY_WORK_INSTINCT && work_type != ABNORMALITY_WORK_ATTACHMENT && user.stat != DEAD)
+		user.client?.give_award(/datum/award/achievement/lc13/nothing_survivor, user)
 	if(get_attribute_level(user, JUSTICE_ATTRIBUTE) < 80)
 		if(!shelled) // Not work failure
 			datum_reference.qliphoth_change(-1)

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/silent_orchestra.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/silent_orchestra.dm
@@ -117,6 +117,11 @@
 		if(current_movement_num < 6)
 			sound_to_playing_players_on_level("sound/abnormalities/silentorchestra/movement[current_movement_num].ogg", movement_volume, zlevel = z)
 			if(current_movement_num == 5)
+				// Award achievement to all humans who heard the full performance
+				for(var/mob/living/carbon/human/listener in GLOB.player_list)
+					if(listener.z == z && listener.stat != DEAD && get_dist(listener, src) <= symphony_range)
+						listener.client?.give_award(/datum/award/achievement/lc13/orchestra_listener, listener)
+
 				for(var/mob/living/carbon/human/H in livinginrange(symphony_range, get_turf(src)))
 					if(H.sanity_lost || (H.sanityhealth < H.maxSanity * 0.5))
 						var/obj/item/bodypart/head/head = H.get_bodypart("head")

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/white_night.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/white_night.dm
@@ -106,6 +106,19 @@ GLOBAL_LIST_EMPTY(apostles)
 
 /mob/living/simple_animal/hostile/abnormality/white_night/death(gibbed)
 	GrantMedal()
+	// Check if anyone nearby has Hammer of Light to award achievement
+	for(var/mob/living/carbon/human/H in view(7, src))
+		if(H.stat != DEAD)
+			for(var/obj/item/ego_weapon/hammer_light/hammer in H.held_items)
+				H.client?.give_award(/datum/award/achievement/lc13/hammer_kill_wn, H)
+				break
+	// Check if Pink Midnight is active
+	for(var/datum/ordeal/boss/pink_midnight/PM in SSlobotomy_corp.current_ordeals)
+		if(PM)
+			// Award achievement to all living players for killing WhiteNight during Pink Midnight
+			for(var/mob/living/carbon/human/H in GLOB.player_list)
+				if(H.stat != DEAD && H.client && H.z == z)
+					H.client.give_award(/datum/award/achievement/lc13/kill_wn_pink_midnight, H)
 	for(var/mob/living/carbon/human/heretic in heretics)
 		if(heretic.stat == DEAD || !heretic.ckey)
 			continue

--- a/code/modules/mob/living/simple_animal/abnormality/he/KHz.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/KHz.dm
@@ -80,8 +80,17 @@
 			H.adjustSanityLoss(-10)
 			to_chat(H, span_notice("You feel a pleasant sound."))
 
+		// Track consecutive successful 680 mHz codes for achievement
+		if(user.mind)
+			user.mind.mhz_codes_streak++
+			if(user.mind.mhz_codes_streak >= 5)
+				user.client?.give_award(/datum/award/achievement/lc13/mhz_codes, user)
+
 	//If you fuck it up
 	else if(bitcalculator != input && bitcalculator != 0 && isopen)
+		// Reset the streak on failure
+		if(user.mind)
+			user.mind.mhz_codes_streak = 0
 		for(var/mob/living/carbon/human/H in GLOB.player_list)
 			if(z != H.z)
 				continue

--- a/code/modules/mob/living/simple_animal/abnormality/he/basilisoup.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/basilisoup.dm
@@ -356,6 +356,10 @@
 			squeaky.play_squeak()
 		else
 			playsound(src, 'sound/effects/bubbles.ogg', 80, TRUE, -3)
+		// Award achievement for feeding plushie to Basilisoup
+		if(ishuman(user))
+			var/mob/living/carbon/human/H = user
+			H.client?.give_award(/datum/award/achievement/lc13/plushie_feeder, H)
 		qdel(wack)
 		return
 	if(istype(wack, /obj/item/food))

--- a/code/modules/mob/living/simple_animal/abnormality/he/fan.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/fan.dm
@@ -67,6 +67,12 @@
 	successcount+=1
 
 /mob/living/simple_animal/hostile/abnormality/fan/PostWorkEffect(mob/living/carbon/human/user, work_type, pe, work_time)
+	// Track FAN triggers for achievement
+	if(user.mind)
+		user.mind.fan_triggers++
+		if(user.mind.fan_triggers >= 5)
+			user.client?.give_award(/datum/award/achievement/lc13/fan_trigger, user)
+
 	if(user in danger)
 		if(safework)
 			to_chat(user, span_notice("You don't feel quite as tempted this time."))

--- a/code/modules/mob/living/simple_animal/abnormality/he/golden_false_apple.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/golden_false_apple.dm
@@ -189,6 +189,10 @@
 			if(do_after(user, 2 SECONDS, target = user))
 				datum_reference.qliphoth_change(-2)
 				DigestPerson()//becomes its "berserk" form; without an argument it defaults to "Yuri"
+				// Award achievement for breaching Golden Apple with Yuri plushie
+				if(ishuman(user))
+					var/mob/living/carbon/human/H = user
+					H.client?.give_award(/datum/award/achievement/lc13/golden_apple_breach, H)
 				qdel(I)
 				return
 			to_chat(user, span_notice("You feel relieved, as if something weird and terrible was about to happen."))

--- a/code/modules/mob/living/simple_animal/abnormality/he/snow_queen.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/snow_queen.dm
@@ -267,6 +267,8 @@
 	var/obj/item/clothing/suit/armor/ego_gear/user_ego = H.get_item_by_slot(ITEM_SLOT_OCLOTHING)
 	if(istype(user_ego, /obj/item/clothing/suit/armor/ego_gear/waw/feather))
 		to_chat(H, span_userdanger("Snow Queen reacts to your ego and freezes you."))
+		// Award achievement for triggering freeze due to Feather of Honour
+		H.client?.give_award(/datum/award/achievement/lc13/snow_queen_frozen, H)
 		return TRUE
 
 		/*-------------------\
@@ -522,6 +524,11 @@
 	rewardee.forceMove(release_location)
 	to_chat(rewardee, "The roses blossom and the Snow Palace falls. Not a single soul remembered the woman sleeping there.")
 	if(ishuman(rewardee))
+		// Award achievement for being rescued from Snow Queen
+		rewardee.client?.give_award(/datum/award/achievement/lc13/snow_queen_rescue, rewardee)
+		// Also award achievement to the hero who saved them
+		if(storybook_hero && storybook_hero != rewardee)
+			storybook_hero.client?.give_award(/datum/award/achievement/lc13/snow_queen_rescue, storybook_hero)
 		var/datum/ego_gifts/frostsplinter/S = new
 		S.datum_reference = datum_reference
 		rewardee.Apply_Gift(S)

--- a/code/modules/mob/living/simple_animal/abnormality/teth/punishing_bird.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/punishing_bird.dm
@@ -188,6 +188,11 @@
 		if(client && obj_damage <= 0 && L.health <= maxHealth*0.45) // User controlled AND not transformed - can't kill things
 			to_chat(src, span_warning("You can't keep punishing them!"))
 			return
+		// Achievement for dying to Punishing Bird without enraging it
+		if(ishuman(L) && !bird_angry && L.stat == DEAD)
+			var/mob/living/carbon/human/H = L
+			if(H.client)
+				H.client.player_details.achievements.unlock(/datum/award/achievement/lc13/die_to_pbird, H)
 		..()
 		if(obj_damage <= 0) // Not transformed
 			if(ishuman(L))
@@ -252,6 +257,11 @@
 	if((health < maxHealth * 0.9) && (obj_damage <= 0))
 		enemies = list() // This is done so it stops attacking random people that punched it before transformation
 		TransformRed()
+		// Achievement for damaging Punishing Bird
+		if(ishuman(A))
+			var/mob/living/carbon/human/H = A
+			if(H.client)
+				H.client.player_details.achievements.unlock(/datum/award/achievement/lc13/damage_pbird, H)
 
 	if(isliving(A))
 		var/mob/living/M = A

--- a/code/modules/mob/living/simple_animal/abnormality/teth/punishing_bird.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/punishing_bird.dm
@@ -189,10 +189,9 @@
 			to_chat(src, span_warning("You can't keep punishing them!"))
 			return
 		// Achievement for dying to Punishing Bird without enraging it
-		if(ishuman(L) && !bird_angry && L.stat == DEAD)
+		if(ishuman(L) && !bird_angry && L.health <= 0 && L.stat != DEAD)
 			var/mob/living/carbon/human/H = L
-			if(H.client)
-				H.client.player_details.achievements.unlock(/datum/award/achievement/lc13/die_to_pbird, H)
+			H.client?.give_award(/datum/award/achievement/lc13/punishing_bird_innocent, H)
 		..()
 		if(obj_damage <= 0) // Not transformed
 			if(ishuman(L))
@@ -215,6 +214,10 @@
 	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/punishing_bird/death(gibbed)
+	// Award achievement to all nearby humans for killing Punishing Bird
+	for(var/mob/living/carbon/human/H in view(7, src))
+		if(H.stat != DEAD)
+			H.client?.give_award(/datum/award/achievement/lc13/kill_pbird, H)
 	animate(src, alpha = 0, time = 10 SECONDS)
 	QDEL_IN(src, 10 SECONDS)
 	..()
@@ -297,6 +300,10 @@
 
 /mob/living/simple_animal/hostile/abnormality/punishing_bird/attackby(obj/item/I, mob/living/user, params)
 	..()
+	// Award achievement for damaging Punishing Bird
+	if(ishuman(user) && health < maxHealth)
+		var/mob/living/carbon/human/H = user
+		H.client?.give_award(/datum/award/achievement/lc13/damage_pbird, H)
 	Retaliate(user)
 
 /mob/living/simple_animal/hostile/abnormality/punishing_bird/BreachEffect(mob/living/carbon/human/user, breach_type)

--- a/code/modules/mob/living/simple_animal/abnormality/waw/big_wolf.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/big_wolf.dm
@@ -136,7 +136,30 @@
 
 /mob/living/simple_animal/hostile/abnormality/big_wolf/death(gibbed)
 	update_icon()
+
+	// Check for Red Hood nearby to award achievements
+	var/mob/living/simple_animal/hostile/abnormality/red_hood/nearby_red = locate() in view(7, src)
+	var/list/saved_humans = list()
+
+	// Check who's in the stomach before spewing
+	for(var/mob/living/carbon/human/H in contents)
+		if(H.client)
+			saved_humans += H
+
 	SpewStomach()
+
+	// Award achievements to those who were saved
+	for(var/mob/living/carbon/human/saved in saved_humans)
+		if(nearby_red)
+			// Award achievement for being saved by Red Hood
+			saved.client?.give_award(/datum/award/achievement/lc13/red_hood_saved, saved)
+
+		// Award achievement to nearby humans who helped kill the wolf
+		for(var/mob/living/carbon/human/potential_savior in view(5, src))
+			if(potential_savior != saved && potential_savior.stat != DEAD && potential_savior.client)
+				potential_savior.client?.give_award(/datum/award/achievement/lc13/wolf_savior, potential_savior)
+				break // Only award to one savior
+
 	density = FALSE
 	animate(src, alpha = 0, time = 10 SECONDS)
 	QDEL_IN(src, 10 SECONDS)

--- a/code/modules/mob/living/simple_animal/abnormality/waw/express_train.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/express_train.dm
@@ -170,6 +170,10 @@
 				seg.forceMove(get_step(seg, seg.dir))
 		damageTiles()
 
+/mob/living/simple_animal/hostile/abnormality/express_train/proc/CheckTrainSurvival(mob/living/carbon/human/H)
+	if(H && H.stat != DEAD)
+		H.client?.give_award(/datum/award/achievement/lc13/train_survivor, H)
+
 /mob/living/simple_animal/hostile/abnormality/express_train/proc/damageTiles()
 	for(var/obj/effect/expresstrain/seg in segments)
 		// I wanted to use bound_width and bound_height. For some GOD FORSAKEN REASON, they don't work. Welcome to hell.
@@ -190,6 +194,10 @@
 						playsound(get_turf(seg), 'sound/abnormalities/expresstrain/express_whistle.ogg', 100, 0, 40)
 					seg.noise = 1
 				M.deal_damage(400, BLACK_DAMAGE)
+				// Award achievement for getting hit by hell train and surviving
+				if(ishuman(M) && M.stat != DEAD)
+					var/mob/living/carbon/human/H = M
+					addtimer(CALLBACK(src, PROC_REF(CheckTrainSurvival), H), 3 SECONDS)
 				var/atom/throw_target = locate(M)
 				throw_target = locate(M.x, M.y + pick(rand(-8, -5), rand(5, 8)), M.z)
 				if(!M.anchored)

--- a/code/modules/mob/living/simple_animal/abnormality/waw/hatred_queen.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/hatred_queen.dm
@@ -235,6 +235,11 @@
 	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/hatred_queen/AttackingTarget(atom/attacked_target)
+	// Check for friendly kill achievement
+	if(friendly && ishuman(attacked_target))
+		var/mob/living/carbon/human/H = attacked_target
+		if(H.stat == DEAD && H.client)
+			H.client.give_award(/datum/award/achievement/lc13/friendly_qoh_kill, H)
 	if(!target)
 		GiveTarget(attacked_target)
 	return OpenFire(attacked_target)

--- a/code/modules/mob/living/simple_animal/abnormality/waw/naked_nest.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/naked_nest.dm
@@ -445,6 +445,10 @@
 	if(target.NAKED_NESTED)
 		var/obj/item/organ/naked_nest/C = target.NAKED_NESTED
 		C.SerpentsPoison(target, TRUE)
+		// Award achievement for curing Naked Nest infection with cure
+		if(ishuman(target))
+			var/mob/living/carbon/human/H = target
+			H.client?.give_award(/datum/award/achievement/lc13/naked_nest_cure_with, H)
 		C.Remove(target)
 
 #undef NAKED_NESTED

--- a/code/modules/mob/living/simple_animal/abnormality/waw/snow_whites_apple.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/snow_whites_apple.dm
@@ -490,6 +490,8 @@
 	if(prob(10))
 		//it would be uncouth for the vines to hinder one gifted by the princess.
 		to_chat(lonely, span_nicegreen("The branches open a path."))
+	// Award achievement for experiencing the special interaction
+	lonely.client?.give_award(/datum/award/achievement/lc13/swa_interaction, lonely)
 	if(lonelyhealth <= 30 && lonely.stat != DEAD)
 		lonely.adjustBruteLoss(-1)
 		if(prob(2))

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/bald.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/bald.dm
@@ -83,6 +83,10 @@
 			for(var/mob/living/carbon/human/H in GLOB.human_list)
 				if(H.z == z)
 					do_bald(H)
+			// Award achievement for bald round
+			for(var/mob/living/carbon/human/H in GLOB.player_list)
+				if(H.client)
+					H.client.give_award(/datum/award/achievement/lc13/bald_round, H)
 
 /mob/living/simple_animal/hostile/abnormality/bald/BreachEffect(mob/living/carbon/human/user, breach_type)
 	if(breach_type == BREACH_PINK)

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/blubbering_toad.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/blubbering_toad.dm
@@ -128,6 +128,9 @@
 		tongue_damage = 5
 		broken = TRUE
 	SetIdiot(user)
+	// Achievement for letting Blubbering Toad out
+	if(user && user.client && breach_type == BREACH_NORMAL)
+		user.client.player_details.achievements.unlock(/datum/award/achievement/lc13/free_toad, user)
 	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/blubbering_toad/attack_hand(mob/living/carbon/human/user)
@@ -248,6 +251,9 @@
 		return
 	..()
 	var/mob/living/carbon/human/H = attacked_target
+	// Achievement for dying to Blubbering Toad
+	if(H.stat == DEAD && H.client)
+		H.client.player_details.achievements.unlock(/datum/award/achievement/lc13/die_to_toad, H)
 	if(H.sanity_lost) //prevents hitting the same guy in an infinite loop
 		melee_damage_type = BLACK_DAMAGE
 	if(H.health < 0)

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/hammer_light.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/hammer_light.dm
@@ -179,6 +179,9 @@
 	chosen_arms = new /obj/item/ego_weapon/hammer_light(get_turf(user))
 	user.put_in_hands(chosen_arms, forced = TRUE)
 	hammer_present = FALSE
+	// Achievement for activating Hammer of Light
+	if(user.client)
+		user.client.player_details.achievements.unlock(/datum/award/achievement/lc13/activate_hammer, user)
 	playsound(get_turf(src), "[pick(pickup_sounds)]", 75, 0, -9)
 	ADD_TRAIT(user, TRAIT_COMBATFEAR_IMMUNE, "Abnormality")
 	ADD_TRAIT(user, TRAIT_WORK_FORBIDDEN, "Abnormality")

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/hammer_light.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/hammer_light.dm
@@ -180,8 +180,7 @@
 	user.put_in_hands(chosen_arms, forced = TRUE)
 	hammer_present = FALSE
 	// Achievement for activating Hammer of Light
-	if(user.client)
-		user.client.player_details.achievements.unlock(/datum/award/achievement/lc13/activate_hammer, user)
+	user.client?.give_award(/datum/award/achievement/lc13/hammer_activate, user)
 	playsound(get_turf(src), "[pick(pickup_sounds)]", 75, 0, -9)
 	ADD_TRAIT(user, TRAIT_COMBATFEAR_IMMUNE, "Abnormality")
 	ADD_TRAIT(user, TRAIT_WORK_FORBIDDEN, "Abnormality")

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/one_sin.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/one_sin.dm
@@ -91,6 +91,8 @@
 				WN.heretics = list()
 				to_chat(WN, span_colossus("The twelfth has betrayed us..."))
 				WN.loot = list() // No loot for you!
+				// Award achievement for killing WhiteNight by confessing
+				user.client?.give_award(/datum/award/achievement/lc13/one_sin_confession, user)
 				var/curr_health = WN.health
 				for(var/i = 1 to 12)
 					sleep(1.5 SECONDS)

--- a/code/modules/projectiles/projectile/magic/abnormality.dm
+++ b/code/modules/projectiles/projectile/magic/abnormality.dm
@@ -56,6 +56,16 @@
 	damage = 25
 	spread = 15
 
+/obj/projectile/hatred/on_hit(atom/target, blocked = FALSE)
+	. = ..()
+	if(ishuman(target) && ishuman(firer))
+		var/mob/living/carbon/human/H = target
+		if(istype(firer, /mob/living/simple_animal/hostile/abnormality/hatred_queen))
+			var/mob/living/simple_animal/hostile/abnormality/hatred_queen/QOH = firer
+			if(QOH.friendly && H.stat == DEAD && H.client)
+				// Award achievement for getting killed by friendly Queen of Hatred
+				H.client.give_award(/datum/award/achievement/lc13/friendly_qoh_kill, H)
+
 /obj/projectile/melting_blob
 	name = "slime projectile"
 	desc = "A glob of infectious slime. It's going for your heart."

--- a/code/modules/reagents/chemistry/recipes/drugs.dm
+++ b/code/modules/reagents/chemistry/recipes/drugs.dm
@@ -19,6 +19,18 @@
 	required_reagents = list(/datum/reagent/medicine/ephedrine = 1, /datum/reagent/iodine = 1, /datum/reagent/phosphorus = 1, /datum/reagent/hydrogen = 1)
 	required_temp = 374
 
+/datum/chemical_reaction/methamphetamine/on_reaction(datum/reagents/holder, created_volume, is_cold_recipe)
+	. = ..()
+	// Award achievement for making meth
+	if(ishuman(holder.my_atom.loc))
+		var/mob/living/carbon/human/H = holder.my_atom.loc
+		H.client?.give_award(/datum/award/achievement/lc13/make_meth, H)
+	else if(istype(holder.my_atom, /obj/item/reagent_containers))
+		var/obj/item/reagent_containers/RC = holder.my_atom
+		if(ishuman(RC.loc))
+			var/mob/living/carbon/human/H = RC.loc
+			H.client?.give_award(/datum/award/achievement/lc13/make_meth, H)
+
 /datum/chemical_reaction/bath_salts
 	results = list(/datum/reagent/drug/bath_salts = 7)
 	required_reagents = list(/datum/reagent/toxin/bad_food = 1, /datum/reagent/saltpetre = 1, /datum/reagent/consumable/nutriment = 1, /datum/reagent/space_cleaner = 1, /datum/reagent/consumable/enzyme = 1, /datum/reagent/consumable/tea = 1, /datum/reagent/mercury = 1)

--- a/code/modules/suppressions/command.dm
+++ b/code/modules/suppressions/command.dm
@@ -26,6 +26,10 @@
 	UnregisterSignal(SSdcs, COMSIG_GLOB_MELTDOWN_FINISHED)
 	SSlobotomy_corp.melt_work_multiplier += 1
 	SSlobotomy_corp.manager_bullet_area = 1 // Bullets will activate in a 3x3 AOE
+	// Award achievement for completing Tiphereth's core suppression
+	for(var/mob/living/carbon/human/H in GLOB.player_list)
+		if(H.stat != DEAD)
+			H.client?.give_award(/datum/award/achievement/lc13/suppress_tiphereth, H)
 	return ..()
 
 /datum/suppression/command/proc/OnQlipMeltdown(datum/source, ordeal = FALSE)

--- a/code/modules/suppressions/control.dm
+++ b/code/modules/suppressions/control.dm
@@ -15,6 +15,10 @@
 		C.scramble_list = list()
 	// Reward!
 	SSlobotomy_corp.AddLobPoints(10, "[CONTROL_CORE_SUPPRESSION] completion reward")
+	// Award achievement for completing Malkuth's core suppression
+	for(var/mob/living/carbon/human/H in GLOB.player_list)
+		if(H.stat != DEAD)
+			H.client?.give_award(/datum/award/achievement/lc13/suppress_malkuth, H)
 	return ..()
 
 // On lobotomy_corp meltdown event

--- a/code/modules/suppressions/extraction.dm
+++ b/code/modules/suppressions/extraction.dm
@@ -19,6 +19,10 @@
 	..()
 	SSlobotomy_corp.core_suppression_state = max(SSlobotomy_corp.core_suppression_state, 3)
 	SSticker.news_report = max(SSticker.news_report, CORE_SUPPRESSED_ARBITER_DEAD)
+	// Award achievement for completing Binah's core suppression
+	for(var/mob/living/carbon/human/H in GLOB.player_list)
+		if(H.stat != DEAD)
+			H.client?.give_award(/datum/award/achievement/lc13/suppress_binah, H)
 
 /datum/suppression/extraction/proc/OnArbiterDeath(datum/source)
 	SIGNAL_HANDLER

--- a/code/modules/suppressions/information.dm
+++ b/code/modules/suppressions/information.dm
@@ -17,6 +17,10 @@
 /datum/suppression/information/End(silent = FALSE)
 	UnregisterSignal(SSdcs, COMSIG_GLOB_MELTDOWN_START)
 	SSlobotomy_corp.box_work_multiplier *= 1.25
+	// Award achievement for completing Yesod's core suppression
+	for(var/mob/living/carbon/human/H in GLOB.player_list)
+		if(H.stat != DEAD)
+			H.client?.give_award(/datum/award/achievement/lc13/suppress_yesod, H)
 	return ..()
 
 // Increase gibberish value every time an ordeal occurs

--- a/code/modules/suppressions/records.dm
+++ b/code/modules/suppressions/records.dm
@@ -42,6 +42,10 @@
 		C.swap = new
 		C.visible_message(span_notice("[C] has received a new ability!"))
 		playsound(get_turf(C), 'sound/machines/ping.ogg', 25, TRUE)
+	// Award achievement for completing Hokma's core suppression
+	for(var/mob/living/carbon/human/H in GLOB.player_list)
+		if(H.stat != DEAD)
+			H.client?.give_award(/datum/award/achievement/lc13/suppress_hokma, H)
 	return ..()
 
 /datum/suppression/records/proc/OnQlipMeltdown(datum/source, ordeal = FALSE)

--- a/code/modules/suppressions/safety.dm
+++ b/code/modules/suppressions/safety.dm
@@ -23,6 +23,10 @@
 		R.regeneration_amount += 3
 	for(var/obj/machinery/sleeper/S in GLOB.sleepers)
 		S.set_machine_stat(S.machine_stat & (~BROKEN))
+	// Award achievement for completing Netzach's core suppression
+	for(var/mob/living/carbon/human/H in GLOB.player_list)
+		if(H.stat != DEAD)
+			H.client?.give_award(/datum/award/achievement/lc13/suppress_netzach, H)
 	return ..()
 
 // On lobotomy_corp meltdown event

--- a/code/modules/suppressions/training.dm
+++ b/code/modules/suppressions/training.dm
@@ -37,6 +37,10 @@
 	affected_mobs = null
 	for(var/datum/job/agent/J in SSjob.occupations)
 		J.normal_attribute_level += 5 // This allows agents to spawn with 100 in all stats
+	// Award achievement for completing Hod's core suppression
+	for(var/mob/living/carbon/human/H in GLOB.player_list)
+		if(H.stat != DEAD)
+			H.client?.give_award(/datum/award/achievement/lc13/suppress_hod, H)
 	return ..()
 
 // When a new employee spawns in

--- a/code/modules/suppressions/welfare.dm
+++ b/code/modules/suppressions/welfare.dm
@@ -44,6 +44,10 @@
 		QDEL_NULL(S)
 	affected_statuses = null
 	new /datum/welfare_reward_tracker() // Gives the reward to late-joiners after it ends
+	// Award achievement for completing Chesed's core suppression
+	for(var/mob/living/carbon/human/H in GLOB.player_list)
+		if(H.stat != DEAD)
+			H.client?.give_award(/datum/award/achievement/lc13/suppress_chesed, H)
 	return ..()
 
 // When a new employee spawns in

--- a/lobotomy-corp13.dme
+++ b/lobotomy-corp13.dme
@@ -451,6 +451,7 @@
 #include "code\datums\achievements\boss_achievements.dm"
 #include "code\datums\achievements\boss_scores.dm"
 #include "code\datums\achievements\LC13_achievements.dm"
+#include "code\datums\achievements\LC13_achievements_extended.dm"
 #include "code\datums\achievements\mafia_achievements.dm"
 #include "code\datums\achievements\misc_achievements.dm"
 #include "code\datums\achievements\misc_scores.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR adds a simple system that allows you to show off your achievements mid-game. Basically, in your preferences menu (where you make your character), you have a new button that allows you to select an achievement that you have unlocked. Then, when you are examined in-game, right below your name, it will show "Their specialization is [chosen achievement name]!" Also, now achievements have colors representing how difficult they are, following this list:

- Pale blue for Easy
- Green for Normal
- Red for Hard
- Purple for Very Hard
- Orange for hardest

## Why It's Good For The Game

It adds a bit more value to Achievements, giving players a reason to collect them, as showcasing them would be pretty cool.

## Changelog
:cl:
add: Added new presenting achievements system
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
