### PR TITLE
Enkephalin Rush + Community E.G.O HP rebalance

### DIFF
--- a/ModularTegustation/tegu_items/enkephalin_rush/enkr_mobs.dm
+++ b/ModularTegustation/tegu_items/enkephalin_rush/enkr_mobs.dm
@@ -6,15 +6,15 @@
 	icon_living = "dskull_corrosion"
 	icon_dead = "dskull_corrosion"
 	faction = list("gold_ordeal")
-	maxHealth = 200
-	health = 200
+	maxHealth = 35
+	health = 35
 	ranged = TRUE
 	ranged_cooldown_time = 5 SECONDS
 	projectilesound = 'sound/abnormalities/hatredqueen/gun.ogg'
 	projectiletype = /obj/projectile/magic/spell/magic_missile
 	melee_damage_type = WHITE_DAMAGE
-	melee_damage_lower = 7
-	melee_damage_upper = 14
+	melee_damage_lower = 2
+	melee_damage_upper = 4
 	attack_verb_continuous = "thwacks"
 	attack_verb_simple = "thwack"
 	attack_sound = 'sound/abnormalities/doomsdaycalendar/Doomsday_Slash.ogg'
@@ -22,7 +22,7 @@
 	butcher_results = list(/obj/item/stack/sheet/mineral/wood = 5)
 	var/chosen_spell
 	var/list/spells = list("Grease","Animation", "Summon", "Fear", "Death",)
-	var/list/cantrips = list(/obj/projectile/magic/spell/magic_missile, /obj/projectile/ego_bullet/ardor_star, /obj/projectile/ego_bullet/ego_harmony,)
+	var/list/cantrips = list(/obj/projectile/magic/spell/magic_missile, /obj/projectile/ego_bullet/ego_swindle, /obj/projectile/ego_bullet/ego_harmony,)
 	var/spell_slots = 3
 	var/casting
 	var/spell_cooldown
@@ -194,10 +194,10 @@
 	icon_dead ="tegu_dead"
 	mob_biotypes = MOB_ORGANIC|MOB_BEAST
 	faction = list("gold_ordeal")
-	health = 150
-	maxHealth = 150
-	melee_damage_lower = 18
-	melee_damage_upper = 22
+	health = 40
+	maxHealth = 40
+	melee_damage_lower = 3
+	melee_damage_upper = 5
 	speed = 5
 	footstep_type = FOOTSTEP_MOB_CLAW
 	attack_verb_continuous = "bites"
@@ -226,8 +226,8 @@
 	icon_living = "tsa_corrosion"
 	del_on_death = TRUE
 	faction = list("gold_ordeal")
-	maxHealth = 600
-	health = 600
+	maxHealth = 250
+	health = 250
 	ranged = TRUE
 	ranged_cooldown_time = 10 SECONDS
 	rapid = 50
@@ -235,8 +235,8 @@
 	projectilesound = 'sound/weapons/gun/smg/shot.ogg'
 	casingtype = /obj/item/ammo_casing/caseless/bigspread
 	melee_damage_type = RED_DAMAGE
-	melee_damage_lower = 10
-	melee_damage_upper = 15
+	melee_damage_lower = 5
+	melee_damage_upper = 8
 	attack_verb_continuous = "batters"
 	attack_verb_simple = "batter"
 	attack_sound = 'sound/weapons/fixer/generic/gen1.ogg'
@@ -263,11 +263,11 @@
 	name = "assorted bullet"
 	desc = "a hodgepodge of live, confiscated rounds."
 	damage_type = RED_DAMAGE
-	damage = 2
+	damage = 1
 
 /mob/living/simple_animal/hostile/ordeal/sin_envy/agent
-	maxHealth = 150
-	health = 150
+	maxHealth = 40
+	health = 40
 	damage_coeff = list(RED_DAMAGE = 1.2, WHITE_DAMAGE = 2, BLACK_DAMAGE = 0.8, PALE_DAMAGE = 2)
 	attack_sound = "swing_hit"
 	outfit = /datum/outfit/job/agent/envy
@@ -301,8 +301,8 @@
 	r_hand = /obj/item/melee/classic_baton
 
 /mob/living/simple_animal/hostile/ordeal/sin_envy/agent/captain
-	maxHealth = 200
-	health = 200
+	maxHealth = 45
+	health = 45
 	outfit = /datum/outfit/job/agent/captain/envy
 	trip_chance = 20
 	var/command_cooldown = 0
@@ -346,12 +346,12 @@
 	icon_state = "ncorp"
 	icon_living = "ncorp"
 	icon_dead = "dead_generic"
