### PR TITLE
Nerfs Pinocchio's justice.

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/he/pinocchio.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/pinocchio.dm
@@ -138,6 +138,7 @@
 	realboy.real_name = "Pinocchio the Liar"
 	realboy.adjust_all_attribute_levels(100)
 	realboy.adjust_attribute_bonus(FORTITUDE_ATTRIBUTE, 400) // 600 health
+	realboy.adjust_attribute_bonus(JUSTICE_ATTRIBUTE, -100)
 	realboy.health = realboy.maxHealth
 	realboy.alpha = 0
 	realboy.pixel_z = 16


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

What it says on the tin. Lowers pinocchio's justice "bonus" from 100 to 0.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Pinocchio's final damage with Liar's Lyre with its justice attribute was 48, which could easily panic an agent with even prudence II. This PR will halve Pinocchio's damage with melee weapons, resulting in a more reasonable 24 damage from Liar's Lyre.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: reduces pinocchio's justice attribute
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
