### PR TITLE
Mermaids no longer invade the rest of the city

### DIFF
--- a/_maps/alphacorp.json
+++ b/_maps/alphacorp.json
@@ -16,5 +16,6 @@
 		"emergency": "emergency_alpha"
 	},
 	"minetype": "none",
-	"maptype": "standard"
+	"maptype": "standard",
+	"map_tags": [""]
 }

--- a/_maps/betacorp.json
+++ b/_maps/betacorp.json
@@ -13,5 +13,6 @@
 	"space_ruin_levels": 0,
 	"space_empty_levels": 0,
 	"minetype": "none",
-	"maptype": "standard"
+	"maptype": "standard",
+	"map_tags": [""]
 }

--- a/_maps/city.json
+++ b/_maps/city.json
@@ -13,5 +13,6 @@
 	"space_ruin_levels": 0,
 	"space_empty_levels": 0,
 	"minetype": "none",
-	"maptype": "city"
+	"maptype": "city",
+	"map_tags": [""]
 }

--- a/_maps/cityfixers.json
+++ b/_maps/cityfixers.json
@@ -13,5 +13,6 @@
 	"space_ruin_levels": 0,
 	"space_empty_levels": 0,
 	"minetype": "none",
-	"maptype": "fixers"
+	"maptype": "fixers",
+	"map_tags": [""]
 }

--- a/_maps/deltacorp.json
+++ b/_maps/deltacorp.json
@@ -13,5 +13,6 @@
 	"space_ruin_levels": 0,
 	"space_empty_levels": 0,
 	"minetype": "none",
-	"maptype": "standard"
+	"maptype": "standard",
+	"map_tags": [""]
 }

--- a/_maps/epsiloncorp.json
+++ b/_maps/epsiloncorp.json
@@ -11,5 +11,6 @@
 		"emergency": "emergency_alpha"
 	},
 	"minetype": "none",
-	"maptype": "fishing"
+	"maptype": "fishing",
+	"map_tags": ["whales"]
 }

--- a/_maps/etacorp.json
+++ b/_maps/etacorp.json
@@ -13,5 +13,6 @@
 	"space_ruin_levels": 0,
 	"space_empty_levels": 0,
 	"minetype": "none",
-	"maptype": "standard"
+	"maptype": "standard",
+	"map_tags": [""]
 }

--- a/_maps/gammacorp.json
+++ b/_maps/gammacorp.json
@@ -13,5 +13,6 @@
 	"space_ruin_levels": 0,
 	"space_empty_levels": 0,
 	"minetype": "none",
-	"maptype": "standard"
+	"maptype": "standard",
+	"map_tags": [""]
 }

--- a/_maps/iotacorp.json
+++ b/_maps/iotacorp.json
@@ -11,5 +11,6 @@
 		"emergency": "emergency_alpha"
 	},
 	"minetype": "none",
-	"maptype": "standard"
+	"maptype": "standard",
+	"map_tags": [""]
 }

--- a/_maps/kappacorp.json
+++ b/_maps/kappacorp.json
@@ -11,5 +11,6 @@
 		"emergency": "emergency_alpha"
 	},
 	"minetype": "none",
-	"maptype": "standard"
+	"maptype": "standard",
+	"map_tags": [""]
 }

--- a/_maps/lambdacorp.json
+++ b/_maps/lambdacorp.json
@@ -16,5 +16,6 @@
 		"emergency": "emergency_alpha"
 	},
 	"minetype": "none",
-	"maptype": "standard"
+	"maptype": "standard",
+	"map_tags": [""]
 }

--- a/_maps/lclabs.json
+++ b/_maps/lclabs.json
@@ -13,5 +13,6 @@
 	"space_ruin_levels": 0,
 	"space_empty_levels": 0,
 	"minetype": "none",
-	"maptype": "limbus_labs"
+	"maptype": "limbus_labs",
+	"map_tags": [""]
 }

--- a/_maps/lcorpcity.json
+++ b/_maps/lcorpcity.json
@@ -21,5 +21,6 @@
 		}
 	],
 	"minetype": "none",
-	"maptype": "lcorp_city"
+	"maptype": "lcorp_city",
+	"map_tags": [""]
 }

--- a/_maps/office.json
+++ b/_maps/office.json
@@ -13,5 +13,6 @@
 	"space_ruin_levels": 0,
 	"space_empty_levels": 0,
 	"minetype": "none",
-	"maptype": "office"
+	"maptype": "office",
+	"map_tags": [""]
 }

--- a/_maps/psicorp.json
+++ b/_maps/psicorp.json
@@ -16,5 +16,6 @@
 		"emergency": "emergency_alpha"
 	},
 	"minetype": "none",
-	"maptype": "mini"
+	"maptype": "mini",
+	"map_tags": [""]
 }

--- a/_maps/rcorp_test.json
+++ b/_maps/rcorp_test.json
@@ -13,5 +13,6 @@
 	"space_ruin_levels": 0,
 	"space_empty_levels": 0,
 	"minetype": "none",
-	"maptype": "rcorp"
+	"maptype": "rcorp",
+	"map_tags": [""]
 }

--- a/_maps/skeld.json
+++ b/_maps/skeld.json
@@ -13,5 +13,6 @@
 	"space_ruin_levels": 0,
 	"space_empty_levels": 0,
 	"minetype": "none",
-	"maptype": "skeld"
+	"maptype": "skeld",
+	"map_tags": [""]
 }

--- a/_maps/thetacorp.json
+++ b/_maps/thetacorp.json
@@ -16,5 +16,6 @@
 		"emergency": "emergency_alpha"
 	},
 	"minetype": "none",
-	"maptype": "standard"
+	"maptype": "standard",
+	"map_tags": [""]
 }

--- a/_maps/wcorp.json
+++ b/_maps/wcorp.json
@@ -13,5 +13,6 @@
 	"space_ruin_levels": 0,
 	"space_empty_levels": 0,
 	"minetype": "none",
-	"maptype": "wcorp"
+	"maptype": "wcorp",
+	"map_tags": [""]
 }

--- a/_maps/xicorp.json
+++ b/_maps/xicorp.json
@@ -21,5 +21,6 @@
 		}
 	],
 	"minetype": "none",
-	"maptype": "Wonderlabs"
+	"maptype": "Wonderlabs",
+	"map_tags": [""]
 }

--- a/_maps/zetacorp.json
+++ b/_maps/zetacorp.json
@@ -11,5 +11,6 @@
 		"emergency": "emergency_alpha"
 	},
 	"minetype": "none",
-	"maptype": "fishing"
+	"maptype": "fishing",
+	"map_tags": ["whales"]
 }


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes a bug where mermaids can spawn outside of district 21, zetacorp, and epsiloncorp. For some reason, an undefined list in the JSON would randomly populate the variable with the tag meant for aquatic maps.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixing bugs is generally good for the game.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixes mermaid ordeal restrictions
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
