### PR TITLE
Adds ranges to work damage

### DIFF
--- a/ModularTegustation/!extra_abnos/joke_abnormalities/aleph/barkley.dm
+++ b/ModularTegustation/!extra_abnos/joke_abnormalities/aleph/barkley.dm
@@ -21,7 +21,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = 35,
 		ABNORMALITY_WORK_REPRESSION = 35,
 	)
-	work_damage_amount = 16
+	work_damage_upper = 9
+	work_damage_lower = 6
 	work_damage_type = RED_DAMAGE
 
 	ego_list = list(

--- a/ModularTegustation/!extra_abnos/joke_abnormalities/aleph/buffdolta.dm
+++ b/ModularTegustation/!extra_abnos/joke_abnormalities/aleph/buffdolta.dm
@@ -31,7 +31,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = list(70, 60, 50, 40, 30),
 		ABNORMALITY_WORK_REPRESSION = list(0, 0, 10, 20, 30),
 	)
-	work_damage_amount = 25
+	work_damage_upper = 15
+	work_damage_lower = 8
 	work_damage_type = RED_DAMAGE
 
 	ego_list = list(

--- a/ModularTegustation/!extra_abnos/joke_abnormalities/aleph/wild_ride.dm
+++ b/ModularTegustation/!extra_abnos/joke_abnormalities/aleph/wild_ride.dm
@@ -22,7 +22,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = list(0, 0, 5, 5, 10),
 		ABNORMALITY_WORK_REPRESSION = list(0, 0, 5, 5, 10),
 	)
-	work_damage_amount = 1
+	work_damage_upper = 1
+	work_damage_lower = 1
 	work_damage_type = PALE_DAMAGE
 	max_boxes = 100 //I WANT OFF THIS WILD RIDE!
 
@@ -65,7 +66,7 @@
 	if(prob(50))
 		return
 	works_in_a_row += 1
-	work_damage_amount = 1
+	work_damage_upper = 1
 	user.SetImmobilized(10, ignore_canstun = TRUE)
 	if(prob(80))
 		addtimer(CALLBACK(src, PROC_REF(ForceToWork),user,work_type,TRUE), 5)
@@ -73,7 +74,7 @@
 /mob/living/simple_animal/hostile/abnormality/wild_ride/FailureEffect(mob/living/carbon/human/user, work_type, pe) //THE RIDE NEVER ENDS
 	. = ..()
 	works_in_a_row += 2
-	work_damage_amount = 2
+	work_damage_upper = 2
 	user.SetImmobilized(10, ignore_canstun = TRUE)
 	addtimer(CALLBACK(src, PROC_REF(ForceToWork),user,work_type,TRUE), 5)
 

--- a/ModularTegustation/!extra_abnos/joke_abnormalities/he/rubber_duck.dm
+++ b/ModularTegustation/!extra_abnos/joke_abnormalities/he/rubber_duck.dm
@@ -24,7 +24,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = list(30, 20, 10, 0, 0),
 		ABNORMALITY_WORK_REPRESSION = list(30, 20, 10, 0, 0),
 	)
-	work_damage_amount = 5
+	work_damage_upper = 6
+	work_damage_lower = 4
 	work_damage_type = WHITE_DAMAGE
 
 	ego_list = list(

--- a/ModularTegustation/!extra_abnos/joke_abnormalities/teth/abnormality.dm
+++ b/ModularTegustation/!extra_abnos/joke_abnormalities/teth/abnormality.dm
@@ -15,7 +15,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = 60,
 		ABNORMALITY_WORK_REPRESSION = 60,
 	)
-	work_damage_amount = 4
+	work_damage_upper = 4
+	work_damage_lower = 3
 	work_damage_type = RED_DAMAGE
 	damage_coeff = list(RED_DAMAGE = 1, WHITE_DAMAGE = 1, BLACK_DAMAGE = 1, PALE_DAMAGE = 1)
 	melee_damage_lower = 8

--- a/ModularTegustation/!extra_abnos/joke_abnormalities/waw/skub.dm
+++ b/ModularTegustation/!extra_abnos/joke_abnormalities/waw/skub.dm
@@ -17,7 +17,8 @@
 		ABNORMALITY_WORK_REPRESSION = list(10, 40, 50, 55, 60),
 	)
 
-	work_damage_amount = 7
+	work_damage_upper = 7
+	work_damage_lower = 6
 	work_damage_type = WHITE_DAMAGE
 	can_patrol = FALSE
 	wander = FALSE

--- a/ModularTegustation/!extra_abnos/joke_abnormalities/zayin/riblin.dm
+++ b/ModularTegustation/!extra_abnos/joke_abnormalities/zayin/riblin.dm
@@ -15,9 +15,9 @@
 		ABNORMALITY_WORK_ATTACHMENT = list(70, 70, 60, 60, 60),
 		ABNORMALITY_WORK_REPRESSION = list(70, 70, 60, 60, 60),
 	)
-	work_damage_amount = 1
+	work_damage_upper = 2
+	work_damage_lower = 1
 	work_damage_type = RED_DAMAGE
-	max_boxes = 10
 
 	stat_attack = HARD_CRIT
 

--- a/code/__HELPERS/abnormalities.dm
+++ b/code/__HELPERS/abnormalities.dm
@@ -48,17 +48,17 @@
 			return "None"
 		if(-INFINITY to 0)
 			return "Healing"
-		if(0 to 1)
+		if(0 to 2)
 			return "Very Low"
-		if(1 to 4)
+		if(2 to 4)
 			return "Low"
-		if(4 to 6)
+		if(4 to 5)
 			return "Moderate"
-		if(6 to 12)
+		if(5 to 6)
 			return "High"
-		if(12 to INFINITY)
+		if(8 to INFINITY)
 			return "Extreme"
-		if(9 to 12)
+		if(6 to 7)
 			return "Very High"
 
 	return "Unknown ([damage])"

--- a/code/datums/abnormality/datum/abnormality.dm
+++ b/code/datums/abnormality/datum/abnormality.dm
@@ -121,8 +121,11 @@
 	qliphoth_meter_max = current.start_qliphoth
 	qliphoth_meter = qliphoth_meter_max
 	maximum_attribute_level = THREAT_TO_ATTRIBUTE_LIMIT[threat_level]
+	// Zayin - 10, TETH - 14, HE - 18, WAW - 22, ALEPH - 30 as baselines.
 	if(!current.max_boxes)
-		max_boxes = threat_level * 6
+		max_boxes = (threat_level * 4) + 6
+		if(threat_level >= 5)
+			max_boxes += 4
 	else
 		max_boxes = current.max_boxes
 	if(!current.success_boxes)

--- a/code/modules/mob/living/simple_animal/abnormality/!tutorial/bill.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/!tutorial/bill.dm
@@ -18,7 +18,8 @@
 	melee_damage_lower = 1
 	melee_damage_upper = 3
 	melee_damage_type = RED_DAMAGE
-	work_damage_amount = 2
+	work_damage_upper = 2
+	work_damage_lower = 1
 	work_damage_type = RED_DAMAGE
 	damage_coeff = list(RED_DAMAGE = 0.5, WHITE_DAMAGE = 1.5, BLACK_DAMAGE = 1, PALE_DAMAGE = 1)
 	can_breach = TRUE

--- a/code/modules/mob/living/simple_animal/abnormality/!tutorial/cube.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/!tutorial/cube.dm
@@ -16,7 +16,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = 70,
 		ABNORMALITY_WORK_REPRESSION = 30,
 	)
-	work_damage_amount = 2
+	work_damage_upper = 2
+	work_damage_lower = 1
 	work_damage_type = WHITE_DAMAGE
 	damage_coeff = list(RED_DAMAGE = 1, WHITE_DAMAGE = 0.5, BLACK_DAMAGE = 1.5, PALE_DAMAGE = 1)
 	can_breach = TRUE

--- a/code/modules/mob/living/simple_animal/abnormality/!tutorial/fairies.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/!tutorial/fairies.dm
@@ -20,7 +20,8 @@
 	melee_damage_lower = 1
 	melee_damage_upper = 2
 	melee_damage_type = PALE_DAMAGE
-	work_damage_amount = 2
+	work_damage_upper = 4
+	work_damage_lower = 2
 	work_damage_type = PALE_DAMAGE
 	damage_coeff = list(RED_DAMAGE = 1.5, WHITE_DAMAGE = 1, BLACK_DAMAGE = 1, PALE_DAMAGE = 0.5)
 	can_breach = TRUE

--- a/code/modules/mob/living/simple_animal/abnormality/!tutorial/shadow.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/!tutorial/shadow.dm
@@ -19,7 +19,8 @@
 	melee_damage_lower = 2
 	melee_damage_upper = 4
 	melee_damage_type = BLACK_DAMAGE
-	work_damage_amount = 2
+	work_damage_upper = 2
+	work_damage_lower = 1
 	work_damage_type = BLACK_DAMAGE
 	damage_coeff = list(RED_DAMAGE = 1, WHITE_DAMAGE = 1, BLACK_DAMAGE = 0.5, PALE_DAMAGE = 1.5)
 	can_breach = TRUE

--- a/code/modules/mob/living/simple_animal/abnormality/_abnormality.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_abnormality.dm
@@ -49,10 +49,11 @@
 	)
 	/// Work Types and corresponding their attributes
 	var/list/work_attribute_types = WORK_TO_ATTRIBUTE
-	/// How much damage is dealt to user on each work failure
-	var/work_damage_amount = 2
+	/// Range of how much damage is dealt to user on each work failure
+	var/work_damage_upper = 2
+	var/work_damage_lower = 1
 	/// What damage type is used for work failures
-	/// Can be a list, work_damage_amount in that case is divided by the objects in the list and visuals are chosen randomly
+	/// Can be a list, work damage in that case is divided by the objects in the list and visuals are chosen randomly
 	var/work_damage_type = RED_DAMAGE
 	/// Maximum amount of PE someone can obtain per work procedure, if not null or 0.
 	var/max_boxes = null
@@ -461,7 +462,7 @@ The variable's key needs to be non-numerical.*/
 
 // Additional effect on each individual work tick failure
 /mob/living/simple_animal/hostile/abnormality/proc/WorktickFailure(mob/living/carbon/human/user)
-	user.deal_damage(work_damage_amount, work_damage_type)
+	user.deal_damage(rand(work_damage_lower,work_damage_upper), work_damage_type)
 	WorkDamageEffect()
 	return
 

--- a/code/modules/mob/living/simple_animal/abnormality/_auxiliary_modes/community/aleph/crying_children.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_auxiliary_modes/community/aleph/crying_children.dm
@@ -33,7 +33,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = list(0, 0, 0, 10, 20),
 		ABNORMALITY_WORK_REPRESSION = list(0, 0, 45, 50, 55),
 	)
-	work_damage_amount = 14
+	work_damage_upper = 9
+	work_damage_lower = 6
 	work_damage_type = WHITE_DAMAGE
 	attack_sound = 'sound/abnormalities/crying_children/attack_salvador.ogg'
 	death_sound = 'sound/abnormalities/crying_children/death.ogg'
@@ -193,7 +194,7 @@
 		new /obj/effect/temp_visual/fire/fast(get_turf(L))
 
 /mob/living/simple_animal/hostile/abnormality/crying_children/BreachEffect(mob/living/carbon/human/user, breach_type)
-	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(show_global_blurb), 20, "No one’s going to cry on my behalf even if I’m sad.", 25))
+	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(show_global_blurb), 20, "No one's going to cry on my behalf even if I'm sad.", 25))
 	..()
 	desc = "A towering angel statue, setting everything on it's path ablaze"
 	icon = 'ModularTegustation/Teguicons/96x96.dmi'
@@ -459,7 +460,7 @@
 		forceMove(T)
 
 /mob/living/simple_animal/hostile/abnormality/crying_children/proc/FinalPhase()
-	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(show_global_blurb), 20, "I don’t want to hear anything. I don’t want to see anything, or speak anything…", 25))
+	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(show_global_blurb), 20, "I don't want to hear anything. I don't want to see anything, or speak anything!", 25))
 	icon_phase = "desperation"
 	icon_living = "[icon_phase]_idle"
 	icon_state = "[icon_phase]_idle"

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/army_in_black.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/army_in_black.dm
@@ -36,7 +36,8 @@ GLOBAL_LIST_EMPTY(army)
 		ABNORMALITY_WORK_REPRESSION = 30,
 		"Protection" = 0, //shouldn't attempt to generate any PE
 	)
-	work_damage_amount = 9
+	work_damage_upper = 9
+	work_damage_lower = 7
 	work_damage_type = WHITE_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/wrath
 

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/black_sun.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/black_sun.dm
@@ -12,7 +12,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = 10,
 		ABNORMALITY_WORK_REPRESSION = 10
 			)
-	work_damage_amount = 9
+	work_damage_upper = 9
+	work_damage_lower = 6
 	work_damage_type = RED_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/sloth
 	start_qliphoth = 3

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/blue_star.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/blue_star.dm
@@ -27,9 +27,11 @@
 		ABNORMALITY_WORK_ATTACHMENT = 0,
 		ABNORMALITY_WORK_REPRESSION = 40,
 	)
-	work_damage_amount = 9
+	work_damage_upper = 9
+	work_damage_lower = 6
 	work_damage_type = WHITE_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/gloom
+	max_boxes = 33
 	can_patrol = FALSE
 
 	wander = FALSE

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/censored.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/censored.dm
@@ -33,9 +33,11 @@
 		ABNORMALITY_WORK_REPRESSION = 0,
 		"Sacrifice" = 999,
 	)
-	work_damage_amount = 8
+	work_damage_upper = 10
+	work_damage_lower = 5
 	work_damage_type = BLACK_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/gluttony
+	max_boxes = 32
 
 	ego_list = list(
 		/datum/ego_datum/weapon/censored,

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/distortedform.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/distortedform.dm
@@ -37,9 +37,11 @@
 		ABNORMALITY_WORK_REPRESSION = list(0, 0, 0, 50, 55),
 	)
 	start_qliphoth = 3
-	work_damage_amount = 9
+	work_damage_upper = 8
+	work_damage_lower = 7
 	work_damage_type = list(RED_DAMAGE, WHITE_DAMAGE, BLACK_DAMAGE, PALE_DAMAGE)
 	chem_type = /datum/reagent/abnormality/sin/lust
