### PR TITLE
Miscellaneous Abnormality Damage Reduction, throwing damage reduction

### DIFF
--- a/ModularTegustation/tegu_clothes_code/head.dm
+++ b/ModularTegustation/tegu_clothes_code/head.dm
@@ -27,7 +27,7 @@
 	worn_icon = 'ModularTegustation/Teguicons/head_worn.dmi'
 	dynamic_hair_suffix = ""
 	force = 3
-	throwforce = 45
+	throwforce = 5
 	throw_speed = 5
 	throw_range = 9
 	w_class = WEIGHT_CLASS_SMALL

--- a/ModularTegustation/tegu_items/gadgets/unpowered.dm
+++ b/ModularTegustation/tegu_items/gadgets/unpowered.dm
@@ -430,7 +430,7 @@
 	usesound = 'sound/items/crowbar.ogg'
 	slot_flags = ITEM_SLOT_BELT
 	force = 5
-	throwforce = 7
+	throwforce = 2
 	w_class = WEIGHT_CLASS_SMALL
 	custom_materials = list(/datum/material/iron=50)
 	drop_sound = 'sound/items/handling/crowbar_drop.ogg'

--- a/code/game/objects/items/RCD.dm
+++ b/code/game/objects/items/RCD.dm
@@ -18,7 +18,7 @@ RLD
 	flags_1 = CONDUCT_1
 	item_flags = NOBLUDGEON
 	force = 0
-	throwforce = 10
+	throwforce = 2
 	throw_speed = 3
 	throw_range = 5
 	w_class = WEIGHT_CLASS_NORMAL

--- a/code/game/objects/items/RCL.dm
+++ b/code/game/objects/items/RCL.dm
@@ -8,7 +8,7 @@
 	var/obj/item/stack/pipe_cleaner_coil/loaded
 	opacity = FALSE
 	force = 5 //Plastic is soft
-	throwforce =5
+	throwforce =2
 	throw_speed = 1
 	throw_range = 7
 	w_class = WEIGHT_CLASS_NORMAL

--- a/code/game/objects/items/RPD.dm
+++ b/code/game/objects/items/RPD.dm
@@ -189,7 +189,7 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'
 	flags_1 = CONDUCT_1
 	force = 10
-	throwforce = 10
+	throwforce = 2
 	throw_speed = 1
 	throw_range = 5
 	w_class = WEIGHT_CLASS_NORMAL

--- a/code/game/objects/items/broom.dm
+++ b/code/game/objects/items/broom.dm
@@ -9,7 +9,7 @@
 	lefthand_file = 'icons/mob/inhands/equipment/custodial_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/custodial_righthand.dmi'
 	force = 8
-	throwforce = 10
+	throwforce = 3
 	throw_speed = 3
 	throw_range = 7
 	w_class = WEIGHT_CLASS_NORMAL

--- a/code/game/objects/items/courtroom.dm
+++ b/code/game/objects/items/courtroom.dm
@@ -8,7 +8,7 @@
 	icon = 'icons/obj/items_and_weapons.dmi'
 	icon_state = "gavelhammer"
 	force = 5
-	throwforce = 6
+	throwforce = 3
 	w_class = WEIGHT_CLASS_SMALL
 	attack_verb_continuous = list("bashes", "batters", "judges", "whacks")
 	attack_verb_simple = list("bash", "batter", "judge", "whack")

--- a/code/game/objects/items/defib.dm
+++ b/code/game/objects/items/defib.dm
@@ -12,7 +12,7 @@
 	righthand_file = 'icons/mob/inhands/equipment/medical_righthand.dmi'
 	slot_flags = ITEM_SLOT_BACK
 	force = 5
-	throwforce = 6
+	throwforce = 2
 	w_class = WEIGHT_CLASS_BULKY
 	actions_types = list(/datum/action/item_action/toggle_paddles)
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 50, ACID = 50)
@@ -295,7 +295,7 @@
 	righthand_file = 'icons/mob/inhands/equipment/medical_righthand.dmi'
 
 	force = 0
