### PR TITLE
Fixes YMBS reviving too many times and reduces its damage dealt

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/he/pink_shoes.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/pink_shoes.dm
@@ -250,7 +250,7 @@ GLOBAL_LIST_EMPTY(ribbon_list)
 		special_possessee.update_icon()
 		special_possessee.gear = 10
 		special_possessee.UpdateGear()
-		special_possessee.gear_health = 0.5
+		special_possessee.gear_health = 1//Sets the gear to 10 and prevents surgery from triggering more than once. We'll give it more HP to compensate on 257
 		special_possessee.name = pick("Clippity-cloppity", "Tap-tap", "Twinkle")+pick("? Tap away!", "? Thoroughly?!", "? Sprinkle Spinny!?")
 	else
 		RibbonVisual(user)

--- a/code/modules/mob/living/simple_animal/abnormality/he/you_strong.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/you_strong.dm
@@ -279,7 +279,7 @@
 	var/gear_cooldown = 1 MINUTES
 	//tracks speed change even if altered by other speed modifiers.
 	var/gear_speed = 0
-	var/gear_health = 0.25 // The percentage of maximum HP you can trigger surgery with, pink shoes modifies this.
+	var/gear_health = 0.35 // This determines the amount of times surgery can activate. If the max HP is lower than this percentage, the creature will gib.
 	var/can_act = TRUE//necessary sanity for spin attacks
 
 /mob/living/simple_animal/hostile/grown_strong/Move(atom/newloc, dir, step_x, step_y)
@@ -302,8 +302,8 @@
 
 /mob/living/simple_animal/hostile/grown_strong/proc/UpdateGear()
 	manual_emote("shifts into [gear]\th gear!")
-	melee_damage_lower = 3 * max(1, gear*0.75)
-	melee_damage_upper = 5 * max(1, gear*0.75)
+	melee_damage_lower = 2 * max(1, gear*0.5)
+	melee_damage_upper = 4 * max(1, gear*0.5)
 	//Reset the speed. First proc changes this only with 0.
 	ChangeMoveToDelayBy(gear_speed)
 	//Calculate speed change.
@@ -332,7 +332,7 @@
 
 /mob/living/simple_animal/hostile/grown_strong/proc/Undie()
 	manual_emote("shudders to a hault, insides whirling...")
-	src.maxHealth = max(maxHealth - initial(maxHealth) * 0.2, initial(maxHealth))
+	src.maxHealth = min(maxHealth - initial(maxHealth) * 0.2, initial(maxHealth))
 	src.adjustBruteLoss(-9999)
 	status_flags |= GODMODE
 	SLEEP_CHECK_DEATH(3 SECONDS)


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

What it says on the tin.

Surgery max HP threshold was raised from 25% to 35%, and a proc in undie() was corrected. The pink shoes version will now also trigger surgery less times.

Melee damage from gear shifts hasn't been properly adjusted by the HP update, it has been changed from a starting value
of 2-5 to 2-4. Gear damage multipliers have been reduced from (gear * 0.75 )to (gear * 0.5)

Damage dealt by its spin attack is unchanged.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixing bugs is generally good for the game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: lowers the damage of YMBS minions
fix: fixes YMBS's surgery reviving itself infinitely
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
