### PR TITLE
RCE Fix: Re-added teleport away to Clan Mobs

### DIFF
--- a/ModularTegustation/tegu_mobs/lc13_resurgence_clan_mobs.dm
+++ b/ModularTegustation/tegu_mobs/lc13_resurgence_clan_mobs.dm
@@ -81,7 +81,6 @@
 
 /mob/living/simple_animal/hostile/clan/Life()
 	. = ..()
-
 	if (last_charge_update < world.time - clan_charge_cooldown)
 		last_charge_update = world.time
 		GainCharge()

--- a/ModularTegustation/tegu_mobs/lc13_resurgence_clan_mobs.dm
+++ b/ModularTegustation/tegu_mobs/lc13_resurgence_clan_mobs.dm
@@ -36,13 +36,13 @@
 	butcher_results = list(/obj/item/raw_anomaly_core/bluespace = 1)
 	guaranteed_butcher_results = list(/obj/item/food/meat/slab/robot = 2)
 	silk_results = list(/obj/item/stack/sheet/silk/azure_simple = 1)
-	
+
 	// Charge system variables
 	var/charge = 5
 	var/max_charge = 10
 	var/clan_charge_cooldown = 2 SECONDS
 	var/last_charge_update = 0
-	
+
 	// Teleport on death
 	var/teleport_away = FALSE
 
@@ -115,6 +115,13 @@
 			if (!(user in GLOB.marked_players ))
 				GLOB.marked_players += user
 				say(attacked_line)
+
+/mob/living/simple_animal/hostile/clan/death(gibbed)
+	. = ..()
+	if (teleport_away)
+		playsound(src, 'sound/effects/ordeals/white/pale_teleport_out.ogg', 25, TRUE)
+		new /obj/effect/temp_visual/beam_out(get_turf(src))
+		qdel(src)
 
 // NPC dialogue interaction
 /mob/living/simple_animal/hostile/clan/examine(mob/user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Re adds the code necessary for clan mobs to qdel themselves in RCE

## Why It's Good For The Game

When I was cleaning up the PR, I forgot to re-add it, so I am adding it now.

## Changelog
:cl:
fix: fixed clan mobs not teleporting away
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