-	throwforce = 6
+	throwforce = 2
 	w_class = WEIGHT_CLASS_BULKY
 	resistance_flags = INDESTRUCTIBLE
 	base_icon_state = "defibpaddles"

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -89,7 +89,7 @@ GENE SCANNER
 	flags_1 = CONDUCT_1
 	item_flags = NOBLUDGEON
 	slot_flags = ITEM_SLOT_BELT
-	throwforce = 3
+	throwforce = 1
 	w_class = WEIGHT_CLASS_TINY
 	throw_speed = 3
 	throw_range = 7
@@ -855,7 +855,7 @@ GENE SCANNER
 	flags_1 = CONDUCT_1
 	item_flags = NOBLUDGEON
 	slot_flags = ITEM_SLOT_BELT
-	throwforce = 3
+	throwforce = 1
 	w_class = WEIGHT_CLASS_TINY
 	throw_speed = 3
 	throw_range = 7
@@ -883,7 +883,7 @@ GENE SCANNER
 	flags_1 = CONDUCT_1
 	item_flags = NOBLUDGEON
 	slot_flags = ITEM_SLOT_BELT
-	throwforce = 3
+	throwforce = 1
 	w_class = WEIGHT_CLASS_TINY
 	throw_speed = 3
 	throw_range = 7

--- a/code/game/objects/items/extinguisher.dm
+++ b/code/game/objects/items/extinguisher.dm
@@ -6,7 +6,7 @@
 	inhand_icon_state = "fire_extinguisher"
 	hitsound = 'sound/weapons/smash.ogg'
 	flags_1 = CONDUCT_1
-	throwforce = 10
+	throwforce = 3
 	w_class = WEIGHT_CLASS_NORMAL
 	throw_speed = 2
 	throw_range = 7

--- a/code/game/objects/items/mop.dm
+++ b/code/game/objects/items/mop.dm
@@ -6,7 +6,7 @@
 	lefthand_file = 'icons/mob/inhands/equipment/custodial_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/custodial_righthand.dmi'
 	force = 8
-	throwforce = 10
+	throwforce = 3
 	throw_speed = 3
 	throw_range = 7
 	w_class = WEIGHT_CLASS_NORMAL
@@ -94,7 +94,7 @@
 	lefthand_file = 'icons/mob/inhands/equipment/custodial_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/custodial_righthand.dmi'
 	force = 12
-	throwforce = 14
+	throwforce = 3
 	throw_range = 4
 	mopspeed = 8
 	var/refill_enabled = TRUE //Self-refill toggle for when a janitor decides to mop with something other than water.