+	max_boxes = 35
 
 	ego_list = list(
 		/datum/ego_datum/armor/distortion,

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/last_shot.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/last_shot.dm
@@ -20,7 +20,8 @@ GLOBAL_LIST_EMPTY(meat_list)
 		ABNORMALITY_WORK_REPRESSION = 40,
 	)
 
-	work_damage_amount = 9
+	work_damage_upper = 9
+	work_damage_lower = 7
 	work_damage_type = RED_DAMAGE
 	chem_type = /datum/reagent/abnormality/last_shot
 	harvest_phrase = span_notice("You peel off some rotten flesh off the floor surrounding %ABNO and collect it in %VESSEL.")
@@ -87,14 +88,14 @@ GLOBAL_LIST_EMPTY(meat_list)
 	else if(get_attribute_level(user, TEMPERANCE_ATTRIBUTE) >= 100)
 		newchance -= 10
 
-	work_damage_amount = initial(work_damage_amount)
+	work_damage_upper = initial(work_damage_upper)
 
 	//Fort or justice too low? take more damage.
 	if(get_attribute_level(user, JUSTICE_ATTRIBUTE) <= 100)
-		work_damage_amount*=2
+		work_damage_upper*=2
 
 	if(get_attribute_level(user, FORTITUDE_ATTRIBUTE) <= 100)
-		work_damage_amount*=2
+		work_damage_upper*=2
 
 	return newchance
 

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/melting_love.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/melting_love.dm
@@ -36,9 +36,11 @@
 		ABNORMALITY_WORK_ATTACHMENT = list(20, 30, 40, 50, 55),
 		ABNORMALITY_WORK_REPRESSION = list(0, 0, 0, 0, 0),
 	)
-	work_damage_amount = 9
+	work_damage_upper = 10
+	work_damage_lower = 4
 	work_damage_type = BLACK_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/lust
+	max_boxes = 32
 	/* Sounds */
 	projectilesound = 'sound/abnormalities/meltinglove/ranged.ogg'
 	attack_sound = 'sound/abnormalities/meltinglove/attack.ogg'

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/mountain.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/mountain.dm
@@ -32,7 +32,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = 0,
 		ABNORMALITY_WORK_REPRESSION = list(0, 0, 0, 50, 55),
 	)
-	work_damage_amount = 9
+	work_damage_upper = 8
+	work_damage_lower = 6
 	work_damage_type = BLACK_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/gluttony
 

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/nihil.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/nihil.dm
@@ -24,7 +24,9 @@
 	melee_damage_upper = 55
 	melee_damage_type = BLACK_DAMAGE
 	stat_attack = HARD_CRIT
-	work_damage_amount = 20
+	work_damage_upper = 10
+	work_damage_lower = 7
+	max_boxes = 35
 	work_damage_type = WHITE_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/pride
 	attack_verb_continuous = "claws"

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/nobody_is.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/nobody_is.dm
@@ -29,7 +29,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = 50,
 		ABNORMALITY_WORK_REPRESSION = 0,
 	)
-	work_damage_amount = 9
+	work_damage_upper = 9
+	work_damage_lower = 6
 	work_damage_type = BLACK_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/gloom
 
@@ -212,9 +213,9 @@
 
 /mob/living/simple_animal/hostile/abnormality/nobody_is/AttemptWork(mob/living/carbon/human/user, work_type)
 	if(solo_punish)
-		work_damage_amount = 15
+		work_damage_upper = 15
 		return ..()
-	work_damage_amount = initial(work_damage_amount)
+	work_damage_upper = initial(work_damage_upper)
 	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/nobody_is/PostWorkEffect(mob/living/carbon/human/user, work_type, pe, work_time)

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/nothing_there.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/nothing_there.dm
@@ -32,9 +32,11 @@
 		ABNORMALITY_WORK_ATTACHMENT = 50,
 		ABNORMALITY_WORK_REPRESSION = 0,
 	)
-	work_damage_amount = 9
+	work_damage_upper = 9
+	work_damage_lower = 6
 	work_damage_type = RED_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/envy
+	max_boxes = 33
 
 	ego_list = list(
 		/datum/ego_datum/weapon/mimicry,

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/seasons.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/seasons.dm
@@ -38,9 +38,11 @@
 		ABNORMALITY_WORK_ATTACHMENT = list(5, 10, 15, 50, 55),
 		ABNORMALITY_WORK_REPRESSION = list(5, 10, 15, 50, 55),
 	)
-	work_damage_amount = 8
+	work_damage_upper = 9
+	work_damage_lower = 7
 	work_damage_type = WHITE_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/wrath
+	max_boxes = 33
 
 	ego_list = list(
 		/datum/ego_datum/weapon/seasons,
@@ -278,7 +280,7 @@
 	Transform()
 	can_breach = FALSE
 	fear_level = WAW_LEVEL
-	work_damage_amount = 8
+	work_damage_upper = 9
 	start_qliphoth = 1
 	datum_reference.qliphoth_meter_max = 5
 	datum_reference.qliphoth_change(4)
@@ -292,7 +294,7 @@
 	Transform()
 	can_breach = TRUE
 	fear_level = ALEPH_LEVEL
-	work_damage_amount = 9
+	work_damage_upper = 10
 	datum_reference.qliphoth_meter_max = 1
 	datum_reference.qliphoth_change(1)
 	is_flying_animal = FALSE

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/silent_orchestra.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/silent_orchestra.dm
@@ -17,7 +17,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = list(0, 0, 40, 40, 50),
 		ABNORMALITY_WORK_REPRESSION = list(0, 0, 10, 20, 30),
 	)
-	work_damage_amount = 9
+	work_damage_upper = 9
+	work_damage_lower = 7
 	work_damage_type = WHITE_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/sloth
 	good_hater = TRUE

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/space_lady.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/space_lady.dm
@@ -21,7 +21,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = list(40, 40, 40, 45, 45),
 		ABNORMALITY_WORK_REPRESSION = list(0, 0, 30, 30, 30),
 	)
-	work_damage_amount = 9	//Half white, half black damage
+	work_damage_upper = 9
+	work_damage_lower = 6	//Half white, half black damage
 	work_damage_type = list(WHITE_DAMAGE, BLACK_DAMAGE)
 	chem_type = /datum/reagent/abnormality/sin/gluttony	//Literally a black hole (and a white hole I guess)
 

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/staining_rose.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/staining_rose.dm
@@ -18,8 +18,10 @@
 		ABNORMALITY_WORK_REPRESSION = list(0, 0, 0, 45, 50),
 	)
 	start_qliphoth = 1
-	work_damage_amount = 9
+	work_damage_upper = 7
+	work_damage_lower = 6
 	work_damage_type = PALE_DAMAGE
+	max_boxes = 33
 	chem_type = /datum/reagent/abnormality/sin/pride
 	pixel_x = -16
 	base_pixel_x = -16

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/titania.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/titania.dm
@@ -21,7 +21,8 @@
 	start_qliphoth = 2
 	move_to_delay = 4
 
-	work_damage_amount = 9
+	work_damage_upper = 9
+	work_damage_lower = 6
 	work_damage_type = RED_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/lust
 	can_breach = TRUE

--- a/code/modules/mob/living/simple_animal/abnormality/aleph/white_night.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/aleph/white_night.dm
@@ -33,9 +33,11 @@ GLOBAL_LIST_EMPTY(apostles)
 		ABNORMALITY_WORK_ATTACHMENT = list(30, 30, 35, 40, 45),
 		ABNORMALITY_WORK_REPRESSION = list(30, 30, 35, 40, 45),
 	)
-	work_damage_amount = 8
+	work_damage_upper = 8
+	work_damage_lower = 7
 	work_damage_type = PALE_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/wrath
+	max_boxes = 35
 	can_patrol = FALSE
 
 	light_system = MOVABLE_LIGHT

--- a/code/modules/mob/living/simple_animal/abnormality/he/KHz.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/KHz.dm
@@ -16,7 +16,8 @@
 		"Input One" = 0,		//These should never be used, but it's here for brevity
 		"Input Zero" = 0,
 	)
-	work_damage_amount = 5
+	work_damage_upper = 4
+	work_damage_lower = 3
 	work_damage_type = WHITE_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/envy
 

--- a/code/modules/mob/living/simple_animal/abnormality/he/KQE.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/KQE.dm
@@ -36,7 +36,8 @@
 		"Write GOODBYE" = 0,
 		"Write DUMBASS" = 0,
 	)
-	work_damage_amount = 5
+	work_damage_upper = 7
+	work_damage_lower = 4
 	work_damage_type = BLACK_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/envy
 

--- a/code/modules/mob/living/simple_animal/abnormality/he/ardor_blossom_moth.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/ardor_blossom_moth.dm
@@ -32,7 +32,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = 20,
 		ABNORMALITY_WORK_REPRESSION = 50,
 	)
-	work_damage_amount = 5
+	work_damage_upper = 6
+	work_damage_lower = 3
 	work_damage_type = RED_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/wrath
 	patrol_cooldown_time = 3 SECONDS

--- a/code/modules/mob/living/simple_animal/abnormality/he/basilisoup.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/basilisoup.dm
@@ -32,7 +32,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = 30,
 		ABNORMALITY_WORK_REPRESSION = 10,
 	)
-	work_damage_amount = 5
+	work_damage_upper = 6
+	work_damage_lower = 3
 	work_damage_type = BLACK_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/lust
 

--- a/code/modules/mob/living/simple_animal/abnormality/he/better_memories.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/better_memories.dm
@@ -25,7 +25,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = list(20, 20, 40, 50, 50),
 		ABNORMALITY_WORK_REPRESSION = list(60, 65, 40, 20, 20)
 		)
-	work_damage_amount = 5
+	work_damage_upper = 6
+	work_damage_lower = 3
 	work_damage_type = WHITE_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/sloth
 

--- a/code/modules/mob/living/simple_animal/abnormality/he/blue_shepherd.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/blue_shepherd.dm
@@ -32,7 +32,8 @@
 	melee_damage_upper = 8
 	melee_damage_type = BLACK_DAMAGE
 	stat_attack = HARD_CRIT
-	work_damage_amount = 5
+	work_damage_upper = 5
+	work_damage_lower = 3
 	work_damage_type = BLACK_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/pride
 	attack_verb_continuous = "cuts"

--- a/code/modules/mob/living/simple_animal/abnormality/he/der_fluschutze.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/der_fluschutze.dm
@@ -25,9 +25,11 @@
 		ABNORMALITY_WORK_ATTACHMENT = 0,
 		ABNORMALITY_WORK_REPRESSION = list(20, 30, 60, 60, 60),
 	)
-	work_damage_amount = 5
+	work_damage_upper = 4
+	work_damage_lower = 3
 	work_damage_type = RED_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/pride
+	max_boxes = 18
 
 	ego_list = list(
 		/datum/ego_datum/weapon/fellbullet,

--- a/code/modules/mob/living/simple_animal/abnormality/he/der_freischutz.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/der_freischutz.dm
@@ -24,9 +24,11 @@
 		ABNORMALITY_WORK_ATTACHMENT = 30, // Can you believe he has actual attachment work rates in LC proper, despite that you can't do attachment work on him there?
 		ABNORMALITY_WORK_REPRESSION = list(0, 0, 60, 60, 60),
 	)
-	work_damage_amount = 5
+	work_damage_upper = 4
+	work_damage_lower = 3
 	work_damage_type = BLACK_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/pride
+	max_boxes = 18
 
 	ego_list = list(
 		/datum/ego_datum/weapon/magicbullet,

--- a/code/modules/mob/living/simple_animal/abnormality/he/doomsday_calendar.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/doomsday_calendar.dm
@@ -19,14 +19,15 @@
 	threat_level = HE_LEVEL
 	damage_coeff = list(BRUTE = 1, RED_DAMAGE = 0.3, WHITE_DAMAGE = 0.3, BLACK_DAMAGE = 0.1, PALE_DAMAGE = 0.3)//only when initialized
 	start_qliphoth = 5
-	max_boxes = 18//this is the normal amount
+	max_boxes = 18 // This must be defined here for later code to work.
 	work_chances = list(
 		ABNORMALITY_WORK_INSTINCT = 60,
 		ABNORMALITY_WORK_INSIGHT = 45,
 		ABNORMALITY_WORK_ATTACHMENT = 20,
 		ABNORMALITY_WORK_REPRESSION = 50,
 	)
-	work_damage_amount = 5
+	work_damage_upper = 6
+	work_damage_lower = 3
 	work_damage_type = BLACK_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/wrath
 	can_patrol = FALSE

--- a/code/modules/mob/living/simple_animal/abnormality/he/drifting_fox.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/drifting_fox.dm
@@ -39,7 +39,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = list(15, 20, 25, 30, 35),
 		ABNORMALITY_WORK_REPRESSION = 15,
 	)
-	work_damage_amount = 5
+	work_damage_upper = 6
+	work_damage_lower = 3
 	work_damage_type = BLACK_DAMAGE
 	abnormality_origin = ABNORMALITY_ORIGIN_LIMBUS
 

--- a/code/modules/mob/living/simple_animal/abnormality/he/eris.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/eris.dm
@@ -29,7 +29,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = 70,
 		ABNORMALITY_WORK_REPRESSION = list(50, 55, 55, 50, 45),
 	)
-	work_damage_amount = 5
+	work_damage_upper = 6
+	work_damage_lower = 3
 	work_damage_type = RED_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/lust
 

--- a/code/modules/mob/living/simple_animal/abnormality/he/fan.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/fan.dm
@@ -18,7 +18,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = 100,
 		ABNORMALITY_WORK_REPRESSION = 100,
 	)
-	work_damage_amount = 5
+	work_damage_upper = 7
+	work_damage_lower = 5
 	work_damage_type = RED_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/sloth
 	max_boxes = 12

--- a/code/modules/mob/living/simple_animal/abnormality/he/funeral.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/funeral.dm
@@ -30,7 +30,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = 0,
 		ABNORMALITY_WORK_REPRESSION = list(0, 0, 60, 60, 60),
 	)
-	work_damage_amount = 5
+	work_damage_upper = 6
+	work_damage_lower = 4
 	work_damage_type = WHITE_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/gloom
 	max_boxes = 16