-	maxHealth = 1000
-	health = 1000
+	maxHealth = 500
+	health = 500
 	damage_coeff = list(RED_DAMAGE = 0.6, WHITE_DAMAGE = 1.2, BLACK_DAMAGE = 0.8, PALE_DAMAGE = 1.5)
 	melee_damage_type = BLACK_DAMAGE
-	melee_damage_lower = 15
-	melee_damage_upper = 25
+	melee_damage_lower = 10
+	melee_damage_upper = 18
 	ranged = TRUE
 	ranged_cooldown_time = 10 SECONDS
 	del_on_death = FALSE
@@ -367,7 +367,7 @@
 	butcher_results = list(/obj/item/food/meat/slab = 1)
 	guaranteed_butcher_results = list(/obj/item/food/meat/slab = 1)
 	var/can_act = TRUE
-	var/ranged_damage = 25
+	var/ranged_damage = 15
 	var/nail_delay = 1 SECONDS
 	var/hammer_aoe = 1
 	var/say_lines = list(
@@ -475,10 +475,10 @@
 /mob/living/simple_animal/hostile/humanoid/ncorp/mittel
 	name = "N Corp Mittelhammer"
 	icon_state = "ncorp_mittelhammer"
-	maxHealth = 2250
-	health = 2250
-	melee_damage_lower = 20
-	melee_damage_upper = 35
+	maxHealth = 1000
+	health = 1000
+	melee_damage_lower = 15
+	melee_damage_upper = 25
 	move_to_delay = 5
 	nail_delay = 0.75 SECONDS
 	hammer_aoe = 2
@@ -488,10 +488,10 @@
 	icon_state = "ncorp_grosshammer"
 	icon_living = "ncorp_grosshammer"
 	icon_dead = "ncorp_grosshammer_dead"
-	maxHealth = 4500//self-revives repeatedly
-	health = 4500
-	melee_damage_lower = 35
-	melee_damage_upper = 50
+	maxHealth = 2000//self-revives repeatedly
+	health = 2000
+	melee_damage_lower = 20
+	melee_damage_upper = 25
 	move_to_delay = 8
 	nail_delay = 0.5 SECONDS
 	hammer_aoe = 2
@@ -513,9 +513,9 @@
 /mob/living/simple_animal/hostile/humanoid/ncorp/kromer
 	name = "The One who Grips"
 	icon_state = "ncorp_kromer"
-	maxHealth = 6000//distort on "death"
-	health = 6000
-	melee_damage_lower = 35
-	melee_damage_upper = 50
+	maxHealth = 3000//distort on "death"
+	health = 3000
+	melee_damage_lower = 20
+	melee_damage_upper = 25
 	nail_delay = 0.5 SECONDS
 	hammer_aoe = 2

--- a/ModularTegustation/tegu_items/enkephalin_rush/ore_turfs.dm
+++ b/ModularTegustation/tegu_items/enkephalin_rush/ore_turfs.dm
@@ -175,7 +175,7 @@
 /turf/closed/mineral/random/facility/proc/MiningEvent(user)
 	if(prob(40))//damage events
 		if(prob(40))//cave-in
-			var/explosion_damage = (risk_level * 30)
+			var/explosion_damage = (risk_level * 10)
 			visible_message(span_danger("Chunks of rubble cave in around you!"))
 			playsound(get_turf(src), 'sound/effects/lc13_environment/day_50/Shake_Start.ogg', 60, TRUE)
 			for(var/turf/T in view(4, src))
@@ -185,7 +185,7 @@
 				R.boom_damage = explosion_damage
 			return
 		if(prob(20))//earthquake
-			var/explosion_damage = (risk_level * 15)
+			var/explosion_damage = (risk_level * 5)
 			visible_message(span_danger("The ground starts shaking!"))
 			playsound(get_turf(src), 'sound/effects/lc13_environment/day_50/Shake_Move.ogg', 60, TRUE)
 			for(var/mob/living/L in view(12, src))
@@ -197,7 +197,7 @@
 					H.Stun(3 SECONDS)
 			return
 		if(prob(100 - (risk_level * 15)))//explode
-			var/explosion_damage = (risk_level * 20)
+			var/explosion_damage = (risk_level * 7)
 			visible_message(span_danger("[src] suddenly explodes!"))
 			new /obj/effect/temp_visual/explosion(get_turf(src))
 			playsound(get_turf(src), 'sound/effects/ordeals/steel/gcorp_boom.ogg', 60, TRUE)

--- a/ModularTegustation/tegu_mobs/lc13_corrosions.dm
+++ b/ModularTegustation/tegu_mobs/lc13_corrosions.dm
@@ -9,12 +9,12 @@
 	icon_living = "everything_there"
 	icon_dead = "dead_generic"
 	faction = list("gold_ordeal")
-	maxHealth = 3000
-	health = 3000
+	maxHealth = 1500
+	health = 1500
 	pixel_x = -8
 	base_pixel_x = -8
-	melee_damage_lower = 24
-	melee_damage_upper = 30
+	melee_damage_lower = 12
+	melee_damage_upper = 15
 	rapid_melee = 2
 	attack_verb_continuous = "slices"
 	attack_verb_simple = "slice"
@@ -31,7 +31,7 @@
 	var/damage_reflection = FALSE
 	var/hello_cooldown
 	var/hello_cooldown_time = 6 SECONDS
-	var/hello_damage = 120
+	var/hello_damage = 60
 
 /mob/living/simple_animal/hostile/ordeal/NT_corrosion/proc/ReflectDamage(mob/living/attacker, attack_type = RED_DAMAGE, damage)
 	if(damage < 1)
@@ -182,10 +182,10 @@
 	icon_living = "wriggling_beast"
 	icon_dead = "dead_generic"
 	faction = list("gold_ordeal")
-	maxHealth = 2500
-	health = 2500
-	melee_damage_lower = 30
-	melee_damage_upper = 35
+	maxHealth = 1250
+	health = 1250
+	melee_damage_lower = 15
+	melee_damage_upper = 20
 	melee_damage_type = BLACK_DAMAGE
 	attack_verb_continuous = "bashes"
 	attack_verb_simple = "bash"
@@ -196,8 +196,8 @@
 	guaranteed_butcher_results = list(/obj/item/food/meat/slab/human = 1)
 	move_to_delay = 4
 	var/poison_releasing = FALSE
-	var/poison_damage = 20
-	var/applied_venom = 3
+	var/poison_damage = 12
+	var/applied_venom = 2
 	var/poison_range = 3
 	var/can_act = TRUE
 	var/guntimer
@@ -333,15 +333,15 @@
 	icon_state = "slithering_beast"
 	icon_living = "slithering_beast"
 	icon_dead = "dead_generic"
-	maxHealth = 4000
-	health = 4000
-	melee_damage_lower = 40
-	melee_damage_upper = 50
+	maxHealth = 2000
+	health = 2000
+	melee_damage_lower = 20
+	melee_damage_upper = 25
 	damage_coeff = list(RED_DAMAGE = 0.8, WHITE_DAMAGE = 0.8, BLACK_DAMAGE = 0, PALE_DAMAGE = 1.3)
 	poison_range = 6
-	poison_damage = 25
+	poison_damage = 15
 	rapid = 2
-	applied_venom = 5
+	applied_venom = 3
 
 /mob/living/simple_animal/hostile/ordeal/dog_corrosion
 	name = "crawling inquisitor"
@@ -352,12 +352,12 @@
 	icon_dead = "dead_generic"
 	var/icon_aggro = "crawling_beast"
 	faction = list("gold_ordeal")
-	maxHealth = 2000
-	health = 2000
+	maxHealth = 1000
+	health = 1000
 	pixel_x = -8
 	base_pixel_x = -8
-	melee_damage_lower = 16
-	melee_damage_upper = 18
+	melee_damage_lower = 8
+	melee_damage_upper = 9
 	rapid_melee = 3
 	attack_verb_continuous = "slices"
 	attack_verb_simple = "slice"
@@ -376,10 +376,10 @@
 	var/dash_count = 2
 	var/current_dash = 1
 	var/list/been_hit = list() // Don't get hit twice.
-	var/heal_amount = 250
+	var/heal_amount = 125
 	var/damage_taken
-	var/damage_threshold = 450
-	var/dash_damage = 80
+	var/damage_threshold = 225
+	var/dash_damage = 40
 	var/charge_sound = 'sound/effects/ordeals/gold/growl1.ogg'
 	var/gibbing = TRUE
 
@@ -508,10 +508,10 @@
 	icon_state = "ravenous_beast"
 	icon_living = "ravenous_beast"
 	faction = list("gold_ordeal")
-	maxHealth = 3000
-	health = 3000
-	melee_damage_lower = 18
-	melee_damage_upper = 20
+	maxHealth = 1500
+	health = 1500
+	melee_damage_lower = 9
+	melee_damage_upper = 10
 	damage_coeff = list(RED_DAMAGE = 1, WHITE_DAMAGE = 0.5, BLACK_DAMAGE = 0.5, PALE_DAMAGE = 1.3)
 	butcher_results = list(/obj/item/food/meat/slab/human = 3)
 	guaranteed_butcher_results = list(/obj/item/food/meat/slab/human = 1)
@@ -528,7 +528,7 @@
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "extinguish"
 	hitsound = 'sound/abnormalities/ichthys/jump.ogg'
-	damage = 20
+	damage = 15
 	speed = 0.7
 	damage_type = BLACK_DAMAGE
 	color = "#218a18"
@@ -537,4 +537,4 @@
 	. = ..()
 	if(isliving(target))
 		var/mob/living/H = target
-		H.apply_venom(3)
+		H.apply_venom(2)

--- a/_maps/map_files/Enkephalin_Rush/district_4.dmm
+++ b/_maps/map_files/Enkephalin_Rush/district_4.dmm
@@ -617,7 +617,10 @@
 "ck" = (
 /mob/living/simple_animal/hostile/bear{
 	desc = "Big & Scary";
-	name = "Big, Scary Bear"
+	name = "Big, Scary Bear";
+	health = 40;
+	melee_damage_lower = 5;
+	melee_damage_upper = 10
 	},
 /turf/open/floor/plating/asteroid,
 /area/surface_ruins/underground)

--- a/code/modules/mining/equipment/mining_tools.dm
+++ b/code/modules/mining/equipment/mining_tools.dm
@@ -5,7 +5,7 @@
 	icon_state = "pickaxe"
 	flags_1 = CONDUCT_1
 	slot_flags = ITEM_SLOT_BELT | ITEM_SLOT_BACK
-	force = 15
+	force = 5
 	throwforce = 10
 	inhand_icon_state = "pickaxe"
 	worn_icon_state = "pickaxe"
@@ -41,7 +41,6 @@
 	desc = "A smaller, compact version of the standard pickaxe."
 	icon_state = "minipick"
 	worn_icon_state = "pickaxe"
-	force = 10
 	throwforce = 7
 	slot_flags = ITEM_SLOT_BELT
 	w_class = WEIGHT_CLASS_NORMAL
@@ -55,7 +54,6 @@
 	worn_icon_state = "spickaxe"
 	toolspeed = 0.5 //mines faster than a normal pickaxe, bought from mining vendor
 	desc = "A silver-plated pickaxe that mines slightly faster than standard-issue."
-	force = 17
 	custom_price = 650
 
 /obj/item/pickaxe/diamond
@@ -118,7 +116,6 @@
 	icon_state = "ipickaxe"
 	inhand_icon_state = "ipickaxe"
 	worn_icon_state = "pickaxe"
-	force = 10
 	throwforce = 7
 	toolspeed = 3 //3 times slower than a normal pickaxe
 	slot_flags = ITEM_SLOT_BELT
@@ -135,7 +132,7 @@
 	righthand_file = 'icons/mob/inhands/equipment/mining_righthand.dmi'
 	flags_1 = CONDUCT_1
 	slot_flags = ITEM_SLOT_BELT
-	force = 8
+	force = 4
 	tool_behaviour = TOOL_SHOVEL
 	toolspeed = 1
 	usesound = 'sound/effects/shovel_dig.ogg'
@@ -166,8 +163,6 @@
 	worn_icon_state = "spade"
 	lefthand_file = 'icons/mob/inhands/equipment/hydroponics_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/hydroponics_righthand.dmi'
-	force = 5
-	throwforce = 7
 	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/shovel/serrated

--- a/code/modules/mob/living/simple_animal/abnormality/_auxiliary_modes/community/ego_weapons.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_auxiliary_modes/community/ego_weapons.dm
@@ -7,19 +7,42 @@
 	icon = 'code/modules/mob/living/simple_animal/abnormality/_auxiliary_modes/community/!icons/ego_weapons.dmi'
 	lefthand_file = 'code/modules/mob/living/simple_animal/abnormality/_auxiliary_modes/community/!icons/ego_lefthand.dmi'
 	righthand_file = 'code/modules/mob/living/simple_animal/abnormality/_auxiliary_modes/community/!icons/ego_righthand.dmi'
-	force = 16
+	force = 6
 	damtype = WHITE_DAMAGE
 	attack_verb_continuous = list("bashes", "whacks", "smacks")
 	attack_verb_simple = list("bash", "whack", "smack")
 	matching_armor = /obj/item/clothing/suit/armor/ego_gear/zayin/dragon_staff
 	ability_cooldown_time = 30 SECONDS
+	use_message = "You prepare a protective spell!"
 
 /obj/item/ego_weapon/support/dragon_staff/Pulse(mob/living/carbon/human/user)
-	for(var/mob/living/carbon/human/L in livinginview(8, user))
-		if((!ishuman(L)) || L.stat == DEAD || L == user)
-			continue
-		to_chat(L, span_warning("[user] casts BARKSKIN!"))
-		L.apply_status_effect(/datum/status_effect/interventionshield/perfect)
+	AdjustCircle(user)
+	if(do_after(user, 12, src))
+		playsound(user, 'sound/abnormalities/faelantern/faelantern_breach.ogg', 100)
+		to_chat(user, span_warning("[user] casts MASS BARKSKIN!"))
+		for(var/mob/living/carbon/human/L in livinginview(8, user))
+			if((!ishuman(L)) || L.stat == DEAD)
+				continue
+			L.apply_status_effect(/datum/status_effect/interventionshield/perfect)
+
+/obj/item/ego_weapon/support/dragon_staff/proc/AdjustCircle(mob/living/carbon/human/user)
+	playsound(user, 'sound/abnormalities/hatredqueen/attack.ogg', 100)
+	var/obj/effect/dragon_circle/S = new(get_turf(src))
+	QDEL_IN(S, 1.2 SECONDS)
+	var/matrix/M = matrix(S.transform)
+	M.Translate(-8, 0)
+	if(user.dir != SOUTH)
+		S.layer -= 0.2
+	switch(user.dir)
+		if(EAST)
+			M.Scale(0.5, 1)
+			M.Translate(12, -8)
+		if(WEST)
+			M.Scale(0.5, 1)
+			M.Translate(-20, -8)
+		if(SOUTH)
+			M.Translate(0, -8)
+	S.transform = M
 
 // TETH
 
@@ -31,7 +54,7 @@
 	icon = 'code/modules/mob/living/simple_animal/abnormality/_auxiliary_modes/community/!icons/ego_weapons.dmi'
 	lefthand_file = 'code/modules/mob/living/simple_animal/abnormality/_auxiliary_modes/community/!icons/ego_lefthand.dmi'
 	righthand_file = 'code/modules/mob/living/simple_animal/abnormality/_auxiliary_modes/community/!icons/ego_righthand.dmi'
-	force = 25
+	force = 16
 	damtype = RED_DAMAGE
 	attack_verb_continuous = list("bashes", "jabs", "smacks")
 	attack_verb_simple = list("bash", "jab", "smack")
@@ -65,7 +88,7 @@
 	righthand_file = 'icons/mob/inhands/64x64_righthand.dmi'
 	inhand_x_dimension = 64
 	inhand_y_dimension = 64
-	force = 54
+	force = 37
 	attack_speed = 1.6
 	swingstyle = WEAPONSWING_LARGESWEEP
 	damtype = RED_DAMAGE
@@ -84,7 +107,7 @@
 	successfull_activation = "You release your charge!"
 	var/can_spin = TRUE
 	var/spinning = FALSE
-	var/aoe_damage = 54
+	var/aoe_damage = 37
 	var/aoe_size = 2
 	var/wide_slash_angle = 290
 	var/current_orientation = 1
@@ -165,7 +188,7 @@
 	icon = 'code/modules/mob/living/simple_animal/abnormality/_auxiliary_modes/community/!icons/ego_weapons.dmi'
 	lefthand_file = 'code/modules/mob/living/simple_animal/abnormality/_auxiliary_modes/community/!icons/ego_lefthand.dmi'
 	righthand_file = 'code/modules/mob/living/simple_animal/abnormality/_auxiliary_modes/community/!icons/ego_righthand.dmi'
-	force = 40
+	force = 24
 	damtype = RED_DAMAGE
 	attack_verb_continuous = list("bashes", "jabs", "picks", "impales", "spikes")
 	attack_verb_simple = list("bash", "jab", "pick", "impale", "spike")
@@ -189,7 +212,7 @@
 	icon = 'code/modules/mob/living/simple_animal/abnormality/_auxiliary_modes/community/!icons/ego_weapons.dmi'
 	worn_icon = 'icons/obj/clothing/belt_overlays.dmi'
 	worn_icon_state = "combust"
-	force = 80 // Quite high with passive buffs, but deals pure damage to yourself
+	force = 40 // Quite high with passive buffs, but deals pure damage to yourself
 	attack_speed = 0.8
 	damtype = RED_DAMAGE
 	attack_verb_continuous = list("slashes", "stabs", "scorches")
@@ -208,7 +231,7 @@
 							JUSTICE_ATTRIBUTE = 80
 							)
 	var/special_attack = FALSE
