### PR TITLE
District4 disposals area fix

### DIFF
--- a/_maps/map_files/Enkephalin_Rush/district_4.dmm
+++ b/_maps/map_files/Enkephalin_Rush/district_4.dmm
@@ -92,7 +92,7 @@
 /area/department_main/control)
 "as" = (
 /turf/closed/mineral/random/facility,
-/area/maintenance/disposal)
+/area/city/backstreets_room)
 "at" = (
 /obj/structure/fluff/bus/dense{
 	icon_state = "fronttire"
@@ -121,7 +121,7 @@
 "aA" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/indestructible/reinforced/old,
-/area/maintenance/disposal)
+/area/city/backstreets_room)
 "aC" = (
 /mob/living/simple_animal/hostile/humanoid/rat/zippy,
 /obj/effect/decal/cleanable/dirt,
@@ -380,7 +380,7 @@
 	baseturfs = /turf/open/floor/plating/asteroid;
 	name = "rocky rubble"
 	},
-/area/maintenance/disposal)
+/area/city/backstreets_room)
 "bx" = (
 /obj/structure/sign/directions/evac{
 	pixel_y = -32
@@ -421,7 +421,7 @@
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/bottle/holywater,
 /turf/open/floor/carpet,
-/area/surface_ruins/underground)
+/area/city/backstreets_room)
 "bE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/broken{
@@ -1114,7 +1114,7 @@
 	dir = 9
 	},
 /turf/open/floor/grass,
-/area/surface_ruins/underground)
+/area/city/backstreets_room)
 "ef" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/rust,
@@ -1460,7 +1460,7 @@
 "fn" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/mineral/random/facility,
-/area/maintenance/disposal)
+/area/city/backstreets_room)
 "fo" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/mineral/random/facility/briah,
@@ -1578,7 +1578,7 @@
 "fH" = (
 /obj/machinery/computer/security/wooden_tv,
 /turf/open/floor/carpet,
-/area/surface_ruins/underground)
+/area/city/backstreets_room)
 "fJ" = (
 /obj/effect/turf_decal/siding/blue{
 	dir = 1
@@ -2107,7 +2107,7 @@
 	pixel_x = 31
 	},
 /turf/open/floor/plasteel/dark,
-/area/maintenance/disposal)
+/area/city/backstreets_room)
 "hN" = (
 /obj/effect/turf_decal/siding/green{
 	dir = 6
@@ -2299,7 +2299,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
-/area/maintenance/disposal)
+/area/city/backstreets_room)
 "iE" = (
 /obj/machinery/computer/med_data{
 	dir = 1
@@ -2414,7 +2414,7 @@
 	},
 /obj/machinery/recycler,
 /turf/open/floor/plating,
-/area/maintenance/disposal)
+/area/city/backstreets_room)
 "iX" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -2648,7 +2648,7 @@
 	set_luminosity = 24
 	},
 /turf/open/floor/carpet,
-/area/surface_ruins/underground)
+/area/city/backstreets_room)
 "jQ" = (
 /obj/structure/mirror{
 	pixel_y = 32
@@ -3043,7 +3043,7 @@
 /turf/closed/mineral/random/facility/abnormality{
 	risk_level = 2
 	},
-/area/maintenance/disposal)
+/area/city/backstreets_room)
 "lj" = (
 /obj/machinery/door/airlock/medical{
 	name = "medbay"
@@ -3143,7 +3143,7 @@
 	id = "welfaregarbage"
 	},
 /turf/open/floor/plating,
-/area/maintenance/disposal)
+/area/city/backstreets_room)
 "lz" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/emergency,
@@ -3170,7 +3170,7 @@
 "lG" = (
 /obj/structure/sign/poster/official/cleanliness,
 /turf/closed/indestructible/reinforced/old,
-/area/maintenance/disposal)
+/area/city/backstreets_room)
 "lH" = (
 /obj/structure/toilet{
 	pixel_y = 15
@@ -3332,7 +3332,7 @@
 	},
 /obj/item/toy/plush/fumo,
 /turf/open/floor/plasteel/dark,
-/area/maintenance/disposal)
+/area/city/backstreets_room)
 "ml" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/siding/yellow,
