### PR TITLE
Realized rebalance

### DIFF
--- a/code/modules/clothing/suits/ego_gear/realized.dm
+++ b/code/modules/clothing/suits/ego_gear/realized.dm
@@ -356,7 +356,7 @@ No Ability	260
 	name = "for whom the bell tolls"
 	desc = "I suppose if a man has something once, always something of it remains."
 	icon_state = "thirteen"
-	armor = list(RED_DAMAGE = 50, WHITE_DAMAGE = 50, BLACK_DAMAGE = 80, PALE_DAMAGE = 80)		//No Ability
+	armor = list(RED_DAMAGE = 50, WHITE_DAMAGE = 60, BLACK_DAMAGE = 70, PALE_DAMAGE = 80)		//No Ability
 
 /obj/item/clothing/suit/armor/ego_gear/realization/capitalism
 	name = "capitalism"

--- a/code/modules/clothing/suits/ego_gear/realized.dm
+++ b/code/modules/clothing/suits/ego_gear/realized.dm
@@ -1,4 +1,4 @@
-/obj/item/clothing/suit/armor/ego_gear/realization // 240 without ability. You have to be an EX level agent to get these.
+/obj/item/clothing/suit/armor/ego_gear/realization // 260 without ability. You have to be an EX level agent to get these.
 	name = "unknown realized ego"
 	desc = "Notify coders immediately!"
 	icon = 'icons/obj/clothing/ego_gear/realization.dmi'
@@ -21,8 +21,8 @@
 	A.SetItem(src)
 
 /*Armor totals:
-Ability 	230
-No Ability	250
+Ability 	240
+No Ability	260
 */
 /* ZAYIN Realizations */
 
@@ -30,14 +30,14 @@ No Ability	250
 	name = "confessional"
 	desc = "Come my child. Tell me your sins."
 	icon_state = "confessional"
-	armor = list(RED_DAMAGE = 50, WHITE_DAMAGE = 100, BLACK_DAMAGE = 40, PALE_DAMAGE = 40)	//Ranged
+	armor = list(RED_DAMAGE = 50, WHITE_DAMAGE = 80, BLACK_DAMAGE = 50, PALE_DAMAGE = 60)	//Ranged
 	realized_ability = /obj/effect/proc_holder/ability/aimed/cross_spawn
 
 /obj/item/clothing/suit/armor/ego_gear/realization/prophet
 	name = "prophet"
 	desc = "And they have conquered him by the blood of the Lamb and by the word of their testimony, for they loved not their lives even unto death."
 	icon_state = "prophet"
-	armor = list(RED_DAMAGE = 40, WHITE_DAMAGE = 80, BLACK_DAMAGE = 70, PALE_DAMAGE = 60)	//No ability.
+	armor = list(RED_DAMAGE = 40, WHITE_DAMAGE = 80, BLACK_DAMAGE = 80, PALE_DAMAGE = 60)	//No ability.
 	flags_inv = HIDEJUMPSUIT|HIDEGLOVES|HIDESHOES
 	hat = /obj/item/clothing/head/ego_hat/prophet_hat
 
@@ -50,14 +50,14 @@ No Ability	250
 	name = "blood maiden"
 	desc = "Soaked in blood, and yet pure in heart."
 	icon_state = "maiden"
-	armor = list(RED_DAMAGE = 60, WHITE_DAMAGE = 60, BLACK_DAMAGE = 80, PALE_DAMAGE = 50)	//No ability. 250
+	armor = list(RED_DAMAGE = 70, WHITE_DAMAGE = 50, BLACK_DAMAGE = 80, PALE_DAMAGE = 60)	//No ability. 250
 
 /obj/item/clothing/suit/armor/ego_gear/realization/wellcheers
 	name = "wellcheers"
 	desc = " I’ve found true happiness in cracking open a cold one after a hard day’s work, covered in sea water and sweat. \
 	I’m at the port now but we gotta take off soon to catch some more shrimp. Never know what your future holds, bros."
 	icon_state = "wellcheers"
-	armor = list(RED_DAMAGE = 80, WHITE_DAMAGE = 50, BLACK_DAMAGE = 50, PALE_DAMAGE = 50)	//Support
+	armor = list(RED_DAMAGE = 80, WHITE_DAMAGE = 60, BLACK_DAMAGE = 60, PALE_DAMAGE = 40)	//Support
 	realized_ability = /obj/effect/proc_holder/ability/wellcheers
 	hat = /obj/item/clothing/head/ego_hat/wellcheers_hat
 
@@ -70,14 +70,14 @@ No Ability	250
 	name = "comatose"
 	desc = "...ZZZ..."
 	icon_state = "comatose"
-	armor = list(RED_DAMAGE = 50, WHITE_DAMAGE = 80, BLACK_DAMAGE = 50, PALE_DAMAGE = 50)	//Defensive
+	armor = list(RED_DAMAGE = 70, WHITE_DAMAGE = 80, BLACK_DAMAGE = 50, PALE_DAMAGE = 40)	//Defensive
 	realized_ability = /obj/effect/proc_holder/ability/comatose
 
 /obj/item/clothing/suit/armor/ego_gear/realization/brokencrown
 	name = "broken crown"
 	desc = "Shall we get to work? All we need to do is what we’ve always done."
 	icon_state = "brokencrown"
-	armor = list(RED_DAMAGE = 70, WHITE_DAMAGE = 60, BLACK_DAMAGE = 50, PALE_DAMAGE = 50)	//Broken Crown
+	armor = list(RED_DAMAGE = 80, WHITE_DAMAGE = 60, BLACK_DAMAGE = 50, PALE_DAMAGE = 50)	//Broken Crown
 	realized_ability = /obj/effect/proc_holder/ability/brokencrown
 	hat = /obj/item/clothing/head/ego_hat/brokencrown
 
@@ -107,14 +107,14 @@ No Ability	250
 	name = "mouth of god"
 	desc = "And the mouth of god spoke: You will be punished."
 	icon_state = "mouth"
