### PR TITLE
Ego Surgery Fix

### DIFF
--- a/ModularTegustation/tegu_items/extraction/egosurgery.dm
+++ b/ModularTegustation/tegu_items/extraction/egosurgery.dm
@@ -91,7 +91,7 @@
 			return
 	var/multiplier_cap = 1.10
 	if (GetFacilityUpgradeValue(UPGRADE_EXTRACTION_1))
-		multiplier_cap = 1.2
+		multiplier_cap = 1.20
 	if(is_ego_melee_weapon(A))
 		var/obj/item/ego_weapon/theweapon = A
 		if(theweapon.force_multiplier >= multiplier_cap)
@@ -144,14 +144,17 @@
 /obj/item/extraction/upgrade_tool/proc/ToolComplete(user)
 	if(!target_item)
 		return
+	var/multiplier_cap = 1.10
+	if (GetFacilityUpgradeValue(UPGRADE_EXTRACTION_1))
+		multiplier_cap = 1.20
 	if(is_ego_melee_weapon(target_item))
 		var/obj/item/ego_weapon/weapon = target_item
-		weapon.force_multiplier = min(weapon.force_multiplier + 0.05, 1.1) // Add 5% to the force multiplier
+		weapon.force_multiplier = min(weapon.force_multiplier + 0.05, multiplier_cap) // Add 5% to the force multiplier
 
 	else if(is_ego_weapon(target_item))
 		var/obj/item/ego_weapon/ranged/gun = target_item
 		var/old_multiplier = gun.force_multiplier
-		gun.force_multiplier = min(gun.force_multiplier + 0.05, 1.1)
+		gun.force_multiplier = min(gun.force_multiplier + 0.05, multiplier_cap)
 		var/difference = gun.force_multiplier - old_multiplier
 		if(difference > 0)
 			gun.projectile_damage_multiplier *= (1 + difference) // Sure we COULD just set it equal to force_multiplier but that would break some guns


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes Ego Surgery with level Extraction Specialization 1 from not being able to go up to 1.2x

## Why It's Good For The Game

I noticed it in game and I feel stupid for not checking how it adds to the force multiplier
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixed a Ego Surgery with level Extraction Specialization 1 ability to go up to 1.2x
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