-	var/special_damage = 100
+	var/special_damage = 54
 	var/special_cooldown
 	var/special_cooldown_time = 10 SECONDS
 	var/special_checks_faction = TRUE
@@ -275,7 +298,7 @@
 				continue
 			if(special_checks_faction && source.faction_check_mob(L))
 				continue
-			L.apply_damage(20, RED_DAMAGE, null, L.run_armor_check(null, RED_DAMAGE), spread_damage = TRUE)
+			L.apply_damage(10, RED_DAMAGE, null, L.run_armor_check(null, RED_DAMAGE), spread_damage = TRUE)
 			L.apply_lc_burn(2)
 	..()
 
@@ -301,7 +324,7 @@
 	special_cooldown = world.time + special_cooldown_time
 
 	Check_Burn(user)
-	var/extra_damage = 10 // Extra damage each 10 stacks, maxed at 320
+	var/extra_damage = 5 // Extra damage each 10 stacks, maxed at 320
 	for(var/i = 0, i < round(burn_stack/10), i++)
 		extra_damage = extra_damage * 2
 
@@ -349,8 +372,8 @@
 	righthand_file = 'icons/mob/inhands/64x64_righthand.dmi'
 	inhand_x_dimension = 64
 	inhand_y_dimension = 64
-	force = 98
-	wielded_force = 98
+	force = 32
+	wielded_force = 32
 	reach = 2		//Has 2 Square Reach.
 	wielded_reach = 2
 	attack_speed = 0.9