-	armor = list(RED_DAMAGE = 70, WHITE_DAMAGE = 60, BLACK_DAMAGE = 40, PALE_DAMAGE = 60)		//Defensive
+	armor = list(RED_DAMAGE = 80, WHITE_DAMAGE = 60, BLACK_DAMAGE = 40, PALE_DAMAGE = 60)		//Defensive
 	realized_ability = /obj/effect/proc_holder/ability/punishment
 
 /obj/item/clothing/suit/armor/ego_gear/realization/universe
 	name = "one with the universe"
 	desc = "One with all, it all comes back to yourself."
 	icon_state = "universe"
-	armor = list(RED_DAMAGE = 40, WHITE_DAMAGE = 50, BLACK_DAMAGE = 80, PALE_DAMAGE = 60)		//Support
+	armor = list(RED_DAMAGE = 60, WHITE_DAMAGE = 40, BLACK_DAMAGE = 80, PALE_DAMAGE = 60)		//Support
 	realized_ability = /obj/effect/proc_holder/ability/universe_song
 	hat = /obj/item/clothing/head/ego_hat/universe_hat
 
@@ -128,7 +128,7 @@ No Ability	250
 	name = "death stare"
 	desc = "Last words are for fools who haven’t said enough."
 	icon_state = "death"
-	armor = list(RED_DAMAGE = 80, WHITE_DAMAGE = 40, BLACK_DAMAGE = 60, PALE_DAMAGE = 50)		//Melee with slow
+	armor = list(RED_DAMAGE = 80, WHITE_DAMAGE = 40, BLACK_DAMAGE = 70, PALE_DAMAGE = 50)		//Melee with slow
 	realized_ability = /obj/effect/proc_holder/ability/aimed/gleaming_eyes
 
 /obj/item/clothing/suit/armor/ego_gear/realization/fear
@@ -136,27 +136,27 @@ No Ability	250
 	desc = "Man fears the darkness, and so he scrapes away at the edges of it with fire.\
 	Grants various buffs to life of a daredevil when equipped."
 	icon_state = "fear"
-	armor = list(RED_DAMAGE = 80, WHITE_DAMAGE = 70, BLACK_DAMAGE = 70, PALE_DAMAGE = 10)		//Melee, makes weapon better
+	armor = list(RED_DAMAGE = 80, WHITE_DAMAGE = 80, BLACK_DAMAGE = 80, PALE_DAMAGE = 0)		//Melee, makes weapon better
 	flags_inv = null
 
 /obj/item/clothing/suit/armor/ego_gear/realization/exsanguination
 	name = "exsaungination"
 	desc = "It keeps your suit relatively clean."
 	icon_state = "exsanguination"
-	armor = list(RED_DAMAGE = 60, WHITE_DAMAGE = 80, BLACK_DAMAGE = 60, PALE_DAMAGE = 50)			//No ability
+	armor = list(RED_DAMAGE = 60, WHITE_DAMAGE = 80, BLACK_DAMAGE = 50, PALE_DAMAGE = 70)			//No ability
 
 /obj/item/clothing/suit/armor/ego_gear/realization/ember_matchlight
 	name = "ember matchlight"
 	desc = "If I must perish, then I'll make you meet the same fate."
 	icon_state = "ember_matchlight"
-	armor = list(RED_DAMAGE = 80, WHITE_DAMAGE = 40, BLACK_DAMAGE = 50, PALE_DAMAGE = 60)		//Melee
+	armor = list(RED_DAMAGE = 80, WHITE_DAMAGE = 60, BLACK_DAMAGE = 40, PALE_DAMAGE = 60)		//Melee
 	realized_ability = /obj/effect/proc_holder/ability/fire_explosion
 
 /obj/item/clothing/suit/armor/ego_gear/realization/sakura_bloom
 	name = "sakura bloom"
 	desc = "The forest will never return to its original state once it dies. Cherish the rain."
 	icon_state = "sakura_bloom"
-	armor = list(RED_DAMAGE = 60, WHITE_DAMAGE = 80, BLACK_DAMAGE = 40, PALE_DAMAGE = 50)		//Healing
+	armor = list(RED_DAMAGE = 50, WHITE_DAMAGE = 70, BLACK_DAMAGE = 60, PALE_DAMAGE = 60)		//Healing
 	realized_ability = /obj/effect/proc_holder/ability/petal_blizzard
 	hat = /obj/item/clothing/head/ego_hat/sakura_hat
 
@@ -170,7 +170,7 @@ No Ability	250
 	name = "stupor"
 	desc = "Drink! Drink yourselves into a stupor! Foul tasting louts like you won't satisfy me until you're all as pickled as me, hah!" //Descriptions made by Anonmare
 	icon_state = "stupor" //Art by TemperanceTempy
-	armor = list(RED_DAMAGE = 80, WHITE_DAMAGE = 30, BLACK_DAMAGE = 50, PALE_DAMAGE = 70)		//Defensive
+	armor = list(RED_DAMAGE = 80, WHITE_DAMAGE = 30, BLACK_DAMAGE = 60, PALE_DAMAGE = 70)		//Defensive
 	hat = /obj/item/clothing/head/ego_hat/stupor
 
 /obj/item/clothing/head/ego_hat/stupor
@@ -184,33 +184,33 @@ No Ability	250
 	name = "grinder MK52"
 	desc = "The blades are not just decorative."
 	icon_state = "grinder"
-	armor = list(RED_DAMAGE = 70, WHITE_DAMAGE = 40, BLACK_DAMAGE = 60, PALE_DAMAGE = 60)		//Melee
+	armor = list(RED_DAMAGE = 80, WHITE_DAMAGE = 40, BLACK_DAMAGE = 60, PALE_DAMAGE = 60)		//Melee
 	realized_ability = /obj/effect/proc_holder/ability/aimed/helper_dash
 
 /obj/item/clothing/suit/armor/ego_gear/realization/bigiron
 	name = "big iron"
 	desc = "A hefty silk coat with a blue smock."
 	icon_state = "big_iron"
-	armor = list(RED_DAMAGE = 60, WHITE_DAMAGE = 50, BLACK_DAMAGE = 60, PALE_DAMAGE = 60)		//Ranged
+	armor = list(RED_DAMAGE = 70, WHITE_DAMAGE = 70, BLACK_DAMAGE = 70, PALE_DAMAGE = 30)		//Ranged
 
 /obj/item/clothing/suit/armor/ego_gear/realization/eulogy
 	name = "solemn eulogy"
 	desc = "Death is not extinguishing the light, it is putting out the lamp as dawn has come."
 	icon_state = "eulogy"
