### PR TITLE
Removes extraction delay and allows for agents to pick a core suppression if theres no manager

### DIFF
--- a/ModularTegustation/lc13_obj/lc13_computers/abnormality_auxiliary.dm
+++ b/ModularTegustation/lc13_obj/lc13_computers/abnormality_auxiliary.dm
@@ -93,6 +93,15 @@
 	popup.open()
 	return
 
+/obj/machinery/computer/abnormality_auxiliary/proc/CheckForManager()
+	for(var/mob/living/carbon/human/H in GLOB.human_list)
+		if(!H.ckey)
+			continue
+		if(H.mind.assigned_role == "Manager")
+			break
+			return TRUE
+	return FALSE
+
 /obj/machinery/computer/abnormality_auxiliary/Topic(href, href_list)
 	. = ..()
 	if(href_list["switch_style"])
@@ -138,7 +147,7 @@
 				to_chat(usr, span_warning("A core suppression is already in the progress!"))
 				selected_core_type = null
 				return FALSE
-			if(usr.mind.assigned_role != "Manager")
+			if(usr.mind.assigned_role != "Manager" && CheckForManager())
 				to_chat(usr, span_warning("Only the Manager can start a Core Suppression!"))
 				playsound(get_turf(src), 'sound/machines/terminal_prompt_deny.ogg', 50, TRUE)
 				return FALSE
@@ -416,7 +425,7 @@
 				return
 			if(istype(SSlobotomy_corp.core_suppression))
 				CRASH("[src] has attempted to activate a core suppression via TGUI whilst its not possible!")
-			if(usr.mind.assigned_role != "Manager")
+			if(usr.mind.assigned_role != "Manager" && CheckForManager())
 				to_chat(usr, span_warning("Only the Manager can start a Core Suppression!"))
 				playsound(get_turf(src), 'sound/machines/terminal_prompt_deny.ogg', 50, TRUE)
 				return

--- a/ModularTegustation/lc13_obj/lc13_computers/abnormality_ego.dm
+++ b/ModularTegustation/lc13_obj/lc13_computers/abnormality_ego.dm
@@ -5,7 +5,6 @@
 	resistance_flags = INDESTRUCTIBLE
 	/// Currently selected(shown) level of abnormalities whose EGO will be on the interface
 	var/selected_level = ZAYIN_LEVEL
-	var/delay = 15 SECONDS
 
 /obj/machinery/computer/ego_purchase/examine(mob/user)
 	. = ..()
@@ -76,12 +75,10 @@
 				return FALSE
 			if(usr.mind.assigned_role == "Extraction Officer")
 				new E.item_path(get_turf(src))
-				to_chat(usr, span_notice("[E.item_path] has been dispensed!"))
+				to_chat(usr, span_notice("[E.name] has been dispensed!"))
 
 			else
-				if (GetFacilityUpgradeValue(UPGRADE_EXTRACTION_2))
-					delay = initial(delay)/2
-				addtimer(CALLBACK(src, PROC_REF(ShipOut), E.item_path),delay)
+				ShipOut(E.item_path)
 				audible_message(span_notice("[usr.name] has purchased a [E.name]"))
 
 			A.stored_boxes -= E.cost * mult

--- a/ModularTegustation/tegu_items/refinery/sales.dm
+++ b/ModularTegustation/tegu_items/refinery/sales.dm
@@ -39,10 +39,10 @@
 		to_chat(user, span_notice("You load PE into the machine."))
 		qdel(I)
 		if (GetFacilityUpgradeValue(UPGRADE_EXTRACTION_2))
-			power_timer = round(power_timer * 0.5)
+			power_timer = round(power_timer * (1/3))
 			if(!boosted)//prevents wierd jank and desycing
 				boosted = TRUE
-				crate_timer = round(crate_timer * 0.5)
+				crate_timer = round(crate_timer * (1/3))
 		counter()
 
 		add_overlay("full")

--- a/code/datums/facility_upgrade.dm
+++ b/code/datums/facility_upgrade.dm
@@ -361,7 +361,7 @@
 
 /datum/facility_upgrade/specialization/tier_2/extraction
 	name = UPGRADE_EXTRACTION_2
-	info = " - Extraction Officer can extract EGO 15% cheaper.<br> - Cuts the shipment delay and PE selling time in half"
+	info = " - Extraction Officer can extract EGO 15% cheaper.<br> - Makes PE selling time 3 times as fast!"
 	requires_one_of = list(UPGRADE_EXTRACTION_1)
 	requires_none_of = list(UPGRADE_DISCIPLINARY_2, UPGRADE_RECORDS_2)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Extraction Delay is removed, Eo no longer gets sent an items file path when purchasing ego, core suppressions can start by anyone if there isn't a manager, and changed the level 2 extraction specialization upgrade to compensate and made purchasing ego as eo show the name instead of the file path
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Extraction delay wasn't good at all while being unable to pick a core if there's no manager can suck alot. Also made pe sales even faster to compensate for the extraction delay removal and Eo getting the file path when purchasing ego is a little weird

## Changelog
:cl:
del: Removed extraction delay
tweak: tweaked level 2 eo lob upgrade and how core suppression are locked
code: changed some code
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