@@ -412,7 +435,7 @@
 /obj/projectile/ego_bullet/ochre
 	name = "ochre sheet"
 	icon_state = "ochre"
-	damage = 80
+	damage = 40
 	damage_type = RED_DAMAGE
 	hitsound = 'sound/weapons/fixer/generic/nail2.ogg'
 
@@ -427,7 +450,7 @@
 	righthand_file = 'icons/mob/inhands/96x96_righthand.dmi'
 	inhand_x_dimension = 96
 	inhand_y_dimension = 96
-	force = 120
+	force = 76
 	reach = 2		//Has 2 Square Reach.
 	stuntime = 6	//Longer reach, gives you a short stun.
 	attack_speed = 1.8// really slow
@@ -527,7 +550,7 @@
 		return FALSE
 	var/mob/living/L = AM
 	L.deal_damage(damage_dealt, BLACK_DAMAGE)
-	new /obj/effect/temp_visual/damage_effect/black(get_turf(L), damage_dealt)
+	new /obj/effect/temp_visual/damage_effect/black(get_turf(L))
 
 /obj/effect/gibspawner/generic/silent/liquid_miasma
 	gibtypes = list(/obj/effect/decal/cleanable/liquid_miasma)
@@ -549,6 +572,7 @@
 	lefthand_file = 'code/modules/mob/living/simple_animal/abnormality/_auxiliary_modes/community/!icons/ego_lefthand.dmi'
 	righthand_file = 'code/modules/mob/living/simple_animal/abnormality/_auxiliary_modes/community/!icons/ego_righthand.dmi'
 	force = 14 // VERY fast attacks potentially
