### PR TITLE
Enkephalin Rush repairs now trigger ordeals

### DIFF
--- a/ModularTegustation/tegu_items/enkephalin_rush/enkr_machines.dm
+++ b/ModularTegustation/tegu_items/enkephalin_rush/enkr_machines.dm
@@ -62,11 +62,15 @@ GLOBAL_VAR(lobotomy_repairs)
 				to_chat(user, span_notice("You start to reconnect the display..."))
 				if(P.use_tool(src, user, 20, volume=50))
 					to_chat(user, span_notice("The panel vanishes. This containment cell will automatically complete when an abnormality is extracted into it."))
-					var/turf/T = get_turf(src)
-					T = get_ranged_target_turf(T, WEST, 4)
-					new /obj/effect/spawner/abnormality_room(T)
-					GLOB.lobotomy_repairs += 1
-					qdel(src)
+					CreateCell()
+
+/obj/machinery/containment_hotspot/proc/CreateCell()
+	var/turf/T = get_turf(src)
+	T = get_ranged_target_turf(T, WEST, 4)
+	new /obj/effect/spawner/abnormality_room(T)
+	GLOB.lobotomy_repairs += 1
+	SSlobotomy_corp.CheckRepairState()
+	qdel(src)
 
 /obj/broken_regenerator
 	name = "broken regenerator"
@@ -92,6 +96,7 @@ GLOBAL_VAR(lobotomy_repairs)
 		qdel(O)
 		new /obj/machinery/regenerator(get_turf(src))
 		GLOB.lobotomy_repairs += 1
+		SSlobotomy_corp.CheckRepairState()
 		qdel(src)
 
 /obj/structure/itemselling/ucorp
@@ -115,6 +120,13 @@ GLOBAL_VAR(lobotomy_repairs)
 	exclude_listing = list()
 
 	prices = list(
+		10,
+		50,
+		200,
+		1000,
+		)
+
+	var/price_path = list(
 		/obj/item/stack/spacecash/c10,
 		/obj/item/stack/spacecash/c50,
 		/obj/item/stack/spacecash/c200,
@@ -127,7 +139,7 @@ GLOBAL_VAR(lobotomy_repairs)
 
 	for (var/i = 1, i <= LAZYLEN(loot_lists), i++)
 		if(is_type_in_typecache(I, loot_lists[i]))
-			spawntype = prices[i]
+			spawntype = price_path[i]
 			break
 
 	if(!spawntype)

--- a/code/controllers/subsystem/lobotomy_corp.dm
+++ b/code/controllers/subsystem/lobotomy_corp.dm
@@ -405,3 +405,13 @@ SUBSYSTEM_DEF(lobotomy_corp)
 	to_chat(world, span_danger("<b>All agents are dead! If ordeals are left unresolved or new agents don't join, the round will automatically end in <u>[round(time/10)] seconds!</u></b>"))
 	addtimer(CALLBACK(src, PROC_REF(OrdealDeathAutoRestart), max(0, time - 30 SECONDS)), 30 SECONDS)
 	return TRUE
+
+/datum/controller/subsystem/lobotomy_corp/proc/CheckRepairState()
+	var/repaired_machines = GLOB.lobotomy_repairs
+	var/total_machines = GLOB.lobotomy_damages
+	var/facility_full_percentage = 100 * (repaired_machines / total_machines)
+
+	if(((next_ordeal_level - 1) * 20) < facility_full_percentage)
+		OrdealEvent()
+
+	return facility_full_percentage


### PR DESCRIPTION
comment removal

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

In Enkephalin Rush, ordeals will now activate at certain thresholds of the facility's repair process. These ordeals respect the regular timelock restrictions in facility mode. Should the facility be completely repaired prior to the midnight ordeal's minimum roundtime, it may activate through ordinary qliphoth meltdowns.

Also fixes a minor oversight left by #3093 where the examine text for the mermaid oil machine displayed item paths, rather than monetary amounts.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

A key concern with this gamemode's progression was the tendency for ordeals to lag behind player progression. Due to the nature of the gamemode, work on abnormalities tends to be discouraged early on.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: ordeals now trigger more often in enkr
fix: fixes whale oil examine
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