-	armor = list(RED_DAMAGE = 30, WHITE_DAMAGE = 80, BLACK_DAMAGE = 80, PALE_DAMAGE = 40)
+	armor = list(RED_DAMAGE = 30, WHITE_DAMAGE = 80, BLACK_DAMAGE = 80, PALE_DAMAGE = 50)
 
 /obj/item/clothing/suit/armor/ego_gear/realization/ourgalaxy
 	name = "our galaxy"
 	desc = "Walk this night sky with me. The galaxy dotted with numerous hopes. We'll count the stars and never be alone."
 	icon_state = "ourgalaxy"
-	armor = list(RED_DAMAGE = 40, WHITE_DAMAGE = 60, BLACK_DAMAGE = 70, PALE_DAMAGE = 60)		//Healing
+	armor = list(RED_DAMAGE = 50, WHITE_DAMAGE = 60, BLACK_DAMAGE = 80, PALE_DAMAGE = 50)		//Healing
 	realized_ability = /obj/effect/proc_holder/ability/galaxy_gift
 
 /obj/item/clothing/suit/armor/ego_gear/realization/forever
 	name = "together forever"
 	desc = "I would move Heaven and Earth to be together forever with you."
 	icon_state = "forever"
-	armor = list(RED_DAMAGE = 60, WHITE_DAMAGE = 80, BLACK_DAMAGE = 60, PALE_DAMAGE = 50)		//No ability
+	armor = list(RED_DAMAGE = 50, WHITE_DAMAGE = 80, BLACK_DAMAGE = 70, PALE_DAMAGE = 60)		//No ability
 	hat = /obj/item/clothing/head/ego_hat/forever_hat
 
 /obj/item/clothing/head/ego_hat/forever_hat
@@ -222,7 +222,7 @@ No Ability	250
 	name = "endless wisdom"
 	desc = "Poor stuffing of straw. I'll give you the wisdom to ponder over anything."
 	icon_state = "wisdom"
-	armor = list(RED_DAMAGE = 60, WHITE_DAMAGE = 80, BLACK_DAMAGE = 60, PALE_DAMAGE = 50)		//No ability
+	armor = list(RED_DAMAGE = 70, WHITE_DAMAGE = 80, BLACK_DAMAGE = 50, PALE_DAMAGE = 60)		//No ability
 	flags_inv = HIDESHOES
 	hat = /obj/item/clothing/head/ego_hat/wisdom_hat
 
@@ -235,20 +235,20 @@ No Ability	250
 	name = "boundless empathy"
 	desc = "Tin-cold woodsman. I'll give you the heart to forgive and love anyone."
 	icon_state = "empathy"
-	armor = list(RED_DAMAGE = 80, WHITE_DAMAGE = 60, BLACK_DAMAGE = 60, PALE_DAMAGE = 50)		//No ABility
+	armor = list(RED_DAMAGE = 80, WHITE_DAMAGE = 60, BLACK_DAMAGE = 70, PALE_DAMAGE = 50)		//No ABility
 	flags_inv = HIDEGLOVES|HIDESHOES
 
 /obj/item/clothing/suit/armor/ego_gear/realization/valor
 	name = "unbroken valor"
 	desc = "Cowardly kitten, I'll give you the courage to stand up to anything and everything."
 	icon_state = "valor"
-	armor = list(RED_DAMAGE = 70, WHITE_DAMAGE = 50, BLACK_DAMAGE = 50, PALE_DAMAGE = 80)		//No ability
+	armor = list(RED_DAMAGE = 70, WHITE_DAMAGE = 50, BLACK_DAMAGE = 60, PALE_DAMAGE = 80)		//No ability
 
 /obj/item/clothing/suit/armor/ego_gear/realization/home //This name would SO much easier if we didnt aleady USE HOMING INSTINCT AHHHHHHHHHHHHHHHHHHH
 	name = "forever home"
 	desc = "Last of all, road that is lost. I will send you home."
 	icon_state = "home"
-	armor = list(RED_DAMAGE = 40, WHITE_DAMAGE = 60, BLACK_DAMAGE = 80, PALE_DAMAGE = 50)		//Support
+	armor = list(RED_DAMAGE = 40, WHITE_DAMAGE = 50, BLACK_DAMAGE = 80, PALE_DAMAGE = 70)		//Support
 	flags_inv = HIDEGLOVES|HIDESHOES
 	realized_ability = /obj/effect/proc_holder/ability/aimed/house_spawn
 
@@ -256,7 +256,7 @@ No Ability	250
 	name = "dimension ripper"
 	desc = "Lost and abandoned, tossed out like trash, having no place left in the City."
 	icon_state = "dimension_ripper"
-	armor = list(RED_DAMAGE = 70, WHITE_DAMAGE = 50, BLACK_DAMAGE = 60, PALE_DAMAGE = 50)		//Melee
+	armor = list(RED_DAMAGE = 80, WHITE_DAMAGE = 50, BLACK_DAMAGE = 60, PALE_DAMAGE = 50)		//Melee
 	realized_ability = /obj/effect/proc_holder/ability/rip_space
 
 /* WAW Realizations */
@@ -265,14 +265,14 @@ No Ability	250
 	name = "gold experience"
 	desc = "A jacket made of gold is hardly light. But it shines like the sun."
 	icon_state = "gold_experience"
-	armor = list(RED_DAMAGE = 80, WHITE_DAMAGE = 60, BLACK_DAMAGE = 50, PALE_DAMAGE = 40)			//Melee
+	armor = list(RED_DAMAGE = 80, WHITE_DAMAGE = 70, BLACK_DAMAGE = 60, PALE_DAMAGE = 30)			//Melee
 	realized_ability = /obj/effect/proc_holder/ability/road_of_gold
 
 /obj/item/clothing/suit/armor/ego_gear/realization/quenchedblood
 	name = "quenched with blood"
 	desc = "A suit of armor, forged with tears and quenched in blood. Justice will prevail."
 	icon_state = "quenchedblood"