+	attack_speed = 0.6
 	damtype = BLACK_DAMAGE
 	swingstyle = WEAPONSWING_THRUST
 	attack_verb_continuous = list("stabs", "attacks", "slashes")
@@ -649,7 +673,7 @@
 	icon = 'code/modules/mob/living/simple_animal/abnormality/_auxiliary_modes/community/!icons/ego_weapons.dmi'
 	lefthand_file = 'code/modules/mob/living/simple_animal/abnormality/_auxiliary_modes/community/!icons/ego_lefthand.dmi'
 	righthand_file = 'code/modules/mob/living/simple_animal/abnormality/_auxiliary_modes/community/!icons/ego_righthand.dmi'
-	force = 70
+	force = 40
 	damtype = BLACK_DAMAGE
 	attack_verb_continuous = list("bashes", "jabs", "smacks")
 	attack_verb_simple = list("bash", "jab", "smack")

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/blubbering_toad.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/blubbering_toad.dm
@@ -122,9 +122,9 @@
 		angry = TRUE
 	if(breach_type == BREACH_MINING)//nerfed to a ZAYIN statline since this is something you'll typically fight roundstart
 		name = "Weakened [name]"
-		maxHealth = 400
-		melee_damage_lower = 4
-		melee_damage_upper = 8
+		maxHealth = 75
+		melee_damage_lower = 2
+		melee_damage_upper = 4
 		tongue_damage = 5
 		broken = TRUE
 	SetIdiot(user)

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/bottle.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/bottle.dm
@@ -7,8 +7,8 @@
 	icon_state = "bottle1"
 	icon_living = "bottle1"
 	portrait = "bottle"
