### PR TITLE
Ego armor and shields now show 0 armor values

### DIFF
--- a/ModularTegustation/ego_weapons/melee/subtype/shield.dm
+++ b/ModularTegustation/ego_weapons/melee/subtype/shield.dm
@@ -49,14 +49,10 @@
 	. = ..()
 	if(LAZYLEN(resistances_list)) //armor tags code
 		resistances_list.Cut()
-	if(reductions[1] != 0)
-		resistances_list += list("RED" = reductions[1])
-	if(reductions[2] != 0)
-		resistances_list += list("WHITE" = reductions[2])
-	if(reductions[3] != 0)
-		resistances_list += list("BLACK" = reductions[3])
-	if(reductions[4] != 0)
-		resistances_list += list("PALE" = reductions[4])
+	resistances_list += list("RED" = reductions[1])
+	resistances_list += list("WHITE" = reductions[2])
+	resistances_list += list("BLACK" = reductions[3])
+	resistances_list += list("PALE" = reductions[4])
 	aggro_on_block = force * 3
 
 //Allows the user to deflect projectiles for however long recovery time is set to on a hit

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -336,14 +336,10 @@
 		white_armor = armor.getRating(mapping[WHITE_DAMAGE])
 		black_armor = armor.getRating(mapping[BLACK_DAMAGE])
 		pale_armor = armor.getRating(mapping[PALE_DAMAGE])
-	if(red_armor)
-		armor_list["RED"] = red_armor
-	if(white_armor)
-		armor_list["WHITE"] = white_armor
-	if(black_armor)
-		armor_list["BLACK"] = black_armor
-	if(pale_armor)
-		armor_list["PALE"] = pale_armor
+	armor_list["RED"] = red_armor
+	armor_list["WHITE"] = white_armor
+	armor_list["BLACK"] = black_armor
+	armor_list["PALE"] = pale_armor
 
 	if(LAZYLEN(durability_list))
 		durability_list.Cut()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Ego armor and Ego shields now display armor values of 0 as 1 when you examine them
<img width="839" height="170" alt="image" src="https://github.com/user-attachments/assets/e1a0ddf7-7fc8-4867-a66b-06162b26b50f" />

## Why It's Good For The Game

It looked weird seeing it jump from red damage to black
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Ego armor and Ego shields now display armor values of 0 as 1 when you examine them
code: changed some code
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