-	armor = list(RED_DAMAGE = 50, WHITE_DAMAGE = 60, BLACK_DAMAGE = 40, PALE_DAMAGE = 80)		//Ranged
+	armor = list(RED_DAMAGE = 50, WHITE_DAMAGE = 60, BLACK_DAMAGE = 50, PALE_DAMAGE = 80)		//Ranged
 	flags_inv = HIDEJUMPSUIT|HIDESHOES|HIDEGLOVES
 	realized_ability = /obj/effect/proc_holder/ability/aimed/despair_swords
 
@@ -280,7 +280,7 @@ No Ability	250
 	name = "love and justice"
 	desc = "If my duty is to defeat and reform evil, can I reform my evil self as well?"
 	icon_state = "lovejustice"
-	armor = list(RED_DAMAGE = 60, WHITE_DAMAGE = 50, BLACK_DAMAGE = 70, PALE_DAMAGE = 50)		//Healing
+	armor = list(RED_DAMAGE = 60, WHITE_DAMAGE = 40, BLACK_DAMAGE = 80, PALE_DAMAGE = 60)		//Healing
 	flags_inv = HIDEGLOVES
 	realized_ability = /obj/effect/proc_holder/ability/aimed/arcana_slave
 
@@ -289,7 +289,7 @@ No Ability	250
 	desc = "'Tis better to have loved and lost than never to have loved at all.\
 	Grants you the ability to use a Blind Rage in both hands and attack with both at the same time."
 	icon_state = "woundedcourage"
-	armor = list(RED_DAMAGE = 70, WHITE_DAMAGE = 40, BLACK_DAMAGE = 70, PALE_DAMAGE = 50)		//Melee
+	armor = list(RED_DAMAGE = 80, WHITE_DAMAGE = 20, BLACK_DAMAGE = 80, PALE_DAMAGE = 60)//vile stat spread		//Melee
 	flags_inv = HIDEJUMPSUIT | HIDEGLOVES | HIDESHOES
 	realized_ability = /obj/effect/proc_holder/ability/justice_and_balance
 	hat = /obj/item/clothing/head/ego_hat/woundedcourage_hat
@@ -304,13 +304,13 @@ No Ability	250
 	name = "crimson lust"
 	desc = "They are always watching you."
 	icon_state = "crimson"
-	armor = list(RED_DAMAGE = 80, WHITE_DAMAGE = 50, BLACK_DAMAGE = 60, PALE_DAMAGE = 60)		//No Ability
+	armor = list(RED_DAMAGE = 80, WHITE_DAMAGE = 60, BLACK_DAMAGE = 60, PALE_DAMAGE = 60)		//No Ability
 
 /obj/item/clothing/suit/armor/ego_gear/realization/eyes
 	name = "eyes of god"
 	desc = "And the eyes of god spoke: You will be saved."
 	icon_state = "eyes"
-	armor = list(RED_DAMAGE = 50, WHITE_DAMAGE = 60, BLACK_DAMAGE = 80, PALE_DAMAGE = 40)		//Support
+	armor = list(RED_DAMAGE = 60, WHITE_DAMAGE = 40, BLACK_DAMAGE = 80, PALE_DAMAGE = 60)		//Support
 	realized_ability = /obj/effect/proc_holder/ability/lamp
 
 /obj/item/clothing/suit/armor/ego_gear/realization/eyes/examine(mob/user)
@@ -349,48 +349,48 @@ No Ability	250
 	name = "wit of cruelty"
 	desc = "In the face of pain there are no heroes."
 	icon_state = "cruelty"
-	armor = list(RED_DAMAGE = 80, WHITE_DAMAGE = 50, BLACK_DAMAGE = 70, PALE_DAMAGE = 50)		//No Ability
+	armor = list(RED_DAMAGE = 80, WHITE_DAMAGE = 50, BLACK_DAMAGE = 70, PALE_DAMAGE = 60)		//No Ability
 	flags_inv = HIDEJUMPSUIT|HIDEGLOVES|HIDESHOES
 
 /obj/item/clothing/suit/armor/ego_gear/realization/bell_tolls
 	name = "for whom the bell tolls"
 	desc = "I suppose if a man has something once, always something of it remains."
 	icon_state = "thirteen"
-	armor = list(RED_DAMAGE = 50, WHITE_DAMAGE = 50, BLACK_DAMAGE = 80, PALE_DAMAGE = 70)		//No Ability
+	armor = list(RED_DAMAGE = 50, WHITE_DAMAGE = 50, BLACK_DAMAGE = 80, PALE_DAMAGE = 80)		//No Ability
 
 /obj/item/clothing/suit/armor/ego_gear/realization/capitalism
 	name = "capitalism"
 	desc = "While the miser is merely a capitalist gone mad, the capitalist is a rational miser."
 	icon_state = "capitalism"
-	armor = list(RED_DAMAGE = 70, WHITE_DAMAGE = 70, BLACK_DAMAGE = 60, PALE_DAMAGE = 30)		//Support
+	armor = list(RED_DAMAGE = 70, WHITE_DAMAGE = 70, BLACK_DAMAGE = 70, PALE_DAMAGE = 30)		//Support
 	realized_ability = /obj/effect/proc_holder/ability/shrimp
 
 /obj/item/clothing/suit/armor/ego_gear/realization/duality_yang
 	name = "duality of harmony"
 	desc = "When good and evil meet discord and assonance will be quelled."
 	icon_state = "duality_yang"
-	armor = list(RED_DAMAGE = 40, WHITE_DAMAGE = 80, BLACK_DAMAGE = 40, PALE_DAMAGE = 70)		//Healing
+	armor = list(RED_DAMAGE = 40, WHITE_DAMAGE = 80, BLACK_DAMAGE = 40, PALE_DAMAGE = 80)		//Healing
 	realized_ability = /obj/effect/proc_holder/ability/tranquility
 
 /obj/item/clothing/suit/armor/ego_gear/realization/duality_yin
 	name = "harmony of duality"
 	desc = "All that isn't shall become all that is."
 	icon_state = "duality_yin"