-	maxHealth = 200
-	health = 200
+	maxHealth = 60
+	health = 60
 	damage_coeff = list(RED_DAMAGE = 1, WHITE_DAMAGE = 1.5, BLACK_DAMAGE = 0.5, PALE_DAMAGE = 2)
 	threat_level = ZAYIN_LEVEL
 	work_chances = list( //In the comic they work on it. They say you can do any work as long as you don't eat the cake

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/fairy_festival.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/fairy_festival.dm
@@ -6,12 +6,12 @@
 	icon_living = "fairy"
 	portrait = "fairy_festival"
 	core_icon = "fairy"
-	maxHealth = 200
-	health = 200
+	maxHealth = 50
+	health = 50
 	move_to_delay = 5
 	damage_coeff = list(RED_DAMAGE = 1, WHITE_DAMAGE = 1.2, BLACK_DAMAGE = 1.3, PALE_DAMAGE = 2)
-	melee_damage_lower = 2
-	melee_damage_upper = 4
+	melee_damage_lower = 1
+	melee_damage_upper = 2
 	stat_attack = DEAD
 	attack_sound = 'sound/abnormalities/fairyfestival/fairyqueen_hit.ogg'
 	is_flying_animal = TRUE
@@ -148,7 +148,7 @@
 		icon = 'ModularTegustation/Teguicons/96x48.dmi'
 		icon_state = "fairy_queen"
 		pixel_x = -16
-		maxHealth = 500
+		maxHealth = 50
 		playsound(get_turf(src), "sound/abnormalities/seasons/fall_change.ogg", 100, FALSE)
 		playsound(get_turf(src), "sound/abnormalities/fairyfestival/fairyqueen_growl.ogg", 100, FALSE)
 	return ..()
@@ -179,7 +179,7 @@
 	if(summon_type != /mob/living/simple_animal/hostile/fairy_mass)//does she have fairy masses?
 		return
 	if(health < (maxHealth * eat_threshold)) //80% health or lower, 20% less for each eat.
-		var/fairy_hp = 300
+		var/fairy_hp = 40
 		var/mob/living/mytarget
 		if(seek_cooldown < world.time)//this check can only be done once every ten seconds, for performance
 			for(var/mob/living/simple_animal/hostile/fairy_mass/M in range(12, src))//finds the fairy with the lowest HP in the vicinity
@@ -226,15 +226,15 @@
 	icon = 'ModularTegustation/Teguicons/tegumobs.dmi'
 	icon_state = "fairy_bastard"
 	icon_living = "fairy_bastard"
-	maxHealth = 83
-	health = 83
+	maxHealth = 10
+	health = 10
 	attack_verb_continuous = "bites"
 	attack_verb_simple = "bite"
 	is_flying_animal = TRUE
 	damage_coeff = list(BRUTE = 1, RED_DAMAGE = 1.2, WHITE_DAMAGE = 1.2, BLACK_DAMAGE = 1.2, PALE_DAMAGE = 1.2)
 	faction = list("hostile", "fairy")
 	melee_damage_lower = 1
-	melee_damage_upper = 5
+	melee_damage_upper = 1
 	melee_damage_type = RED_DAMAGE
 	obj_damage = 3
 	rapid_melee = 3

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/oceanwaves.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/oceanwaves.dm
@@ -4,8 +4,8 @@
 	icon = 'ModularTegustation/Teguicons/32x32.dmi'
 	icon_state = "oceanicwaves"
 	portrait = "oceanicwaves"
-	maxHealth = 200
-	health = 200
+	maxHealth = 100
+	health = 100
 	threat_level = ZAYIN_LEVEL
 	damage_coeff = list(RED_DAMAGE = 1.2, WHITE_DAMAGE = 1.2, BLACK_DAMAGE = 0.8, PALE_DAMAGE = 0.8)
 	speak_emote = list("advertises")
@@ -172,7 +172,7 @@
 	icon = 'icons/obj/drinks.dmi'
 	icon_state = "oceanbreeze"
 	spread = 15
-	damage = 15
+	damage = 4
 	var/item_type = null
 
 /obj/projectile/oceanic/on_hit(atom/target, blocked = FALSE)

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/one_sin.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/one_sin.dm
@@ -5,11 +5,11 @@
 	icon_state = "onesin_halo_normal"
 	icon_living = "onesin_halo_normal"
 	portrait = "one_sin"
-	maxHealth = 777
-	health = 777
+	maxHealth = 75
+	health = 75
 	damage_coeff = list(RED_DAMAGE = 1.5, WHITE_DAMAGE = 1, BLACK_DAMAGE = 1, PALE_DAMAGE = 2)
-	melee_damage_lower = 3
-	melee_damage_upper = 5
+	melee_damage_lower = 2
+	melee_damage_upper = 4
 	melee_damage_type = WHITE_DAMAGE
 	attack_sound = 'sound/abnormalities/onesin/onesin_attack.ogg'
 	attack_verb_continuous = "smites"

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/oracle.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/oracle.dm
@@ -7,8 +7,8 @@
 	icon_state = "oracle"
 	icon_living = "oracle"
 	portrait = "oracle"
-	maxHealth = 300
-	health = 300
+	maxHealth = 100
+	health = 100
 	damage_coeff = list(RED_DAMAGE = 2, WHITE_DAMAGE = 0, BLACK_DAMAGE = 2, PALE_DAMAGE = 2)
 	threat_level = ZAYIN_LEVEL
 	work_chances = list(

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/pile_of_mail.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/pile_of_mail.dm
@@ -5,8 +5,8 @@
 	icon = 'ModularTegustation/Teguicons/32x48.dmi'
 	icon_state = "mailbox"
 	portrait = "pile_of_mail"
-	maxHealth = 150
-	health = 150
+	maxHealth = 100
+	health = 100
 	threat_level = ZAYIN_LEVEL
 	work_chances = list(
 		ABNORMALITY_WORK_INSTINCT = 60,
@@ -524,4 +524,4 @@
 	desc = "a shuriken made from paper."
 	icon_state = "shuriken_paper"
 	damage_type = RED_DAMAGE
-	damage = 2
+	damage = 1

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/we_can_change_anything.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/we_can_change_anything.dm
@@ -5,8 +5,8 @@
 	icon = 'ModularTegustation/Teguicons/tegumobs.dmi'
 	icon_state = "wecanchange"
 	portrait = "we_can_change_anything"
-	maxHealth = 250
-	health = 250
+	maxHealth = 125
+	health = 125
 	threat_level = ZAYIN_LEVEL
 	damage_coeff = list(RED_DAMAGE = 2, WHITE_DAMAGE = 0.8, BLACK_DAMAGE = 1, PALE_DAMAGE = 0.5)
 	work_chances = list(

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/wellcheers.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/wellcheers.dm
@@ -8,8 +8,8 @@
 	portrait = "wellcheers"
 	layer = BELOW_OBJ_LAYER
 	threat_level = ZAYIN_LEVEL
-	maxHealth = 200
-	health = 200
+	maxHealth = 100
+	health = 100
 	damage_coeff = list(RED_DAMAGE = 1, WHITE_DAMAGE = 1, BLACK_DAMAGE = 1, PALE_DAMAGE = 1)
 	work_chances = list(
 		ABNORMALITY_WORK_INSTINCT = list(70, 70, 60, 60, 60),

--- a/code/modules/mob/living/simple_animal/hostile/ordeal/gold/midnight.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/gold/midnight.dm
@@ -7,8 +7,8 @@
 	icon_living = "al_fine"
 	icon_dead = "al_fine_dead"
 	faction = list("gold_ordeal")
-	maxHealth = 1400 //it's a boss, more or less
-	health = 1400
+	maxHealth = 900 //it's a boss, more or less
+	health = 900
 	death_sound = 'sound/effects/limbus_death.ogg'
 	damage_coeff = list(RED_DAMAGE = 0.2, WHITE_DAMAGE = 0.2, BLACK_DAMAGE = 0.2, PALE_DAMAGE = 0.2)
 	butcher_results = list(/obj/item/food/meat/slab/corroded = 1)

--- a/code/modules/reagents/chemistry/reagents/lc13_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/lc13_reagents.dm
@@ -24,7 +24,7 @@
 
 /datum/reagent/toxin/lc13_toxin/strong
 	name = "Concentrated Red Toxin"
-	damage = 5
+	damage = 4
 	toxpwr = 0.5
 
 /datum/reagent/toxin/lc13_toxin/white
@@ -41,7 +41,7 @@
 
 /datum/reagent/toxin/lc13_toxin/white/strong
 	name = "Concentrated White Toxin"
-	damage = 5
+	damage = 4
 	toxpwr = 0.5
 
 /datum/reagent/toxin/lc13_toxin/black
@@ -59,7 +59,7 @@
 
 /datum/reagent/toxin/lc13_toxin/black/strong
 	name = "Concentrated Black Toxin"
-	damage = 5
+	damage = 4
 	toxpwr = 0.5
 
 /datum/reagent/toxin/lc13_toxin/pale


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adjusts the damage of all community E.G.O in compliance to the HP rebalance, with Enkephalin Rush in bold:

- **Dragon staff**
- **Security**
- Sunspit
- **Furrows**
- Waxen pinion (Philip's E.G.O)
- Ochre Sheet
- Miasma Skin
- Limos
- **Lucid Nightmares**

Reduces the stats of Enkephalin Rush-exlusive enemies across the board, including summoned dire tegus and the secret bear.
Dragon wizards can now fire "swindle" bullets as cantrips instead of ardor blossom star.

Also fast-tracks a visual effect from an upcoming PR for Dragon staff.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Having mismatched stats would be terrible for the game.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: visual effect for dragon staff
balance: HP rebalance expansion- community ego, enkephalin rush mobs, mapped district4 enemies
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