@@ -3548,7 +3548,7 @@
 	dir = 5
 	},
 /turf/open/floor/grass,
-/area/surface_ruins/underground)
+/area/city/backstreets_room)
 "nc" = (
 /obj/effect/turf_decal/siding/yellow,
 /obj/structure/disposalpipe/broken{
@@ -3603,7 +3603,7 @@
 	baseturfs = /turf/open/floor/plating/asteroid;
 	name = "rocky rubble"
 	},
-/area/maintenance/disposal)
+/area/city/backstreets_room)
 "np" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/extraction_belt,
@@ -3924,7 +3924,7 @@
 	pixel_x = 31
 	},
 /turf/closed/indestructible/reinforced/old,
-/area/maintenance/disposal)
+/area/city/backstreets_room)
 "oy" = (
 /obj/effect/turf_decal/siding/red{
 	dir = 1
@@ -4467,7 +4467,7 @@
 "qf" = (
 /obj/effect/turf_decal/siding/wood/corner,
 /turf/open/floor/grass,
-/area/surface_ruins/underground)
+/area/city/backstreets_room)
 "qg" = (
 /obj/structure/disposalpipe/junction/flip{
 	dir = 2
@@ -4636,7 +4636,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/maint_drugs,
 /turf/closed/mineral/random/facility,
-/area/maintenance/disposal)
+/area/city/backstreets_room)
 "qO" = (
 /turf/open/floor/carpet/orange,
 /area/department_main/training)
@@ -4950,7 +4950,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/disposal)
+/area/city/backstreets_room)
 "sg" = (
 /obj/structure/rack,
 /obj/item/ego_weapon/ranged/clerk,
@@ -5268,7 +5268,7 @@
 "to" = (
 /obj/structure/sign/poster/ripped,
 /turf/closed/indestructible/reinforced/old,
-/area/maintenance/disposal)
+/area/city/backstreets_room)
 "tp" = (
 /obj/broken_regenerator,
 /turf/closed/mineral/random/facility/briah,
@@ -5380,7 +5380,7 @@
 	id = "welfaregarbage"
 	},
 /turf/open/floor/plating,
-/area/maintenance/disposal)
+/area/city/backstreets_room)
 "tM" = (
 /obj/machinery/light/broken{
 	dir = 4
@@ -5395,7 +5395,7 @@
 	name = "disposal conveyor"
 	},
 /turf/closed/mineral/random/facility,
-/area/maintenance/disposal)
+/area/city/backstreets_room)
 "tO" = (
 /obj/structure/fans/tiny,
 /obj/structure/barricade/wooden,
@@ -5527,7 +5527,7 @@
 "uh" = (
 /obj/structure/sign/warning/chemdiamond,
 /turf/closed/indestructible/wood,
-/area/surface_ruins/underground)
+/area/city/backstreets_room)
 "uj" = (
 /obj/machinery/newscaster{
 	pixel_x = 32
@@ -5792,7 +5792,7 @@
 /area/department_main/safety)
 "vc" = (
 /turf/closed/indestructible/rock,
-/area/maintenance/disposal)
+/area/city/backstreets_room)
 "ve" = (
 /obj/effect/turf_decal/siding/yellow{
 	dir = 10
@@ -5935,11 +5935,11 @@
 	pixel_y = -32
 	},
 /turf/open/floor/plating,
-/area/maintenance/disposal)
+/area/city/backstreets_room)
 "vC" = (
 /obj/structure/sign/warning/enginesafety,
 /turf/closed/indestructible/wood,
-/area/surface_ruins/underground)
+/area/city/backstreets_room)
 "vD" = (
 /obj/effect/turf_decal/siding/yellow{
 	dir = 10
@@ -6920,7 +6920,7 @@
 	dir = 4
 	},
 /turf/open/floor/grass,
-/area/surface_ruins/underground)
+/area/city/backstreets_room)
 "zl" = (
 /obj/structure/sink{
 	dir = 8;
@@ -7085,7 +7085,7 @@
 	},
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating,
-/area/maintenance/disposal)
+/area/city/backstreets_room)
 "zR" = (
 /obj/structure/chair/office,
 /turf/open/floor/carpet/red,
@@ -7352,7 +7352,7 @@
 	baseturfs = /turf/open/floor/plating/asteroid;
 	name = "rocky rubble"
 	},