--- a/code/modules/mob/living/simple_animal/abnormality/he/galaxy_child.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/galaxy_child.dm
@@ -15,7 +15,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = 45,
 		ABNORMALITY_WORK_REPRESSION = 45,
 	)
-	work_damage_amount = 5
+	work_damage_upper = 3
+	work_damage_lower = 2
 	work_damage_type = BLACK_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/gloom
 	max_boxes = 16

--- a/code/modules/mob/living/simple_animal/abnormality/he/golden_false_apple.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/golden_false_apple.dm
@@ -49,9 +49,9 @@
 		ABNORMALITY_WORK_ATTACHMENT = 0,
 		ABNORMALITY_WORK_REPRESSION = list(0, 0, 15, 30, 45),
 	)
-	work_damage_amount = 5
+	work_damage_upper = 4
+	work_damage_lower = 3
 	work_damage_type = RED_DAMAGE
-	max_boxes = 18
 
 	ego_list = list(
 		/datum/ego_datum/weapon/legerdemain,

--- a/code/modules/mob/living/simple_animal/abnormality/he/happy_teddy_bear.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/happy_teddy_bear.dm
@@ -18,7 +18,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = list(60, 60, 60, 50, 45),
 		ABNORMALITY_WORK_REPRESSION = list(40, 45, 45, 40, 35),
 	)
-	work_damage_amount = 5
+	work_damage_upper = 4
+	work_damage_lower = 2
 	work_damage_type = WHITE_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/gloom
 	max_boxes = 15

--- a/code/modules/mob/living/simple_animal/abnormality/he/headless_ichthys.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/headless_ichthys.dm
@@ -33,7 +33,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = list(50, 55, 55, 50, 45),
 		ABNORMALITY_WORK_REPRESSION = list(35, 40, 40, 35, 35),
 	)
-	work_damage_amount = 5
+	work_damage_upper = 5
+	work_damage_lower = 3
 	work_damage_type = BLACK_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/gloom
 

--- a/code/modules/mob/living/simple_animal/abnormality/he/helper.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/helper.dm
@@ -37,9 +37,11 @@
 		ABNORMALITY_WORK_ATTACHMENT = list(35, 40, 40, 35, 35),
 		ABNORMALITY_WORK_REPRESSION = list(50, 55, 55, 50, 45),
 	)
-	work_damage_amount = 5
+	work_damage_upper = 5
+	work_damage_lower = 3
 	work_damage_type = RED_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/wrath
+	max_boxes = 16
 
 	ego_list = list(
 		/datum/ego_datum/weapon/grinder,

--- a/code/modules/mob/living/simple_animal/abnormality/he/highway_devotee.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/highway_devotee.dm
@@ -24,7 +24,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = list(30, 20, 10, 0, 0),
 		ABNORMALITY_WORK_REPRESSION = list(30, 20, 10, 0, 0),
 	)
-	work_damage_amount = 5
+	work_damage_upper = 5
+	work_damage_lower = 2
 	work_damage_type = RED_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/sloth
 

--- a/code/modules/mob/living/simple_animal/abnormality/he/jangsan.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/jangsan.dm
@@ -28,7 +28,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = 60,
 		ABNORMALITY_WORK_REPRESSION = 60,
 	)
-	work_damage_amount = 5
+	work_damage_upper = 5
+	work_damage_lower = 3
 	work_damage_type = RED_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/gluttony
 

--- a/code/modules/mob/living/simple_animal/abnormality/he/laetitia.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/laetitia.dm
@@ -14,7 +14,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = list(60, 60, 60, 65, 65),
 		ABNORMALITY_WORK_REPRESSION = 0,
 	)
-	work_damage_amount = 5
+	work_damage_upper = 4
+	work_damage_lower = 2
 	work_damage_type = BLACK_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/lust
 	max_boxes = 16 // Accurate to base game

--- a/code/modules/mob/living/simple_animal/abnormality/he/missed_reaper.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/missed_reaper.dm
@@ -22,7 +22,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = 55,
 		ABNORMALITY_WORK_REPRESSION = list(50, 45, 40, 0, 0),
 	)
-	work_damage_amount = 8
+	work_damage_upper = 6
+	work_damage_lower = 4
 	work_damage_type = PALE_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/pride
 

--- a/code/modules/mob/living/simple_animal/abnormality/he/nameless_fetus.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/nameless_fetus.dm
@@ -17,10 +17,11 @@
 	pixel_x = -8
 	base_pixel_x = -8
 
-	max_boxes = 16
-	work_damage_amount = 5
+	work_damage_upper = 6
+	work_damage_lower = 4
 	work_damage_type = RED_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/gluttony
+	max_boxes = 18
 
 	ego_list = list(
 		/datum/ego_datum/weapon/syrinx,

--- a/code/modules/mob/living/simple_animal/abnormality/he/norinori.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/norinori.dm
@@ -31,7 +31,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = -80,
 		ABNORMALITY_WORK_REPRESSION = 35,
 	)
-	work_damage_amount = 5
+	work_damage_upper = 5
+	work_damage_lower = 2
 	work_damage_type = RED_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/gluttony
 

--- a/code/modules/mob/living/simple_animal/abnormality/he/pink_shoes.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/pink_shoes.dm
@@ -26,7 +26,8 @@ GLOBAL_LIST_EMPTY(ribbon_list)
 						ABNORMALITY_WORK_ATTACHMENT = list(80, 50, 50, 40, 30),
 						ABNORMALITY_WORK_REPRESSION = list(50, 60, 50, 55, 60)
 						)
-	work_damage_amount = 5
+	work_damage_upper = 6
+	work_damage_lower = 4
 	work_damage_type = WHITE_DAMAGE
 	del_on_death = FALSE
 	death_message = "falls, leaving tattered ribbons."

--- a/code/modules/mob/living/simple_animal/abnormality/he/pinocchio.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/pinocchio.dm
@@ -21,7 +21,8 @@
 	)
 
 	damage_coeff = list(RED_DAMAGE = 1.2, WHITE_DAMAGE = 0.5, BLACK_DAMAGE = 0.7, PALE_DAMAGE = 0.9, FIRE = 1.5)
-	work_damage_amount = 5
+	work_damage_upper = 6
+	work_damage_lower = 3
 	work_damage_type = WHITE_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/envy
 	max_boxes = 16

--- a/code/modules/mob/living/simple_animal/abnormality/he/pisc_mermaid.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/pisc_mermaid.dm
@@ -32,7 +32,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = list(40, 45, 55, 55, 55),
 		ABNORMALITY_WORK_REPRESSION = list(40, 50, 60, 60, 60),
 	)
-	work_damage_amount = 5
+	work_damage_upper = 6
+	work_damage_lower = 2
 	work_damage_type = WHITE_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/lust
 	melee_damage_type = BLACK_DAMAGE

--- a/code/modules/mob/living/simple_animal/abnormality/he/porccubus.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/porccubus.dm
@@ -24,7 +24,9 @@
 	melee_damage_upper = 4
 	rapid_melee = 3 //you can withdraw out of its range very easily so it needs to be a little harder to melee it
 	melee_reach = 2
-	work_damage_amount = 5
+	work_damage_upper = 5
+	work_damage_lower = 1
+	max_boxes = 18
 	can_patrol = FALSE //it can't move anyway but why not
 	stat_attack = HARD_CRIT
 	work_damage_type = BLACK_DAMAGE

--- a/code/modules/mob/living/simple_animal/abnormality/he/puss_in_boots.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/puss_in_boots.dm
@@ -30,7 +30,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = 45,
 		ABNORMALITY_WORK_REPRESSION = list(50, 45, 40, 40, 40),
 	)
-	work_damage_amount = 5
+	work_damage_upper = 6
+	work_damage_lower = 1
 	work_damage_type = RED_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/pride
 

--- a/code/modules/mob/living/simple_animal/abnormality/he/red_buddy.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/red_buddy.dm
@@ -28,7 +28,8 @@
 	melee_damage_upper = 12 //has a wide range, he can critically hit you
 	melee_damage_type = RED_DAMAGE
 	stat_attack = HARD_CRIT
-	work_damage_amount = 0 //his work damage now is entirely related to suffering
+	work_damage_upper = 0
+	work_damage_lower = 0 //his work damage now is entirely related to suffering
 	work_damage_type = RED_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/gloom
 	attack_verb_continuous = "chomps"
@@ -117,7 +118,7 @@
 
 /mob/living/simple_animal/hostile/abnormality/red_buddy/WorktickFailure(mob/living/carbon/human/user)
 	AdjustSuffering(1)
-	work_damage_amount = suffering
+	work_damage_upper = suffering * 0.5
 	UpdateScars()
 	return ..()
 

--- a/code/modules/mob/living/simple_animal/abnormality/he/red_queen.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/red_queen.dm
@@ -15,7 +15,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = 65,
 		ABNORMALITY_WORK_REPRESSION = 65,
 	)
-	work_damage_amount = 7			//Unlikely to hurt you but if she ever does she'll fuck you
+	work_damage_upper = 10	//Unlikely to hurt you but if she ever does she'll fuck you
+	work_damage_lower = 1
 	work_damage_type = RED_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/sloth
 

--- a/code/modules/mob/living/simple_animal/abnormality/he/red_shoes.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/red_shoes.dm
@@ -20,9 +20,11 @@
 		ABNORMALITY_WORK_ATTACHMENT = list(99, 99, 50, 40, 30),
 		ABNORMALITY_WORK_REPRESSION = 0,
 	)
-	work_damage_amount = 5
+	work_damage_upper = 6
+	work_damage_lower = 4
 	work_damage_type = RED_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/wrath
+	max_boxes = 16
 	del_on_death = FALSE
 	death_message = "crumples into a pile of bones."
 	attack_sound = 'sound/abnormalities/redshoes/RedShoes_Attack.ogg'

--- a/code/modules/mob/living/simple_animal/abnormality/he/road_home.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/road_home.dm
@@ -23,7 +23,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = 45,
 		ABNORMALITY_WORK_REPRESSION = list(50, 60, 70, 80, 90),
 	)
-	work_damage_amount = 5
+	work_damage_upper = 4
+	work_damage_lower = 3
 	work_damage_type = BLACK_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/envy
 	can_patrol = FALSE

--- a/code/modules/mob/living/simple_animal/abnormality/he/rudolta.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/rudolta.dm
@@ -25,9 +25,11 @@
 		ABNORMALITY_WORK_ATTACHMENT = list(40, 50, 50, 45, 40),
 		ABNORMALITY_WORK_REPRESSION = 0,
 	)
-	work_damage_amount = 5
+	work_damage_upper = 4
+	work_damage_lower = 3
 	work_damage_type = WHITE_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/sloth
+	max_boxes = 18
 	friendly_verb_continuous = "scorns"
 	friendly_verb_simple = "scorns"
 

--- a/code/modules/mob/living/simple_animal/abnormality/he/scarecrow.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/scarecrow.dm
@@ -28,9 +28,11 @@
 		ABNORMALITY_WORK_ATTACHMENT = 45,
 		ABNORMALITY_WORK_REPRESSION = 45,
 	)
-	work_damage_amount = 5
+	work_damage_upper = 6
+	work_damage_lower = 2
 	work_damage_type = WHITE_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/envy
+	max_boxes = 18
 	death_message = "stops moving, with its torso rotating forwards."
 	death_sound = 'sound/abnormalities/scarecrow/death.ogg'
 

--- a/code/modules/mob/living/simple_animal/abnormality/he/scaredy_cat.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/scaredy_cat.dm
@@ -30,7 +30,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = list(40, 50, 55, 55, 55),
 		ABNORMALITY_WORK_REPRESSION = list(20, 30, 40, 40, 40),
 	)
-	work_damage_amount = 4 //Shit damage because it's a small cat
+	work_damage_upper = 3
+	work_damage_lower = 1 //Shit damage because it's a small cat
 	work_damage_type = RED_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/gluttony
 	can_patrol = FALSE

--- a/code/modules/mob/living/simple_animal/abnormality/he/schadenfreude.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/schadenfreude.dm
@@ -28,9 +28,11 @@
 		ABNORMALITY_WORK_ATTACHMENT = list(40, 40, 40, 30, 20),
 		ABNORMALITY_WORK_REPRESSION = list(40, 45, 50, 55, 60),
 	)
-	work_damage_amount = 5
+	work_damage_upper = 6
+	work_damage_lower = 3
 	work_damage_type = RED_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/wrath
+	max_boxes = 18
 
 	ego_list = list(
 		/datum/ego_datum/weapon/gaze,

--- a/code/modules/mob/living/simple_animal/abnormality/he/shock_centipede.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/shock_centipede.dm
@@ -33,7 +33,8 @@
 						ABNORMALITY_WORK_ATTACHMENT = 10,
 						ABNORMALITY_WORK_REPRESSION = list(75, 75, 95, 95, 95)
 						)
-	work_damage_amount = 5
+	work_damage_upper = 5
+	work_damage_lower = 3
 	work_damage_type = RED_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/gloom
 
@@ -115,14 +116,14 @@
 /mob/living/simple_animal/hostile/abnormality/shock_centipede/AttemptWork(mob/living/carbon/human/user, work_type)
 	//Temp too high, random damage type time.
 	if(get_attribute_level(user, JUSTICE_ATTRIBUTE) <= 60)
-		work_damage_amount = 7
+		work_damage_upper = 7
 	if(datum_reference?.qliphoth_meter == 1)
 		work_damage_type = BLACK_DAMAGE
 	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/shock_centipede/PostWorkEffect(mob/living/carbon/human/user, work_type, pe, work_time, canceled)
-	work_damage_amount = 5
-	work_damage_type = RED_DAMAGE
+	work_damage_upper = initial(work_damage_upper)
+	work_damage_type = initial(work_damage_type)
 
 /mob/living/simple_animal/hostile/abnormality/shock_centipede/proc/CheckQliphoth(mob/living/carbon/human/user, work_type, pe, work_time, canceled)
 	if(datum_reference?.qliphoth_meter == 3 && work_type == ABNORMALITY_WORK_REPRESSION)

--- a/code/modules/mob/living/simple_animal/abnormality/he/silent_girl.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/silent_girl.dm
@@ -23,7 +23,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = -50,
 		ABNORMALITY_WORK_REPRESSION = list(50, 55, 55, 60, 60),
 	)
