### PR TITLE
Containment cells now use the walls of the map they're placed in.

### DIFF
--- a/_maps/templates/abnormality_containment.dmm
+++ b/_maps/templates/abnormality_containment.dmm
@@ -1,6 +1,6 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/turf/closed/indestructible/reinforced,
+/turf/template_noop,
 /area/containment_zone)
 "b" = (
 /obj/machinery/requests_console{
@@ -10,7 +10,7 @@
 /area/containment_zone)
 "c" = (
 /obj/machinery/containment_panel,
-/turf/closed/indestructible/reinforced,
+/turf/template_noop,
 /area/containment_zone)
 "f" = (
 /obj/machinery/door/airlock/vault,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes the containment cell template to use noop tiles instead of iron walls. A few maps use different walls (district4, district21), and this caused their containment cells to appear inconsistent with the surrounding area.

BEFORE:
<img width="831" height="603" alt="image" src="https://github.com/user-attachments/assets/429aae8e-b618-46df-8f3d-19d1d5c158a2" />

AFTER:
<img width="1063" height="677" alt="image" src="https://github.com/user-attachments/assets/6e230a4b-fe3d-4e86-b884-bf3c509818e9" />


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This PR is mostly futureproofing for any new maps or new wall designs being assigned to them. It will improve the appearance of a few existing maps as well.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: containment cells now use the walls of their surroundings
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