-/area/maintenance/disposal)
+/area/city/backstreets_room)
 "AG" = (
 /obj/machinery/computer/extraction_cargo,
 /turf/open/floor/pod,
@@ -7764,7 +7764,6 @@
 /area/facility_hallway/welfare)
 "Cl" = (
 /obj/effect/turf_decal/box/white,
-/obj/structure/toolabnormality/touch,
 /turf/closed/mineral/random/facility/briah,
 /area/department_main/records)
 "Cm" = (
@@ -7971,7 +7970,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/mineral/random/facility,
-/area/maintenance/disposal)
+/area/city/backstreets_room)
 "Dc" = (
 /obj/structure/sign/poster/ripped,
 /turf/closed/indestructible/reinforced/old,
@@ -8155,7 +8154,7 @@
 	dir = 4
 	},
 /turf/open/floor/grass,
-/area/surface_ruins/underground)
+/area/city/backstreets_room)
 "DL" = (
 /obj/effect/turf_decal/siding/yellow{
 	dir = 1
@@ -8222,7 +8221,7 @@
 	dir = 8
 	},
 /turf/open/floor/grass,
-/area/surface_ruins/underground)
+/area/city/backstreets_room)
 "DT" = (
 /obj/machinery/computer/slot_machine,
 /turf/open/floor/carpet/donk,
@@ -8368,7 +8367,7 @@
 	dir = 8
 	},
 /turf/open/floor/grass,
-/area/surface_ruins/underground)
+/area/city/backstreets_room)
 "Eu" = (
 /obj/effect/turf_decal/siding/yellow,
 /turf/open/floor/plasteel/dark,
@@ -8414,6 +8413,10 @@
 /obj/effect/mob_spawn/human/manager,
 /turf/open/floor/pod,
 /area/facility_hallway/manager)
+"EG" = (
+/obj/structure/toolabnormality/touch,
+/turf/open/floor/plasteel/dark,
+/area/city)
 "EI" = (
 /obj/effect/turf_decal/siding/blue/corner{
 	dir = 8
@@ -8730,7 +8733,7 @@
 	dir = 7
 	},
 /turf/open/floor/grass,
-/area/surface_ruins/underground)
+/area/city/backstreets_room)
 "FV" = (
 /obj/effect/turf_decal/plaque{
 	alpha = 230;
@@ -8764,7 +8767,7 @@
 "Gc" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
-/area/maintenance/disposal)
+/area/city/backstreets_room)
 "Ge" = (
 /obj/item/rawpe,
 /obj/item/rawpe,
@@ -8816,7 +8819,7 @@
 	dir = 10
 	},
 /turf/open/floor/grass,
-/area/surface_ruins/underground)
+/area/city/backstreets_room)
 "Gn" = (
 /obj/effect/turf_decal/siding/yellow{
 	dir = 1
@@ -8911,16 +8914,13 @@
 	id = "welfaregarbage"
 	},
 /turf/open/floor/plating,
-/area/maintenance/disposal)
+/area/city/backstreets_room)
 "GG" = (
 /obj/effect/turf_decal/siding/yellow{
 	dir = 4
 	},
 /turf/closed/mineral/random/facility,
 /area/department_main/control)
-"GH" = (
-/turf/closed/indestructible/reinforced,
-/area/maintenance/disposal)
 "GI" = (
 /obj/effect/turf_decal/siding/green{
 	dir = 9
@@ -9022,7 +9022,7 @@
 	},
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating,
-/area/maintenance/disposal)
+/area/city/backstreets_room)
 "GY" = (
 /obj/effect/turf_decal/siding/yellow/corner{
 	dir = 4
@@ -9053,7 +9053,7 @@
 	},
 /obj/item/toy/figure/chef,
 /turf/open/floor/carpet,
-/area/surface_ruins/underground)
+/area/city/backstreets_room)
 "Hb" = (
 /obj/item/reagent_containers/syringe/contraband/fentanyl,
 /obj/machinery/light/broken{
@@ -9359,7 +9359,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/hatch,
 /turf/open/floor/plasteel/elevatorshaft,
-/area/maintenance/disposal)
+/area/city/backstreets_room)
 "Ii" = (
 /obj/effect/turf_decal/siding/red{
 	dir = 4
@@ -9599,7 +9599,7 @@
 /area/department_main/control)
 "Jg" = (
 /turf/closed/indestructible/wood,
-/area/surface_ruins/underground)
+/area/city/backstreets_room)
 "Ji" = (
 /turf/closed/mineral/iron,
 /area/facility_hallway/control)