-	work_damage_amount = 5
+	work_damage_upper = 5
+	work_damage_lower = 2
 	work_damage_type = WHITE_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/gloom
 	start_qliphoth = 3

--- a/code/modules/mob/living/simple_animal/abnormality/he/singing_machine.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/singing_machine.dm
@@ -23,9 +23,12 @@ Finally, an abnormality that DOESN'T have to do any fancy movement shit. It's a 
 		ABNORMALITY_WORK_REPRESSION = 40,
 	)
 	// Adjusted the work chances a little to really funnel people through Instinct work. You can do other stuff... sort of.
-	work_damage_amount = 5
+	work_damage_upper = 6
+	work_damage_lower = 4
 	work_damage_type = WHITE_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/gluttony
+	max_boxes = 18
+
 	ego_list = list(
 		/datum/ego_datum/weapon/harmony,
 		/datum/ego_datum/weapon/rhythm,
@@ -38,7 +41,6 @@ Finally, an abnormality that DOESN'T have to do any fancy movement shit. It's a 
 	base_pixel_x = -8
 	buckled_mobs = list()
 	buckle_lying = TRUE
-	max_boxes = 16
 
 	observation_prompt = "You know that people die every time this machine sings. <br>\
 		Or perhaps this machine sings when people die. <br>Though it has spilled blood of countless people, the song put you in a rapturous mood."

--- a/code/modules/mob/living/simple_animal/abnormality/he/siren.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/siren.dm
@@ -19,7 +19,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = 40,
 		ABNORMALITY_WORK_REPRESSION = 50,
 	)
-	work_damage_amount = 5
+	work_damage_upper = 4
+	work_damage_lower = 2
 	work_damage_type = WHITE_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/sloth
 

--- a/code/modules/mob/living/simple_animal/abnormality/he/snow_queen.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/snow_queen.dm
@@ -41,9 +41,11 @@
 		ABNORMALITY_WORK_REPRESSION = 0,
 		"Rescue" = 100,
 		)
-	work_damage_amount = 5
+	work_damage_upper = 5
+	work_damage_lower = 4
 	work_damage_type = WHITE_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/gloom
+	max_boxes = 18
 	wander = FALSE
 
 	observation_prompt = "You remember her. <br>\

--- a/code/modules/mob/living/simple_animal/abnormality/he/steam_transport_machine.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/steam_transport_machine.dm
@@ -36,7 +36,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = 0,
 		ABNORMALITY_WORK_REPRESSION = 60,
 	)
-	work_damage_amount = 5
+	work_damage_upper = 3
+	work_damage_lower = 2
 	work_damage_type = RED_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/sloth
 
@@ -127,13 +128,13 @@
 			BLACK_DAMAGE = (2 - (gear * 0.1)),
 			PALE_DAMAGE = (1.5 - (gear * 0.1)),
 		))
-		melee_damage_lower = (4 + (4 * gear))
-		melee_damage_upper = (7 + (4 * gear))
-		steam_damage = (2 + (3 * gear))
+		melee_damage_lower = (4 + (3 * gear))
+		melee_damage_upper = (7 + (3 * gear))
+		steam_damage = (2 + (2 * gear))
 	var/oldhealth = maxHealth
 	maxHealth = (1600 + (400 * gear))
 	adjustBruteLoss(oldhealth - maxHealth) //Heals 400 health in a gear shift if it's already breached
-	work_damage_amount = (5 + (2 * gear))
+	work_damage_upper = (3 + (2 * gear))
 	ranged_cooldown_time = (40 - (5 * gear))
 	start_qliphoth = (max(1,(4 - gear)))
 	if(datum_reference.qliphoth_meter > start_qliphoth) //we want to bring the qliphoth down to the new maximum

--- a/code/modules/mob/living/simple_animal/abnormality/he/watchman.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/watchman.dm
@@ -28,7 +28,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = 40,
 		ABNORMALITY_WORK_REPRESSION = 10,
 	)
-	work_damage_amount = 5
+	work_damage_upper = 6
+	work_damage_lower = 3
 	work_damage_type = BLACK_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/pride
 

--- a/code/modules/mob/living/simple_animal/abnormality/he/wayward_passenger.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/wayward_passenger.dm
@@ -32,7 +32,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = 30,
 		ABNORMALITY_WORK_REPRESSION = list(55, 60, 60, 60, 55),
 	)
-	work_damage_amount = 5
+	work_damage_upper = 6
+	work_damage_lower = 3
 	work_damage_type = RED_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/envy
 	fear_level = WAW_LEVEL

--- a/code/modules/mob/living/simple_animal/abnormality/he/white_lake.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/white_lake.dm
@@ -17,7 +17,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = 50,
 		ABNORMALITY_WORK_REPRESSION = 40,
 	)
-	work_damage_amount = 5
+	work_damage_upper = 6
+	work_damage_lower = 3
 	work_damage_type = RED_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/lust
 	//Has the weapon been given out?

--- a/code/modules/mob/living/simple_animal/abnormality/he/will_you_play.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/will_you_play.dm
@@ -13,7 +13,8 @@
 		"Paper" = 60,
 		"Scissors" = 60,
 	)
-	work_damage_amount = 5
+	work_damage_upper = 6
+	work_damage_lower = 3
 	work_damage_type = WHITE_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/wrath
 	max_boxes = 15

--- a/code/modules/mob/living/simple_animal/abnormality/he/woodsman.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/woodsman.dm
@@ -27,8 +27,10 @@
 		ABNORMALITY_WORK_ATTACHMENT = list(50, 60, 70, 80, 90),
 		ABNORMALITY_WORK_REPRESSION = 45,
 	)
-	work_damage_amount = 5
+	work_damage_upper = 5
+	work_damage_lower = 3
 	work_damage_type = WHITE_DAMAGE
+	max_boxes = 18
 	chem_type = /datum/reagent/abnormality/sin/sloth
 	move_to_delay = 4
 	base_pixel_x = -16

--- a/code/modules/mob/living/simple_animal/abnormality/he/you_strong.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/you_strong.dm
@@ -18,7 +18,8 @@
 		"YES" = 0,
 		"NO" = 0,
 	)
-	work_damage_amount = 5
+	work_damage_upper = 6
+	work_damage_lower = 3
 	work_damage_type = RED_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/envy
 	ego_list = list(

--- a/code/modules/mob/living/simple_animal/abnormality/teth/MHz.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/MHz.dm
@@ -20,9 +20,11 @@
 		ABNORMALITY_WORK_ATTACHMENT = list(20, 10, 0, 0, 0),
 		ABNORMALITY_WORK_REPRESSION = list(55, 55, 60, 60, 60),
 	)
-	work_damage_amount = 3
+	work_damage_upper = 4
+	work_damage_lower = 2
 	work_damage_type = WHITE_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/wrath
+	max_boxes = 12
 
 	ego_list = list(
 		/datum/ego_datum/weapon/noise,

--- a/code/modules/mob/living/simple_animal/abnormality/teth/beanstalk.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/beanstalk.dm
@@ -16,7 +16,8 @@
 	)
 	pixel_x = -16
 	base_pixel_x = -16
-	work_damage_amount = 3
+	work_damage_upper = 4
+	work_damage_lower = 2
 	work_damage_type = BLACK_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/wrath
 
@@ -47,9 +48,14 @@
 //Performing instinct work at >4 fortitude starts a special work
 /mob/living/simple_animal/hostile/abnormality/beanstalk/AttemptWork(mob/living/carbon/human/user, work_type)
 	if((get_attribute_level(user, FORTITUDE_ATTRIBUTE) >= 80) && (work_type == ABNORMALITY_WORK_INSTINCT))
-		work_damage_amount *= 2
+		work_damage_upper *= 2
+		work_damage_lower *= 1.5
 		climbing = TRUE
 	return TRUE
+
+/mob/living/simple_animal/hostile/abnormality/beanstalk/proc/ResetWorkDamage()
+	work_damage_upper = initial(work_damage_upper)
+	work_damage_lower = initial(work_damage_lower)
 
 //When working at <2 Temperance and Prudence, or when panicking it is an instant death.
 /mob/living/simple_animal/hostile/abnormality/beanstalk/PostWorkEffect(mob/living/carbon/human/user, work_type, pe)
@@ -70,7 +76,7 @@
 //The special work, if you survive you get a powerful EGO gift.
 	if(climbing)
 		if(user.sanity_lost || user.stat >= SOFT_CRIT || user.stat == DEAD)
-			work_damage_amount = initial(work_damage_amount)
+			work_damage_lower = initial(work_damage_lower)
 			climbing = FALSE
 			return
 
@@ -78,13 +84,13 @@
 		step_towards(user, src)
 		sleep(0.5 SECONDS)
 		if(QDELETED(user))
-			work_damage_amount = initial(work_damage_amount)
+			ResetWorkDamage()
 			climbing = FALSE
 			return
 		step_towards(user, src)
 		sleep(0.5 SECONDS)
 		if(QDELETED(user))
-			work_damage_amount = initial(work_damage_amount)
+			ResetWorkDamage()
 			climbing = FALSE
 			return
 		to_chat(user, span_userdanger("You start to climb!"))
@@ -93,7 +99,7 @@
 		user.Stun(10 SECONDS)
 		sleep(6 SECONDS)
 		if(QDELETED(user))
-			work_damage_amount = initial(work_damage_amount)
+			ResetWorkDamage()
 			climbing = FALSE
 			return
 		var/datum/ego_gifts/giant/BWJEG = new
@@ -103,7 +109,7 @@
 		user.pixel_z = 0
 		to_chat(user, span_userdanger("You return with the giant's treasure!"))
 
-	work_damage_amount = initial(work_damage_amount)
+	ResetWorkDamage()
 	climbing = FALSE
 
 /datum/ego_gifts/giant

--- a/code/modules/mob/living/simple_animal/abnormality/teth/beauty_beast.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/beauty_beast.dm
@@ -20,7 +20,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = list(30, 15, -50, -50, -50),
 		ABNORMALITY_WORK_REPRESSION = 65,
 	)
-	work_damage_amount = 3
+	work_damage_upper = 4
+	work_damage_lower = 2
 	work_damage_type = WHITE_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/envy
 

--- a/code/modules/mob/living/simple_animal/abnormality/teth/blood_bath.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/blood_bath.dm
@@ -24,10 +24,11 @@
 		ABNORMALITY_WORK_ATTACHMENT = 60,
 		ABNORMALITY_WORK_REPRESSION = list(30, 20, 10, 0, 0),
 	)
-	work_damage_amount = 3
+	work_damage_upper = 4
+	work_damage_lower = 2
 	work_damage_type = WHITE_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/pride
-	max_boxes = 14
+	max_boxes = 14 // Must be defined here for later code to work.
 
 	ego_list = list(
 		/datum/ego_datum/weapon/wrist,

--- a/code/modules/mob/living/simple_animal/abnormality/teth/book.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/book.dm
@@ -15,7 +15,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = 40,
 		ABNORMALITY_WORK_REPRESSION = 30,
 	)
-	work_damage_amount = 3
+	work_damage_upper = 4
+	work_damage_lower = 2
 	work_damage_type = BLACK_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/pride
 
@@ -68,7 +69,7 @@
 				icon_state = "book_[wordcount]"
 
 /mob/living/simple_animal/hostile/abnormality/book/AttemptWork(mob/living/carbon/human/user, work_type)
-	work_damage_amount = 3 + wordcount
+	work_damage_upper = 4 + wordcount
 	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/book/WorkChance(mob/living/carbon/human/user, chance, work_type)

--- a/code/modules/mob/living/simple_animal/abnormality/teth/cherry_blossoms.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/cherry_blossoms.dm
@@ -19,9 +19,11 @@
 		ABNORMALITY_WORK_REPRESSION = 20,
 	)
 	start_qliphoth = 3
-	work_damage_amount = 3
+	work_damage_upper = 4
+	work_damage_lower = 2
 	work_damage_type = WHITE_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/lust
+	max_boxes = 12
 	good_hater = TRUE
 
 	ego_list = list(

--- a/code/modules/mob/living/simple_animal/abnormality/teth/cinderella.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/cinderella.dm
@@ -18,7 +18,8 @@
 	)
 	pixel_x = -16
 	base_pixel_x = -16
-	work_damage_amount = 3
+	work_damage_upper = 4
+	work_damage_lower = 2
 	work_damage_type = WHITE_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/lust
 	ego_list = list(

--- a/code/modules/mob/living/simple_animal/abnormality/teth/clayman.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/clayman.dm
@@ -31,7 +31,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = list(50, 50, 50, 50, 50),
 		ABNORMALITY_WORK_REPRESSION = list(50, 50, 50, 50, 50),
 	)
-	work_damage_amount = 0
+	work_damage_upper = 4
+	work_damage_lower = 2
 	work_damage_type = RED_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/gluttony
 	death_message = "loses form."
@@ -46,9 +47,8 @@
 
 /mob/living/simple_animal/hostile/abnormality/clayman/WorktickFailure(mob/living/carbon/human/user)
 	var/dtype = list(RED_DAMAGE, WHITE_DAMAGE, BLACK_DAMAGE, PALE_DAMAGE)
-	work_damage_type = dtype
-	user.deal_damage(2, dtype)
-	WorkDamageEffect()
+	work_damage_type = pick(dtype)
+	..()
 
 /mob/living/simple_animal/hostile/abnormality/clayman/CanAttack(atom/the_target)
 	melee_damage_type = pick(RED_DAMAGE, WHITE_DAMAGE, BLACK_DAMAGE, PALE_DAMAGE)

--- a/code/modules/mob/living/simple_animal/abnormality/teth/cleaner.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/cleaner.dm
@@ -30,7 +30,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = list(35, 40, 40, 35, 35),
 		ABNORMALITY_WORK_REPRESSION = list(0, 0, -30, -60, -90),
 	)
-	work_damage_amount = 3
+	work_damage_upper = 4
+	work_damage_lower = 2
 	work_damage_type = RED_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/wrath
 

--- a/code/modules/mob/living/simple_animal/abnormality/teth/crumbling_armor.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/crumbling_armor.dm
@@ -15,9 +15,11 @@
 		ABNORMALITY_WORK_ATTACHMENT = 0,
 		ABNORMALITY_WORK_REPRESSION = list(60, 60, 65, 65, 70),
 	)