-	armor = list(RED_DAMAGE = 70, WHITE_DAMAGE = 40, BLACK_DAMAGE = 80, PALE_DAMAGE = 40)		//Support
+	armor = list(RED_DAMAGE = 80, WHITE_DAMAGE = 40, BLACK_DAMAGE = 80, PALE_DAMAGE = 40)		//Support
 	realized_ability = /obj/effect/proc_holder/ability/aimed/yin_laser
 
 /obj/item/clothing/suit/armor/ego_gear/realization/repentance
 	name = "repentance"
 	desc = "If you pray hard enough, perhaps god will answer it?"
 	icon_state = "repentance"
-	armor = list(RED_DAMAGE = 80, WHITE_DAMAGE = 40, BLACK_DAMAGE = 40, PALE_DAMAGE = 70)		//Healing
+	armor = list(RED_DAMAGE = 80, WHITE_DAMAGE = 40, BLACK_DAMAGE = 40, PALE_DAMAGE = 80)		//Healing
 	realized_ability = /obj/effect/proc_holder/ability/prayer
 
 /obj/item/clothing/suit/armor/ego_gear/realization/nest
 	name = "living nest"
 	desc = "Grow eternally, let our nest reach the horizon!"
 	icon_state = "nest"
-	armor = list(RED_DAMAGE = 80, WHITE_DAMAGE = 60, BLACK_DAMAGE = 50, PALE_DAMAGE = 40)		//Support
+	armor = list(RED_DAMAGE = 80, WHITE_DAMAGE = 60, BLACK_DAMAGE = 60, PALE_DAMAGE = 40)		//Support
 	realized_ability = /obj/effect/proc_holder/ability/nest
 	var/CanSpawn = FALSE
 
@@ -423,13 +423,13 @@ No Ability	250
 	name = "al coda"
 	desc = "Harmonizes well."
 	icon_state = "coda"
-	armor = list(RED_DAMAGE = 70, WHITE_DAMAGE = 100, BLACK_DAMAGE = 60, PALE_DAMAGE = 20)		//No Ability
+	armor = list(RED_DAMAGE = 70, WHITE_DAMAGE = 80, BLACK_DAMAGE = 70, PALE_DAMAGE = 40)		//No Ability
 
 /obj/item/clothing/suit/armor/ego_gear/realization/head
 	name = "head of god"
 	desc = "And the head of god spoke: You will be judged."
 	icon_state = "head"
-	armor = list(RED_DAMAGE = 50, WHITE_DAMAGE = 50, BLACK_DAMAGE = 50, PALE_DAMAGE = 80)		//Support
+	armor = list(RED_DAMAGE = 60, WHITE_DAMAGE = 50, BLACK_DAMAGE = 50, PALE_DAMAGE = 80)		//Support
 	realized_ability = /obj/effect/proc_holder/ability/judgement
 
 /obj/item/clothing/suit/armor/ego_gear/realization/shell
@@ -437,14 +437,14 @@ No Ability	250
 	desc = "Armor of humans, for humans, by humans. Is it as 'human' as you?"
 	icon_state = "shell"
 	realized_ability = /obj/effect/proc_holder/ability/goodbye
-	armor = list(RED_DAMAGE = 80, WHITE_DAMAGE = 60, BLACK_DAMAGE = 30, PALE_DAMAGE = 60)			//Melee
+	armor = list(RED_DAMAGE = 80, WHITE_DAMAGE = 50, BLACK_DAMAGE = 50, PALE_DAMAGE = 60)			//Melee
 
 /obj/item/clothing/suit/armor/ego_gear/realization/laughter
 	name = "laughter"
 	desc = "I do not recognize them, I must not, lest I end up like them. \
 			Through the silence, I hear them, I see them. The faces of all my friends are with me laughing too."
 	icon_state = "laughter"
-	armor = list(RED_DAMAGE = 50, WHITE_DAMAGE = 50, BLACK_DAMAGE = 80, PALE_DAMAGE = 50)		//Support
+	armor = list(RED_DAMAGE = 50, WHITE_DAMAGE = 50, BLACK_DAMAGE = 80, PALE_DAMAGE = 60)		//Support
 	flags_inv = HIDEJUMPSUIT|HIDESHOES|HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR
 	realized_ability = /obj/effect/proc_holder/ability/screach
 
@@ -453,7 +453,7 @@ No Ability	250
 	desc = "Where does one go after falling into a black hole?"
 	icon_state = "fallencolors"
 	realized_ability = /obj/effect/proc_holder/ability/aimed/blackhole
-	armor = list(RED_DAMAGE = 40, WHITE_DAMAGE = 80, BLACK_DAMAGE = 80, PALE_DAMAGE = 30)		//Defensive
+	armor = list(RED_DAMAGE = 30, WHITE_DAMAGE = 80, BLACK_DAMAGE = 80, PALE_DAMAGE = 60)		//Defensive
 	var/canSUCC = TRUE
 
 /obj/item/clothing/suit/armor/ego_gear/realization/fallencolors/equipped(mob/user, slot, initial = FALSE)
@@ -493,7 +493,7 @@ No Ability	250
 	name = "farmwatch"
 	desc = "Haha. You're right, the calf doesn't recognize me."
 	icon_state = "farmwatch"
-	armor = list(RED_DAMAGE = 70, WHITE_DAMAGE = 70, BLACK_DAMAGE = 40, PALE_DAMAGE = 60)
+	armor = list(RED_DAMAGE = 80, WHITE_DAMAGE = 70, BLACK_DAMAGE = 40, PALE_DAMAGE = 60)
 	hat = /obj/item/clothing/head/ego_hat/farmwatch_hat
 	realized_ability = /obj/effect/proc_holder/ability/ego_assimilation/farmwatch
 
@@ -506,19 +506,19 @@ No Ability	250
 	name = "spicebush"
 	desc = "I've always wished to be a bud. Soon to bloom, bearing a scent within."
 	icon_state = "spicebush"
-	armor = list(RED_DAMAGE = 40, WHITE_DAMAGE = 70, BLACK_DAMAGE = 70, PALE_DAMAGE = 60)
+	armor = list(RED_DAMAGE = 40, WHITE_DAMAGE = 80, BLACK_DAMAGE = 70, PALE_DAMAGE = 60)
 	realized_ability = /obj/effect/proc_holder/ability/ego_assimilation/spicebush
 
 /obj/item/clothing/suit/armor/ego_gear/realization/desperation
 	name = "Scorching Desperation"
 	desc = "Those feelings only become more dull over time."
 	icon_state = "desperation"