@@ -9979,7 +9979,7 @@
 	},
 /obj/item/reagent_containers/glass/bucket,
 /turf/closed/mineral/random/facility,
-/area/maintenance/disposal)
+/area/city/backstreets_room)
 "KC" = (
 /turf/open/floor/plasteel/grimy,
 /area/city/backstreets_room)
@@ -10004,7 +10004,7 @@
 	dir = 1
 	},
 /turf/open/floor/grass,
-/area/surface_ruins/underground)
+/area/city/backstreets_room)
 "KI" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Records Office Secure Area"
@@ -10120,7 +10120,7 @@
 	id = "welfaregarbage"
 	},
 /turf/open/floor/plating,
-/area/maintenance/disposal)
+/area/city/backstreets_room)
 "Lc" = (
 /obj/machinery/light/broken,
 /obj/effect/decal/cleanable/dirt,
@@ -10253,7 +10253,7 @@
 /obj/item/storage/box/lights/mixed,
 /obj/item/mop/advanced,
 /turf/open/floor/plasteel/dark,
-/area/maintenance/disposal)
+/area/city/backstreets_room)
 "Lw" = (
 /obj/machinery/telecomms/server/presets/command,
 /turf/open/floor/circuit/telecomms/mainframe,
@@ -10330,7 +10330,7 @@
 	pixel_y = -1
 	},
 /turf/closed/mineral/random/facility,
-/area/maintenance/disposal)
+/area/city/backstreets_room)
 "LF" = (
 /obj/item/papercutter,
 /obj/structure/table_frame/wood,
@@ -10345,7 +10345,7 @@
 	id = "trainingfurnace"
 	},
 /turf/open/floor/plasteel/dark,
-/area/maintenance/disposal)
+/area/city/backstreets_room)
 "LI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -10600,7 +10600,7 @@
 /area/facility_hallway/command)
 "MB" = (
 /turf/closed/indestructible/reinforced/old,
-/area/maintenance/disposal)
+/area/city/backstreets_room)
 "MC" = (
 /obj/effect/turf_decal/siding/yellow,
 /obj/effect/decal/cleanable/dirt,
@@ -11086,7 +11086,7 @@
 /obj/item/mop,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
-/area/maintenance/disposal)
+/area/city/backstreets_room)
 "Os" = (
 /obj/machinery/jukebox{
 	req_access = list()
@@ -11190,7 +11190,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/maintenance/disposal)
+/area/city/backstreets_room)
 "OL" = (
 /obj/effect/turf_decal/siding/green{
 	dir = 10
@@ -11224,9 +11224,6 @@
 /obj/structure/table/wood/fancy/blue,
 /turf/open/floor/carpet/royalblue,
 /area/department_main/command)
-"OR" = (
-/turf/open/floor/carpet,
-/area/surface_ruins/underground)
 "OT" = (
 /obj/effect/landmark/start,
 /obj/effect/decal/cleanable/dirt,
@@ -11321,7 +11318,7 @@
 	dir = 5
 	},
 /turf/closed/indestructible/reinforced/old,
-/area/maintenance/disposal)
+/area/city/backstreets_room)
 "Pk" = (
 /obj/effect/turf_decal/siding/blue{
 	dir = 4
@@ -11376,7 +11373,7 @@
 	id = "controlgarbage"
 	},
 /turf/open/floor/plating,
-/area/maintenance/disposal)
+/area/city/backstreets_room)
 "PA" = (
 /obj/machinery/newscaster{
 	pixel_y = 32
@@ -11415,7 +11412,7 @@
 	baseturfs = /turf/open/floor/plating/asteroid;
 	name = "rocky rubble"
 	},
-/area/maintenance/disposal)
+/area/city/backstreets_room)
 "PF" = (
 /obj/structure/table/glass,
 /obj/item/documents,
@@ -11496,7 +11493,7 @@
 	dir = 1
 	},
 /turf/open/floor/grass,