-	work_damage_amount = 3
+	work_damage_upper = 4
+	work_damage_lower = 2
 	work_damage_type = RED_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/wrath
+	max_boxes = 12
 
 	ego_list = list(
 		/datum/ego_datum/weapon/daredevil,

--- a/code/modules/mob/living/simple_animal/abnormality/teth/dealerdamned.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/dealerdamned.dm
@@ -13,7 +13,8 @@
 		ABNORMALITY_WORK_REPRESSION = 25,
 		"Gamble" = 100
 	)
-	work_damage_amount = 3
+	work_damage_upper = 4
+	work_damage_lower = 2
 	work_damage_type = BLACK_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/gluttony
 	speak_emote = list("states")

--- a/code/modules/mob/living/simple_animal/abnormality/teth/dingle_dangle.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/dingle_dangle.dm
@@ -17,7 +17,8 @@
 	start_qliphoth = 3
 	pixel_x = -16
 	base_pixel_x = -16
-	work_damage_amount = 3
+	work_damage_upper = 4
+	work_damage_lower = 2
 	work_damage_type = WHITE_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/envy
 

--- a/code/modules/mob/living/simple_animal/abnormality/teth/drowned_sisters.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/drowned_sisters.dm
@@ -15,7 +15,8 @@
 		ABNORMALITY_WORK_REPRESSION = 20,
 	)
 	start_qliphoth = 3
-	work_damage_amount = 3 //Calculated later
+	work_damage_upper = 5 //Calculated later
+	work_damage_lower = 2
 	work_damage_type = WHITE_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/gloom
 	pixel_x = -32
@@ -44,8 +45,8 @@
 /mob/living/simple_animal/hostile/abnormality/drownedsisters/AttemptWork(mob/living/carbon/human/user, work_type)
 	if(breaching)
 		return FALSE
-	work_damage_amount = (get_attribute_level(user, PRUDENCE_ATTRIBUTE) -60) * -0.2
-	work_damage_amount = max(3, work_damage_amount)	//So you don't get healing
+	work_damage_upper = (get_attribute_level(user, PRUDENCE_ATTRIBUTE) -60) * -0.2
+	work_damage_upper = max(3, work_damage_upper)	//So you don't get healing
 	return ..()
 
 /mob/living/simple_animal/hostile/abnormality/drownedsisters/PostWorkEffect(mob/living/carbon/human/user, work_type, pe, work_time)

--- a/code/modules/mob/living/simple_animal/abnormality/teth/faelantern.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/faelantern.dm
@@ -28,7 +28,8 @@
 	ranged = TRUE
 	ranged_cooldown_time = 1.5 SECONDS
 
-	work_damage_amount = 3
+	work_damage_upper = 4
+	work_damage_lower = 2
 	work_damage_type = WHITE_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/gluttony
 	start_qliphoth = 1

--- a/code/modules/mob/living/simple_animal/abnormality/teth/fairy_gentleman.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/fairy_gentleman.dm
@@ -30,7 +30,8 @@
 	)
 	pixel_x = -34
 	base_pixel_x = -34
-	work_damage_amount = 3
+	work_damage_upper = 4
+	work_damage_lower = 2
 	work_damage_type = RED_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/sloth
 

--- a/code/modules/mob/living/simple_animal/abnormality/teth/fairy_long_legs.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/fairy_long_legs.dm
@@ -32,7 +32,8 @@
 		ABNORMALITY_WORK_REPRESSION = 0,
 		"Take cover" = 0,
 	)
-	work_damage_amount = 3
+	work_damage_upper = 4
+	work_damage_lower = 2
 	work_damage_type = RED_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/gluttony
 	death_message = "coalesces into a primordial egg."

--- a/code/modules/mob/living/simple_animal/abnormality/teth/falada.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/falada.dm
@@ -22,7 +22,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = 30,
 		ABNORMALITY_WORK_REPRESSION = 30,
 	)
-	work_damage_amount = 3
+	work_damage_upper = 3
+	work_damage_lower = 2
 	work_damage_type = BLACK_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/pride
 

--- a/code/modules/mob/living/simple_animal/abnormality/teth/forsaken_employee.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/forsaken_employee.dm
@@ -13,7 +13,7 @@
 		ABNORMALITY_WORK_ATTACHMENT = list(40, 40, 30, 30, 30),
 		ABNORMALITY_WORK_REPRESSION = list(60, 60, 50, 50, 50),
 	)
-	work_damage_amount = 3
+	work_damage_lower = 3
 	work_damage_type = RED_DAMAGE
 
 	ego_list = list(

--- a/code/modules/mob/living/simple_animal/abnormality/teth/forsaken_murderer.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/forsaken_murderer.dm
@@ -47,7 +47,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = list(50, 50, 40, 40, 40),
 		ABNORMALITY_WORK_REPRESSION = list(30, 20, 0, -80, -80),
 	)
-	work_damage_amount = 3
+	work_damage_upper = 3
+	work_damage_lower = 2
 	work_damage_type = RED_DAMAGE
 
 	chem_type = /datum/reagent/abnormality/sin/pride

--- a/code/modules/mob/living/simple_animal/abnormality/teth/fragment.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/fragment.dm
@@ -29,9 +29,11 @@
 		ABNORMALITY_WORK_ATTACHMENT = list(60, 60, 50, 50, 50),
 		ABNORMALITY_WORK_REPRESSION = list(50, 50, 40, 40, 40),
 	)
-	work_damage_amount = 3
+	work_damage_upper = 3
+	work_damage_lower = 1
 	work_damage_type = BLACK_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/envy
+	max_boxes = 12
 
 	ego_list = list(
 		/datum/ego_datum/weapon/fragment,

--- a/code/modules/mob/living/simple_animal/abnormality/teth/hurting_teddy.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/hurting_teddy.dm
@@ -31,14 +31,14 @@
 	can_breach = TRUE
 	threat_level = TETH_LEVEL
 	start_qliphoth = 3
-	max_boxes = 14
 	work_chances = list(
 		ABNORMALITY_WORK_INSTINCT = 55,
 		ABNORMALITY_WORK_INSIGHT = 55,
 		ABNORMALITY_WORK_ATTACHMENT = 60,
 		ABNORMALITY_WORK_REPRESSION = 10,
 		)
-	work_damage_amount = 3
+	work_damage_upper = 4
+	work_damage_lower = 2
 	work_damage_type = BLACK_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/envy //all of its EGO is envy. makes sense to me.
 	ego_list = list(

--- a/code/modules/mob/living/simple_animal/abnormality/teth/kikimora.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/kikimora.dm
@@ -19,7 +19,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = list(50, 50, 40, 40, 40),
 		ABNORMALITY_WORK_REPRESSION = list(30, 20, 0, -80, -80),
 	)
-	work_damage_amount = 3
+	work_damage_upper = 4
+	work_damage_lower = 2
 	work_damage_type = WHITE_DAMAGE
 	death_message = "falls over."
 	ego_list = list(

--- a/code/modules/mob/living/simple_animal/abnormality/teth/lady_facing_the_wall.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/lady_facing_the_wall.dm
@@ -16,7 +16,8 @@
 	pixel_x = -32
 	base_pixel_x = -8
 
-	work_damage_amount = 3
+	work_damage_upper = 3
+	work_damage_lower = 2
 	work_damage_type = WHITE_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/sloth
 	start_qliphoth = 2

--- a/code/modules/mob/living/simple_animal/abnormality/teth/meat_lantern.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/meat_lantern.dm
@@ -23,11 +23,11 @@
 	del_on_death = FALSE
 	death_message = "explodes in a shower of gore."
 
-	work_damage_amount = 3
+	work_damage_upper = 3
+	work_damage_lower = 1
 	work_damage_type = WHITE_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/sloth
 	start_qliphoth = 1
-	max_boxes = 14
 	ego_list = list(
 		/datum/ego_datum/weapon/lantern,
 		/datum/ego_datum/armor/lantern,

--- a/code/modules/mob/living/simple_animal/abnormality/teth/my_sweet_home.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/my_sweet_home.dm
@@ -34,7 +34,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = list(70, 70, 80, 80, 90),
 		ABNORMALITY_WORK_REPRESSION = list(60, 60, 50, 40, 40),
 	)
-	work_damage_amount = 3
+	work_damage_upper = 4
+	work_damage_lower = 2
 	work_damage_type = BLACK_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/envy
 

--- a/code/modules/mob/living/simple_animal/abnormality/teth/old_lady.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/old_lady.dm
@@ -15,7 +15,8 @@
 		"Clear Solitude" = -100,
 	)
 	start_qliphoth = 4
-	work_damage_amount = 3
+	work_damage_upper = 3
+	work_damage_lower = 1
 	work_damage_type = WHITE_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/gloom
 	ego_list = list(

--- a/code/modules/mob/living/simple_animal/abnormality/teth/pale_horse.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/pale_horse.dm
@@ -25,7 +25,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = 55,
 		ABNORMALITY_WORK_REPRESSION = list(70, 65, 60, 50, 50),
 	)
-	work_damage_amount = 6
+	work_damage_upper = 5
+	work_damage_lower = 3
 	work_damage_type = PALE_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/gloom
 
@@ -69,7 +70,7 @@
 	if(user.health < (user.maxHealth * 0.5))
 		return
 	else
-		user.deal_damage(work_damage_amount, PALE_DAMAGE)
+		user.deal_damage(work_damage_upper, PALE_DAMAGE)
 
 /mob/living/simple_animal/hostile/abnormality/pale_horse/Initialize()
 	. = ..()

--- a/code/modules/mob/living/simple_animal/abnormality/teth/penitent_girl.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/penitent_girl.dm
@@ -17,7 +17,8 @@
 		ABNORMALITY_WORK_REPRESSION = 50,
 	)
 	is_flying_animal = TRUE
-	work_damage_amount = 3
+	work_damage_upper = 4
+	work_damage_lower = 2
 	work_damage_type = WHITE_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/gloom
 

--- a/code/modules/mob/living/simple_animal/abnormality/teth/ppodae.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/ppodae.dm
@@ -20,8 +20,10 @@
 		ABNORMALITY_WORK_ATTACHMENT = 40,
 		ABNORMALITY_WORK_REPRESSION = list(40, 40, 30, 30, 30),
 	)
-	work_damage_amount = 3
+	work_damage_upper = 3
+	work_damage_lower = 2
 	work_damage_type = RED_DAMAGE
+	max_boxes = 12
 	chem_type = /datum/reagent/abnormality/sin/wrath
 	damage_coeff = list(RED_DAMAGE = 1.5, WHITE_DAMAGE = 0.8, BLACK_DAMAGE = 1, PALE_DAMAGE = 2)
 	can_breach = TRUE

--- a/code/modules/mob/living/simple_animal/abnormality/teth/punishing_bird.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/punishing_bird.dm
@@ -43,8 +43,10 @@
 		ABNORMALITY_WORK_ATTACHMENT = list(55, 55, 50, 50, 50),
 		ABNORMALITY_WORK_REPRESSION = list(30, 20, 10, 0, 0),
 	)
-	work_damage_amount = 3
+	work_damage_upper = 4
+	work_damage_lower = 2
 	work_damage_type = RED_DAMAGE
+	max_boxes = 12
 
 	ego_list = list(
 		/datum/ego_datum/weapon/beak,

--- a/code/modules/mob/living/simple_animal/abnormality/teth/redblooded.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/redblooded.dm
@@ -36,8 +36,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = 0,
 		ABNORMALITY_WORK_REPRESSION = list(60, 60, 60, 55, 55),
 	)
-	max_boxes = 14
-	work_damage_amount = 3
+	work_damage_upper = 4
+	work_damage_lower = 2
 	work_damage_type = RED_DAMAGE
 	chem_type = /datum/reagent/abnormality/red_blooded
 	harvest_phrase = span_notice("You take a blood sample from %ABNO. The blood fizzles inside the %VESSEL.")
@@ -102,7 +102,7 @@
 		You passively reload 1 ammo every 2 seconds, but you can also reload 1 ammo by hitting humans or mechs.</b>")
 
 /mob/living/simple_animal/hostile/abnormality/redblooded/AttemptWork(mob/living/carbon/human/user, work_type)
-	work_damage_amount = 3 + bloodlust
+	work_damage_upper = 4 + bloodlust
 	if(work_type == ABNORMALITY_WORK_REPRESSION)
 		say(pick(fighting_quotes))
 		bloodlust +=2

--- a/code/modules/mob/living/simple_animal/abnormality/teth/scorched_girl.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/scorched_girl.dm
@@ -20,9 +20,11 @@
 		ABNORMALITY_WORK_ATTACHMENT = list(30, 15, 0, -40, -50),
 		ABNORMALITY_WORK_REPRESSION = list(50, 50, 40, 40, 40),
 	)
-	work_damage_amount = 3
+	work_damage_upper = 4
+	work_damage_lower = 2
 	work_damage_type = RED_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/envy
+	max_boxes = 12
 	damage_coeff = list(RED_DAMAGE = 0.5, WHITE_DAMAGE = 2, BLACK_DAMAGE = 1, PALE_DAMAGE = 2)
 	faction = list("hostile")
 	can_breach = TRUE

--- a/code/modules/mob/living/simple_animal/abnormality/teth/shy_look.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/shy_look.dm
@@ -22,9 +22,11 @@
 		ABNORMALITY_WORK_ATTACHMENT = list(50, 45, 45, 40, 40),
 		ABNORMALITY_WORK_REPRESSION = list(50, 45, 45, 40, 40),
 	)
-	work_damage_amount = 3
+	work_damage_upper = 3
+	work_damage_lower = 2
 	work_damage_type = BLACK_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/pride
