### PR TITLE
Adjustable EGO Refactor

### DIFF
--- a/ModularTegustation/tegu_items/refinery/crates/syndicate.dm
+++ b/ModularTegustation/tegu_items/refinery/crates/syndicate.dm
@@ -15,7 +15,7 @@
 	rareloot =	list(
 		/obj/item/clothing/suit/armor/ego_gear/city/blade_lineage_cutthroat,
 		/obj/item/clothing/suit/armor/ego_gear/city/thumb_capo,
-		/obj/item/clothing/suit/armor/ego_gear/adjustable/index_proxy,
+		/obj/item/clothing/suit/armor/ego_gear/index_proxy,
 		/obj/item/ego_weapon/city/index,
 		/obj/item/ego_weapon/city/awl,
 		/obj/item/ego_weapon/city/kurokumo,

--- a/_maps/templates/syndicate_office/indexfinger.dmm
+++ b/_maps/templates/syndicate_office/indexfinger.dmm
@@ -947,8 +947,8 @@
 	opened = 1;
 	pixel_y = 5
 	},
-/obj/item/clothing/suit/armor/ego_gear/adjustable/index_proxy,
-/obj/item/clothing/suit/armor/ego_gear/adjustable/index_proxy,
+/obj/item/clothing/suit/armor/ego_gear/index_proxy,
+/obj/item/clothing/suit/armor/ego_gear/index_proxy,
 /obj/effect/spawner/lootdrop/proxy,
 /obj/effect/spawner/lootdrop/proxy,
 /obj/machinery/light{

--- a/code/datums/components/adjustable_clothes.dm
+++ b/code/datums/components/adjustable_clothes.dm
@@ -1,0 +1,68 @@
+/**
+ * Adjustable clothing;
+ * Takes a list of styles and a generic adjustment text.
+ * If one is not provided, it automates to my awful one you have to cope with.
+ * Updates the Examine Text and does all its actions through a radial menu.
+ */
+
+/datum/component/adjustable_clothing
+	var/list/alternative_styles = list()
+	var/icon
+	var/obj/item/clothing/parent_clothes
+	var/adjust_text
+
+/datum/component/adjustable_clothing/Initialize(list/_alternative_styles, _adjust_text)
+	if(!isclothing(parent))
+		return COMPONENT_INCOMPATIBLE
+	parent_clothes = parent
+	if(!islist(_alternative_styles))
+		if(isnull(_alternative_styles))
+			return COMPONENT_INCOMPATIBLE
+		_alternative_styles = list(_alternative_styles)
+	alternative_styles = _alternative_styles
+	icon = parent_clothes.icon
+	adjust_text = _adjust_text ? _adjust_text : "You adjust [parent_clothes] to a new style~!"
+
+/datum/component/adjustable_clothing/RegisterWithParent()
+	parent_clothes.verbs += /obj/item/clothing/proc/AdjustStyle
+	RegisterSignal(parent, COMSIG_PARENT_EXAMINE, PROC_REF(ExamineMessage))
+
+/datum/component/adjustable_clothing/UnregisterFromParent()
+	parent_clothes.verbs -= /obj/item/clothing/proc/AdjustStyle
+	UnregisterSignal(parent, COMSIG_PARENT_EXAMINE)
+
+/datum/component/adjustable_clothing/proc/ExamineMessage(datum/source, mob/user, list/examine_list)
+	SIGNAL_HANDLER
+	examine_list += span_notice("It is able to be adjusted.")
+
+/datum/component/adjustable_clothing/proc/Adjust()
+	if(!ishuman(usr))
+		return
+	var/list/choice_list = list()
+	for(var/styles in alternative_styles)
+		choice_list[styles] = image(icon = icon, icon_state = styles)
+
+	var/choice = show_radial_menu(usr, parent_clothes, choice_list, custom_check = CALLBACK(src, PROC_REF(check_menu), usr), radius = 42, require_near = TRUE)
+	if(!choice || !check_menu(usr))
+		return
+	parent_clothes.icon_state = choice
+	to_chat(usr, span_notice(adjust_text))
+	var/mob/living/carbon/human/H = usr
+	H.regenerate_icons()
+
+/datum/component/adjustable_clothing/proc/check_menu(mob/user)
+	if(!istype(user))
+		return FALSE
+	if(QDELETED(src) || QDELETED(parent))
+		return FALSE
+	if(user.incapacitated())
+		return FALSE
+	return TRUE
+
+/obj/item/clothing/proc/AdjustStyle()
+	set name = "Adjust Style"
+	set category = "Object"
+	set src in view(1)
+	var/datum/component/adjustable_clothing/adj_comp = GetComponent(/datum/component/adjustable_clothing)
+	if(adj_comp)
+		adj_comp.Adjust()

--- a/code/datums/components/crafting/recipes/carnival_silk/armor_weaving/carnival_index.dm
+++ b/code/datums/components/crafting/recipes/carnival_silk/armor_weaving/carnival_index.dm
@@ -15,7 +15,7 @@
 
 /datum/crafting_recipe/index_proxy
 	name = "Index Proxy Armor"
-	result = /obj/item/clothing/suit/armor/ego_gear/adjustable/index_proxy
+	result = /obj/item/clothing/suit/armor/ego_gear/index_proxy
 	reqs = list(
 		/obj/item/stack/sheet/silk/violet_simple = 4,
 		/obj/item/stack/sheet/silk/indigo_advanced = 2,

--- a/code/modules/antagonists/head/claw.dm
+++ b/code/modules/antagonists/head/claw.dm
@@ -91,7 +91,7 @@
 	name = "Claw"
 
 	uniform = /obj/item/clothing/under/suit/lobotomy/claw
-	suit = /obj/item/clothing/suit/armor/ego_gear/adjustable/claw
+	suit = /obj/item/clothing/suit/armor/ego_gear/claw
 	gloves = /obj/item/clothing/gloves/color/black
 	l_hand = /obj/item/ego_weapon/the_claw
 	shoes = /obj/item/clothing/shoes/combat

--- a/code/modules/clothing/suits/ego_gear/_ego_gear.dm
+++ b/code/modules/clothing/suits/ego_gear/_ego_gear.dm
@@ -114,39 +114,3 @@
 				display_text += "\n <span class='warning'>[atr]: [attribute_requirements[atr]].</span>"
 		display_text += SpecialGearRequirements()
 		to_chat(usr, display_text)
-
-
-/obj/item/clothing/suit/armor/ego_gear/adjustable
-	var/list/alternative_styles = list()
-	var/index = 1
-
-/obj/item/clothing/suit/armor/ego_gear/adjustable/Initialize()
-	. = ..()
-	alternative_styles |= icon_state
-	index = alternative_styles.len
-
-/obj/item/clothing/suit/armor/ego_gear/adjustable/examine(mob/user)
-	. = ..()
-	. += "<span class='notice'>It can be adjusted by right-clicking the armor.</span>"
-
-/obj/item/clothing/suit/armor/ego_gear/adjustable/verb/AdjustStyle()
-	set name = "Adjust EGO Style"
-	set category = null
-	set src in usr
-	Adjust()
-
-/obj/item/clothing/suit/armor/ego_gear/adjustable/proc/Adjust()
-	if(!ishuman(usr))
-		return
-	if(alternative_styles.len <= 1)
-		to_chat(usr, "<span class='notice'>Has no other styles!</span>")
-		return
-	index++
-	if(index > alternative_styles.len)
-		index = 1
-	icon_state = alternative_styles[index]
-	to_chat(usr, "<span class='notice'>You adjust [src] to a new style~!</span>")
-	var/mob/living/carbon/human/H = usr
-	H.update_inv_wear_suit()
-	H.update_body()
-

--- a/code/modules/clothing/suits/ego_gear/non_abnormality/index.dm
+++ b/code/modules/clothing/suits/ego_gear/non_abnormality/index.dm
@@ -11,7 +11,7 @@
 							JUSTICE_ATTRIBUTE = 60
 							)
 
-/obj/item/clothing/suit/armor/ego_gear/adjustable/index_proxy //Choose your Drip babey
+/obj/item/clothing/suit/armor/ego_gear/index_proxy //Choose your Drip babey
 	name = "index proxy armor"
 	desc = "Armor worn by index proxies."
 	icon_state = "index_proxy_open"
@@ -24,15 +24,18 @@
 							TEMPERANCE_ATTRIBUTE = 80,
 							JUSTICE_ATTRIBUTE = 80
 							)
