### PR TITLE
Don't Touch me's span is more reasonable

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/_tools/zayin/touch.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_tools/zayin/touch.dm
@@ -28,7 +28,8 @@
 
 	cooldown = world.time + 60 SECONDS // Spam prevention
 	for(var/mob/M in GLOB.player_list)
-		to_chat(M, span_narsie("[uppertext(user.real_name)] WILL PUSH DON'T TOUCH ME[round_end ? "" : " TO BREACH ABNORMALITIES"]."))
+		to_chat(M, span_hypnophrase("[uppertext(user.real_name)] WILL PUSH DON'T TOUCH ME[round_end ? "" : " TO BREACH ABNORMALITIES"]."))
+		playsound(src, 'sound/machines/terminal_prompt.ogg', 50, FALSE)
 
 	if(round_end)
 		bastards += user.ckey


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Whilst I accomplished my goal of making the button impossible to miss - it ended up being _too_ big. This should keep it eyecatching and the addition of a sound cue ought to be get people's attention without it being the _only_ thing you can notice. The sound cue also shouldn't be too annoying if multiple people spammed the button for whatever reason.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This should be more reasonable
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Don't Touch Me's span is made a more reasonable size whilst remaining eyecatching
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