+	max_boxes = 12
 
 	ego_list = list(
 		/datum/ego_datum/weapon/shy,
@@ -60,25 +62,22 @@
 	switch(next_mood)
 		if(1) //From Smiling to angry
 			chance_modifier = 1.3
-			work_damage_amount = initial(work_damage_amount)*0.5
+			work_damage_upper = initial(work_damage_upper)*0.5
 		if(2)
 			chance_modifier = 1.1
-			work_damage_amount = initial(work_damage_amount)
+			work_damage_upper = initial(work_damage_upper)
 		if(3)
 			chance_modifier = 1
-			work_damage_amount = initial(work_damage_amount)
+			work_damage_upper = initial(work_damage_upper)
 		if(4)
 			chance_modifier = 0.7
-			work_damage_amount = initial(work_damage_amount)*1.5
+			work_damage_upper = initial(work_damage_upper)*1.5
 		if(5)
 			chance_modifier = 0.5
-			work_damage_amount = initial(work_damage_amount)*2
+			work_damage_upper = initial(work_damage_upper)*2
 	if(!special_breach)
 		ChangeIcon()
 		return
-	var/damage_total = (initial(work_damage_amount) * 0.75) * (next_mood - 1)//Basically (6 * mood -1). the happiest expression deals no damage.
-	melee_damage_upper = damage_total
-	melee_damage_lower = damage_total
 	ChangeOverlay(next_mood)
 
 /mob/living/simple_animal/hostile/abnormality/shy_look/proc/ChangeIcon()

--- a/code/modules/mob/living/simple_animal/abnormality/teth/simple_smile.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/simple_smile.dm
@@ -34,7 +34,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = 85,
 		ABNORMALITY_WORK_REPRESSION = 85,
 	)
-	work_damage_amount = 3
+	work_damage_upper = 3
+	work_damage_lower = 2
 	work_damage_type = BLACK_DAMAGE
 
 	ego_list = list(

--- a/code/modules/mob/living/simple_animal/abnormality/teth/sirocco.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/sirocco.dm
@@ -29,7 +29,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = 60,
 		ABNORMALITY_WORK_REPRESSION = list(40, 20, -20, -20, -20),
 	)
-	work_damage_amount = 4
+	work_damage_upper = 4
+	work_damage_lower = 2
 	work_damage_type = RED_DAMAGE
 
 	ego_list = list(

--- a/code/modules/mob/living/simple_animal/abnormality/teth/skin_prophet.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/skin_prophet.dm
@@ -14,7 +14,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = 0,
 		ABNORMALITY_WORK_REPRESSION = 0,
 	)
-	work_damage_amount = 3	//Gets more later
+	work_damage_upper = 3
+	work_damage_lower = 2	//Gets more later
 	work_damage_type = WHITE_DAMAGE
 
 	ego_list = list(
@@ -54,13 +55,13 @@
 
 /mob/living/simple_animal/hostile/abnormality/skin_prophet/WorkChance(mob/living/carbon/human/user, chance)
 	//work damage starts at 7, + candles stuffed
-	work_damage_amount = initial(work_damage_amount) + candles
+	work_damage_upper = initial(work_damage_upper) + candles
 
 	//If you're doing rep or temeprance then your work chance is your total buffs combined, and damage is increased too
 	if(chance == 0)
 		var/totalbuff = get_level_buff(user, FORTITUDE_ATTRIBUTE) + get_level_buff(user, PRUDENCE_ATTRIBUTE) + get_level_buff(user, TEMPERANCE_ATTRIBUTE) + get_level_buff(user, JUSTICE_ATTRIBUTE)
 		chance = totalbuff
-		work_damage_amount += totalbuff/10
+		work_damage_upper += totalbuff/10
 	return chance
 
 /mob/living/simple_animal/hostile/abnormality/skin_prophet/WorktickFailure(mob/living/carbon/human/user)

--- a/code/modules/mob/living/simple_animal/abnormality/teth/so_that_no_cry.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/so_that_no_cry.dm
@@ -28,7 +28,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = 0,
 		ABNORMALITY_WORK_REPRESSION = 60,
 	)
-	work_damage_amount = 3
+	work_damage_upper = 4
+	work_damage_lower = 2
 	work_damage_type = BLACK_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/lust
 	base_pixel_x = -12

--- a/code/modules/mob/living/simple_animal/abnormality/teth/someonesportrait.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/someonesportrait.dm
@@ -15,7 +15,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = list(45, 45, 40, 40, 40),
 		ABNORMALITY_WORK_REPRESSION = list(55, 55, 50, 50, 50),
 	)
-	work_damage_amount = 3
+	work_damage_upper = 4
+	work_damage_lower = 2
 	work_damage_type = WHITE_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/envy
 	damage_coeff = list(RED_DAMAGE = 1, WHITE_DAMAGE = 1, BLACK_DAMAGE = 1, PALE_DAMAGE = 1)

--- a/code/modules/mob/living/simple_animal/abnormality/teth/spider_bud.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/spider_bud.dm
@@ -17,9 +17,11 @@
 	pixel_x = -8
 	base_pixel_x = -8
 
-	work_damage_amount = 3
+	work_damage_upper = 3
+	work_damage_lower = 2
 	work_damage_type = RED_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/lust	//Limbus Company Red Eyes EGO
+
 	damage_coeff = list(RED_DAMAGE = 1.2, WHITE_DAMAGE = 2, BLACK_DAMAGE = 0.8, PALE_DAMAGE = 2)
 	good_hater = TRUE
 	ego_list = list(

--- a/code/modules/mob/living/simple_animal/abnormality/teth/tangle.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/tangle.dm
@@ -23,7 +23,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = list(50, 50, 40, 40, 40),
 		ABNORMALITY_WORK_REPRESSION = list(50, 50, 40, 40, 40),
 	)
-	work_damage_amount = 3
+	work_damage_upper = 4
+	work_damage_lower = 2
 	work_damage_type = WHITE_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/sloth
 	ego_list = list(

--- a/code/modules/mob/living/simple_animal/abnormality/teth/training_rabbit.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/training_rabbit.dm
@@ -16,9 +16,11 @@
 		ABNORMALITY_WORK_ATTACHMENT = 100,
 		ABNORMALITY_WORK_REPRESSION = 40,
 	)
-	work_damage_amount = 2
+	work_damage_upper = 2
+	work_damage_lower = 1
 	work_damage_type = RED_DAMAGE
 	chem_type = /datum/reagent/blood
+	max_boxes = 10
 	damage_coeff = list(RED_DAMAGE = 0.5, WHITE_DAMAGE = 1.5, BLACK_DAMAGE = 1, PALE_DAMAGE = 1)
 	can_breach = TRUE
 	start_qliphoth = 1

--- a/code/modules/mob/living/simple_animal/abnormality/teth/void_dream.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/void_dream.dm
@@ -26,7 +26,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = 60,
 		ABNORMALITY_WORK_REPRESSION = 20,
 	)
-	work_damage_amount = 3
+	work_damage_upper = 3
+	work_damage_lower = 1
 	work_damage_type = BLACK_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/sloth
 

--- a/code/modules/mob/living/simple_animal/abnormality/waw/alriune.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/alriune.dm
@@ -24,7 +24,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = list(0, 0, 40, 35, 30),
 		ABNORMALITY_WORK_REPRESSION = list(0, 0, 35, 30, 25),
 	)
-	work_damage_amount = 7
+	work_damage_upper = 6
+	work_damage_lower = 4
 	work_damage_type = WHITE_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/pride
 	good_hater = TRUE

--- a/code/modules/mob/living/simple_animal/abnormality/waw/apex_predator.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/apex_predator.dm
@@ -37,7 +37,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = list(25, 20, 15, 10, 0),
 		ABNORMALITY_WORK_REPRESSION = list(0, 0, 50, 55, 55),
 	)
-	work_damage_amount = 7
+	work_damage_upper = 7
+	work_damage_lower = 4
 	work_damage_type = RED_DAMAGE
 	chem_type = /datum/reagent/abnormality/apex_predator
 	harvest_phrase = span_notice("A cloudy liquid leaks from %ABNO, stinking of burnt plastic. You collect it using %VESSEL.")
@@ -103,14 +104,14 @@
 
 /mob/living/simple_animal/hostile/abnormality/apex_predator/AttemptWork(mob/living/carbon/human/user, work_type)
 	if(user.health != user.maxHealth)
-		work_damage_amount = 10
+		work_damage_upper = 10
 	return TRUE
 
 /mob/living/simple_animal/hostile/abnormality/apex_predator/PostWorkEffect(mob/living/carbon/human/user, work_type, pe, work_time)
 	if(user.health < 0)
 		datum_reference.qliphoth_change(-1)
 
-	work_damage_amount = initial(work_damage_amount)
+	work_damage_upper = initial(work_damage_lower)
 	return
 
 /mob/living/simple_animal/hostile/abnormality/apex_predator/BreachEffect(mob/living/carbon/human/user, breach_type)

--- a/code/modules/mob/living/simple_animal/abnormality/waw/babayaga.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/babayaga.dm
@@ -27,7 +27,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = 0,
 		ABNORMALITY_WORK_REPRESSION = list(0, 0, 40, 40, 40),
 	)
-	work_damage_amount = 7
+	work_damage_upper = 6
+	work_damage_lower = 4
 	work_damage_type = RED_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/gloom
 	ego_list = list(

--- a/code/modules/mob/living/simple_animal/abnormality/waw/big_bird.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/big_bird.dm
@@ -32,9 +32,11 @@
 		ABNORMALITY_WORK_ATTACHMENT = list(40, 45, 50, 55, 55),
 		ABNORMALITY_WORK_REPRESSION = list(25, 20, 15, 10, 0),
 	)
-	work_damage_amount = 7
+	work_damage_upper = 6
+	work_damage_lower = 2
 	work_damage_type = BLACK_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/gluttony
+	max_boxes = 20
 
 	light_color = COLOR_ORANGE
 	light_range = 5

--- a/code/modules/mob/living/simple_animal/abnormality/waw/big_wolf.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/big_wolf.dm
@@ -38,7 +38,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = list(45, 50, 50, 55, 55),
 		ABNORMALITY_WORK_REPRESSION = 0,
 	)
-	work_damage_amount = 7
+	work_damage_upper = 8
+	work_damage_lower = 4
 	work_damage_type = RED_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/gluttony
 	melee_damage_type = RED_DAMAGE

--- a/code/modules/mob/living/simple_animal/abnormality/waw/black_swan.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/black_swan.dm
@@ -40,9 +40,11 @@
 		ABNORMALITY_WORK_ATTACHMENT = 0,
 		ABNORMALITY_WORK_REPRESSION = list(0, 0, 45, 50, 55),
 	)
-	work_damage_amount = 7
+	work_damage_upper = 6
+	work_damage_lower = 5
 	work_damage_type = WHITE_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/pride
+	max_boxes = 24
 	death_message = "weeps a green sludge while clutching her brooch."
 	base_pixel_x = -16
 	pixel_x = -16

--- a/code/modules/mob/living/simple_animal/abnormality/waw/caterpillar.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/caterpillar.dm
@@ -29,7 +29,8 @@
 		ABNORMALITY_WORK_REPRESSION = list(20, 20, 20, 20, 65),
 	)
 	max_boxes = 18
-	work_damage_amount = 5
+	work_damage_upper = 6
+	work_damage_lower = 5
 	work_damage_type = PALE_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/sloth
 	patrol_cooldown_time = 3 SECONDS
@@ -79,7 +80,7 @@
 		darts_smoked++	//Smoke a fat stoogie if it's not repression
 
 		if(darts_smoked<8)
-			work_damage_amount+=2
+			work_damage_lower+=2
 			datum_reference.max_boxes+=2
 
 		if(darts_smoked>=3)

--- a/code/modules/mob/living/simple_animal/abnormality/waw/clouded_monk.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/clouded_monk.dm
@@ -32,7 +32,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = list(20, 45, 45, 45, 45),
 		ABNORMALITY_WORK_REPRESSION = list(40, 20, 40, 40, 40),
 	)
-	work_damage_amount = 7
+	work_damage_upper = 6
+	work_damage_lower = 4
 	work_damage_type = WHITE_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/gluttony
 

--- a/code/modules/mob/living/simple_animal/abnormality/waw/clown_smiling.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/clown_smiling.dm
@@ -38,7 +38,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = list(50, 55, 60, 65, 65),
 		ABNORMALITY_WORK_REPRESSION = 35,
 	)
-	work_damage_amount = 7
+	work_damage_upper = 5
+	work_damage_lower = 4
 	work_damage_type = WHITE_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/gluttony
 	good_hater = TRUE

--- a/code/modules/mob/living/simple_animal/abnormality/waw/contract.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/contract.dm
@@ -17,7 +17,8 @@
 	pixel_x = -16
 	base_pixel_x = -16
 	start_qliphoth = 2
-	work_damage_amount = 8
+	work_damage_upper = 8
+	work_damage_lower = 4
 	work_damage_type = PALE_DAMAGE	//Lawyers take your fucking soul
 	chem_type = /datum/reagent/abnormality/sin/lust
 
@@ -91,11 +92,11 @@
 	return
 
 /mob/living/simple_animal/hostile/abnormality/contract/AttemptWork(mob/living/carbon/human/user, work_type)
-	work_damage_amount = initial(work_damage_amount)
+	work_damage_upper = initial(work_damage_upper)
 	if(ContractedUser(user, work_type) && .)
-		work_damage_amount *= 0.3
+		work_damage_upper *= 0.3
 	if(user in total_havers)
-		work_damage_amount *= 0.8
+		work_damage_upper *= 0.8
 		say("Yes, yes... I remember the contract.")
 
 	. = ..()
@@ -188,7 +189,7 @@
 	NewContract(user, work_type)
 
 /mob/living/simple_animal/hostile/abnormality/contract/PostWorkEffect(mob/living/carbon/human/user, work_type, pe, work_time)
-	work_damage_amount = initial(work_damage_amount)
+	work_damage_upper = initial(work_damage_upper)
 	return
 
 /mob/living/simple_animal/hostile/abnormality/contract/NeutralEffect(mob/living/carbon/human/user, work_type, pe)

--- a/code/modules/mob/living/simple_animal/abnormality/waw/despair_knight.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/despair_knight.dm
@@ -31,7 +31,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = list(50, 50, 55, 55, 60),
 		ABNORMALITY_WORK_REPRESSION = list(40, 40, 40, 35, 30),
 	)
-	work_damage_amount = 7
+	work_damage_upper = 6
+	work_damage_lower = 4
 	work_damage_type = WHITE_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/gloom
 

--- a/code/modules/mob/living/simple_animal/abnormality/waw/dimension_refraction.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/dimension_refraction.dm
@@ -29,7 +29,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = list(0, 0, 40, 40, 40),
 		ABNORMALITY_WORK_REPRESSION = list(0, 0, 40, 40, 40),
 	)
