### PR TITLE
The manager now has his own floor and makes pod doors easier to break

### DIFF
--- a/_maps/map_files/generic/Manager.dmm
+++ b/_maps/map_files/generic/Manager.dmm
@@ -148,20 +148,14 @@
 /turf/open/floor/plasteel/dark,
 /area/facility_hallway/manager)
 "dj" = (
-/obj/machinery/light/floor,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/obj/machinery/door/airlock/wood{
+	name = s
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/machinery/door/poddoor/preopen{
+	id = "managerlockdown2";
+	name = "Manager's Office Lockdown Blast Door"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/displaycase/trophy{
-	alert = 0
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel,
 /area/department_main/manager)
 "dl" = (
 /obj/machinery/vending/lobotomyarmband,
@@ -183,8 +177,10 @@
 /turf/open/floor/wood,
 /area/facility_hallway/manager)
 "dt" = (
-/obj/machinery/computer/abnormality_queue,
-/turf/open/floor/facility/dark,
+/obj/structure/railing/corner,
+/obj/structure/table/wood,
+/obj/item/modular_computer/laptop/preset/civilian,
+/turf/open/floor/carpet/royalblack,
 /area/department_main/manager)
 "dK" = (
 /obj/structure/filingcabinet/zayininfo{
@@ -201,18 +197,19 @@
 /turf/open/floor/carpet/royalblack,
 /area/facility_hallway/manager)
 "dL" = (
-/obj/machinery/computer/camera_advanced/manager,
-/obj/machinery/light/cold/no_nightlight{
-	dir = 1
+/obj/structure/railing,
+/obj/structure/table/wood,
+/obj/item/kirbyplants{
+	icon_state = "plant-11";
+	pixel_y = 13
 	},
-/obj/machinery/camera/autoname{
-	dir = 6
-	},
-/turf/open/floor/facility/dark,
+/turf/open/floor/carpet/royalblack,
 /area/department_main/manager)
 "dQ" = (
-/obj/machinery/computer/crew,
-/turf/open/floor/facility/dark,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
 /area/department_main/manager)
 "dS" = (
 /obj/effect/turf_decal/tile{
@@ -270,12 +267,49 @@
 /obj/effect/turf_decal/siding/blue,
 /turf/open/floor/carpet/cyan,
 /area/department_main/manager)
+"eO" = (
+/obj/machinery/requests_console{
+	department = "R-Corp Representative";
+	payment_department = "SEC";
+	pixel_x = -32
+	},
+/obj/effect/turf_decal/tile{
+	color = "#CC5500";
+	dir = 1
+	},
+/obj/effect/turf_decal/tile{
+	color = "#CC5500"
+	},
+/turf/open/floor/plasteel/dark,
+/area/department_main/manager)
 "eR" = (
 /obj/structure/sign/poster/official/soft_cap_pop_art{
 	pixel_y = 32
 	},
 /turf/open/floor/facility/dark,
 /area/facility_hallway/manager)
+"eU" = (
+/obj/structure/table,
+/obj/structure/sign/ordealmonitor{
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/tile{
+	color = "#CC5500";
+	dir = 4
+	},
+/obj/effect/turf_decal/tile{
+	color = "#CC5500";
+	dir = 1
+	},
+/obj/effect/turf_decal/tile{
+	color = "#CC5500"
+	},
+/turf/open/floor/plasteel/dark,
+/area/department_main/manager)
+"fa" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating/airless,
+/area/department_main/manager)
 "fb" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
@@ -327,25 +361,41 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/facility_hallway/manager)
+"fu" = (
+/obj/structure/railing,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/dark,
+/area/department_main/manager)
 "fx" = (
 /obj/structure/chair/office{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/facility_hallway/manager)
-"fJ" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+"fH" = (
+/obj/machinery/photocopier,
+/obj/effect/turf_decal/tile{
+	color = "#CC5500";
 	dir = 4
 	},
-/obj/machinery/light/floor,
-/obj/structure/displaycase/trophy{
-	alert = 0
+/obj/effect/turf_decal/tile{
+	color = "#CC5500";
+	dir = 1
+	},
+/obj/effect/turf_decal/tile{
+	color = "#CC5500"
 	},
 /turf/open/floor/plasteel/dark,
+/area/department_main/manager)
+"fJ" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/computer/crew,
+/obj/structure/sign/ordealmonitor{
+	pixel_y = 32
+	},
+/turf/open/floor/carpet/royalblack,
 /area/department_main/manager)
 "fU" = (
 /obj/structure/table/wood,
@@ -375,10 +425,8 @@
 /turf/open/floor/carpet/green,
 /area/facility_hallway/manager)
 "gc" = (
-/obj/machinery/computer/communications{
-	dir = 4
-	},
-/turf/open/floor/facility/dark,
+/obj/structure/closet/crate/bin,
+/turf/open/floor/plasteel/dark,
 /area/department_main/manager)
 "gs" = (
 /obj/effect/turf_decal/tile{
@@ -418,6 +466,11 @@
 /obj/item/toy/clockwork_watch{
 	pixel_x = 7;
 	pixel_y = 2
+	},
+/obj/machinery/button/door/indestructible{
+	id = "managerlockdown";
+	name = "Adminstrative Offices Lockdown button";
+	pixel_y = 25
 	},
 /turf/open/floor/carpet/royalblack,
 /area/department_main/manager)
@@ -495,10 +548,14 @@
 /turf/open/floor/carpet/orange,
 /area/facility_hallway/manager)
 "hD" = (
-/obj/effect/turf_decal/siding/yellow{
-	dir = 9
+/obj/machinery/door/airlock/wood{
+	name = "Manager's Office Entrance"
 	},
-/turf/open/floor/carpet/royalblack,
+/obj/machinery/door/poddoor/preopen{
+	id = "managerlockdown2";
+	name = "Manager's Office Lockdown Blast Door"
+	},
+/turf/open/floor/plasteel,
 /area/department_main/manager)
 "hS" = (
 /obj/effect/turf_decal/tile{
@@ -513,10 +570,31 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/white,
 /area/facility_hallway/manager)
+"hT" = (
+/obj/structure/chair/office,
+/turf/open/floor/carpet/royalblack,
+/area/department_main/manager)
 "hW" = (
 /obj/effect/spawner/randomcolavend,
 /turf/open/floor/plasteel/dark,
 /area/facility_hallway/manager)
+"ib" = (
+/obj/machinery/computer/crew{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile{
+	color = "#CC5500"
+	},
+/obj/effect/turf_decal/tile{
+	color = "#CC5500";
+	dir = 8
+	},
+/obj/effect/turf_decal/tile{
+	color = "#CC5500";
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/department_main/manager)
 "if" = (
 /obj/machinery/chem_master,
 /turf/open/floor/plasteel/white,
@@ -620,13 +698,15 @@
 /turf/open/floor/carpet/black,
 /area/facility_hallway/manager)
 "ka" = (
-/obj/structure/chair/comfy/black{
-	dir = 1
+/obj/docking_port/stationary{
+	dir = 2;
+	dwidth = 3;
+	height = 5;
+	id = "elevator_away_2";
+	name = "manager floor";
+	width = 6
 	},
-/obj/effect/turf_decal/siding/yellow{
-	dir = 1
-	},
-/turf/open/floor/carpet/royalblack,
+/turf/open/floor/plasteel/elevatorshaft,
 /area/department_main/manager)
 "kd" = (
 /obj/structure/rack,
@@ -683,10 +763,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/facility_hallway/manager)
-"lc" = (
-/obj/effect/turf_decal/siding/yellow{
-	dir = 5
+"kR" = (
+/obj/machinery/facility_holomap{
+	dir = 1;
+	forced_zLevel = 2
 	},
+/turf/open/floor/wood,
+/area/department_main/manager)
+"lc" = (
+/obj/machinery/computer/camera_advanced/manager,
 /turf/open/floor/carpet/royalblack,
 /area/department_main/manager)
 "lh" = (
@@ -741,10 +826,20 @@
 /turf/open/floor/carpet/royalblack,
 /area/facility_hallway/manager)
 "lE" = (
-/obj/machinery/computer/abnormality_archive{
-	dir = 8
+/obj/structure/chair/stool,
+/turf/open/floor/wood,
+/area/department_main/manager)
+"lN" = (
+/obj/machinery/button/door/indestructible{
+	id = "managerlockdown";
+	name = "Adminstrative Offices Lockdown button";
+	pixel_y = 25;
+	pixel_x = -5
 	},
-/turf/open/floor/facility/dark,
+/obj/machinery/computer/abnormality_logs{
+	dir = 4
+	},
+/turf/open/floor/carpet/royalblack,
 /area/department_main/manager)
 "lO" = (
 /obj/structure/mirror{
@@ -774,18 +869,10 @@
 /turf/open/floor/wood,
 /area/facility_hallway/manager)
 "lW" = (
-/obj/structure/sign/ordealmonitor{
-	pixel_y = 32
+/obj/machinery/status_display{
+	pixel_x = -32
 	},
-/obj/machinery/light/cold/no_nightlight{
-	dir = 1
-	},
-/obj/structure/table/wood,
-/obj/item/folder/syndicate/blue{
-	desc = "You have a feeling that these series of documents within this folder are not for the average person to gaze at.";
-	name = "Highly Confidential Folder"
-	},
-/turf/open/floor/facility/dark,
+/turf/open/floor/plasteel/dark,
 /area/department_main/manager)
 "mc" = (
 /obj/effect/turf_decal/siding/white{
@@ -875,10 +962,7 @@
 /turf/open/floor/carpet/green,
 /area/facility_hallway/manager)
 "mQ" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 9
-	},
-/turf/open/floor/carpet/black,
+/turf/open/floor/plasteel/dark,
 /area/department_main/manager)
 "mR" = (
 /obj/effect/turf_decal/tile{
@@ -906,11 +990,43 @@
 /obj/structure/curtain/cloth,
 /turf/open/floor/plasteel/white,
 /area/facility_hallway/manager)
-"nm" = (
-/obj/machinery/computer/abnormality_logs{
-	dir = 4
+"mY" = (
+/obj/structure/table,
+/obj/effect/turf_decal/tile{
+	color = "#CC5500"
 	},
-/turf/open/floor/facility/dark,
+/obj/effect/turf_decal/tile{
+	color = "#CC5500";
+	dir = 8
+	},
+/obj/effect/turf_decal/tile{
+	color = "#CC5500";
+	dir = 1
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel/dark,
+/area/department_main/manager)
+"nh" = (
+/obj/machinery/door/window/brigdoor/southleft,
+/turf/open/floor/carpet/royalblack,
+/area/department_main/manager)
+"nm" = (
+/obj/machinery/computer/security/hos{
+	dir = 1;
+	name = "\improper R-Corp Representative's camera console"
+	},
+/obj/effect/turf_decal/tile{
+	color = "#CC5500"
+	},
+/obj/effect/turf_decal/tile{
+	color = "#CC5500";
+	dir = 8
+	},
+/obj/effect/turf_decal/tile{
+	color = "#CC5500";
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
 /area/department_main/manager)
 "nz" = (
 /obj/effect/turf_decal/siding/wood{
@@ -919,10 +1035,18 @@
 /turf/open/floor/wood,
 /area/facility_hallway/manager)
 "nG" = (
-/obj/effect/turf_decal/siding/yellow{
-	dir = 8
+/obj/structure/table/wood/fancy/orange,
+/obj/item/toy/katana,
+/obj/item/reagent_containers/food/drinks/coffee{
+	pixel_x = -3;
+	pixel_y = 5
 	},
-/turf/open/floor/carpet/royalblack,
+/obj/machinery/button/door/indestructible{
+	id = "sephirah";
+	name = "Sephirah CIC opening";
+	pixel_y = 25
+	},
+/turf/open/floor/carpet/orange,
 /area/department_main/manager)
 "nJ" = (
 /obj/machinery/light/floor,
@@ -1059,6 +1183,10 @@
 /obj/effect/turf_decal/siding/white,
 /turf/open/floor/carpet/black,
 /area/facility_hallway/manager)
+"pN" = (
+/obj/machinery/jukebox,
+/turf/open/floor/carpet/royalblack,
+/area/department_main/manager)
 "qe" = (
 /obj/machinery/computer/crew,
 /turf/open/floor/carpet/orange,
@@ -1149,10 +1277,10 @@
 /turf/open/floor/carpet/royalblack,
 /area/facility_hallway/manager)
 "rl" = (
-/obj/machinery/computer/abnormality_auxiliary{
-	dir = 8
+/obj/structure/sign/ordealmonitor{
+	pixel_x = 32
 	},
-/turf/open/floor/facility/dark,
+/turf/open/floor/plasteel/dark,
 /area/department_main/manager)
 "rq" = (
 /obj/effect/turf_decal/tile{
@@ -1179,21 +1307,9 @@
 /turf/open/floor/carpet/orange,
 /area/facility_hallway/manager)
 "rz" = (
-/obj/machinery/newscaster/security_unit{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
+/obj/structure/railing,
 /obj/structure/table/wood,
-/obj/item/kirbyplants/random{
-	pixel_y = 10
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/carpet/royalblack,
 /area/department_main/manager)
 "rD" = (
 /obj/structure/closet,
@@ -1310,36 +1426,19 @@
 /turf/open/floor/wood,
 /area/facility_hallway/manager)
 "tc" = (
-/obj/machinery/newscaster/security_unit{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/structure/table/wood,
-/obj/item/kirbyplants/random{
-	pixel_y = 10
-	},
-/turf/open/floor/plasteel/dark,
+/obj/machinery/door/window/brigdoor/southright,
+/obj/effect/turf_decal/caution/stand_clear,
+/turf/open/floor/plasteel,
 /area/department_main/manager)
 "td" = (
-/obj/effect/turf_decal/tile/neutral{
+/obj/structure/table,
+/obj/effect/turf_decal/tile{
+	color = "#CC5500";
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/effect/turf_decal/tile{
+	color = "#CC5500"
 	},
-/obj/machinery/status_display{
-	pixel_x = -32
-	},
-/obj/structure/table/wood,
-/obj/item/storage/lockbox/medal,
 /turf/open/floor/plasteel/dark,
 /area/department_main/manager)
 "tn" = (
@@ -1373,10 +1472,19 @@
 /turf/open/floor/carpet/black,
 /area/facility_hallway/manager)
 "tV" = (
-/obj/effect/turf_decal/siding/white{
+/obj/item/kirbyplants/fullysynthetic,
+/obj/effect/turf_decal/tile{
+	color = "#CC5500"
+	},
+/obj/effect/turf_decal/tile{
+	color = "#CC5500";
 	dir = 8
 	},
-/turf/open/floor/carpet/black,
+/obj/effect/turf_decal/tile{
+	color = "#CC5500";
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
 /area/department_main/manager)
 "tZ" = (
 /obj/machinery/light{
@@ -1385,6 +1493,11 @@
 /obj/machinery/roulette,
 /turf/open/floor/plasteel/dark,
 /area/facility_hallway/manager)
+"uc" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/railing,
+/turf/open/floor/plasteel/dark,
+/area/department_main/manager)
 "ug" = (
 /obj/machinery/door/poddoor{
 	id = "sephirah";
@@ -1393,10 +1506,17 @@
 /turf/closed/indestructible/fakeglass,
 /area/department_main/manager)
 "ui" = (
-/obj/effect/turf_decal/siding/white{
+/obj/machinery/door/window/brigdoor/southright,
+/turf/open/floor/carpet/royalblack,
+/area/department_main/manager)
+"uq" = (
+/obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/carpet/black,
+/obj/machinery/newscaster/security_unit{
+	pixel_x = 32
+	},
+/turf/open/floor/carpet/royalblack,
 /area/department_main/manager)
 "uz" = (
 /obj/structure/chair/stool,
@@ -1427,17 +1547,27 @@
 /turf/open/floor/carpet/green,
 /area/facility_hallway/manager)
 "va" = (
-/turf/open/floor/facility/dark,
+/obj/item/clothing/suit/toggle/labcoat{
+	pixel_y = 4
+	},
+/obj/item/storage/lockbox/medal,
+/obj/structure/closet/secure_closet/personal{
+	anchored = 1
+	},
+/obj/item/encryptionkey/heads/manager,
+/obj/item/radio/headset/heads/manager,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/carpet/royalblack,
 /area/department_main/manager)
 "vc" = (
 /obj/effect/landmark/custom_office/crate,
 /turf/closed/indestructible/reinforced,
 /area/facility_hallway/manager)
 "vf" = (
-/obj/effect/turf_decal/siding/yellow{
-	dir = 10
-	},
-/turf/open/floor/carpet/royalblack,
+/obj/structure/chair/wood/wings,
+/turf/open/floor/plasteel/dark,
 /area/department_main/manager)
 "vk" = (
 /obj/structure/railing{
@@ -1452,7 +1582,8 @@
 /turf/open/floor/carpet/orange,
 /area/facility_hallway/manager)
 "vw" = (
-/obj/effect/turf_decal/siding/yellow,
+/obj/structure/table/wood,
+/obj/item/toy/plush/angela,
 /turf/open/floor/carpet/royalblack,
 /area/department_main/manager)
 "vB" = (
@@ -1556,8 +1687,15 @@
 /turf/open/floor/carpet/black,
 /area/facility_hallway/manager)
 "wy" = (
-/obj/effect/turf_decal/siding/yellow{
-	dir = 6
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/bottle/champagne{
+	pixel_y = 17
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
+	pixel_x = -7
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
+	pixel_x = 7
 	},
 /turf/open/floor/carpet/royalblack,
 /area/department_main/manager)
@@ -1566,14 +1704,12 @@
 /turf/open/floor/facility/dark,
 /area/facility_hallway/manager)
 "wF" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/structure/railing{
+	dir = 10
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/machinery/status_display{
-	pixel_x = 32
-	},
-/turf/open/floor/plasteel/dark,
+/obj/item/clipboard,
+/obj/structure/table/wood,
+/turf/open/floor/carpet/royalblack,
 /area/department_main/manager)
 "wI" = (
 /obj/effect/turf_decal/bot,
@@ -1605,12 +1741,11 @@
 /turf/open/floor/carpet/red,
 /area/facility_hallway/manager)
 "xg" = (
-/obj/machinery/button/door/indestructible{
-	id = "sephirah";
-	name = "Sephirah CIC opening";
-	pixel_y = -25
+/obj/structure/plaque/static_plaque/golden{
+	pixel_x = -32;
+	pixel_y = 32
 	},
-/turf/open/floor/wood,
+/turf/open/floor/carpet/royalblack,
 /area/department_main/manager)
 "xq" = (
 /obj/machinery/vending/lobotomyuniform,
@@ -1768,6 +1903,10 @@
 "zb" = (
 /turf/open/floor/carpet/orange,
 /area/facility_hallway/manager)
+"zn" = (
+/obj/machinery/door/airlock/public/glass,
+/turf/open/floor/plasteel/dark,
+/area/department_main/manager)
 "zy" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -1787,29 +1926,15 @@
 /turf/open/floor/carpet/orange,
 /area/facility_hallway/manager)
 "zF" = (
-/obj/machinery/light/floor,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/structure/displaycase/trophy{
-	alert = 0
-	},
-/turf/open/floor/plasteel/dark,
-/area/department_main/manager)
-"zL" = (
-/obj/effect/turf_decal/siding/white{
+/obj/structure/railing{
 	dir = 6
 	},
-/obj/machinery/light/cold/no_nightlight,
-/obj/machinery/facility_holomap{
-	dir = 1;
-	forced_zLevel = 2
-	},
-/turf/open/floor/carpet/black,
+/obj/structure/table/wood,
+/obj/item/folder/red,
+/turf/open/floor/carpet/royalblack,
+/area/department_main/manager)
+"zL" = (
+/turf/open/floor/plasteel/elevatorshaft,
 /area/department_main/manager)
 "zN" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -1826,21 +1951,18 @@
 /turf/open/floor/carpet/orange,
 /area/facility_hallway/manager)
 "zS" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 10
+/obj/machinery/light{
+	dir = 8
 	},
-/turf/open/floor/carpet/black,
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/railing,
+/turf/open/floor/plasteel/dark,
 /area/department_main/manager)
 "zV" = (
-/obj/item/paper_bin,
-/obj/item/pen/fourcolor,
-/obj/machinery/button/door/indestructible{
-	id = "facilitylockdown";
-	name = "Facility Lockdown button";
-	pixel_y = -25
-	},
+/obj/structure/railing,
 /obj/structure/table/wood,
-/turf/open/floor/facility/dark,
+/obj/item/storage/lockbox/medal,
+/turf/open/floor/carpet/royalblack,
 /area/department_main/manager)
 "Ab" = (
 /obj/item/kirbyplants/random,
@@ -1875,17 +1997,13 @@
 /turf/open/floor/carpet/green,
 /area/facility_hallway/manager)
 "Au" = (
-/obj/item/clothing/suit/toggle/labcoat{
-	pixel_y = 4
+/obj/structure/railing/corner{
+	dir = 8
 	},
-/obj/structure/closet/secure_closet/personal{
-	anchored = 1
-	},
-/obj/item/encryptionkey/heads/manager,
-/obj/item/radio/headset/heads/manager,
-/obj/machinery/light/cold/no_nightlight,
-/obj/item/food/grown/star_cactus,
-/turf/open/floor/facility/dark,
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/obj/item/pen/fourcolor,
+/turf/open/floor/carpet/royalblack,
 /area/department_main/manager)
 "AI" = (
 /obj/structure/table,
@@ -1909,24 +2027,33 @@
 /turf/open/floor/carpet/green,
 /area/facility_hallway/manager)
 "AV" = (
-/obj/machinery/button/door/indestructible{
-	id = "managerlockdown";
-	name = "Adminstrative Offices Lockdown button";
-	pixel_y = -25
+/obj/structure/table,
+/obj/machinery/status_display{
+	pixel_y = 32
 	},
-/obj/item/clipboard,
-/obj/structure/table/wood,
-/turf/open/floor/facility/dark,
+/obj/effect/turf_decal/tile{
+	color = "#CC5500";
+	dir = 4
+	},
+/obj/effect/turf_decal/tile{
+	color = "#CC5500";
+	dir = 1
+	},
+/obj/effect/turf_decal/tile{
+	color = "#CC5500"
+	},
+/obj/item/toy/plush/rabbit,
+/turf/open/floor/plasteel/dark,
 /area/department_main/manager)
 "AZ" = (
-/obj/structure/filingcabinet/wawinfo{
-	pixel_x = -10
-	},
-/obj/structure/filingcabinet/alephinfo,
-/obj/structure/filingcabinet/toolinfo{
+/obj/structure/filingcabinet/heinfo{
 	pixel_x = 10
 	},
-/turf/open/floor/facility/dark,
+/obj/structure/filingcabinet/zayininfo{
+	pixel_x = -10
+	},
+/obj/structure/filingcabinet/tethinfo,
+/turf/open/floor/carpet/royalblack,
 /area/department_main/manager)
 "Bi" = (
 /obj/machinery/light/floor,
@@ -1996,21 +2123,29 @@
 /turf/open/floor/carpet/green,
 /area/facility_hallway/manager)
 "Cy" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 10
+/obj/machinery/button/door/indestructible{
+	id = "sephirah";
+	name = "Sephirah CIC opening";
+	pixel_y = 25
 	},
-/obj/machinery/light/cold/no_nightlight,
-/obj/machinery/facility_holomap{
-	dir = 1;
-	forced_zLevel = 2
-	},
-/turf/open/floor/carpet/black,
+/turf/open/floor/wood,
 /area/department_main/manager)
 "CI" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 6
+/obj/structure/closet/secure_closet/personal{
+	anchored = 1
 	},
-/turf/open/floor/carpet/black,
+/obj/effect/turf_decal/tile{
+	color = "#CC5500";
+	dir = 4
+	},
+/obj/effect/turf_decal/tile{
+	color = "#CC5500";
+	dir = 1
+	},
+/obj/effect/turf_decal/tile{
+	color = "#CC5500"
+	},
+/turf/open/floor/plasteel/dark,
 /area/department_main/manager)
 "CJ" = (
 /obj/docking_port/stationary{
@@ -2018,7 +2153,7 @@
 	dwidth = 3;
 	height = 5;
 	id = "elevator_away";
-	name = "manager floor";
+	name = "outsider/personal floor";
 	width = 6
 	},
 /turf/open/floor/plasteel/elevatorshaft,
@@ -2079,18 +2214,7 @@
 /turf/open/floor/wood,
 /area/facility_hallway/manager)
 "Ec" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/light/floor,
-/obj/structure/displaycase/trophy{
-	alert = 0
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel,
 /area/department_main/manager)
 "Ei" = (
 /obj/effect/turf_decal/tile{
@@ -2107,22 +2231,28 @@
 /turf/open/floor/wood,
 /area/facility_hallway/manager)
 "El" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/bottle/champagne{
-	pixel_y = 17
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
-	pixel_x = -7
+/obj/machinery/computer/shuttle/mining{
+	dir = 1;
+	name = "elevator console";
+	possible_destinations = "elevator_home;elevator_away";
+	shuttleId = "manager"
 	},
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
-	pixel_x = 7
+/obj/structure/railing,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/dark,
+/area/department_main/manager)
+"Em" = (
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/structure/plaque/static_plaque{
-	desc = "Zerantio, XFirebirdX, Chris Pulsar, Fena";
-	name = "Investor's Plaque";
+/obj/machinery/computer/communications,
+/obj/machinery/status_display{
 	pixel_y = 32
 	},
-/turf/open/floor/facility/dark,
+/turf/open/floor/carpet/royalblack,
 /area/department_main/manager)
 "En" = (
 /obj/structure/curtain/cloth,
@@ -2193,6 +2323,12 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/facility_hallway/manager)
+"FV" = (
+/obj/structure/displaycase/trophy{
+	alert = 0
+	},
+/turf/open/floor/wood,
+/area/department_main/manager)
 "FY" = (
 /obj/structure/rack,
 /obj/item/toy/plush/qoh,
@@ -2274,14 +2410,17 @@
 /turf/open/floor/plasteel/white,
 /area/facility_hallway/manager)
 "GO" = (
-/obj/structure/filingcabinet/zayininfo{
-	pixel_x = -10
+/obj/effect/turf_decal/tile{
+	color = "#CC5500";
+	dir = 1
 	},
-/obj/structure/filingcabinet/tethinfo,
-/obj/structure/filingcabinet/heinfo{
-	pixel_x = 10
+/obj/effect/turf_decal/tile{
+	color = "#CC5500"
 	},
-/turf/open/floor/facility/dark,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/department_main/manager)
 "Hj" = (
 /obj/structure/chair/comfy/beige{
@@ -2290,14 +2429,14 @@
 /turf/open/floor/carpet/green,
 /area/department_main/manager)
 "Ht" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "managerlockdown";
-	name = "Manager's Office Lockdown Blast Door"
+/obj/effect/turf_decal/tile{
+	color = "#CC5500";
+	dir = 1
 	},
-/obj/machinery/door/airlock/wood{
-	name = "Manager's Office"
+/obj/effect/turf_decal/tile{
+	color = "#CC5500"
 	},
-/turf/open/floor/facility/dark,
+/turf/open/floor/plasteel/dark,
 /area/department_main/manager)
 "Hw" = (
 /obj/item/toy/plush/gebura,
@@ -2691,13 +2830,36 @@
 /turf/open/floor/wood,
 /area/facility_hallway/manager)
 "Oo" = (
-/obj/structure/table/wood/fancy/orange,
-/obj/item/toy/katana,
-/obj/item/reagent_containers/food/drinks/coffee{
-	pixel_x = -3;
-	pixel_y = 5
+/obj/machinery/computer/security/telescreen{
+	network = list("ss13");
+	pixel_y = 39
 	},
-/turf/open/floor/carpet/orange,
+/obj/machinery/computer/security/telescreen{
+	network = list("ss13");
+	pixel_y = 27
+	},
+/obj/machinery/computer/security/telescreen{
+	network = list("ss13");
+	pixel_x = 20;
+	pixel_y = 39
+	},
+/obj/machinery/computer/security/telescreen{
+	network = list("ss13");
+	pixel_x = 20;
+	pixel_y = 27
+	},
+/obj/machinery/computer/security/telescreen{
+	network = list("ss13");
+	pixel_x = -20;
+	pixel_y = 39
+	},
+/obj/machinery/computer/security/telescreen{
+	network = list("ss13");
+	pixel_x = -20;
+	pixel_y = 27
+	},
+/obj/machinery/computer/abnormality_auxiliary,
+/turf/open/floor/carpet/royalblack,
 /area/department_main/manager)
 "Ou" = (
 /obj/effect/turf_decal/siding/wood/corner{
@@ -2745,6 +2907,9 @@
 /obj/machinery/light/cold/no_nightlight{
 	dir = 1
 	},
+/obj/structure/sign/ordealmonitor{
+	pixel_y = 32
+	},
 /turf/open/floor/wood,
 /area/department_main/manager)
 "PK" = (
@@ -2788,17 +2953,22 @@
 /turf/open/floor/wood,
 /area/department_main/manager)
 "Qt" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 5
+/obj/structure/chair/office{
+	dir = 4
 	},
-/turf/open/floor/carpet/black,
+/obj/effect/turf_decal/tile{
+	color = "#CC5500";
+	dir = 1
+	},
+/obj/effect/turf_decal/tile{
+	color = "#CC5500"
+	},
+/obj/item/toy/plush/myo,
+/turf/open/floor/plasteel/dark,
 /area/department_main/manager)
 "Qy" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
-	},
-/obj/structure/sign/ordealmonitor{
-	pixel_y = 32
 	},
 /obj/machinery/camera/autoname{
 	dir = 6
@@ -2806,8 +2976,12 @@
 /turf/open/floor/wood,
 /area/department_main/manager)
 "QG" = (
-/obj/machinery/door/airlock/wood/glass{
-	name = "Manager's Office"
+/obj/machinery/door/poddoor/preopen{
+	id = "managerlockdown";
+	name = "Adminstrative Offices Lockdown"
+	},
+/obj/machinery/door/airlock/wood{
+	name = "Sefirot Auxiliary Offices Entrance"
 	},
 /turf/open/floor/facility/dark,
 /area/department_main/manager)
@@ -2902,6 +3076,17 @@
 	},
 /turf/open/floor/wood,
 /area/facility_hallway/manager)
+"Sf" = (
+/obj/structure/chair/stool,
+/obj/effect/turf_decal/tile{
+	color = "#CC5500";
+	dir = 1
+	},
+/obj/effect/turf_decal/tile{
+	color = "#CC5500"
+	},
+/turf/open/floor/plasteel/dark,
+/area/department_main/manager)
 "Sk" = (
 /obj/machinery/modular_computer/console/preset,
 /obj/effect/turf_decal/siding/green{
@@ -3141,7 +3326,6 @@
 /area/department_main/manager)
 "WU" = (
 /obj/structure/chair/office,
-/obj/item/toy/plush/angela,
 /obj/effect/turf_decal/siding/blue{
 	dir = 1
 	},
@@ -3284,6 +3468,27 @@
 /obj/effect/turf_decal/siding/white,
 /turf/open/floor/carpet/black,
 /area/facility_hallway/manager)
+"Yi" = (
+/obj/machinery/button/door/indestructible{
+	id = "managerlockdown2";
+	name = "Manager Office Lockdown button";
+	pixel_y = 22;
+	pixel_x = 5
+	},
+/obj/machinery/button/door/indestructible{
+	id = "facilitylockdown";
+	name = "Facility Lockdown button";
+	pixel_y = 30;
+	pixel_x = 5
+	},
+/obj/machinery/button/door/indestructible{
+	id = "managerlockdown";
+	name = "Adminstrative Offices Lockdown button";
+	pixel_y = 26;
+	pixel_x = -5
+	},
+/turf/open/floor/carpet/royalblack,
+/area/department_main/manager)
 "Yq" = (
 /obj/effect/turf_decal/siding/wood/corner,
 /turf/open/floor/wood,
@@ -3395,8 +3600,12 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/facility_hallway/manager)
 "Zg" = (
-/obj/effect/turf_decal/siding/yellow{
-	dir = 4
+/obj/structure/filingcabinet/wawinfo{
+	pixel_x = -10
+	},
+/obj/structure/filingcabinet/alephinfo,
+/obj/structure/filingcabinet/toolinfo{
+	pixel_x = 10
 	},
 /turf/open/floor/carpet/royalblack,
 /area/department_main/manager)
@@ -3410,16 +3619,8 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/facility_hallway/manager)
 "Zw" = (
-/obj/structure/sign/ordealmonitor{
-	pixel_y = 32
-	},
-/obj/machinery/light/cold/no_nightlight{
-	dir = 1
-	},
-/obj/machinery/jukebox{
-	req_access = list()
-	},
-/turf/open/floor/facility/dark,
+/obj/machinery/computer/abnormality_queue,
+/turf/open/floor/carpet/royalblack,
 /area/department_main/manager)
 "ZF" = (
 /obj/structure/toilet{
@@ -7269,10 +7470,10 @@ XL
 XL
 XL
 XL
-Qf
-Qf
-Qf
-Qf
+XL
+XL
+XL
+XL
 Qf
 Qf
 Qf
@@ -7366,15 +7567,15 @@ XL
 XL
 XL
 XL
+XL
+XL
+XL
+XL
+XL
+XL
 Qf
 Qf
 Qf
-Qf
-Qf
-Qf
-tc
-td
-zF
 Qf
 FC
 UD
@@ -7467,17 +7668,17 @@ XL
 XL
 XL
 XL
+XL
+XL
+XL
+XL
+XL
+XL
 Qf
 Qf
 Cl
 it
-Qf
-Qf
-El
-mQ
-tV
-zS
-Ht
+uL
 Pk
 UO
 zy
@@ -7569,16 +7770,16 @@ XL
 XL
 XL
 XL
+XL
+XL
+XL
+XL
+XL
+XL
 Qf
 HY
 Hj
 Vw
-Qf
-Qf
-Zw
-Qt
-ui
-zL
 Qf
 Pv
 Vw
@@ -7671,17 +7872,17 @@ XL
 XL
 XL
 XL
+XL
+XL
+XL
+XL
+XL
+XL
 Qf
 If
 Gw
 Vw
 ug
-dj
-gc
-nm
-va
-GO
-Qf
 PN
 VJ
 Xt
@@ -7773,17 +7974,17 @@ XL
 XL
 XL
 XL
+XL
+XL
+XL
+XL
+XL
+XL
 Qf
-Oo
+nG
 eD
 Vw
 ug
-dt
-hD
-nG
-vf
-zV
-Qf
 PN
 Xs
 WS
@@ -7875,17 +8076,17 @@ XL
 XL
 XL
 XL
+XL
+XL
+XL
+XL
+XL
+XL
 Qf
 jL
 yA
 Vw
 ug
-dL
-ka
-or
-vw
-Au
-Qf
 Qy
 WU
 Pe
@@ -7977,17 +8178,17 @@ XL
 XL
 XL
 XL
+XL
+XL
+XL
+XL
+XL
+XL
 Qf
 qe
 eD
 Vw
 ug
-dQ
-lc
-Zg
-wy
-AV
-Qf
 PN
 Xq
 NF
@@ -8079,17 +8280,17 @@ XL
 XL
 XL
 XL
+XL
+XL
+XL
+XL
+XL
+XL
 Qf
 gX
 or
 Vw
 ug
-fJ
-lE
-rl
-va
-AZ
-Qf
 PN
 Xt
 yX
@@ -8181,15 +8382,15 @@ XL
 XL
 XL
 XL
+XL
+XL
+XL
+XL
+XL
+XL
 Qf
 Ya
 mu
-xg
-Qf
-Qf
-lW
-mQ
-tV
 Cy
 Qf
 Pv
@@ -8283,17 +8484,17 @@ XL
 XL
 XL
 XL
+XL
+XL
+XL
+XL
+XL
+XL
 Qf
 rF
 or
 Vw
-Vw
 uL
-va
-Qt
-ui
-CI
-Ht
 Pk
 Yq
 Zc
@@ -8385,16 +8586,16 @@ XL
 XL
 XL
 XL
+XL
+XL
+XL
+XL
+XL
+XL
 Qf
 Qf
 fU
 mx
-Vw
-Qf
-Qf
-rz
-wF
-Ec
 Qf
 QL
 Yw
@@ -8488,12 +8689,12 @@ XL
 XL
 XL
 XL
-Qf
-Qf
-Qf
-Qf
-Qf
-Qf
+XL
+XL
+XL
+XL
+XL
+XL
 Qf
 Qf
 Qf
@@ -11909,13 +12110,13 @@ XL
 XL
 XL
 XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
+Qf
+Qf
+Qf
+Qf
+Qf
+Qf
+Qf
 XL
 XL
 XL
@@ -12011,13 +12212,13 @@ XL
 XL
 XL
 XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
+Qf
+CI
+Ht
+GO
+eO
+ib
+Qf
 XL
 XL
 XL
@@ -12113,13 +12314,13 @@ XL
 XL
 XL
 XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
+Qf
+AV
+Ht
+td
+Qt
+nm
+Qf
 XL
 XL
 XL
@@ -12215,13 +12416,13 @@ XL
 XL
 XL
 XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
+Qf
+eU
+Ht
+td
+td
+mY
+Qf
 XL
 XL
 XL
@@ -12311,19 +12512,19 @@ XL
 XL
 XL
 XL
+Qf
+Qf
+Qf
+Qf
+Qf
 XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
+Qf
+fH
+Ht
+Ht
+Sf
+tV
+Qf
 XL
 XL
 XL
@@ -12413,19 +12614,19 @@ XL
 XL
 XL
 XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
+Qf
+lN
+va
+pN
+Qf
+Qf
+Qf
+Qf
+Qf
+zn
+fa
+Qf
+Qf
 XL
 XL
 XL
@@ -12514,28 +12715,28 @@ XL
 XL
 XL
 XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
+Qf
+Qf
+or
+or
+or
+nh
+Vw
+Vw
+Qf
+Qf
+mQ
+mQ
+Qf
+Qf
+Qf
+Qf
+Qf
+Qf
+Qf
+Qf
+Qf
+Qf
 XL
 "}
 (90,1,1) = {"
@@ -12616,28 +12817,28 @@ XL
 XL
 XL
 XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
+Qf
+Em
+xg
+or
+vw
+zV
+Vw
+Vw
+FV
+Qf
+Ec
+Ec
+Qf
+vf
+lW
+zS
+zL
+zL
+zL
+zL
+zL
+Qf
 XL
 "}
 (91,1,1) = {"
@@ -12718,28 +12919,28 @@ XL
 XL
 XL
 XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
+Qf
+Zw
+or
+or
+or
+Au
+wF
+Vw
+Vw
+Qf
+dQ
+mQ
+Qf
+vf
+mQ
+uc
+zL
+zL
+zL
+zL
+zL
+Qf
 XL
 "}
 (92,1,1) = {"
@@ -12820,28 +13021,28 @@ XL
 XL
 XL
 XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
+Qf
+Oo
+mu
+or
+or
+hT
+rz
+lE
+Vw
+dj
+Ec
+Ec
+hD
+Ec
+Ec
+tc
+ka
+zL
+zL
+zL
+zL
+Qf
 XL
 "}
 (93,1,1) = {"
@@ -12922,28 +13123,28 @@ XL
 XL
 XL
 XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
+Qf
+lc
+or
+or
+or
+dt
+zF
+Vw
+kR
+Qf
+dQ
+mQ
+Qf
+vf
+mQ
+fu
+zL
+zL
+zL
+zL
+zL
+Qf
 XL
 "}
 (94,1,1) = {"
@@ -13024,28 +13225,28 @@ XL
 XL
 XL
 XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
+Qf
+fJ
+or
+or
+wy
+dL
+Vw
+Vw
+FV
+Qf
+Ec
+Ec
+Qf
+vf
+rl
+El
+zL
+zL
+zL
+zL
+zL
+Qf
 XL
 "}
 (95,1,1) = {"
@@ -13126,28 +13327,28 @@ XL
 XL
 XL
 XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
+Qf
+Qf
+Yi
+or
+uq
+ui
+Vw
+Vw
+Qf
+Qf
+gc
+mQ
+Qf
+Qf
+Qf
+Qf
+Qf
+Qf
+Qf
+Qf
+Qf
+Qf
 XL
 "}
 (96,1,1) = {"
@@ -13229,18 +13430,18 @@ XL
 XL
 XL
 XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
+Qf
+AZ
+Zg
+Qf
+Qf
+Qf
+Qf
+Qf
+Qf
+Qf
+Qf
+Qf
 XL
 XL
 XL
@@ -13331,11 +13532,11 @@ XL
 XL
 XL
 XL
-XL
-XL
-XL
-XL
-XL
+Qf
+Qf
+Qf
+Qf
+Qf
 XL
 XL
 XL

--- a/_maps/map_files/generic/Manager.dmm
+++ b/_maps/map_files/generic/Manager.dmm
@@ -148,12 +148,12 @@
 /turf/open/floor/plasteel/dark,
 /area/facility_hallway/manager)
 "dj" = (
-/obj/machinery/door/airlock/wood{
-	name = s
-	},
 /obj/machinery/door/poddoor/preopen{
 	id = "managerlockdown2";
 	name = "Manager's Office Lockdown Blast Door"
+	},
+/obj/machinery/door/airlock/wood{
+	name = "Manager's Office Entrance"
 	},
 /turf/open/floor/plasteel,
 /area/department_main/manager)
@@ -246,9 +246,6 @@
 	},
 /turf/open/floor/wood,
 /area/facility_hallway/manager)
-"eD" = (
-/turf/open/floor/carpet/orange,
-/area/department_main/manager)
 "eE" = (
 /obj/structure/chair/comfy/brown{
 	dir = 8
@@ -264,9 +261,11 @@
 /turf/open/floor/plasteel/dark,
 /area/facility_hallway/manager)
 "eL" = (
-/obj/effect/turf_decal/siding/blue,
-/turf/open/floor/carpet/cyan,
-/area/department_main/manager)
+/obj/structure/chair/comfy/brown{
+	dir = 1
+	},
+/turf/open/floor/carpet/orange,
+/area/facility_hallway/manager)
 "eO" = (
 /obj/machinery/requests_console{
 	department = "R-Corp Representative";
@@ -282,12 +281,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/department_main/manager)
-"eR" = (
-/obj/structure/sign/poster/official/soft_cap_pop_art{
-	pixel_y = 32
-	},
-/turf/open/floor/facility/dark,
-/area/facility_hallway/manager)
 "eU" = (
 /obj/structure/table,
 /obj/structure/sign/ordealmonitor{
@@ -341,12 +334,11 @@
 /turf/open/floor/wood,
 /area/facility_hallway/manager)
 "fq" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 10
+/obj/machinery/computer/abnormality_logs{
+	dir = 4
 	},
-/obj/machinery/light/cold/no_nightlight,
 /turf/open/floor/wood,
-/area/department_main/manager)
+/area/facility_hallway/manager)
 "fr" = (
 /obj/structure/table/glass,
 /obj/item/clothing/glasses/science{
@@ -397,12 +389,6 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/department_main/manager)
-"fU" = (
-/obj/structure/table/wood,
-/obj/item/clipboard,
-/obj/item/pen/fourcolor,
-/turf/open/floor/carpet/royalblack,
-/area/department_main/manager)
 "fW" = (
 /obj/machinery/computer/crew{
 	dir = 1
@@ -448,6 +434,9 @@
 /area/facility_hallway/manager)
 "gx" = (
 /obj/machinery/vending/coffee,
+/obj/structure/sign/poster/official/soft_cap_pop_art{
+	pixel_y = 32
+	},
 /turf/open/floor/facility/dark,
 /area/facility_hallway/manager)
 "gC" = (
@@ -457,23 +446,6 @@
 	},
 /turf/open/floor/wood,
 /area/facility_hallway/manager)
-"gX" = (
-/obj/structure/table/wood/fancy/royalblack,
-/obj/item/reagent_containers/food/drinks/mug/tea{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/toy/clockwork_watch{
-	pixel_x = 7;
-	pixel_y = 2
-	},
-/obj/machinery/button/door/indestructible{
-	id = "managerlockdown";
-	name = "Adminstrative Offices Lockdown button";
-	pixel_y = 25
-	},
-/turf/open/floor/carpet/royalblack,
-/area/department_main/manager)
 "hj" = (
 /obj/machinery/computer/crew{
 	dir = 8
@@ -604,12 +576,6 @@
 /obj/item/toy/plush/kod,
 /turf/open/floor/plasteel/dark,
 /area/facility_hallway/manager)
-"it" = (
-/obj/machinery/computer/abnormality_logs{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/department_main/manager)
 "iv" = (
 /obj/structure/closet/crate/science/abnochem_startercrate,
 /obj/item/clothing/suit/armor/ego_gear/limbus_labs/chem{
@@ -680,10 +646,6 @@
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/facility/dark,
 /area/facility_hallway/manager)
-"jL" = (
-/obj/machinery/computer/camera_advanced/manager/sephirah,
-/turf/open/floor/carpet/orange,
-/area/department_main/manager)
 "jT" = (
 /obj/machinery/holopad/secure,
 /turf/open/floor/carpet/green,
@@ -896,12 +858,6 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/department_main/manager)
-"mx" = (
-/obj/machinery/computer/abnormality_archive{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/department_main/manager)
 "my" = (
 /obj/machinery/door/window/brigdoor/southright,
 /obj/effect/turf_decal/siding/green{
@@ -1028,20 +984,6 @@
 	},
 /turf/open/floor/wood,
 /area/facility_hallway/manager)
-"nG" = (
-/obj/structure/table/wood/fancy/orange,
-/obj/item/toy/katana,
-/obj/item/reagent_containers/food/drinks/coffee{
-	pixel_x = -3;
-	pixel_y = 5
-	},
-/obj/machinery/button/door/indestructible{
-	id = "sephirah";
-	name = "Sephirah CIC opening";
-	pixel_y = 25
-	},
-/turf/open/floor/carpet/orange,
-/area/department_main/manager)
 "nJ" = (
 /obj/machinery/light/floor,
 /obj/effect/turf_decal/siding/white{
@@ -1183,10 +1125,6 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/department_main/manager)
-"qe" = (
-/obj/machinery/computer/crew,
-/turf/open/floor/carpet/orange,
-/area/department_main/manager)
 "qj" = (
 /obj/machinery/status_display{
 	pixel_y = -32
@@ -1314,10 +1252,6 @@
 /obj/item/storage/box/beakers,
 /turf/open/floor/plasteel/white,
 /area/facility_hallway/manager)
-"rF" = (
-/obj/machinery/computer/crew,
-/turf/open/floor/carpet/royalblack,
-/area/department_main/manager)
 "rH" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
@@ -1365,14 +1299,17 @@
 /turf/open/floor/plasteel/dark,
 /area/facility_hallway/manager)
 "sA" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 6
+/obj/structure/table/wood/fancy/royalblack,
+/obj/item/reagent_containers/food/drinks/mug/tea{
+	pixel_x = -3;
+	pixel_y = 3
 	},
-/obj/item/kirbyplants{
-	icon_state = "plant-04"
+/obj/item/toy/clockwork_watch{
+	pixel_x = 7;
+	pixel_y = 2
 	},
-/turf/open/floor/wood,
-/area/department_main/manager)
+/turf/open/floor/carpet/royalblack,
+/area/facility_hallway/manager)
 "sH" = (
 /obj/structure/bed/pod{
 	dir = 6
@@ -1494,13 +1431,6 @@
 /obj/structure/railing,
 /turf/open/floor/plasteel/dark,
 /area/department_main/manager)
-"ug" = (
-/obj/machinery/door/poddoor{
-	id = "sephirah";
-	name = "cic blast door"
-	},
-/turf/closed/indestructible/fakeglass,
-/area/department_main/manager)
 "ui" = (
 /obj/machinery/door/window/brigdoor/southright,
 /turf/open/floor/carpet/royalblack,
@@ -1521,17 +1451,6 @@
 	},
 /turf/open/floor/wood,
 /area/facility_hallway/manager)
-"uL" = (
-/obj/machinery/door/airlock/public/glass{
-	hackProof = 1;
-	max_integrity = 250000000;
-	name = "Sefirot Auxiliary Offices";
-	normal_integrity = 250000000;
-	req_access_txt = "67";
-	whitelist_door = 1
-	},
-/turf/open/floor/facility/dark,
-/area/department_main/manager)
 "uY" = (
 /obj/machinery/light{
 	dir = 4;
@@ -1839,11 +1758,16 @@
 /turf/open/floor/wood,
 /area/facility_hallway/manager)
 "yA" = (
-/obj/structure/chair/comfy/brown{
-	dir = 1
+/obj/machinery/door/airlock/public/glass{
+	hackProof = 1;
+	max_integrity = 250000000;
+	name = "Sefirot Auxiliary Offices";
+	normal_integrity = 250000000;
+	req_access_txt = "67";
+	whitelist_door = 1
 	},
-/turf/open/floor/carpet/orange,
-/area/department_main/manager)
+/turf/open/floor/facility/dark,
+/area/facility_hallway/manager)
 "yD" = (
 /obj/effect/turf_decal/tile{
 	color = "#111111";
@@ -1884,13 +1808,9 @@
 /turf/open/floor/carpet/royalblue,
 /area/facility_hallway/manager)
 "yX" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-11";
-	pixel_y = 13
-	},
-/obj/structure/table/glass,
-/turf/open/floor/wood,
-/area/department_main/manager)
+/obj/machinery/computer/camera_advanced/manager/sephirah,
+/turf/open/floor/carpet/royalblack,
+/area/facility_hallway/manager)
 "yY" = (
 /obj/structure/table/wood,
 /obj/item/paicard,
@@ -1902,15 +1822,6 @@
 "zn" = (
 /obj/machinery/door/airlock/public/glass,
 /turf/open/floor/plasteel/dark,
-/area/department_main/manager)
-"zy" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/machinery/status_display{
-	pixel_x = -32
-	},
-/turf/open/floor/wood,
 /area/department_main/manager)
 "zE" = (
 /obj/machinery/light{
@@ -1979,12 +1890,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/facility_hallway/manager)
-"Ao" = (
-/obj/effect/turf_decal/siding/blue{
-	dir = 6
-	},
-/turf/open/floor/carpet/cyan,
-/area/department_main/manager)
 "Aq" = (
 /obj/structure/chair/comfy/brown,
 /obj/effect/turf_decal/siding/yellow{
@@ -2093,17 +1998,6 @@
 	},
 /turf/open/floor/carpet/orange,
 /area/facility_hallway/manager)
-"Cg" = (
-/obj/effect/turf_decal/siding/blue{
-	dir = 10
-	},
-/turf/open/floor/carpet/cyan,
-/area/department_main/manager)
-"Cl" = (
-/obj/structure/table/wood/fancy/green,
-/obj/item/reagent_containers/hypospray/medipen,
-/turf/open/floor/carpet/green,
-/area/department_main/manager)
 "Cn" = (
 /obj/structure/rack,
 /obj/item/toy/plush/sow,
@@ -2118,14 +2012,6 @@
 	},
 /turf/open/floor/carpet/green,
 /area/facility_hallway/manager)
-"Cy" = (
-/obj/machinery/button/door/indestructible{
-	id = "sephirah";
-	name = "Sephirah CIC opening";
-	pixel_y = 25
-	},
-/turf/open/floor/wood,
-/area/department_main/manager)
 "CI" = (
 /obj/structure/closet/secure_closet/personal{
 	anchored = 1
@@ -2289,22 +2175,6 @@
 	},
 /turf/open/floor/facility/dark,
 /area/facility_hallway/manager)
-"FC" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 9
-	},
-/obj/item/kirbyplants{
-	icon_state = "plant-04"
-	},
-/turf/open/floor/wood,
-/area/department_main/manager)
-"FK" = (
-/obj/effect/turf_decal/siding/wood/corner,
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/department_main/manager)
 "FL" = (
 /obj/structure/filingcabinet/wawinfo{
 	pixel_x = -10
@@ -2374,13 +2244,6 @@
 	},
 /turf/open/floor/carpet/orange,
 /area/facility_hallway/manager)
-"Gw" = (
-/turf/open/floor/carpet/green,
-/area/department_main/manager)
-"Gy" = (
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/wood,
-/area/department_main/manager)
 "GA" = (
 /obj/structure/chair/sofa/corp/left,
 /turf/open/floor/facility/dark,
@@ -2417,12 +2280,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/department_main/manager)
-"Hj" = (
-/obj/structure/chair/comfy/beige{
-	dir = 1
-	},
-/turf/open/floor/carpet/green,
 /area/department_main/manager)
 "Ht" = (
 /obj/effect/turf_decal/tile{
@@ -2482,17 +2339,9 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/facility_hallway/manager)
-"HY" = (
-/obj/machinery/computer/camera_advanced/manager/sephirah,
-/turf/open/floor/carpet/green,
-/area/department_main/manager)
 "HZ" = (
 /turf/closed/indestructible/fakeglass,
 /area/facility_hallway/manager)
-"If" = (
-/obj/machinery/computer/crew,
-/turf/open/floor/carpet/green,
-/area/department_main/manager)
 "Ik" = (
 /obj/structure/chair/sofa/corp/left{
 	dir = 8
@@ -2813,12 +2662,12 @@
 /turf/closed/indestructible/reinforced,
 /area/facility_hallway/manager)
 "NF" = (
-/obj/effect/turf_decal/siding/blue{
-	dir = 4
+/obj/machinery/computer/crew,
+/obj/structure/sign/ordealmonitor{
+	pixel_y = 32
 	},
-/obj/structure/table/glass,
-/turf/open/floor/carpet/cyan,
-/area/department_main/manager)
+/turf/open/floor/carpet/orange,
+/area/facility_hallway/manager)
 "NK" = (
 /obj/machinery/door/airlock/wood{
 	name = "Representative's Room"
@@ -2883,31 +2732,22 @@
 /turf/open/floor/facility/dark,
 /area/facility_hallway/manager)
 "Pe" = (
-/obj/item/modular_computer/laptop/preset/civilian,
-/obj/structure/table/glass,
-/turf/open/floor/carpet/cyan,
-/area/department_main/manager)
-"Pk" = (
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 4
+/obj/structure/table/wood/fancy/orange,
+/obj/item/toy/katana,
+/obj/item/reagent_containers/food/drinks/coffee{
+	pixel_x = -3;
+	pixel_y = 5
 	},
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 1
+/obj/machinery/button/door/indestructible{
+	id = "managerlockdown";
+	name = "Adminstrative Offices Lockdown button";
+	pixel_y = 25
 	},
-/turf/open/floor/wood,
-/area/department_main/manager)
-"Pv" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
+/obj/machinery/camera/autoname{
+	dir = 6
 	},
-/obj/machinery/light/cold/no_nightlight{
-	dir = 1
-	},
-/obj/structure/sign/ordealmonitor{
-	pixel_y = 32
-	},
-/turf/open/floor/wood,
-/area/department_main/manager)
+/turf/open/floor/carpet/orange,
+/area/facility_hallway/manager)
 "PK" = (
 /obj/machinery/requests_console{
 	announcementConsole = 1;
@@ -2918,12 +2758,6 @@
 /obj/effect/turf_decal/siding/white,
 /turf/open/floor/carpet/black,
 /area/facility_hallway/manager)
-"PN" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/department_main/manager)
 "Qf" = (
 /turf/closed/indestructible/reinforced,
 /area/department_main/manager)
@@ -2940,14 +2774,10 @@
 /turf/open/floor/carpet/royalblack,
 /area/facility_hallway/manager)
 "Ql" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 10
-	},
-/obj/item/kirbyplants{
-	icon_state = "plant-04"
-	},
-/turf/open/floor/wood,
-/area/department_main/manager)
+/obj/structure/table/wood/fancy/green,
+/obj/item/reagent_containers/hypospray/medipen,
+/turf/open/floor/carpet/green,
+/area/facility_hallway/manager)
 "Qt" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -2963,33 +2793,18 @@
 /turf/open/floor/plasteel/dark,
 /area/department_main/manager)
 "Qy" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/machinery/camera/autoname{
-	dir = 6
-	},
-/turf/open/floor/wood,
-/area/department_main/manager)
-"QG" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "managerlockdown";
-	name = "Adminstrative Offices Lockdown"
-	},
-/obj/machinery/door/airlock/wood{
-	name = "Sefirot Auxiliary Offices Entrance"
+/obj/item/kirbyplants/random,
+/obj/structure/sign/poster/official/high_class_martini{
+	pixel_y = 32
 	},
 /turf/open/floor/facility/dark,
-/area/department_main/manager)
-"QL" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 5
-	},
-/obj/item/kirbyplants{
-	icon_state = "plant-04"
+/area/facility_hallway/manager)
+"QG" = (
+/obj/machinery/computer/abnormality_archive{
+	dir = 8
 	},
 /turf/open/floor/wood,
-/area/department_main/manager)
+/area/facility_hallway/manager)
 "QO" = (
 /obj/effect/turf_decal/tile{
 	color = "#111111";
@@ -3203,12 +3018,6 @@
 	},
 /turf/open/floor/carpet/black,
 /area/facility_hallway/manager)
-"UD" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 10
-	},
-/turf/open/floor/wood,
-/area/department_main/manager)
 "UF" = (
 /obj/structure/chair/office,
 /obj/effect/turf_decal/siding/white{
@@ -3221,11 +3030,11 @@
 /turf/open/floor/carpet/black,
 /area/facility_hallway/manager)
 "UO" = (
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 8
+/obj/structure/chair/comfy/beige{
+	dir = 1
 	},
-/turf/open/floor/wood,
-/area/department_main/manager)
+/turf/open/floor/carpet/green,
+/area/facility_hallway/manager)
 "Vb" = (
 /turf/open/floor/carpet/black,
 /area/facility_hallway/manager)
@@ -3242,12 +3051,6 @@
 /turf/open/floor/wood,
 /area/facility_hallway/manager)
 "Vw" = (
-/turf/open/floor/wood,
-/area/department_main/manager)
-"VJ" = (
-/obj/item/paper_bin,
-/obj/item/pen/fourcolor,
-/obj/structure/table/glass,
 /turf/open/floor/wood,
 /area/department_main/manager)
 "VL" = (
@@ -3314,19 +3117,12 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/facility_hallway/manager)
 "WS" = (
-/obj/effect/turf_decal/siding/blue{
-	dir = 8
+/obj/machinery/computer/camera_advanced/manager/sephirah,
+/obj/structure/sign/ordealmonitor{
+	pixel_y = 32
 	},
-/obj/structure/table/glass,
-/turf/open/floor/carpet/cyan,
-/area/department_main/manager)
-"WU" = (
-/obj/structure/chair/office,
-/obj/effect/turf_decal/siding/blue{
-	dir = 1
-	},
-/turf/open/floor/carpet/cyan,
-/area/department_main/manager)
+/turf/open/floor/carpet/orange,
+/area/facility_hallway/manager)
 "WX" = (
 /obj/structure/closet/secure_closet/discipline,
 /turf/open/floor/carpet/red,
@@ -3363,23 +3159,10 @@
 /obj/item/food/bread/plain,
 /turf/open/floor/plasteel/white,
 /area/facility_hallway/manager)
-"Xq" = (
-/obj/effect/turf_decal/siding/blue{
-	dir = 5
-	},
-/turf/open/floor/carpet/cyan,
-/area/department_main/manager)
-"Xs" = (
-/obj/effect/turf_decal/siding/blue{
-	dir = 9
-	},
-/obj/machinery/holopad/secure,
-/turf/open/floor/carpet/cyan,
-/area/department_main/manager)
 "Xt" = (
-/obj/structure/table/glass,
-/turf/open/floor/wood,
-/area/department_main/manager)
+/obj/machinery/computer/crew,
+/turf/open/floor/carpet/green,
+/area/facility_hallway/manager)
 "Xy" = (
 /turf/open/floor/plasteel/white,
 /area/facility_hallway/manager)
@@ -3439,12 +3222,6 @@
 	},
 /turf/open/floor/facility/dark,
 /area/facility_hallway/manager)
-"XT" = (
-/obj/structure/sign/poster/official/high_class_martini{
-	pixel_y = 32
-	},
-/turf/open/floor/facility/dark,
-/area/facility_hallway/manager)
 "XZ" = (
 /obj/effect/turf_decal/siding/blue{
 	color = "#3234B9";
@@ -3453,10 +3230,6 @@
 /obj/machinery/text_adventure_console,
 /turf/open/floor/carpet/royalblue,
 /area/facility_hallway/manager)
-"Ya" = (
-/obj/machinery/computer/camera_advanced/manager/sephirah,
-/turf/open/floor/carpet/royalblack,
-/area/department_main/manager)
 "Yc" = (
 /obj/structure/chair/comfy/black{
 	dir = 1
@@ -3485,9 +3258,12 @@
 /turf/open/floor/carpet/royalblack,
 /area/department_main/manager)
 "Yq" = (
-/obj/effect/turf_decal/siding/wood/corner,
-/turf/open/floor/wood,
-/area/department_main/manager)
+/obj/machinery/computer/camera_advanced/manager/sephirah,
+/obj/machinery/light/cold/no_nightlight{
+	dir = 1
+	},
+/turf/open/floor/carpet/green,
+/area/facility_hallway/manager)
 "Yv" = (
 /obj/structure/table/wood/fancy/royalblack,
 /obj/structure/railing{
@@ -3503,12 +3279,6 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/facility_hallway/manager)
-"Yw" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 6
-	},
-/turf/open/floor/wood,
-/area/department_main/manager)
 "Yy" = (
 /obj/effect/turf_decal/tile{
 	color = "#111111";
@@ -3550,21 +3320,12 @@
 /turf/open/floor/carpet/red,
 /area/facility_hallway/manager)
 "YW" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 6
+/obj/machinery/computer/crew,
+/obj/machinery/light/cold/no_nightlight{
+	dir = 1
 	},
-/obj/machinery/light/cold/no_nightlight,
-/turf/open/floor/wood,
-/area/department_main/manager)
-"Zc" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/obj/machinery/status_display{
-	pixel_x = 32
-	},
-/turf/open/floor/wood,
-/area/department_main/manager)
+/turf/open/floor/carpet/royalblack,
+/area/facility_hallway/manager)
 "Zd" = (
 /obj/effect/turf_decal/tile{
 	color = "#111111";
@@ -7469,10 +7230,10 @@ XL
 XL
 XL
 XL
-Qf
-Qf
-Qf
-Qf
+XL
+YQ
+YQ
+YQ
 xf
 LS
 Ik
@@ -7568,15 +7329,15 @@ XL
 XL
 XL
 XL
-Qf
-Qf
-Qf
-Qf
-FC
-UD
-Qf
-Qf
-Qf
+XL
+XL
+XL
+XL
+XL
+XL
+YQ
+YQ
+YQ
 YQ
 YQ
 wz
@@ -7669,17 +7430,17 @@ XL
 XL
 XL
 XL
-Qf
-Qf
-Cl
-it
-uL
-Pk
-UO
-zy
+XL
+XL
+XL
+XL
+XL
+XL
+YQ
+YQ
 Ql
-Qf
-Qf
+fq
+YQ
 YQ
 oI
 JT
@@ -7771,17 +7532,17 @@ XL
 XL
 XL
 XL
-Qf
-HY
-Hj
-Vw
-Qf
-Pv
-Vw
-Vw
+XL
+XL
+XL
+XL
+XL
+XL
+YQ
+Yq
 UO
-fq
-Qf
+wb
+YQ
 gx
 Zi
 JT
@@ -7873,18 +7634,18 @@ XL
 XL
 XL
 XL
-Qf
-If
-Gw
-Vw
-ug
-PN
-VJ
+XL
+XL
+XL
+XL
+XL
+XL
+YQ
 Xt
-Vw
-Gy
-Qf
-eR
+EQ
+wb
+HZ
+Zi
 XA
 oP
 Vb
@@ -7975,17 +7736,17 @@ XL
 XL
 XL
 XL
-Qf
-nG
-eD
-Vw
-ug
-PN
-Xs
+XL
+XL
+XL
+XL
+XL
+XL
+YQ
 WS
-Cg
-Gy
-Qf
+zb
+wb
+yA
 ZV
 JT
 Vb
@@ -8077,17 +7838,17 @@ XL
 XL
 XL
 XL
-Qf
-jL
-yA
-Vw
-ug
-Qy
-WU
+XL
+XL
+XL
+XL
+XL
+XL
+YQ
 Pe
 eL
-FK
-QG
+wb
+HZ
 Zi
 JT
 Vb
@@ -8179,17 +7940,17 @@ XL
 XL
 XL
 XL
-Qf
-qe
-eD
-Vw
-ug
-PN
-Xq
+XL
+XL
+XL
+XL
+XL
+XL
+YQ
 NF
-Ao
-Gy
-Qf
+zb
+wb
+yA
 ZV
 JT
 Vb
@@ -8281,18 +8042,18 @@ XL
 XL
 XL
 XL
-Qf
-gX
-or
-Vw
-ug
-PN
-Xt
+XL
+XL
+XL
+XL
+XL
+XL
+YQ
 yX
-Vw
-Gy
-Qf
-XT
+Ks
+wb
+HZ
+Zi
 nJ
 vB
 Vb
@@ -8383,18 +8144,18 @@ XL
 XL
 XL
 XL
-Qf
-Ya
-mu
-Cy
-Qf
-Pv
-Vw
-Vw
-Yq
+XL
+XL
+XL
+XL
+XL
+XL
+YQ
 YW
-Qf
-OF
+Ae
+wb
+YQ
+Qy
 Zi
 JT
 Vb
@@ -8485,17 +8246,17 @@ XL
 XL
 XL
 XL
-Qf
-rF
-or
-Vw
-uL
-Pk
-Yq
-Zc
+XL
+XL
+XL
+XL
+XL
+XL
+YQ
+YQ
 sA
-Qf
-Qf
+QG
+YQ
 YQ
 Rj
 JT
@@ -8587,16 +8348,16 @@ XL
 XL
 XL
 XL
-Qf
-Qf
-fU
-mx
-Qf
-QL
-Yw
-Qf
-Qf
-Qf
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+YQ
+YQ
+YQ
 YQ
 ND
 wz
@@ -8690,13 +8451,13 @@ XL
 XL
 XL
 XL
-Qf
-Qf
-Qf
-Qf
-Qf
-Qf
-Qf
+XL
+XL
+XL
+XL
+XL
+YQ
+YQ
 if
 WB
 rD

--- a/_maps/map_files/generic/Manager.dmm
+++ b/_maps/map_files/generic/Manager.dmm
@@ -830,12 +830,6 @@
 /turf/open/floor/wood,
 /area/department_main/manager)
 "lN" = (
-/obj/machinery/button/door/indestructible{
-	id = "managerlockdown";
-	name = "Adminstrative Offices Lockdown button";
-	pixel_y = 25;
-	pixel_x = -5
-	},
 /obj/machinery/computer/abnormality_logs{
 	dir = 4
 	},
@@ -1184,7 +1178,9 @@
 /turf/open/floor/carpet/black,
 /area/facility_hallway/manager)
 "pN" = (
-/obj/machinery/jukebox,
+/obj/machinery/jukebox{
+	req_access = list()
+	},
 /turf/open/floor/carpet/royalblack,
 /area/department_main/manager)
 "qe" = (
@@ -3472,20 +3468,19 @@
 /obj/machinery/button/door/indestructible{
 	id = "managerlockdown2";
 	name = "Manager Office Lockdown button";
-	pixel_y = 22;
-	pixel_x = 5
+	pixel_y = 25;
+	pixel_x = -8
 	},
 /obj/machinery/button/door/indestructible{
 	id = "facilitylockdown";
 	name = "Facility Lockdown button";
-	pixel_y = 30;
-	pixel_x = 5
+	pixel_y = 25;
+	pixel_x = 8
 	},
 /obj/machinery/button/door/indestructible{
 	id = "managerlockdown";
 	name = "Adminstrative Offices Lockdown button";
-	pixel_y = 26;
-	pixel_x = -5
+	pixel_y = 33
 	},
 /turf/open/floor/carpet/royalblack,
 /area/department_main/manager)

--- a/_maps/map_files/generic/Manager.dmm
+++ b/_maps/map_files/generic/Manager.dmm
@@ -118,6 +118,18 @@
 /obj/effect/turf_decal/siding/white/corner,
 /turf/open/floor/carpet/black,
 /area/facility_hallway/manager)
+"cQ" = (
+/obj/structure/curtain,
+/obj/machinery/shower,
+/obj/item/soap/deluxe,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/noslip,
+/area/department_main/manager)
 "cR" = (
 /obj/structure/table/glass,
 /obj/item/work_console_upgrade/chemical_extraction_attachment,
@@ -148,14 +160,15 @@
 /turf/open/floor/plasteel/dark,
 /area/facility_hallway/manager)
 "dj" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "managerlockdown2";
-	name = "Manager's Office Lockdown Blast Door"
+/obj/structure/table/glass,
+/obj/item/razor{
+	pixel_x = 5;
+	pixel_y = 5
 	},
-/obj/machinery/door/airlock/wood{
-	name = "Manager's Office Entrance"
+/obj/item/lipstick/random{
+	pixel_x = -5
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/showroomfloor,
 /area/department_main/manager)
 "dl" = (
 /obj/machinery/vending/lobotomyarmband,
@@ -300,8 +313,14 @@
 /turf/open/floor/plasteel/dark,
 /area/department_main/manager)
 "fa" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = 11
+	},
+/obj/structure/mirror{
+	pixel_x = 28
+	},
+/turf/open/floor/plasteel/showroomfloor,
 /area/department_main/manager)
 "fb" = (
 /obj/effect/turf_decal/siding/wood{
@@ -446,6 +465,9 @@
 	},
 /turf/open/floor/wood,
 /area/facility_hallway/manager)
+"he" = (
+/turf/closed/indestructible/fakeglass,
+/area/department_main/manager)
 "hj" = (
 /obj/machinery/computer/crew{
 	dir = 8
@@ -991,6 +1013,13 @@
 	},
 /turf/open/floor/carpet/black,
 /area/facility_hallway/manager)
+"nQ" = (
+/obj/structure/toilet,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/department_main/manager)
 "nY" = (
 /obj/structure/table/glass,
 /obj/item/hand_labeler,
@@ -1418,6 +1447,14 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
+/area/department_main/manager)
+"tY" = (
+/obj/structure/table/glass,
+/obj/item/storage/pill_bottle/psicodine,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/showroomfloor,
 /area/department_main/manager)
 "tZ" = (
 /obj/machinery/light{
@@ -1864,6 +1901,9 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/railing,
 /turf/open/floor/plasteel/dark,
+/area/department_main/manager)
+"zT" = (
+/turf/open/floor/plasteel/showroomfloor,
 /area/department_main/manager)
 "zV" = (
 /obj/structure/railing,
@@ -2399,6 +2439,16 @@
 /obj/structure/table/wood/fancy/black,
 /turf/open/floor/carpet/green,
 /area/facility_hallway/manager)
+"IH" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "managerlockdown2";
+	name = "Manager's Office Lockdown Blast Door"
+	},
+/obj/machinery/door/airlock/wood{
+	name = "Manager's Office Entrance"
+	},
+/turf/open/floor/plasteel,
+/area/department_main/manager)
 "IK" = (
 /obj/structure/filingcabinet/wawinfo{
 	pixel_x = -10
@@ -3035,6 +3085,12 @@
 	},
 /turf/open/floor/carpet/green,
 /area/facility_hallway/manager)
+"UP" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/department_main/manager)
 "Vb" = (
 /turf/open/floor/carpet/black,
 /area/facility_hallway/manager)
@@ -3368,6 +3424,10 @@
 "Zi" = (
 /turf/open/floor/facility/dark,
 /area/facility_hallway/manager)
+"Zj" = (
+/obj/machinery/door/window/brigdoor/southleft,
+/turf/open/floor/plasteel/showroomfloor,
+/area/department_main/manager)
 "Zu" = (
 /obj/structure/chair/plastic{
 	dir = 4
@@ -11560,13 +11620,13 @@ XL
 XL
 XL
 XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
+Qf
+Qf
+Qf
+Qf
+Qf
+Qf
+Qf
 XL
 XL
 XL
@@ -11578,312 +11638,6 @@ XL
 XL
 "}
 (81,1,1) = {"
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-"}
-(82,1,1) = {"
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-"}
-(83,1,1) = {"
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-Qf
-Qf
-Qf
-Qf
-Qf
-Qf
-Qf
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-"}
-(84,1,1) = {"
 XL
 XL
 XL
@@ -11985,7 +11739,7 @@ XL
 XL
 XL
 "}
-(85,1,1) = {"
+(82,1,1) = {"
 XL
 XL
 XL
@@ -12087,7 +11841,7 @@ XL
 XL
 XL
 "}
-(86,1,1) = {"
+(83,1,1) = {"
 XL
 XL
 XL
@@ -12189,7 +11943,7 @@ XL
 XL
 XL
 "}
-(87,1,1) = {"
+(84,1,1) = {"
 XL
 XL
 XL
@@ -12291,7 +12045,7 @@ XL
 XL
 XL
 "}
-(88,1,1) = {"
+(85,1,1) = {"
 XL
 XL
 XL
@@ -12380,7 +12134,7 @@ Qf
 Qf
 Qf
 zn
-fa
+he
 Qf
 Qf
 XL
@@ -12393,7 +12147,7 @@ XL
 XL
 XL
 "}
-(89,1,1) = {"
+(86,1,1) = {"
 XL
 XL
 XL
@@ -12495,7 +12249,7 @@ Qf
 Qf
 XL
 "}
-(90,1,1) = {"
+(87,1,1) = {"
 XL
 XL
 XL
@@ -12597,7 +12351,7 @@ zL
 Qf
 XL
 "}
-(91,1,1) = {"
+(88,1,1) = {"
 XL
 XL
 XL
@@ -12699,7 +12453,7 @@ zL
 Qf
 XL
 "}
-(92,1,1) = {"
+(89,1,1) = {"
 XL
 XL
 XL
@@ -12786,7 +12540,7 @@ hT
 rz
 lE
 Vw
-dj
+IH
 Ec
 Ec
 hD
@@ -12801,7 +12555,7 @@ zL
 Qf
 XL
 "}
-(93,1,1) = {"
+(90,1,1) = {"
 XL
 XL
 XL
@@ -12903,7 +12657,7 @@ zL
 Qf
 XL
 "}
-(94,1,1) = {"
+(91,1,1) = {"
 XL
 XL
 XL
@@ -13005,7 +12759,7 @@ zL
 Qf
 XL
 "}
-(95,1,1) = {"
+(92,1,1) = {"
 XL
 XL
 XL
@@ -13093,8 +12847,8 @@ Vw
 Vw
 Qf
 Qf
-gc
 mQ
+gc
 Qf
 Qf
 Qf
@@ -13107,7 +12861,7 @@ Qf
 Qf
 XL
 "}
-(96,1,1) = {"
+(93,1,1) = {"
 XL
 XL
 XL
@@ -13195,10 +12949,316 @@ Qf
 Qf
 Qf
 Qf
+zn
 Qf
 Qf
 Qf
 XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+"}
+(94,1,1) = {"
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+Qf
+Qf
+Qf
+Qf
+Qf
+XL
+Qf
+nQ
+Zj
+zT
+zT
+dj
+Qf
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+"}
+(95,1,1) = {"
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+Qf
+Qf
+Qf
+zT
+zT
+zT
+Qf
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+"}
+(96,1,1) = {"
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+XL
+Qf
+Qf
+Qf
+zT
+zT
+zT
+Qf
 XL
 XL
 XL
@@ -13288,19 +13348,19 @@ XL
 XL
 XL
 XL
+XL
+XL
+XL
+XL
+XL
+XL
 Qf
+cQ
+Zj
+UP
+fa
+tY
 Qf
-Qf
-Qf
-Qf
-XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
 XL
 XL
 XL
@@ -13396,13 +13456,13 @@ XL
 XL
 XL
 XL
-XL
-XL
-XL
-XL
-XL
-XL
-XL
+Qf
+Qf
+Qf
+Qf
+Qf
+Qf
+Qf
 XL
 XL
 XL

--- a/_maps/shuttles/manager_elevator.dmm
+++ b/_maps/shuttles/manager_elevator.dmm
@@ -18,7 +18,7 @@
 /obj/machinery/computer/shuttle/mining{
 	name = "elevator console";
 	shuttleId = "manager";
-	possible_destinations = "elevator_home;elevator_away";
+	possible_destinations = "elevator_home;elevator_away;elevator_away_2";
 	dir = 4
 	},
 /obj/machinery/light{

--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -13,7 +13,7 @@
 	max_integrity = 600
 	armor = list(MELEE = 50, BULLET = 100, LASER = 100, ENERGY = 100, BOMB = 50, BIO = 100, RAD = 100, FIRE = 100, ACID = 70)
 	resistance_flags = FIRE_PROOF
-	damage_deflection = 70
+	damage_deflection = 40
 	poddoor = TRUE
 	var/ertblast = FALSE //If this is true the blast door cannot be deconstructed
 	var/deconstruction = INTACT //For the deconstruction steps
@@ -37,7 +37,7 @@
 			var/change_id = input("Set the shutters/blast door/blast door controllers ID. It must be a number between 1 and 100.", "ID", id) as num|null
 			if(change_id)
 				id = clamp(round(change_id, 1), 1, 100)
-				to_chat(user, "<span class='notice'>You change the ID to [id].</span>")	
+				to_chat(user, "<span class='notice'>You change the ID to [id].</span>")
 
 		if(W.tool_behaviour == TOOL_CROWBAR && deconstruction == INTACT)
 			to_chat(user, "<span class='notice'>You start to remove the airlock electronics.</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Gives the manager his own floor from the old days(its modified a small bit), separated from the sephirot/do/abno chem/rep floor with some map changes to that floor and a rename. Also pod doors can be damaged by things with a force of 40 or above now.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Manager needs his own space to not be distracted by other roles, also the second sephirot room fucking stole the managers static cameras which were useful for some timer abnos. Pod doors were basically unbreakable with the hp rework.
## Changelog
:cl:
add: Added a new floor
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