-	armor = list(RED_DAMAGE = 70, WHITE_DAMAGE = 40, BLACK_DAMAGE = 60, PALE_DAMAGE = 60)
+	armor = list(RED_DAMAGE = 70, WHITE_DAMAGE = 50, BLACK_DAMAGE = 60, PALE_DAMAGE = 60)
 	realized_ability = /obj/effect/proc_holder/ability/overheat
 
 /obj/item/clothing/suit/armor/ego_gear/realization/gasharpoon
 	name = "gasharpoon"
 	desc = "We must find the Pallid Whale! Look alive, men! Spring! Roar!"
 	icon_state = "gasharpoon"
-	armor = list(RED_DAMAGE = 60, WHITE_DAMAGE = 70, BLACK_DAMAGE = 20, PALE_DAMAGE = 80)//230, required for the corresponding weapon abilities
+	armor = list(RED_DAMAGE = 60, WHITE_DAMAGE = 70, BLACK_DAMAGE = 30, PALE_DAMAGE = 80)//230, required for the corresponding weapon abilities
 	realized_ability = /obj/effect/proc_holder/ability/ego_assimilation/gasharpoon

--- a/code/modules/mob/living/simple_animal/abnormality/_tools/zayin/realizer.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_tools/zayin/realizer.dm
@@ -133,7 +133,7 @@
 	for(var/attribute in user.attributes)
 		stat_total += get_raw_level(user, attribute)
 
-	if(stat_total < 500) // ~125 in all stats required
+	if(stat_total < 520) // ~130 in all stats required
 		to_chat(user, span_warning("You are too weak to use this machine."))
 		return
 
@@ -143,6 +143,7 @@
 		return
 
 	qdel(I)
+	user.adjust_all_attribute_levels(-20)
 	realized_users |= user.ckey
 	var/atom/new_item = new item_out(get_turf(user))
 	user.put_in_hands(new_item)

--- a/code/modules/spells/ability_types/realized.dm
+++ b/code/modules/spells/ability_types/realized.dm
@@ -875,13 +875,16 @@
 		return
 	new /obj/effect/temp_visual/explosion/fast(get_turf(user))
 	var/turf/orgin = get_turf(user)
-	var/list/all_turfs = RANGE_TURFS(explosion_range, orgin)
+	var/list/all_turfs = RANGE_TURFS(explosion_range, orgin)\
+	var/list/been_hit = list()
+	. = ..()
 	for(var/i = 0 to explosion_range)
 		for(var/turf/T in all_turfs)
 			if(get_dist(user, T) > i)
 				continue
 			new /obj/effect/temp_visual/dir_setting/speedbike_trail(T)
-			user.HurtInTurf(damage_amount, list(), WHITE_DAMAGE)
+			var/list/new_hits = user.HurtInTurf(damage_amount, been_hit, WHITE_DAMAGE)  - been_hit
+			been_hit += new_hits
 			for(var/mob/living/carbon/human/L in T)
 				if(!user.faction_check_mob(L, FALSE))
 					continue
@@ -889,14 +892,16 @@
 					continue
 				if(L.is_working) //no work heal :(
 					continue
+				if(L in been_hit)
+					continue
+				been_hit += L
 				L.adjustBruteLoss(-70)
 				L.adjustSanityLoss(-70)
 				new /obj/effect/temp_visual/healing(get_turf(L))
 				if(istype(L.get_item_by_slot(ITEM_SLOT_OCLOTHING), /obj/item/clothing/suit/armor/ego_gear/realization/duality_yin))
 					L.apply_status_effect(/datum/status_effect/duality_yang)
 			all_turfs -= T
-			SLEEP_CHECK_DEATH(1)//Well this could allow for double hit
-	return ..()
+		sleep(1)
 
 /datum/status_effect/duality_yang
 	id = "EGO_YANG"

--- a/code/modules/spells/ability_types/realized.dm
+++ b/code/modules/spells/ability_types/realized.dm
@@ -69,7 +69,7 @@
 	base_icon_state = "universe_song"
 	cooldown_time = 20 SECONDS
 
-	var/damage_amount = 50 // Amount of white damage dealt to enemies per "pulse".
+	var/damage_amount = 25 // Amount of white damage dealt to enemies per "pulse".
 	var/damage_slowdown = 0.7 // Slowdown per pulse
 	var/damage_count = 5 // How many times the damage and slowdown is applied
 	var/damage_range = 6
@@ -178,7 +178,7 @@
 	base_icon_state = "goodbye"
 	cooldown_time = 30 SECONDS
 
-	var/damage_amount = 400 // Amount of good bye damage
+	var/damage_amount = 150 // Amount of good bye damage
 
 /obj/effect/proc_holder/ability/goodbye/Perform(target, mob/user)
 	var/mob/living/carbon/human/H = user
@@ -208,7 +208,7 @@
 	base_icon_state = "screach"
 	cooldown_time = 20 SECONDS
 
-	var/damage_amount = 200 // Amount of black damage dealt to enemies. Humans receive half of it.
+	var/damage_amount = 100 // Amount of black damage dealt to enemies. Humans receive half of it.
 	var/damage_range = 7
 
 /obj/effect/proc_holder/ability/screach/Perform(target, mob/user)
@@ -268,7 +268,7 @@
 	base_icon_state = "judgement"
 	cooldown_time = 20 SECONDS
 
-	var/damage_amount = 150 // Amount of pale damage dealt to enemies. Humans receive half of it.
+	var/damage_amount = 75 // Amount of pale damage dealt to enemies. Humans receive half of it.
 	var/damage_range = 9
 
 /obj/effect/proc_holder/ability/judgement/Perform(target, mob/user)
@@ -326,7 +326,7 @@
 	action_icon_state = "fire0"
 	base_icon_state = "fire"
 	cooldown_time = 30 SECONDS
-	var/explosion_damage = 1000 // Humans receive half of it.
+	var/explosion_damage = 500 // Humans receive half of it.
 	var/explosion_range = 6
 
 /obj/effect/proc_holder/ability/fire_explosion/Perform(target, mob/user)