-	work_damage_amount = 7
+	work_damage_upper = 7
+	work_damage_lower = 4
 	work_damage_type = WHITE_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/sloth
 

--- a/code/modules/mob/living/simple_animal/abnormality/waw/dreaming_current.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/dreaming_current.dm
@@ -24,9 +24,11 @@
 		ABNORMALITY_WORK_ATTACHMENT = list(45, 45, 45, 50, 55),
 		ABNORMALITY_WORK_REPRESSION = 45,
 	)
-	work_damage_amount = 7
+	work_damage_upper = 6
+	work_damage_lower = 3
 	work_damage_type = WHITE_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/gluttony
+	max_boxes = 20
 
 	can_breach = TRUE
 	start_qliphoth = 2

--- a/code/modules/mob/living/simple_animal/abnormality/waw/ebony_queen.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/ebony_queen.dm
@@ -41,7 +41,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = list(0, 0, 40, 40, 40),
 		ABNORMALITY_WORK_REPRESSION = list(20, 30, 55, 55, 60),
 	)
-	work_damage_amount = 7
+	work_damage_upper = 6
+	work_damage_lower = 2
 	work_damage_type = BLACK_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/gluttony
 

--- a/code/modules/mob/living/simple_animal/abnormality/waw/express_train.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/express_train.dm
@@ -16,7 +16,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = 35,
 		ABNORMALITY_WORK_REPRESSION = 35,
 	)
-	work_damage_amount = 7
+	work_damage_upper = 6
+	work_damage_lower = 4
 	work_damage_type = BLACK_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/sloth
 	pixel_x = -16

--- a/code/modules/mob/living/simple_animal/abnormality/waw/fire_bird.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/fire_bird.dm
@@ -22,7 +22,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = list(45, 45, 40, 40, 50),
 		ABNORMALITY_WORK_REPRESSION = list(45, 45, 40, 40, 50),
 	)
-	work_damage_amount = 7
+	work_damage_upper = 4
+	work_damage_lower = 3
 	work_damage_type = RED_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/lust
 	good_hater = TRUE
@@ -92,17 +93,17 @@
 	. = ..()
 	switch(datum_reference?.qliphoth_meter)
 		if(1)
-			work_damage_amount = 11
+			work_damage_upper = 11
 			light_range = 10
 			light_power = 20
 			update_light()
 		if(2)
-			work_damage_amount = 9
+			work_damage_upper = 9
 			light_range = 2
 			light_power = 10
 			update_light()
 		else
-			work_damage_amount = 7
+			work_damage_upper = 7
 			light_range = 0
 			light_power = 0
 			update_light()

--- a/code/modules/mob/living/simple_animal/abnormality/waw/flesh_idol.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/flesh_idol.dm
@@ -17,7 +17,8 @@
 	)
 	start_qliphoth = 4
 	max_boxes = 20
-	work_damage_amount = 0		//Work damage is later
+	work_damage_upper = 0
+	work_damage_lower = 0		//Work damage is later
 	work_damage_type = RED_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/lust
 
@@ -39,7 +40,7 @@
 	var/counter_interval = 5 MINUTES
 	var/next_counter_gain //What was the next time you gain Qlip?
 	var/reset_time = 1 MINUTES
-	var/damage_amount = 7
+	var/damage_amount = 6
 	var/run_num = 2		//How many things you breach
 
 	var/list/blacklist = list(

--- a/code/modules/mob/living/simple_animal/abnormality/waw/generalb.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/generalb.dm
@@ -16,7 +16,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = 0,						//DO NOT FUCK THE BEEGIRL
 		ABNORMALITY_WORK_REPRESSION = list(0, 0, 40, 40, 40),
 	)
-	work_damage_amount = 7
+	work_damage_upper = 6
+	work_damage_lower = 4
 	work_damage_type = RED_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/pride
 	ego_list = list(

--- a/code/modules/mob/living/simple_animal/abnormality/waw/greed_king.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/greed_king.dm
@@ -30,7 +30,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = list(0, 0, 50, 50, 55),
 		ABNORMALITY_WORK_REPRESSION = list(0, 0, 40, 40, 40),
 	)
-	work_damage_amount = 7
+	work_damage_upper = 7
+	work_damage_lower = 5
 	work_damage_type = RED_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/gluttony
 

--- a/code/modules/mob/living/simple_animal/abnormality/waw/hatred_queen.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/hatred_queen.dm
@@ -40,7 +40,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = list(50, 50, 55, 55, 60),
 		ABNORMALITY_WORK_REPRESSION = list(20, 20, 20, 0, 0),
 	)
-	work_damage_amount = 5
+	work_damage_upper = 4
+	work_damage_lower = 3
 	work_damage_type = BLACK_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/lust
 
@@ -634,12 +635,12 @@
 /mob/living/simple_animal/hostile/abnormality/hatred_queen/proc/GoCrazy()
 	icon_state = icon_crazy
 	chance_modifier = 0.8
-	work_damage_amount *= 2
+	work_damage_upper *= 2
 
 /mob/living/simple_animal/hostile/abnormality/hatred_queen/proc/GoNormal()
 	icon_state = icon_living
 	chance_modifier = 1
-	work_damage_amount = initial(work_damage_amount)
+	work_damage_upper = initial(work_damage_upper)
 
 /mob/living/simple_animal/hostile/abnormality/hatred_queen/proc/GoHysteric(retries = 0)
 	if(!friendly || !breach_max_death || nihil_present)

--- a/code/modules/mob/living/simple_animal/abnormality/waw/judgement_bird.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/judgement_bird.dm
@@ -33,9 +33,11 @@
 		ABNORMALITY_WORK_ATTACHMENT = list(20, 20, 35, 45, 45),
 		ABNORMALITY_WORK_REPRESSION = 0,
 	)
-	work_damage_amount = 12
+	work_damage_upper = 7
+	work_damage_lower = 5
 	work_damage_type = PALE_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/wrath
+	max_boxes = 24
 
 	attack_action_types = list(/datum/action/innate/abnormality_attack/judgement)
 

--- a/code/modules/mob/living/simple_animal/abnormality/waw/little_prince.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/little_prince.dm
@@ -13,9 +13,11 @@
 		ABNORMALITY_WORK_ATTACHMENT = list(0, 0, 50, 50, 55),
 		ABNORMALITY_WORK_REPRESSION = list(0, 0, 50, 50, 55),
 	)
-	work_damage_amount = 7
+	work_damage_upper = 4
+	work_damage_lower = 3
 	work_damage_type = BLACK_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/envy
+	max_boxes = 24
 	start_qliphoth = 2
 
 	ego_list = list(

--- a/code/modules/mob/living/simple_animal/abnormality/waw/luna.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/luna.dm
@@ -19,7 +19,8 @@
 	)
 	pixel_x = -32
 	base_pixel_x = -32
-	work_damage_amount = 7
+	work_damage_upper = 4
+	work_damage_lower = 3
 	work_damage_type = WHITE_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/sloth
 	max_boxes = 20
@@ -106,7 +107,7 @@
 
 /mob/living/simple_animal/hostile/abnormality/luna/Worktick(mob/living/carbon/human/user, work_type)
 	if(performance)
-		user.deal_damage(work_damage_amount*0.60, BLACK_DAMAGE)	//take work damage
+		user.deal_damage(work_damage_upper*0.60, BLACK_DAMAGE)	//take work damage
 
 
 /mob/living/simple_animal/hostile/abnormality/luna/AttemptWork(mob/living/carbon/human/user, work_type)

--- a/code/modules/mob/living/simple_animal/abnormality/waw/my_form_empties.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/my_form_empties.dm
@@ -18,7 +18,6 @@
 
 	threat_level = WAW_LEVEL
 	can_breach = TRUE
-	max_boxes = 22
 	start_qliphoth = 2
 	work_chances = list(
 		ABNORMALITY_WORK_INSTINCT = 15,
@@ -26,7 +25,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = 25,
 		ABNORMALITY_WORK_REPRESSION = list(0, 0, 45, 50, 55),
 	)
-	work_damage_amount = 7
+	work_damage_upper = 5
+	work_damage_lower = 3
 	work_damage_type = WHITE_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/lust
 

--- a/code/modules/mob/living/simple_animal/abnormality/waw/naked_nest.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/naked_nest.dm
@@ -19,10 +19,10 @@
 		ABNORMALITY_WORK_ATTACHMENT = list(0, 0, 45, 45, 50),
 		ABNORMALITY_WORK_REPRESSION = list(40, 40, 40, 40, 40),
 	)
-	work_damage_amount = 7
+	work_damage_upper = 7
+	work_damage_lower = 5
 	work_damage_type = RED_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/pride
-	max_boxes = 22
 	start_qliphoth = 1
 	fear_level = 1
 

--- a/code/modules/mob/living/simple_animal/abnormality/waw/nosferatu.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/nosferatu.dm
@@ -24,7 +24,8 @@
 	melee_damage_upper = 11 //has a wide range, he can critically hit you
 	melee_damage_type = RED_DAMAGE
 	stat_attack = HARD_CRIT
-	work_damage_amount = 7
+	work_damage_upper = 7
+	work_damage_lower = 3
 	work_damage_type = RED_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/envy
 	attack_verb_continuous = "claws"

--- a/code/modules/mob/living/simple_animal/abnormality/waw/orange_tree.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/orange_tree.dm
@@ -20,7 +20,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = list(0, 0, 55, 55, 60),
 		ABNORMALITY_WORK_REPRESSION = list(0, 0, 45, 45, 45),
 	)
-	work_damage_amount = 7
+	work_damage_upper = 6
+	work_damage_lower = 4
 	work_damage_type = WHITE_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/sloth
 

--- a/code/modules/mob/living/simple_animal/abnormality/waw/parasite_tree.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/parasite_tree.dm
@@ -25,9 +25,11 @@
 		ABNORMALITY_WORK_ATTACHMENT = list(50, 50, 50, 50, 55),
 		ABNORMALITY_WORK_REPRESSION = 20,
 	)
-	work_damage_amount = 7
+	work_damage_upper = 6
+	work_damage_lower = 5
 	work_damage_type = WHITE_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/sloth
+	max_boxes = 24
 
 	ego_list = list(
 		/datum/ego_datum/weapon/hypocrisy,

--- a/code/modules/mob/living/simple_animal/abnormality/waw/pygmalion.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/pygmalion.dm
@@ -33,7 +33,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = 50,
 		ABNORMALITY_WORK_REPRESSION = list(40, 40, 40, 35, 30),
 	)
-	work_damage_amount = 7
+	work_damage_upper = 6
+	work_damage_lower = 4
 	work_damage_type = WHITE_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/lust
 

--- a/code/modules/mob/living/simple_animal/abnormality/waw/queen_bee.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/queen_bee.dm
@@ -19,7 +19,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = list(0, 0, 40, 40, 40),
 		ABNORMALITY_WORK_REPRESSION = 0,
 	)
-	work_damage_amount = 10
+	work_damage_upper = 6
+	work_damage_lower = 4
 	work_damage_type = RED_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/pride
 

--- a/code/modules/mob/living/simple_animal/abnormality/waw/red_riding_mercenary.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/red_riding_mercenary.dm
@@ -35,9 +35,11 @@ It has now been over four months. Now we get her for real. -Coxswain
 	attack_action_types = list(/datum/action/innate/abnormality_attack/find_target, /datum/action/innate/abnormality_attack/catch_breath, /datum/action/innate/abnormality_attack/hollowpoint_shell, /datum/action/innate/abnormality_attack/strike_without_hesitation)
 	melee_damage_type = RED_DAMAGE
 	stat_attack = HARD_CRIT
-	work_damage_amount = 7
+	work_damage_upper = 6
+	work_damage_lower = 4
 	work_damage_type = RED_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/pride
+	max_boxes = 20
 	patrol_cooldown_time = 10 SECONDS // She's restless
 	attack_verb_continuous = "cuts"
 	attack_verb_simple = "cuts"

--- a/code/modules/mob/living/simple_animal/abnormality/waw/rose_sign.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/rose_sign.dm
@@ -23,7 +23,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = list(0, 10, 20, 20, 20),
 		ABNORMALITY_WORK_REPRESSION = 0,
 	)
-	work_damage_amount = 7
+	work_damage_upper = 7
+	work_damage_lower = 5
 	work_damage_type = WHITE_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/lust	///Of course the gregnant ID is a lust one.
 	can_breach = TRUE

--- a/code/modules/mob/living/simple_animal/abnormality/waw/screenwriter.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/screenwriter.dm
@@ -33,7 +33,8 @@ Defeating the murderer also surpresses the abnormality.
 		"Violence" = JUSTICE_ATTRIBUTE,
 	)
 	max_boxes = 24
-	work_damage_amount = 7
+	work_damage_upper = 6
+	work_damage_lower = 4
 	work_damage_type = WHITE_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/gluttony
 

--- a/code/modules/mob/living/simple_animal/abnormality/waw/shrimp.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/shrimp.dm
@@ -17,7 +17,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = 30,
 		ABNORMALITY_WORK_REPRESSION = -100,	//He's a snobby shrimp dude.
 	)
-	work_damage_amount = 7
+	work_damage_upper = 6
+	work_damage_lower = 4
 	work_damage_type = WHITE_DAMAGE	//He insults you
 	chem_type = /datum/reagent/abnormality/sin/pride
 

--- a/code/modules/mob/living/simple_animal/abnormality/waw/silence.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/silence.dm
@@ -13,7 +13,8 @@
 		ABNORMALITY_WORK_REPRESSION = list(0, 0, 50, 45, 45),
 	)
 	start_qliphoth = 1
-	work_damage_amount = 10
+	work_damage_upper = 8
+	work_damage_lower = 6
 	work_damage_type = PALE_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/gloom
 

--- a/code/modules/mob/living/simple_animal/abnormality/waw/siltcurrent.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/siltcurrent.dm
@@ -40,7 +40,8 @@
 						ABNORMALITY_WORK_ATTACHMENT = -100,//you thought it would work like current eh?
 						ABNORMALITY_WORK_REPRESSION = list(70, 65, 60, 55, 50)//Incase you reach waw with justice 1
 						)