-	alternative_styles = list("index_proxy_open", "index_proxy_closed")
 
-/obj/item/clothing/suit/armor/ego_gear/adjustable/index_proxy/examine(mob/user)
+/obj/item/clothing/suit/armor/ego_gear/index_proxy/ComponentInitialize()
+	. = ..()
+	AddComponent(/datum/component/adjustable_clothing, list("index_proxy_open", "index_proxy_closed"))
+
+/obj/item/clothing/suit/armor/ego_gear/index_proxy/examine(mob/user)
 	. = ..()
 	if(user.mind)
 		if(user.mind.assigned_role in list("Disciplinary Officer", "Combat Research Agent")) //These guys get a bonus to equipping gacha.
 			. += span_notice("Due to your abilities, you get a -20 reduction to stat requirements when equipping this armor.")
 
-/obj/item/clothing/suit/armor/ego_gear/adjustable/index_proxy/CanUseEgo(mob/living/user)
+/obj/item/clothing/suit/armor/ego_gear/index_proxy/CanUseEgo(mob/living/user)
 	if(user.mind)
 		if(user.mind.assigned_role in list("Disciplinary Officer", "Combat Research Agent")) //These guys get a bonus to equipping gacha.
 			equip_bonus = 20

--- a/code/modules/clothing/suits/ego_gear/ordeal.dm
+++ b/code/modules/clothing/suits/ego_gear/ordeal.dm
@@ -1,4 +1,4 @@
-/obj/item/clothing/suit/armor/ego_gear/adjustable/claw
+/obj/item/clothing/suit/armor/ego_gear/claw
 	name = "claw armor"
 	desc = "A simple suit and tie with several injectors attached. The fabric is near indestructable."
 	icon_state = "claw"