@@ -475,7 +475,7 @@
 
 /datum/status_effect/GoldStaggered
 	status_type = STATUS_EFFECT_UNIQUE
-	duration = 5 SECONDS
+	duration = 10 SECONDS
 
 /datum/status_effect/GoldStaggered/on_apply()
 	. = ..()
@@ -505,7 +505,7 @@
 		'sound/abnormalities/wrath_servant/big_smash2.ogg',
 		'sound/abnormalities/wrath_servant/big_smash1.ogg'
 		)
-	var/damage = 30
+	var/damage = 20
 	var/list/targets_hit = list()
 
 /obj/effect/proc_holder/ability/justice_and_balance/Perform(target, user)
@@ -641,7 +641,7 @@
 				continue
 			if(L.stat == DEAD)
 				continue
-			L.apply_damage(500, RED_DAMAGE, null, L.run_armor_check(null, RED_DAMAGE), spread_damage = TRUE)
+			L.apply_damage(250, RED_DAMAGE, null, L.run_armor_check(null, RED_DAMAGE), spread_damage = TRUE)
 			if(L.health < 0)
 				L.gib()
 
@@ -676,7 +676,7 @@
 	action_icon_state = "petalblizzard0"
 	base_icon_state = "petalblizzard"
 	cooldown_time = 30 SECONDS
-	var/healing_amount = 70 // Amount of healing to plater per "pulse".
+	var/healing_amount = 40 // Amount of healing to plater per "pulse".
 	var/healing_range = 8
 
 /obj/effect/proc_holder/ability/petal_blizzard/Perform(target, mob/user)
@@ -729,6 +729,7 @@
 			if(H.stat != DEAD)
 				H.adjustBruteLoss(-100) // It heals everyone to full
 				H.adjustSanityLoss(-100) // It heals everyone to full
+		qdel(src)
 
 /datum/status_effect/bloomdebuff/on_remove()
 	. = ..()
@@ -864,7 +865,7 @@
 	base_icon_state = "yangform"
 	cooldown_time = 60 SECONDS
 
-	var/damage_amount = 300 // Amount of explosion damage
+	var/damage_amount = 200 // Amount of explosion damage
 	var/explosion_range = 15
 
 /obj/effect/proc_holder/ability/tranquility/Perform(target, mob/living/carbon/human/user)
@@ -888,12 +889,13 @@
 					continue
 				if(L.is_working) //no work heal :(
 					continue
-				L.adjustBruteLoss(-120)
-				L.adjustSanityLoss(-120)
+				L.adjustBruteLoss(-70)
+				L.adjustSanityLoss(-70)
 				new /obj/effect/temp_visual/healing(get_turf(L))
 				if(istype(L.get_item_by_slot(ITEM_SLOT_OCLOTHING), /obj/item/clothing/suit/armor/ego_gear/realization/duality_yin))
 					L.apply_status_effect(/datum/status_effect/duality_yang)
 			all_turfs -= T
+			SLEEP_CHECK_DEATH(1)//Well this could allow for double hit
 	return ..()
 
 /datum/status_effect/duality_yang
@@ -973,7 +975,7 @@
 	duration = 30 SECONDS
 	alert_type = /atom/movable/screen/alert/status_effect/galaxy_gift
 	var/base_heal_amt = 0.5
-	var/base_dmg_amt = 45
+	var/base_dmg_amt = 25
 	var/watch_death = FALSE
 	var/list/gifted
 	var/mob/living/carbon/human/caster
@@ -1155,11 +1157,11 @@
 
 /mob/living/simple_animal/hostile/shrimp/friendly //HUGE buff shrimp
 	name = "wellcheers boat fisherman"
-	health = 700
-	maxHealth = 700
+	health = 400
+	maxHealth = 400
 	desc = "Are those fists?"
-	melee_damage_lower = 40
-	melee_damage_upper = 45
+	melee_damage_lower = 25
+	melee_damage_upper = 30
 	icon_state = "wellcheers_ripped"
 	icon_living = "wellcheers_ripped"
 	faction = list("neutral", "shrimp")
@@ -1175,6 +1177,7 @@
 		var/mob/living/L = attacked_target
 		if(L.health < 0 || L.stat == DEAD)
 			L.gib() //Punch them so hard they explode
+
 /* Flesh Idol - Repentance */
 /obj/effect/proc_holder/ability/prayer
 	name = "Prayer"
@@ -1200,8 +1203,8 @@
 			continue
 		playsound(H, 'sound/abnormalities/onesin/bless.ogg', 100, FALSE, 12)
 		to_chat(H, span_nicegreen("[user]'s prayer was heard!"))
-		H.adjustBruteLoss(-100)
-		H.adjustSanityLoss(-100)
+		H.adjustBruteLoss(-70)
+		H.adjustSanityLoss(-70)
 		H.apply_status_effect(/datum/status_effect/flesh2)
 		new /obj/effect/temp_visual/healing(get_turf(H))
 	return ..()
@@ -1229,7 +1232,7 @@
 	var/mob/living/carbon/human/H = owner
 	var/list/damtypes = list(RED_DAMAGE, WHITE_DAMAGE, BLACK_DAMAGE, PALE_DAMAGE)
 	var/damage = pick(damtypes)
-	H.apply_damage(7, damage, null, H.run_armor_check(null, damage), spread_damage = TRUE)
+	H.apply_damage(4, damage, null, H.run_armor_check(null, damage), spread_damage = TRUE)
 
 /datum/status_effect/flesh1/on_remove()
 	. = ..()
@@ -1264,8 +1267,6 @@
 	action_icon_state = "worm0"
 	base_icon_state = "worm"
 	cooldown_time = 30 SECONDS
-
-
 
 /obj/effect/proc_holder/ability/nest/Perform(target, mob/user)
 	for(var/i = 1 to 7)
@@ -1440,7 +1441,7 @@
 	user.orbit(DE, 0, 0, 0, 0, 0)
 
 	sleep(1)