-/area/surface_ruins/underground)
+/area/city/backstreets_room)
 "PT" = (
 /obj/structure/fluff/bus/dense{
 	icon_state = "frontwallbottomrear"
@@ -11606,7 +11603,7 @@
 	},
 /obj/structure/table/wood,
 /turf/open/floor/carpet,
-/area/surface_ruins/underground)
+/area/city/backstreets_room)
 "Ql" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/white,
@@ -11651,7 +11648,7 @@
 /obj/effect/turf_decal/bot,
 /obj/item/lightreplacer,
 /turf/closed/mineral/random/facility,
-/area/maintenance/disposal)
+/area/city/backstreets_room)
 "Qy" = (
 /obj/effect/turf_decal/siding/purple,
 /obj/effect/turf_decal/siding/purple{
@@ -11885,7 +11882,7 @@
 	dir = 6
 	},
 /turf/open/floor/grass,
-/area/surface_ruins/underground)
+/area/city/backstreets_room)
 "Rs" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/indestructible/reinforced/old,
@@ -11998,7 +11995,7 @@
 	pixel_y = -1
 	},
 /turf/open/floor/plasteel/dark,
-/area/maintenance/disposal)
+/area/city/backstreets_room)
 "RM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -12341,7 +12338,7 @@
 	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/maintenance/disposal)
+/area/city/backstreets_room)
 "SY" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/dark,
@@ -12442,7 +12439,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/rawpe,
 /turf/open/floor/plasteel/dark,
-/area/maintenance/disposal)
+/area/city/backstreets_room)
 "Tu" = (
 /obj/machinery/camera/autoname,
 /obj/effect/decal/cleanable/dirt,
@@ -12523,7 +12520,7 @@
 "TH" = (
 /obj/structure/sign/poster/contraband/c20r,
 /turf/closed/indestructible/wood,
-/area/surface_ruins/underground)
+/area/city/backstreets_room)
 "TI" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/indestructible/rock,
@@ -12531,7 +12528,7 @@
 "TJ" = (
 /obj/structure/sign/poster/contraband/clown,
 /turf/closed/indestructible/wood,
-/area/surface_ruins/underground)
+/area/city/backstreets_room)
 "TK" = (
 /obj/effect/decal/cleanable/food/flour,
 /turf/open/floor/plating/rust,
@@ -12730,7 +12727,7 @@
 /area/city)
 "Ul" = (
 /turf/open/floor/plating,
-/area/maintenance/disposal)
+/area/city/backstreets_room)
 "Um" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating/rust,
@@ -12753,7 +12750,7 @@
 "Ur" = (
 /obj/structure/sign/poster/official/anniversary_vintage_reprint,
 /turf/closed/indestructible/wood,
-/area/surface_ruins/underground)
+/area/city/backstreets_room)
 "Ut" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/telecomms/hub/preset,
@@ -12821,7 +12818,7 @@
 	dir = 4
 	},
 /turf/closed/indestructible/reinforced/old,
-/area/maintenance/disposal)
+/area/city/backstreets_room)
 "UH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -12905,7 +12902,7 @@
 	dir = 4
 	},
 /turf/closed/indestructible/reinforced/old,
-/area/maintenance/disposal)
+/area/city/backstreets_room)
 "UX" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -13188,7 +13185,7 @@
 	id = "controlgarbage"
 	},
 /turf/open/floor/plasteel/dark,