@@ -7,7 +7,10 @@
 	armor = list(RED_DAMAGE = 90, WHITE_DAMAGE = 100, BLACK_DAMAGE = 90, PALE_DAMAGE = 90) // The arbiter's henchman
 	equip_slowdown = 0 // In accordance of arbiter armor
 	hat = /obj/item/clothing/head/ego_hat/claw_head
-	alternative_styles = list("claw", "claw_baral")
+
+/obj/item/clothing/suit/armor/ego_gear/claw/ComponentInitialize()
+	. = ..()
+	AddComponent(/datum/component/adjustable_clothing, list("claw", "claw_baral"))
 
 /obj/item/clothing/head/ego_hat/claw_head
 	name = "mask of the claw"

--- a/lobotomy-corp13.dme
+++ b/lobotomy-corp13.dme
@@ -489,6 +489,7 @@
 #include "code\datums\components\_component.dm"
 #include "code\datums\components\acid.dm"
 #include "code\datums\components\ai_leadership.dm"
+#include "code\datums\components\adjustable_clothes.dm"
 #include "code\datums\components\anti_magic.dm"
 #include "code\datums\components\aquarium.dm"
 #include "code\datums\components\areabound.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Moves Adjustable EGO out of a subtype into a Component that can be placed on any Clothing. This limitation is currently self-enforced by the Component.
The Component takes two arguments: A list of Alternative Styles, all sharing the same `icon` file, and a String of text displayed whenever you _do_ adjust the clothes.
If the first is not provided, the component doesn't Initialize.
If the second is not provided, it defaults to my default text.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Better code. The previous itteration was done out of laziness and the inability to learn Component code. This is a better implementation that allows it to apply to ANY clothing, allowing for adjustable hats and more. This adjustability is still entirely cosmetic; It does not account for damage zones or anything but that should be fine because our armor is Outfit entirely.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
refactor: /ego_gear/adjustable -> /datum/component/adjust_clothing
refactor: adjustable code from _ego_gear.dm -> /code/datum/component/adjustable_clothes.dm
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