-	target.apply_damage(100, RED_DAMAGE, null, target.run_armor_check(null, RED_DAMAGE))
+	target.apply_damage(50, RED_DAMAGE, null, target.run_armor_check(null, RED_DAMAGE))
 	new /obj/effect/temp_visual/rip_space_slash(get_turf(target))
 	new /obj/effect/temp_visual/ripped_space(get_turf(target))
 	playsound(user, 'sound/abnormalities/wayward_passenger/ripspace_hit.ogg', 75, 0)

--- a/code/modules/spells/ability_types/realized_aimed.dm
+++ b/code/modules/spells/ability_types/realized_aimed.dm
@@ -6,7 +6,7 @@
 	base_icon_state = "helper_dash"
 	cooldown_time = 10 SECONDS
 
-	var/dash_damage = 300
+	var/dash_damage = 150
 	var/dash_range = 6
 	var/dash_ignore_walls = FALSE
 
@@ -70,7 +70,7 @@
 	base_icon_state = "cross_spawn"
 	cooldown_time = 20 SECONDS
 
-	var/damage_amount = 200 // Amount of white damage dealt to enemies in the epicenter. Allies heal that amount of sanity instead.
+	var/damage_amount = 100 // Amount of white damage dealt to enemies in the epicenter. Allies heal that amount of sanity instead.
 	var/damage_range = 6
 
 /obj/effect/proc_holder/ability/aimed/cross_spawn/Perform(target, mob/user)
@@ -103,7 +103,7 @@
 /obj/effect/proc_holder/ability/aimed/despair_swords
 	name = "Blades Whetted with Tears"
 	desc = "An ability that summons 2 swords to attack and slow nearby enemies. \
-		Each sword deals damage equal to 5% of the target's max HP as Pale, to a minimum of 120."
+		Each sword deals 50 Pale damage plus an addition 5% of the target's max HP as Pale"
 	action_icon_state = "despair0"
 	base_icon_state = "despair"
 	cooldown_time = 20 SECONDS
@@ -145,7 +145,7 @@
 	if(ishostile(target))
 		var/mob/living/simple_animal/hostile/H = target
 		H.TemporarySpeedChange(1, 10 SECONDS)
-		H.apply_damage(max(0.05 * H.maxHealth, 120), PALE_DAMAGE)
+		H.apply_damage(50 + (0.05 * H.maxHealth), PALE_DAMAGE)
 	..()
 	qdel(src)
 
@@ -226,7 +226,7 @@
 	beamloop.start(user)
 	beamloop.max_loops = 0
 	var/beam_stage = 1
-	var/beam_damage = 16
+	var/beam_damage = 8
 	var/justice = get_attribute_level(H, JUSTICE_ATTRIBUTE)
 	justice /= 100
 	justice++
@@ -255,13 +255,13 @@
 				already_hit += L
 				if(H.faction_check_mob(L))
 					if(L.stat < DEAD) // Small bit of healing to all our living allies.
-						L.adjustBruteLoss(-1.5*justice)
+						L.adjustBruteLoss(-1*justice)
 						if(L.stat > CONSCIOUS) // But more effective on softcrit/hardcrit allies.
-							L.adjustBruteLoss(-1.5*justice)
+							L.adjustBruteLoss(-1*justice)
 					if(ishuman(L))
 						var/mob/living/carbon/human/LH = L
 						if(LH.sanity_lost)
-							LH.adjustSanityLoss(-12*justice) // Pretty fast resaning, but this only applies to insanes
+							LH.adjustSanityLoss(-6*justice) // Pretty fast resaning, but this only applies to insanes
 					continue
 				L.apply_damage(beam_damage, BLACK_DAMAGE, null, L.run_armor_check(null, BLACK_DAMAGE))
 				accumulated_beam_damage += beam_damage
@@ -339,7 +339,7 @@
 	action_icon_state = "cocoon0"
 	base_icon_state = "cocoon"
 	cooldown_time = 20 SECONDS
-	var/damage_amount = 120 // Amount of red damage dealt to enemies in the epicenter.
+	var/damage_amount = 80 // Amount of red damage dealt to enemies in the epicenter.
 	var/damage_range = 2
 	var/damage_slowdown = 0.5
 
@@ -446,7 +446,7 @@
 
 	projectile_piercing = PASSMOB
 	hit_nondense_targets = TRUE
-	var/damage_amount = 200 // Amount of black damage dealt to enemies in the epicenter.
+	var/damage_amount = 100 // Amount of black damage dealt to enemies in the epicenter.
 	var/damage_range = 3
 
 /obj/projectile/black_hole_realized/Initialize()
@@ -462,7 +462,7 @@
 		new /obj/effect/temp_visual/revenant(T)
 	for(var/mob/living/L in view(damage_range, src))
 		if(ishostile(L))
-			var/distance_decrease = get_dist(src, L) * 40
+			var/distance_decrease = get_dist(src, L) * 20
 			L.apply_damage(ishuman(L) ? (damage_amount - distance_decrease)*0.5 : (damage_amount - distance_decrease), BLACK_DAMAGE, null, L.run_armor_check(null, BLACK_DAMAGE), spread_damage = TRUE)
 			var/atom/throw_target = get_edge_target_turf(L, get_dir(L, get_step_towards(L, get_turf(src))))
 			L.throw_at(throw_target, 1, 2)
@@ -501,7 +501,7 @@
 /obj/effect/temp_visual/revenant/cracks/yinfriend
 	icon_state = "yincracks"
 	duration = 9
-	var/damage = 175  // Amount of black damage dealt to enemies from the laser.
+	var/damage = 100  // Amount of black damage dealt to enemies from the laser.
 	var/list/faction = list("neutral")
 
 /obj/effect/temp_visual/revenant/cracks/yinfriend/Destroy()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

 Reworks realized armors stats rebalances abilities.
Realized armors abilities have a stat total of 240 while ones without has 260
Most realized armors abilities were nerfed, generally damage by half, healing is around 50-60% as much.
Realizer now requires atleast 130 in all to realize and lowers your stats by 20 apon doing so
## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Realized armors we're ass to balance around for aleph which made them either useless or just better than aleph, making them aleph+ability or aleph+20 stats while making it much harder and costly to get should help them reflect the original idea while making them have an actual cost to obtain

## Changelog
:cl:
balance: rebalanced realized armor in general
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