-/area/maintenance/disposal)
+/area/city/backstreets_room)
 "Wb" = (
 /obj/machinery/modular_computer/console/preset/research{
 	name = "information department console"
@@ -13278,7 +13275,7 @@
 /obj/item/reagent_containers/glass/bucket,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
-/area/maintenance/disposal)
+/area/city/backstreets_room)
 "Wt" = (
 /obj/effect/turf_decal/siding/yellow{
 	dir = 4
@@ -13306,7 +13303,7 @@
 	name = "disposal conveyor"
 	},
 /turf/open/floor/plasteel/dark,
-/area/maintenance/disposal)
+/area/city/backstreets_room)
 "Wy" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -13523,7 +13520,7 @@
 "Xp" = (
 /obj/effect/spawner/lootdrop/maint_drugs,
 /turf/closed/mineral/random/facility,
-/area/maintenance/disposal)
+/area/city/backstreets_room)
 "Xq" = (
 /obj/structure/sign/poster/ripped,
 /obj/machinery/button/door/indestructible{
@@ -45033,7 +45030,7 @@ TV
 If
 bf
 WR
-eB
+EG
 VD
 ZL
 ZL
@@ -45732,9 +45729,9 @@ ZL
 ZL
 Jg
 Jg
-CQ
-CQ
-CQ
+vc
+vc
+vc
 Jg
 Jg
 ZL
@@ -46243,12 +46240,12 @@ ZL
 ZL
 ZL
 ZL
-CQ
+vc
 qf
 Rq
-OR
-OR
-OR
+Iy
+Iy
+Iy
 nb
 DK
 Jg
@@ -46500,13 +46497,13 @@ ZL
 ZL
 ZL
 ZL
-CQ
+vc
 FR
-OR
+Iy
 Ha
-OR
+Iy
 Qk
-OR
+Iy
 PS
 Jg
 ZL
@@ -46757,13 +46754,13 @@ ZL
 ZL
 ZL
 ZL
-CQ
+vc
 FR
-OR
-OR
+Iy
+Iy
 jO
-OR
-OR
+Iy
+Iy
 PS
 uh
 ZL
@@ -47016,11 +47013,11 @@ ZL
 ZL
 vC
 FR
-OR
+Iy
 bD
-OR
+Iy
 fH
-OR
+Iy
 PS
 Jg
 ZL
@@ -47274,12 +47271,12 @@ ZL
 Jg
 Es
 Gm
-OR
-OR
-OR
+Iy
+Iy
+Iy
 ee
 KH
-CQ
+vc
 ZL
 zg
 aN
@@ -47535,8 +47532,8 @@ DS
 DS
 DS
 KH
-CQ
-CQ
+vc
+vc
 ZL
 zg
 jZ
@@ -47786,13 +47783,13 @@ zW
 ZL
 ZL
 ZL
-CQ
-CQ
-CQ
-pC
-CQ
-CQ
-CQ
+vc
+vc
+vc
+PE
+vc
+vc
+vc
 ZL
 ZL
 zg
@@ -48045,9 +48042,9 @@ ZL
 ZL
 ZL
 ZL
-CQ
-pC
-CQ
+vc
+PE
+vc
 ZL
 ZL
 ZL
@@ -48302,9 +48299,9 @@ ZL
 ZL
 ZL
 ZL
-CQ
-pC
-CQ
+vc
+PE
+vc
 ZL
 ZL
 ZL
@@ -48559,9 +48556,9 @@ ZL
 ZL
 ZL
 ZL
-CQ
-pC
-CQ
+vc
+PE
+vc
 ZL
 ZL
 ZL
@@ -48816,9 +48813,9 @@ zW
 zW
 zW
 ZL
-CQ
-pC
-CQ
+vc
+PE
+vc
 ZL
 ZL
 ZL
@@ -49073,8 +49070,8 @@ Wn
 CV
 zW
 ZL
-CQ
-pC
+vc
+PE
 vc
 MB
 MB
@@ -49330,8 +49327,8 @@ Df
 ZA
 zW
 ZL
-CQ
-pC
+vc
+PE
 PE
 no
 Qx
@@ -49587,8 +49584,8 @@ CV
 ZA
 zW
 ZL
-CQ
-CQ
+vc
+vc
 vc
 li
 tN
@@ -63721,7 +63718,7 @@ vc
 OK
 Or
 iD
-GH
+zg
 MB
 ML
 sL


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes the areas in the control & welfare departments of District4 into city streets. The original areas had zero gravity.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixing bugs is good for the game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixed zero gravity areas in district4
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
