### PR TITLE
Ego Armor Slowdown Removal but take twice as long to equip

### DIFF
--- a/code/modules/clothing/suits/ego_gear/_ego_gear.dm
+++ b/code/modules/clothing/suits/ego_gear/_ego_gear.dm
@@ -11,7 +11,7 @@
 	w_class = WEIGHT_CLASS_BULKY								//No more stupid 10 egos in bag
 	allowed = list(/obj/item/gun, /obj/item/ego_weapon, /obj/item/melee)
 	drag_slowdown = 1
-	var/equip_slowdown = 3 SECONDS
+	var/equip_slowdown = 6 SECONDS
 
 	var/obj/item/clothing/head/ego_hat/hat = null // Hat type, see clothing/head/_ego_head.dm
 	var/obj/item/clothing/neck/ego_neck/neck = null // Neckwear, see clothing/neck/_neck.dm
@@ -60,18 +60,6 @@
 			return
 		neckwear.Destroy()
 
-/obj/item/clothing/suit/armor/ego_gear/pickup(mob/user)
-	. = ..()
-	if(!user.has_movespeed_modifier(/datum/movespeed_modifier/too_many_armors) && ishuman(user))
-		var/obj/item/clothing/suit/armor/ego_gear/equipped_armor = user.get_item_by_slot(ITEM_SLOT_OCLOTHING)
-		if(istype(equipped_armor))
-			if((SSmaptype.maptype in SSmaptype.citymaps) || (SSmaptype.maptype in SSmaptype.combatmaps))
-				return
-			else
-				var/list/slowdown_free_roles = list("Clerk", "Agent Support Clerk", "Facility Support Clerk", "Extraction Officer")
-				if(!(user.mind.assigned_role in slowdown_free_roles))
-					user.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/too_many_armors)
-
 /obj/item/clothing/suit/armor/ego_gear/dropped(mob/user)
 	. = ..()
 	if(hat)
@@ -84,8 +72,6 @@
 		if(!istype(neckwear, neck))
 			return
 		neckwear.Destroy()
-	if(user.has_movespeed_modifier(/datum/movespeed_modifier/too_many_armors))
-		user.remove_movespeed_modifier(/datum/movespeed_modifier/too_many_armors)
 
 /obj/item/clothing/suit/armor/ego_gear/proc/CanUseEgo(mob/living/carbon/human/user)
 	if(!ishuman(user))
@@ -164,6 +150,3 @@
 	H.update_inv_wear_suit()
 	H.update_body()
 
-/datum/movespeed_modifier/too_many_armors
-	variable = TRUE
-	multiplicative_slowdown = 1.5 //Roughly 1/3 speed for holding too many armors


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes the slow down for holding 2 armors/holding 1 while wearing one but doubles the time it takes to equip it.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The slowdown system had many bugs like how it wouldn't affect you if you equip one of the 2 armors you were holding or how it interacted with other speed changes from armors. the slow down was overall slower than just dragging the armor around. I doubled the time to equip armors to compensate since that does a better job of preventing players from switching armors in risky situations like when a pale abno is melting,
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Removes ego armor slowdown
balance: Ego armors take twice as long to equip
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