-	work_damage_amount = 7//does constant oxygen damage during work
+	work_damage_upper = 5
+	work_damage_lower = 4//does constant oxygen damage during work
 	work_damage_type = RED_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/pride
 	ranged = 1

--- a/code/modules/mob/living/simple_animal/abnormality/waw/snow_whites_apple.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/snow_whites_apple.dm
@@ -36,9 +36,11 @@
 		ABNORMALITY_WORK_ATTACHMENT = list(0, 0, 0, 0, 0),
 		ABNORMALITY_WORK_REPRESSION = list(20, 30, 55, 55, 60),
 	)
-	work_damage_amount = 7
+	work_damage_upper = 5
+	work_damage_lower = 3
 	work_damage_type = BLACK_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/envy
+	max_boxes = 20
 
 	ego_list = list(
 		/datum/ego_datum/weapon/stem,

--- a/code/modules/mob/living/simple_animal/abnormality/waw/sphinx.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/sphinx.dm
@@ -30,7 +30,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = 15,
 		ABNORMALITY_WORK_REPRESSION = list(5, 10, 25, 25, 30),
 	)
-	work_damage_amount = 7
+	work_damage_upper = 6
+	work_damage_lower = 4
 	work_damage_type = WHITE_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/wrath
 

--- a/code/modules/mob/living/simple_animal/abnormality/waw/thunder_bird.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/thunder_bird.dm
@@ -41,7 +41,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = list(10, 10, 5, 5, 15),
 		ABNORMALITY_WORK_REPRESSION = list(50, 45, 50, 55, 55),
 	)
-	work_damage_amount = 7
+	work_damage_upper = 6
+	work_damage_lower = 4
 	work_damage_type = WHITE_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/wrath
 

--- a/code/modules/mob/living/simple_animal/abnormality/waw/warden.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/warden.dm
@@ -30,7 +30,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = 0,
 		ABNORMALITY_WORK_REPRESSION = 50,
 	)
-	work_damage_amount = 8
+	work_damage_upper = 7
+	work_damage_lower = 4
 	work_damage_type = BLACK_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/gluttony
 

--- a/code/modules/mob/living/simple_animal/abnormality/waw/wrath_servant.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/wrath_servant.dm
@@ -31,7 +31,8 @@
 		ABNORMALITY_WORK_REPRESSION = list(30, 30, 40, 40, 50),
 		"Request" = 100,
 	)
-	work_damage_amount = 7
+	work_damage_upper = 6
+	work_damage_lower = 4
 	work_damage_type = BLACK_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/wrath
 

--- a/code/modules/mob/living/simple_animal/abnormality/waw/yang.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/yang.dm
@@ -21,7 +21,8 @@
 	can_breach = TRUE
 	start_qliphoth = 2
 	threat_level = WAW_LEVEL
-	work_damage_amount = 7
+	work_damage_upper = 6
+	work_damage_lower = 4
 	work_damage_type = WHITE_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/envy
 	work_chances = list(

--- a/code/modules/mob/living/simple_animal/abnormality/waw/yin.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/yin.dm
@@ -21,7 +21,8 @@
 	can_breach = TRUE
 	start_qliphoth = 2
 	threat_level = WAW_LEVEL
-	work_damage_amount = 7
+	work_damage_upper = 6
+	work_damage_lower = 4
 	work_damage_type = BLACK_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/envy
 	work_chances = list(

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/bald.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/bald.dm
@@ -16,8 +16,10 @@
 		ABNORMALITY_WORK_ATTACHMENT = 0,
 		ABNORMALITY_WORK_REPRESSION = 0,
 	)
-	work_damage_amount = 2
+	work_damage_upper = 2
+	work_damage_lower = 1
 	work_damage_type = BLACK_DAMAGE
+	max_boxes = 6
 
 	melee_damage_lower = -1
 	melee_damage_upper = -1

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/blubbering_toad.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/blubbering_toad.dm
@@ -24,7 +24,6 @@
 	move_to_delay = 3
 	melee_damage_lower = 2
 	melee_damage_upper = 4
-	max_boxes = 10
 	ranged = TRUE
 	attack_sound = 'sound/abnormalities/blubbering_toad/attack.ogg'
 	attack_verb_continuous = "mauls"
@@ -36,7 +35,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = list(50, 40, 30, 30, 30),
 		ABNORMALITY_WORK_REPRESSION = list(70, 30, 30, 30, 30),
 	)
-	work_damage_amount = 2
+	work_damage_upper = 2
+	work_damage_lower = 1
 	work_damage_type = BLACK_DAMAGE
 
 	// Petting

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/bottle.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/bottle.dm
@@ -19,8 +19,10 @@
 		"Dining" = 100, //You can instead decide to eat the cake.
 		"Drink" = 100, //Or Drink the water
 	)
-	work_damage_amount = 2
+	work_damage_upper = 2
+	work_damage_lower = 1
 	work_damage_type = BLACK_DAMAGE
+	max_boxes = 10 // Must be defined here for later code to work.
 
 	ego_list = list(
 		/datum/ego_datum/weapon/little_alice,
@@ -30,7 +32,6 @@
 	gift_message = "Welcome to your very own Wonderland~"
 	abnormality_origin = ABNORMALITY_ORIGIN_WONDERLAB
 
-	max_boxes = 10
 	verb_say = "begs"
 	move_to_delay = 5
 

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/fairy_festival.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/fairy_festival.dm
@@ -22,9 +22,9 @@
 		ABNORMALITY_WORK_ATTACHMENT = list(70, 60, 50, 50, 50),
 		ABNORMALITY_WORK_REPRESSION = list(50, 40, 30, 30, 30),
 	)
-	work_damage_amount = 2
+	work_damage_upper = 2
+	work_damage_lower = 1
 	work_damage_type = RED_DAMAGE
-	max_boxes = 10
 
 	ego_list = list(
 		/datum/ego_datum/weapon/wingbeat,

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/fallen_amurdad.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/fallen_amurdad.dm
@@ -13,9 +13,9 @@
 		ABNORMALITY_WORK_ATTACHMENT = list(50, 40, 30, 30, 30),
 		ABNORMALITY_WORK_REPRESSION = list(70, 60, 50, 50, 50),
 	)
-	work_damage_amount = 2
+	work_damage_upper = 2
+	work_damage_lower = 1
 	work_damage_type = BLACK_DAMAGE
-	max_boxes = 10
 	chem_type = /datum/reagent/abnormality/sin/envy
 
 	ego_list = list(

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/hammer_light.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/hammer_light.dm
@@ -19,7 +19,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = 70,
 		ABNORMALITY_WORK_REPRESSION = 70,
 	)
-	work_damage_amount = 2
+	work_damage_upper = 2
+	work_damage_lower = 1
 	work_damage_type = RED_DAMAGE
 	max_boxes = 8
 	chem_type = /datum/reagent/abnormality/sin/lust

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/oceanwaves.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/oceanwaves.dm
@@ -16,9 +16,9 @@
 		ABNORMALITY_WORK_ATTACHMENT = 50,
 		ABNORMALITY_WORK_REPRESSION = 50,
 	)
-	work_damage_amount = 2
+	work_damage_upper = 2
+	work_damage_lower = 1
 	work_damage_type = RED_DAMAGE
-	max_boxes = 10
 	success_boxes = 9
 	neutral_boxes = 6
 	chem_type = /datum/reagent/abnormality/sin/gloom

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/one_sin.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/one_sin.dm
@@ -23,14 +23,14 @@
 		ABNORMALITY_WORK_REPRESSION = list(50, 40, 30, 30, 30),
 		"Confess" = 50,
 	)
-	work_damage_amount = 2
+	work_damage_upper = 2
+	work_damage_lower = 1
 	work_damage_type = WHITE_DAMAGE
 
 	ego_list = list(
 		/datum/ego_datum/weapon/penitence,
 		/datum/ego_datum/armor/penitence
 	)
-	max_boxes = 10
 	gift_type = /datum/ego_gifts/penitence
 	gift_message = "From this day forth, you shall never forget his words."
 	abnormality_origin = ABNORMALITY_ORIGIN_LOBOTOMY

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/oracle.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/oracle.dm
@@ -18,7 +18,8 @@
 		ABNORMALITY_WORK_REPRESSION = 80,
 		"Fall Asleep" = 100,
 	)
-	work_damage_amount = 2
+	work_damage_upper = 2
+	work_damage_lower = 1
 	work_damage_type = WHITE_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/wrath
 

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/pile_of_mail.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/pile_of_mail.dm
@@ -15,7 +15,8 @@
 		ABNORMALITY_WORK_REPRESSION = 40,
 	)
 
-	work_damage_amount = 2
+	work_damage_upper = 2
+	work_damage_lower = 1
 	work_damage_type = RED_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/pride
 

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/quiet_day.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/quiet_day.dm
@@ -21,7 +21,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = 60,
 		ABNORMALITY_WORK_REPRESSION = 60,
 	)
-	work_damage_amount = 2
+	work_damage_upper = 2
+	work_damage_lower = 1
 	work_damage_type = WHITE_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/gloom
 

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/sleeping_beauty.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/sleeping_beauty.dm
@@ -21,7 +21,8 @@
 		ABNORMALITY_WORK_ATTACHMENT = 50,
 		ABNORMALITY_WORK_REPRESSION = 70,
 	)
-	work_damage_amount = 2
+	work_damage_upper = 2
+	work_damage_lower = 1
 	work_damage_type = WHITE_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/sloth
 
@@ -29,7 +30,6 @@
 		/datum/ego_datum/weapon/doze,
 		/datum/ego_datum/armor/doze,
 	)
-	max_boxes = 10
 	gift_type =  /datum/ego_gifts/doze
 	abnormality_origin = ABNORMALITY_ORIGIN_ARTBOOK
 

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/sunset_traveller.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/sunset_traveller.dm
@@ -15,7 +15,8 @@
 		ABNORMALITY_WORK_REPRESSION = 50,
 	)
 	max_boxes = 8
-	work_damage_amount = 2
+	work_damage_upper = 2
+	work_damage_lower = 1
 	work_damage_type = WHITE_DAMAGE
 	chem_type = /datum/reagent/abnormality/sin/lust
 	light_color = COLOR_ORANGE

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/we_can_change_anything.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/we_can_change_anything.dm
@@ -24,9 +24,9 @@
 	blood_volume = 0 // Doesn't normally bleed
 	layer = LARGE_MOB_LAYER
 
-	work_damage_amount = 0
+	work_damage_upper = 0
+	work_damage_lower = 0
 	work_damage_type = RED_DAMAGE
-	max_boxes = 10
 	speech_span = SPAN_ROBOT
 
 	ego_list = list(

--- a/code/modules/mob/living/simple_animal/abnormality/zayin/wellcheers.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/wellcheers.dm
@@ -17,9 +17,9 @@
 		ABNORMALITY_WORK_ATTACHMENT = list(50, 50, 40, 40, 40),
 		ABNORMALITY_WORK_REPRESSION = list(50, 50, 40, 40, 40),
 	)
-	work_damage_amount = 1
+	work_damage_upper = 2
+	work_damage_lower = 1
 	work_damage_type = RED_DAMAGE
-	max_boxes = 10
 
 	blood_volume = 0
 

--- a/code/modules/paperwork/records/info/_info.dm
+++ b/code/modules/paperwork/records/info/_info.dm
@@ -73,8 +73,10 @@ For escape damage you will have to get creative and figure out how dangerous it 
 		abno_work_damage_type = uppertext(initial_work_damage_type)
 	if(GLOB.damage_type_shuffler?.is_enabled && IsColorDamageType(initial_work_damage_type))
 		abno_work_damage_type = uppertext(GLOB.damage_type_shuffler.mapping_offense[initial_work_damage_type])
+	// We need to get the average work damage, and it only accepts whole numbers. So we get the average and round.
 	if(isnull(abno_work_damage_count))
-		abno_work_damage_count = SimpleWorkDamageToText(initial(abno_type.work_damage_amount))
+		var/avgworkdamage = round((initial(abno_type.work_damage_upper) + initial(abno_type.work_damage_lower)) * 0.5)
+		abno_work_damage_count = SimpleWorkDamageToText(avgworkdamage)
 	info += "Work Damage Type: [abno_work_damage_type]<br>"
 	info += "Work Damage: [abno_work_damage_count]<br><br>"
 

--- a/code/modules/paperwork/records/info/aleph.dm
+++ b/code/modules/paperwork/records/info/aleph.dm
@@ -238,7 +238,7 @@
 		BLACK_DAMAGE = "Resistant/Immune/Immune",
 		PALE_DAMAGE = "Weak/Normal/Endured")
 
-// Black Sun
+/*// Black Sun
 /obj/item/paper/fluff/info/aleph/blacksun
 	abno_type = /mob/living/simple_animal/hostile/abnormality/black_sun
 	abno_code = "M-03-192"
@@ -248,3 +248,4 @@
 		"As time goes on, this abnormality boosts your stats significantly.",
 		"Working on the abnormality will cause it to set once more, and cause all of it's boosts to subside.",
 		)
+*/

--- a/code/modules/paperwork/records/info/teth.dm
+++ b/code/modules/paperwork/records/info/teth.dm
@@ -423,6 +423,7 @@
 		"During work and breaches, the damage type dealt seemed to vary from hit to hit.",
 		"When the work result was Bad, the Qliphoth Counter lowered."
 	)
+	abno_work_damage_type = "Random"
 
 //Sirocco
 /obj/item/paper/fluff/info/teth/sirocco


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Abnormality work damage is now in a set range (i.e 1-2).

This allows us to use the exact values from the base game.
This is also a direct nerf to work damage in general - this was probably warranted, given the increase in game pace in recent changes and difficulty increases across the board.

- Tidies up abnormality information

Damage ranges listed in abnormality information pamphlets now much more accurately represent the damage dealt by the abnormality.
Comments out black sun's information, as it currently cannot spawn.

- Implements proper maximums for PE boxes

In the past, max PE was only sparsely enforced, largely being up to whoever coded the abnormality. This means that most of the time, it was simply ignored. This PR now adds at a minimum, the max PE values used in Lobotomy Corporation. Perhaps more will come later.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The floating damage numbers that show up while you work now have some variation. Players can now gamble and hope they only take low damage only during a work (They won't).
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: lowered and added randomness to work damage.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