--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -14,7 +14,7 @@ GLOBAL_LIST_INIT(rod_recipes, list ( \
 	flags_1 = CONDUCT_1
 	w_class = WEIGHT_CLASS_NORMAL
 	force = 9
-	throwforce = 10
+	throwforce = 3
 	throw_speed = 3
 	throw_range = 7
 	mats_per_unit = list(/datum/material/iron=1000)

--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -366,7 +366,7 @@ GLOBAL_LIST_INIT(plastitaniumglass_recipes, list(
 	name = "purple shard"
 	desc = "A nasty looking shard of plasma glass."
 	force = 6
-	throwforce = 11
+	throwforce = 4
 	icon_state = "plasmalarge"
 	custom_materials = list(/datum/material/alloy/plasmaglass=MINERAL_MATERIAL_AMOUNT)
 	icon_prefix = "plasma"

--- a/code/game/objects/items/stacks/sheets/light.dm
+++ b/code/game/objects/items/stacks/sheets/light.dm
@@ -6,7 +6,7 @@
 	icon_state = "glass_wire"
 	w_class = WEIGHT_CLASS_NORMAL
 	force = 3
-	throwforce = 5
+	throwforce = 3
 	throw_speed = 3
 	throw_range = 7
 	flags_1 = CONDUCT_1

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -123,7 +123,7 @@ GLOBAL_LIST_INIT(skeld_metal_recipes, list ( \
 	icon_state = "sheet-metal"
 	inhand_icon_state = "sheet-metal"
 	mats_per_unit = list(/datum/material/iron=MINERAL_MATERIAL_AMOUNT)
-	throwforce = 10
+	throwforce = 2
 	flags_1 = CONDUCT_1
 	resistance_flags = FIRE_PROOF
 	merge_type = /obj/item/stack/sheet/metal
@@ -182,7 +182,7 @@ GLOBAL_LIST_INIT(plasteel_recipes, list ( \
 	inhand_icon_state = "sheet-plasteel"
 	mats_per_unit = list(/datum/material/alloy/plasteel=MINERAL_MATERIAL_AMOUNT)
 	material_type = /datum/material/alloy/plasteel
-	throwforce = 10
+	throwforce = 2
 	flags_1 = CONDUCT_1
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 100, ACID = 80)
 	resistance_flags = FIRE_PROOF
@@ -286,7 +286,7 @@ GLOBAL_LIST_INIT(bamboo_recipes, list())
 	inhand_icon_state = "sheet-bamboo"
 	icon = 'icons/obj/stack_objects.dmi'
 	mats_per_unit = list(/datum/material/bamboo = MINERAL_MATERIAL_AMOUNT)
-	throwforce = 15
+	throwforce = 3
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 50, ACID = 0)
 	resistance_flags = FLAMMABLE
 	merge_type = /obj/item/stack/sheet/mineral/bamboo
@@ -608,7 +608,7 @@ GLOBAL_LIST_INIT(bronze_recipes, list ( \
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 	sheettype = "bronze"
 	force = 5
-	throwforce = 10
+	throwforce = 2
 	max_amount = 50
 	throw_speed = 1
 	throw_range = 3
@@ -665,7 +665,7 @@ GLOBAL_LIST_INIT(bronze_recipes, list ( \
 	singular_name = "bone"
 	desc = "Someone's been drinking their milk."
 	force = 7
-	throwforce = 5
+	throwforce = 1
 	max_amount = 12
 	w_class = WEIGHT_CLASS_NORMAL
 	throw_speed = 1
@@ -690,7 +690,7 @@ GLOBAL_LIST_INIT(plastic_recipes, list(
 	icon_state = "sheet-plastic"
 	inhand_icon_state = "sheet-plastic"
 	mats_per_unit = list(/datum/material/plastic=MINERAL_MATERIAL_AMOUNT)
-	throwforce = 7
+	throwforce = 1
 	material_type = /datum/material/plastic
 	merge_type = /obj/item/stack/sheet/plastic
 

--- a/code/game/objects/items/stacks/sheets/sheets.dm
+++ b/code/game/objects/items/stacks/sheets/sheets.dm
@@ -4,7 +4,7 @@
 	righthand_file = 'icons/mob/inhands/misc/sheets_righthand.dmi'
 	full_w_class = WEIGHT_CLASS_NORMAL
 	force = 5
-	throwforce = 5
+	throwforce = 1
 	max_amount = 50
 	throw_speed = 1
 	throw_range = 3

--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -396,7 +396,7 @@
 	inhand_icon_state = "tile"
 	force = 6
 	mats_per_unit = list(/datum/material/iron=500)
-	throwforce = 10
+	throwforce = 2
 	flags_1 = CONDUCT_1
 	turf_type = /turf/open/floor/plasteel
 	mineralType = "metal"
@@ -420,7 +420,7 @@
 	name = "floor tile"
 	singular_name = "floor tile"
 	desc = "The ground you walk on."
-	throwforce = 10
+	throwforce = 2
 	icon_state = "material_tile"
 	turf_type = /turf/open/floor/material
 	material_flags = MATERIAL_ADD_PREFIX | MATERIAL_COLOR | MATERIAL_AFFECT_STATISTICS

--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -311,7 +311,7 @@
 	worn_icon_state = "tray"
 	desc = "A metal tray to lay food on."
 	force = 3
-	throwforce = 5
+	throwforce = 3
 	throw_speed = 3
 	throw_range = 5
 	flags_1 = CONDUCT_1

--- a/code/game/objects/items/storage/toolbox.dm
+++ b/code/game/objects/items/storage/toolbox.dm
@@ -7,7 +7,7 @@
 	righthand_file = 'icons/mob/inhands/equipment/toolbox_righthand.dmi'
 	flags_1 = CONDUCT_1
 	force = 6
-	throwforce = 6
+	throwforce = 4
 	throw_speed = 2
 	throw_range = 7
 	w_class = WEIGHT_CLASS_BULKY

--- a/code/game/objects/items/tools/crowbar.dm
+++ b/code/game/objects/items/tools/crowbar.dm
@@ -9,7 +9,7 @@
 	flags_1 = CONDUCT_1
 	slot_flags = ITEM_SLOT_BELT
 	force = 3
-	throwforce = 4
+	throwforce = 2
 	w_class = WEIGHT_CLASS_SMALL
 	custom_materials = list(/datum/material/iron=50)
 	drop_sound = 'sound/items/handling/crowbar_drop.ogg'

--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -12,7 +12,7 @@
 	flags_1 = CONDUCT_1
 	slot_flags = ITEM_SLOT_BELT
 	force = 2
-	throwforce = 4
+	throwforce = 2
 	hitsound = "swing_hit"
 	usesound = list('sound/items/welder.ogg', 'sound/items/welder2.ogg')
 	drop_sound = 'sound/items/handling/weldingtool_drop.ogg'

--- a/code/game/objects/items/tools/wrench.dm
+++ b/code/game/objects/items/tools/wrench.dm
@@ -9,7 +9,7 @@
 	flags_1 = CONDUCT_1
 	slot_flags = ITEM_SLOT_BELT
 	force = 2
-	throwforce = 4
+	throwforce = 2
 	w_class = WEIGHT_CLASS_SMALL
 	usesound = 'sound/items/ratchet.ogg'
 	custom_materials = list(/datum/material/iron=150)

--- a/code/game/objects/items/vending_items.dm
+++ b/code/game/objects/items/vending_items.dm
@@ -13,7 +13,7 @@
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
 	flags_1 = CONDUCT_1
 	force = 7
-	throwforce = 10
+	throwforce = 2
 	throw_speed = 1
 	throw_range = 7
 	w_class = WEIGHT_CLASS_BULKY

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -273,7 +273,7 @@
 	righthand_file = 'icons/mob/inhands/misc/chairs_righthand.dmi'
 	w_class = WEIGHT_CLASS_HUGE
 	force = 8
-	throwforce = 10
+	throwforce = 4
 	throw_range = 3
 	hitsound = 'sound/items/trayhit1.ogg'
 	hit_reaction_chance = 50

--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -307,8 +307,8 @@
 	desc = "A little bit of nature contained in a pot."
 	layer = ABOVE_MOB_LAYER
 	w_class = WEIGHT_CLASS_HUGE
-	force = 10
-	throwforce = 13
+	force = 4
+	throwforce = 2
 	throw_speed = 2
 	throw_range = 4
 	item_flags = NO_PIXEL_RANDOM_DROP

--- a/code/game/objects/structures/statues.dm
+++ b/code/game/objects/structures/statues.dm
@@ -301,7 +301,7 @@
 	slot_flags = ITEM_SLOT_BELT
 	force = 5
 	w_class = WEIGHT_CLASS_TINY
-	throwforce = 5
+	throwforce = 2
 	throw_speed = 3
 	throw_range = 5
 	custom_materials = list(/datum/material/iron=75)

--- a/code/modules/antagonists/wizard/equipment/artefact.dm
+++ b/code/modules/antagonists/wizard/equipment/artefact.dm
@@ -161,7 +161,7 @@
 	icon_state ="bluespace"
 	throw_speed = 3
 	throw_range = 7
-	throwforce = 15
+	throwforce = 4
 	damtype = FIRE
 	force = 15
 	hitsound = 'sound/items/welder2.ogg'

--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -47,8 +47,8 @@
 	hitsound = 'sound/weapons/tap.ogg'
 	var/hitsound_on = 'sound/weapons/sear.ogg' //so we can differentiate between cakehat and energyhat
 	var/hitsound_off = 'sound/weapons/tap.ogg'
-	var/force_on = 15
-	var/throwforce_on = 15
+	var/force_on = 6
+	var/throwforce_on = 4
 	var/damtype_on = FIRE
 	flags_inv = HIDEEARS|HIDEHAIR
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0,ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 0, ACID = 0)

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -536,7 +536,7 @@
 	lefthand_file = 'icons/mob/inhands/equipment/custodial_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/custodial_righthand.dmi'
 	force = 1
-	throwforce = 3
+	throwforce = 2
 	throw_speed = 2
 	throw_range = 5
 	w_class = WEIGHT_CLASS_SMALL

--- a/code/modules/food_and_drinks/drinks/drinks/bottle.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/bottle.dm
@@ -13,7 +13,7 @@
 	amount_per_transfer_from_this = 10
 	volume = 100
 	force = 15 //Smashing bottles over someone's head hurts.
-	throwforce = 15
+	throwforce = 3
 	inhand_icon_state = "broken_beer" //Generic held-item sprite until unique ones are made.
 	lefthand_file = 'icons/mob/inhands/misc/food_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/food_righthand.dmi'
@@ -139,7 +139,7 @@
 	icon = 'icons/obj/drinks.dmi'
 	icon_state = "broken_bottle"
 	force = 9
-	throwforce = 5
+	throwforce = 4
 	throw_speed = 3
 	throw_range = 5
 	w_class = WEIGHT_CLASS_TINY

--- a/code/modules/hydroponics/grown/nettle.dm
+++ b/code/modules/hydroponics/grown/nettle.dm
@@ -26,7 +26,7 @@
 	damtype = FIRE
 	force = 15
 	hitsound = 'sound/weapons/bladeslice.ogg'
-	throwforce = 5
+	throwforce = 2
 	w_class = WEIGHT_CLASS_TINY
 	throw_speed = 1
 	throw_range = 3

--- a/code/modules/hydroponics/grown/pineapple.dm
+++ b/code/modules/hydroponics/grown/pineapple.dm
@@ -20,7 +20,7 @@
 	desc = "Blorble."
 	icon_state = "pineapple"
 	force = 4
-	throwforce = 8
+	throwforce = 2
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb_continuous = list("stings", "pines")
 	attack_verb_simple = list("sting", "pine")

--- a/code/modules/hydroponics/grown/towercap.dm
+++ b/code/modules/hydroponics/grown/towercap.dm
@@ -39,7 +39,7 @@
 	desc = "It's better than bad, it's good!"
 	icon_state = "logs"
 	force = 5
-	throwforce = 5
+	throwforce = 2
 	w_class = WEIGHT_CLASS_NORMAL
 	throw_speed = 2
 	throw_range = 3

--- a/code/modules/mining/equipment/mining_tools.dm
+++ b/code/modules/mining/equipment/mining_tools.dm
@@ -6,7 +6,7 @@
 	flags_1 = CONDUCT_1
 	slot_flags = ITEM_SLOT_BELT | ITEM_SLOT_BACK
 	force = 5
-	throwforce = 10
+	throwforce = 5
 	inhand_icon_state = "pickaxe"
 	worn_icon_state = "pickaxe"
 	lefthand_file = 'icons/mob/inhands/equipment/mining_lefthand.dmi'

--- a/code/modules/mob/living/carbon/human/species_types/dullahan.dm
+++ b/code/modules/mob/living/carbon/human/species_types/dullahan.dm
@@ -27,7 +27,7 @@
 	if(head)
 		head.drop_limb()
 		if(!QDELETED(head)) //drop_limb() deletes the limb if no drop location exists and character setup dummies are located in nullspace.
-			head.throwforce = 25
+			head.throwforce = 2
 			myhead = new /obj/item/dullahan_relay (head, H)
 			H.put_in_hands(head)
 			var/obj/item/organ/eyes/E = H.getorganslot(ORGAN_SLOT_EYES)

--- a/code/modules/mob/living/simple_animal/abnormality/he/doomsday_calendar.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/doomsday_calendar.dm
@@ -118,7 +118,7 @@
 	if(IsContained() && datum_reference.qliphoth_meter != datum_reference.qliphoth_meter_max)
 		if(do_after(user, gibtime, target = src))
 			to_chat(user, span_warning("[src] bites you! It seems to have been appeased."))
-			user.adjustBruteLoss(75 - (datum_reference.qliphoth_meter * 15))
+			user.adjustBruteLoss(18 - (datum_reference.qliphoth_meter * 4))
 			datum_reference.qliphoth_change(1)
 			return
 		else
@@ -160,7 +160,7 @@
 	if(work_type != ABNORMALITY_WORK_INSTINCT)// Sets bonus damage on instinct work only.
 		bonusRed = 0
 		return..()
-	bonusRed = (5 - (datum_reference.qliphoth_meter))//It samples your blood if it's below the maximum counter, damage is RED instead of typeless
+	bonusRed = (2.5 - (datum_reference.qliphoth_meter / 2))//It samples your blood if it's below the maximum counter, damage is RED instead of typeless
 	if(bonusRed)
 		to_chat(user, span_warning("A clay doll arrives with a bowl, demanding blood."))
 		playsound(src, 'sound/abnormalities/doomsdaycalendar/Lor_Slash_Generic.ogg', 40, 0, 1)

--- a/code/modules/mob/living/simple_animal/bot/construction.dm
+++ b/code/modules/mob/living/simple_animal/bot/construction.dm
@@ -168,7 +168,7 @@
 	desc = "It's a toolbox with tiles sticking out the top."
 	name = "tiles and toolbox"
 	icon_state = "toolbox_tiles"
-	throwforce = 10
+	throwforce = 3
 	created_name = "Floorbot"
 	var/toolbox = /obj/item/storage/toolbox/mechanical
 	var/toolbox_color = "" //Blank for blue, r for red, y for yellow, etc.

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -15,7 +15,7 @@
 	hud_possible = list(ANTAG_HUD)
 	pressure_resistance = 8
 	mouse_drag_pointer = MOUSE_ACTIVE_POINTER
-	throwforce = 10
+	throwforce = 2
 	blocks_emissive = EMISSIVE_BLOCK_GENERIC
 	pass_flags_self = PASSMOB
 

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -11,7 +11,7 @@
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
 	force = 5
-	throwforce = 5
+	throwforce = 4
 	throw_speed = 2
 	throw_range = 5
 	w_class = WEIGHT_CLASS_SMALL

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -850,7 +850,7 @@
 /obj/item/light
 	icon = 'icons/obj/lighting.dmi'
 	force = 2
-	throwforce = 5
+	throwforce = 2
 	w_class = WEIGHT_CLASS_TINY
 	var/status = LIGHT_OK		// LIGHT_OK, LIGHT_BURNED or LIGHT_BROKEN
 	var/base_state


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

What it says on the tin. Specifically nerfs the abnormalities Doomsday Calendar and Sirocco- both of whom require nerfs to some of their damage sources.

Damage from Doomsday Calendar Funpet interaction reduced from **(75 - (qliphoth counte * 15))** to (18 - (qliphoth counter * 4))

RED damage from Doomsday Calendar instinct work reduced from **(5 - (qliphoth counter ))** to **(2.5 - 1/2( qliphoth counter))**

Reduces the throwforce of mobs from 10 to 2 (clerks only have 20 max HP)

Reduces the throwforce of many miscellaneous objects such as mops to a range of 2-5.

Throwforce amounts need to be collaborated with https://github.com/vlggms/lobotomy-corp13/pull/3079/files

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Dying in two hits from having your buddy slammed into you by cleaner is bad for the game.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: rebalanced sirocco and doomsday calendar
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
