### PR TITLE
Minor Medbay improvements

### DIFF
--- a/_maps/map_files/Enkephalin_Rush/district_21.dmm
+++ b/_maps/map_files/Enkephalin_Rush/district_21.dmm
@@ -6,6 +6,7 @@
 /obj/item/food/cookie/sugar/pbird,
 /obj/item/food/cookie/sugar/pbird,
 /obj/item/food/cookie/sugar/pbird,
+/obj/item/reagent_containers/hypospray/emais,
 /turf/open/floor/plasteel/white,
 /area/city)
 "ap" = (
@@ -434,6 +435,9 @@
 "dJ" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/shelter,
+/area/department_main/architecture)
+"dN" = (
+/turf/open/floor/plating/rust,
 /area/department_main/architecture)
 "dO" = (
 /obj/structure/sign/poster/official/cleanliness,
@@ -1098,7 +1102,6 @@
 /obj/item/storage/box/beakers/bluespace{
 	pixel_x = 10
 	},
-/obj/item/reagent_containers/hypospray/emais,
 /turf/open/floor/plasteel/white,
 /area/city)
 "kn" = (
@@ -1156,8 +1159,6 @@
 	pixel_y = 10
 	},
 /obj/item/storage/backpack/duffelbag/med/upgradedsurgery,
-/obj/item/hemostat,
-/obj/item/ego_weapon/support/penitence,
 /turf/open/floor/facility/white,
 /area/city)
 "kR" = (
@@ -1499,7 +1500,7 @@
 /turf/closed/mineral/random/facility/pallid/briah,
 /area/department_main/command)
 "ob" = (
-/turf/closed/mineral/random/snow,
+/turf/open/floor/white,
 /area/space)
 "oh" = (
 /obj/machinery/fat_sucker,
@@ -2596,6 +2597,9 @@
 	footstep = "plating"
 	},
 /area/facility_hallway/command)
+"zk" = (
+/turf/closed/indestructible/reinforced/ucorp,
+/area/space)
 "zl" = (
 /obj/machinery/telecomms/broadcaster/preset_left,
 /obj/effect/turf_decal/bot,
@@ -5304,153 +5308,153 @@
 /area/department_main/command)
 
 (1,1,1) = {"
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
 "}
 (2,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -5593,10 +5597,10 @@ CL
 CL
 kp
 kp
-kp
+zk
 "}
 (3,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -5739,10 +5743,10 @@ CL
 CL
 CL
 CL
-kp
+zk
 "}
 (4,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -5885,10 +5889,10 @@ kp
 CL
 CL
 CL
-kp
+zk
 "}
 (5,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -6031,10 +6035,10 @@ kp
 CL
 CL
 kp
-kp
+zk
 "}
 (6,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -6177,10 +6181,10 @@ kp
 CL
 CL
 CL
-kp
+zk
 "}
 (7,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -6323,10 +6327,10 @@ CL
 CL
 CL
 CL
-kp
+zk
 "}
 (8,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -6469,10 +6473,10 @@ kp
 kp
 kp
 kp
-kp
+zk
 "}
 (9,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -6615,10 +6619,10 @@ kp
 kp
 kp
 kp
-kp
+zk
 "}
 (10,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -6761,9 +6765,10 @@ Xm
 hY
 Xm
 Xm
-kp
+zk
 "}
 (11,1,1) = {"
+zk
 kp
 kp
 kp
@@ -6897,9 +6902,8 @@ kp
 kp
 kp
 kp
-kp
-kp
-kp
+Xm
+Xm
 Xm
 MM
 uX
@@ -6907,11 +6911,10 @@ dB
 uX
 iF
 hY
-kp
+zk
 "}
 (12,1,1) = {"
-kp
-kp
+zk
 kp
 kp
 kp
@@ -7046,18 +7049,18 @@ kp
 kp
 kp
 Xm
-Xm
+dN
+dN
 vJ
 ar
 aI
 cK
 jo
 Xm
-kp
+zk
 "}
 (13,1,1) = {"
-kp
-kp
+zk
 kp
 kp
 kp
@@ -7192,6 +7195,7 @@ kp
 kp
 kp
 Xm
+dN
 cW
 Cu
 ot
@@ -7199,11 +7203,10 @@ fp
 dJ
 fH
 Xm
-kp
+zk
 "}
 (14,1,1) = {"
-kp
-kp
+zk
 kp
 kp
 kp
@@ -7338,16 +7341,18 @@ kp
 kp
 kp
 Xm
-Xm
+dN
+dN
 sW
 wB
 YV
 hH
 jo
 Xm
-kp
+zk
 "}
 (15,1,1) = {"
+zk
 kp
 kp
 kp
@@ -7481,9 +7486,8 @@ kp
 kp
 kp
 kp
-kp
-kp
-kp
+Xm
+Xm
 Xm
 lO
 xz
@@ -7491,10 +7495,10 @@ Bf
 Bf
 Yv
 hY
-kp
+zk
 "}
 (16,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -7637,9 +7641,10 @@ Xm
 hY
 Xm
 Xm
-kp
+zk
 "}
 (17,1,1) = {"
+zk
 kp
 kp
 kp
@@ -7782,10 +7787,10 @@ kp
 kp
 kp
 kp
-kp
-kp
+zk
 "}
 (18,1,1) = {"
+zk
 kp
 kp
 kp
@@ -7928,10 +7933,10 @@ kp
 kp
 kp
 kp
-kp
-kp
+zk
 "}
 (19,1,1) = {"
+zk
 kp
 kp
 kp
@@ -8074,10 +8079,10 @@ kp
 kp
 kp
 kp
-kp
-kp
+zk
 "}
 (20,1,1) = {"
+zk
 kp
 kp
 kp
@@ -8220,10 +8225,10 @@ kp
 kp
 kp
 kp
-kp
-kp
+zk
 "}
 (21,1,1) = {"
+zk
 kp
 kp
 kp
@@ -8366,10 +8371,10 @@ kp
 kp
 kp
 kp
-kp
-kp
+zk
 "}
 (22,1,1) = {"
+zk
 kp
 kp
 kp
@@ -8512,10 +8517,10 @@ kp
 kp
 kp
 kp
-kp
-kp
+zk
 "}
 (23,1,1) = {"
+zk
 kp
 kp
 kp
@@ -8658,10 +8663,10 @@ kp
 kp
 kp
 kp
-kp
-kp
+zk
 "}
 (24,1,1) = {"
+zk
 kp
 kp
 kp
@@ -8804,10 +8809,10 @@ kp
 kp
 kp
 kp
-kp
-kp
+zk
 "}
 (25,1,1) = {"
+zk
 kp
 kp
 kp
@@ -8950,10 +8955,10 @@ kp
 kp
 kp
 kp
-kp
-kp
+zk
 "}
 (26,1,1) = {"
+zk
 kp
 kp
 kp
@@ -9096,10 +9101,10 @@ kp
 kp
 kp
 kp
-kp
-kp
+zk
 "}
 (27,1,1) = {"
+zk
 kp
 kp
 kp
@@ -9242,10 +9247,10 @@ kp
 kp
 kp
 kp
-kp
-kp
+zk
 "}
 (28,1,1) = {"
+zk
 kp
 kp
 kp
@@ -9388,10 +9393,10 @@ kp
 kp
 kp
 kp
-kp
-kp
+zk
 "}
 (29,1,1) = {"
+zk
 kp
 kp
 kp
@@ -9534,10 +9539,10 @@ kp
 kp
 kp
 kp
-kp
-kp
+zk
 "}
 (30,1,1) = {"
+zk
 kp
 kp
 kp
@@ -9680,10 +9685,10 @@ kp
 kp
 kp
 kp
-kp
-kp
+zk
 "}
 (31,1,1) = {"
+zk
 kp
 kp
 kp
@@ -9826,10 +9831,10 @@ kp
 kp
 kp
 kp
-kp
-kp
+zk
 "}
 (32,1,1) = {"
+zk
 kp
 kp
 kp
@@ -9972,10 +9977,10 @@ kp
 kp
 kp
 kp
-kp
-kp
+zk
 "}
 (33,1,1) = {"
+zk
 kp
 kp
 kp
@@ -10118,10 +10123,10 @@ kp
 kp
 kp
 kp
-kp
-kp
+zk
 "}
 (34,1,1) = {"
+zk
 kp
 kp
 kp
@@ -10264,10 +10269,10 @@ kp
 kp
 kp
 kp
-kp
-kp
+zk
 "}
 (35,1,1) = {"
+zk
 kp
 kp
 kp
@@ -10410,10 +10415,10 @@ kp
 kp
 kp
 kp
-kp
-kp
+zk
 "}
 (36,1,1) = {"
+zk
 kp
 kp
 kp
@@ -10556,10 +10561,10 @@ kp
 kp
 kp
 kp
-kp
-kp
+zk
 "}
 (37,1,1) = {"
+zk
 kp
 kp
 kp
@@ -10702,10 +10707,10 @@ kp
 kp
 kp
 kp
-kp
-kp
+zk
 "}
 (38,1,1) = {"
+zk
 kp
 kp
 kp
@@ -10848,10 +10853,10 @@ kp
 kp
 kp
 kp
-kp
-kp
+zk
 "}
 (39,1,1) = {"
+zk
 kp
 kp
 kp
@@ -10994,10 +10999,10 @@ kp
 kp
 kp
 kp
-kp
-kp
+zk
 "}
 (40,1,1) = {"
+zk
 kp
 kp
 kp
@@ -11140,10 +11145,10 @@ kp
 kp
 kp
 kp
-kp
-kp
+zk
 "}
 (41,1,1) = {"
+zk
 kp
 kp
 kp
@@ -11286,10 +11291,10 @@ kp
 kp
 kp
 kp
-kp
-kp
+zk
 "}
 (42,1,1) = {"
+zk
 kp
 kp
 kp
@@ -11432,10 +11437,10 @@ kp
 kp
 kp
 kp
-kp
-kp
+zk
 "}
 (43,1,1) = {"
+zk
 kp
 kp
 kp
@@ -11578,11 +11583,10 @@ kp
 kp
 kp
 kp
-kp
-kp
+zk
 "}
 (44,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -11725,10 +11729,10 @@ kp
 kp
 kp
 kp
-kp
+zk
 "}
 (45,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -11871,10 +11875,10 @@ kp
 kp
 kp
 kp
-kp
+zk
 "}
 (46,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -12017,10 +12021,10 @@ kp
 kp
 kp
 kp
-kp
+zk
 "}
 (47,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -12163,10 +12167,10 @@ kp
 kp
 kp
 kp
-kp
+zk
 "}
 (48,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -12309,10 +12313,10 @@ kp
 kp
 kp
 kp
-kp
+zk
 "}
 (49,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -12455,10 +12459,10 @@ kp
 kp
 kp
 kp
-kp
+zk
 "}
 (50,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -12601,10 +12605,10 @@ kp
 kp
 kp
 kp
-kp
+zk
 "}
 (51,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -12747,10 +12751,10 @@ kp
 kp
 kp
 kp
-kp
+zk
 "}
 (52,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -12893,10 +12897,10 @@ kp
 kp
 kp
 kp
-kp
+zk
 "}
 (53,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -13039,10 +13043,10 @@ kp
 kp
 kp
 kp
-kp
+zk
 "}
 (54,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -13185,10 +13189,10 @@ kp
 kp
 kp
 kp
-kp
+zk
 "}
 (55,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -13331,10 +13335,10 @@ kp
 kp
 kp
 kp
-kp
+zk
 "}
 (56,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -13477,10 +13481,10 @@ kp
 kp
 kp
 kp
-kp
+zk
 "}
 (57,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -13623,10 +13627,10 @@ kp
 kp
 kp
 kp
-kp
+zk
 "}
 (58,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -13769,10 +13773,10 @@ kp
 kp
 kp
 kp
-kp
+zk
 "}
 (59,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -13915,10 +13919,10 @@ kp
 kp
 kp
 kp
-kp
+zk
 "}
 (60,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -14061,10 +14065,10 @@ kp
 kp
 kp
 kp
-kp
+zk
 "}
 (61,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -14207,10 +14211,10 @@ kp
 kp
 kp
 kp
-kp
+zk
 "}
 (62,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -14353,10 +14357,10 @@ kp
 kp
 kp
 kp
-kp
+zk
 "}
 (63,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -14499,10 +14503,10 @@ kp
 kp
 kp
 kp
-kp
+zk
 "}
 (64,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -14645,10 +14649,10 @@ kp
 kp
 kp
 kp
-kp
+zk
 "}
 (65,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -14791,10 +14795,10 @@ kp
 kp
 kp
 kp
-kp
+zk
 "}
 (66,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -14937,10 +14941,10 @@ kp
 kp
 kp
 kp
-kp
+zk
 "}
 (67,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -15083,10 +15087,10 @@ kp
 kp
 kp
 kp
-kp
+zk
 "}
 (68,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -15229,10 +15233,10 @@ kp
 kp
 kp
 kp
-kp
+zk
 "}
 (69,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -15375,10 +15379,10 @@ kp
 kp
 kp
 kp
-kp
+zk
 "}
 (70,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -15521,10 +15525,10 @@ kp
 kp
 kp
 kp
-kp
+zk
 "}
 (71,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -15667,10 +15671,10 @@ kp
 kp
 kp
 kp
-kp
+zk
 "}
 (72,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -15813,10 +15817,10 @@ kp
 kp
 kp
 kp
-kp
+zk
 "}
 (73,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -15959,10 +15963,10 @@ kp
 kp
 kp
 kp
-kp
+zk
 "}
 (74,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -16105,10 +16109,10 @@ kp
 kp
 kp
 kp
-kp
+zk
 "}
 (75,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -16251,10 +16255,10 @@ kp
 kp
 kp
 kp
-kp
+zk
 "}
 (76,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -16397,10 +16401,10 @@ kp
 kp
 kp
 kp
-kp
+zk
 "}
 (77,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -16543,10 +16547,10 @@ kp
 kp
 kp
 kp
-kp
+zk
 "}
 (78,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -16689,10 +16693,10 @@ kp
 kp
 kp
 kp
-kp
+zk
 "}
 (79,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -16835,10 +16839,10 @@ kp
 kp
 kp
 kp
-kp
+zk
 "}
 (80,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -16981,10 +16985,10 @@ kp
 kp
 kp
 kp
-kp
+zk
 "}
 (81,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -17127,10 +17131,10 @@ kp
 kp
 kp
 kp
-kp
+zk
 "}
 (82,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -17273,10 +17277,10 @@ kp
 kp
 kp
 kp
-kp
+zk
 "}
 (83,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -17419,10 +17423,10 @@ kp
 kp
 kp
 kp
-kp
+zk
 "}
 (84,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -17565,10 +17569,10 @@ kp
 kp
 kp
 kp
-kp
+zk
 "}
 (85,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -17711,10 +17715,10 @@ kp
 kp
 kp
 kp
-kp
+zk
 "}
 (86,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -17857,10 +17861,10 @@ kp
 kp
 kp
 kp
-kp
+zk
 "}
 (87,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -18003,10 +18007,10 @@ kp
 kp
 kp
 kp
-ob
+zk
 "}
 (88,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -18149,10 +18153,10 @@ kp
 kp
 kp
 ob
-bA
+zk
 "}
 (89,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -18295,10 +18299,10 @@ kp
 kp
 ob
 bA
-bA
+zk
 "}
 (90,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -18441,10 +18445,10 @@ kp
 ob
 bA
 bA
-bA
+zk
 "}
 (91,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -18587,10 +18591,10 @@ ob
 bA
 bA
 bA
-bA
+zk
 "}
 (92,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -18733,10 +18737,10 @@ bA
 bA
 bA
 bA
-bA
+zk
 "}
 (93,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -18879,10 +18883,10 @@ bA
 bA
 bA
 bA
-bA
+zk
 "}
 (94,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -19025,10 +19029,10 @@ bA
 bA
 bA
 bA
-bA
+zk
 "}
 (95,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -19171,10 +19175,10 @@ bA
 bA
 bA
 bA
-bA
+zk
 "}
 (96,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -19317,10 +19321,10 @@ bA
 bA
 bA
 bA
-bA
+zk
 "}
 (97,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -19463,10 +19467,10 @@ bA
 bA
 bA
 bA
-bA
+zk
 "}
 (98,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -19609,10 +19613,10 @@ bA
 bA
 bA
 bA
-bA
+zk
 "}
 (99,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -19755,10 +19759,10 @@ bA
 bA
 bA
 bA
-bA
+zk
 "}
 (100,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -19901,10 +19905,10 @@ bA
 bA
 bA
 bA
-bA
+zk
 "}
 (101,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -20047,10 +20051,10 @@ bA
 bA
 bA
 bA
-bA
+zk
 "}
 (102,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -20193,10 +20197,10 @@ bA
 bA
 bA
 bA
-bA
+zk
 "}
 (103,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -20339,10 +20343,10 @@ bA
 bA
 bA
 bA
-bA
+zk
 "}
 (104,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -20485,10 +20489,10 @@ bA
 bA
 bA
 bA
-bA
+zk
 "}
 (105,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -20631,10 +20635,10 @@ bA
 bA
 bA
 bA
-bA
+zk
 "}
 (106,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -20777,10 +20781,10 @@ bA
 bA
 bA
 bA
-bA
+zk
 "}
 (107,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -20923,10 +20927,10 @@ bA
 bA
 bA
 bA
-bA
+zk
 "}
 (108,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -21069,10 +21073,10 @@ bA
 bA
 bA
 bA
-bA
+zk
 "}
 (109,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -21215,10 +21219,10 @@ bA
 bA
 bA
 bA
-bA
+zk
 "}
 (110,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -21361,10 +21365,10 @@ bA
 bA
 bA
 bA
-bA
+zk
 "}
 (111,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -21507,10 +21511,10 @@ bA
 bA
 bA
 bA
-bA
+zk
 "}
 (112,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -21653,10 +21657,10 @@ bA
 bA
 bA
 bA
-bA
+zk
 "}
 (113,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -21799,10 +21803,10 @@ bA
 bA
 bA
 bA
-bA
+zk
 "}
 (114,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -21945,10 +21949,10 @@ bA
 bA
 bA
 bA
-bA
+zk
 "}
 (115,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -22091,10 +22095,10 @@ bA
 bA
 bA
 bA
-bA
+zk
 "}
 (116,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -22237,10 +22241,10 @@ bA
 bA
 bA
 bA
-bA
+zk
 "}
 (117,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -22383,10 +22387,10 @@ bA
 bA
 bA
 bA
-bA
+zk
 "}
 (118,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -22529,10 +22533,10 @@ bA
 bA
 bA
 bA
-bA
+zk
 "}
 (119,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -22675,10 +22679,10 @@ bA
 bA
 bA
 bA
-bA
+zk
 "}
 (120,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -22821,10 +22825,10 @@ bA
 bA
 bA
 bA
-bA
+zk
 "}
 (121,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -22967,10 +22971,10 @@ bA
 bA
 bA
 bA
-bA
+zk
 "}
 (122,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -23113,10 +23117,10 @@ bA
 bA
 bA
 bA
-bA
+zk
 "}
 (123,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -23259,10 +23263,10 @@ bA
 bA
 bA
 bA
-bA
+zk
 "}
 (124,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -23405,10 +23409,10 @@ bA
 bA
 bA
 bA
-bA
+zk
 "}
 (125,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -23551,10 +23555,10 @@ bA
 bA
 bA
 bA
-bA
+zk
 "}
 (126,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -23697,10 +23701,10 @@ bA
 bA
 bA
 bA
-bA
+zk
 "}
 (127,1,1) = {"
-kp
+zk
 kp
 kp
 kp
@@ -23843,10 +23847,10 @@ bA
 bA
 bA
 bA
-bA
+zk
 "}
 (128,1,1) = {"
-ob
+zk
 kp
 kp
 kp
@@ -23989,10 +23993,10 @@ bA
 bA
 bA
 bA
-bA
+zk
 "}
 (129,1,1) = {"
-CL
+zk
 ob
 kp
 kp
@@ -24135,10 +24139,10 @@ bA
 bA
 bA
 bA
-bA
+zk
 "}
 (130,1,1) = {"
-CL
+zk
 CL
 ob
 kp
@@ -24281,10 +24285,10 @@ bA
 bA
 bA
 bA
-bA
+zk
 "}
 (131,1,1) = {"
-CL
+zk
 CL
 CL
 ob
@@ -24427,10 +24431,10 @@ bA
 bA
 bA
 bA
-bA
+zk
 "}
 (132,1,1) = {"
-CL
+zk
 CL
 CL
 CL
@@ -24573,10 +24577,10 @@ bA
 bA
 bA
 bA
-bA
+zk
 "}
 (133,1,1) = {"
-CL
+zk
 CL
 CL
 CL
@@ -24719,10 +24723,10 @@ bA
 bA
 bA
 bA
-bA
+zk
 "}
 (134,1,1) = {"
-CL
+zk
 CL
 CL
 CL
@@ -24865,10 +24869,10 @@ bA
 bA
 bA
 bA
-bA
+zk
 "}
 (135,1,1) = {"
-CL
+zk
 CL
 CL
 CL
@@ -25011,10 +25015,10 @@ bA
 bA
 bA
 bA
-bA
+zk
 "}
 (136,1,1) = {"
-CL
+zk
 CL
 CL
 CL
@@ -25157,10 +25161,10 @@ bA
 bA
 bA
 bA
-bA
+zk
 "}
 (137,1,1) = {"
-CL
+zk
 CL
 CL
 CL
@@ -25303,10 +25307,10 @@ bA
 bA
 bA
 bA
-bA
+zk
 "}
 (138,1,1) = {"
-CL
+zk
 CL
 CL
 CL
@@ -25449,10 +25453,10 @@ bA
 bA
 bA
 bA
-bA
+zk
 "}
 (139,1,1) = {"
-CL
+zk
 CL
 CL
 CL
@@ -25595,10 +25599,10 @@ bA
 bA
 bA
 bA
-bA
+zk
 "}
 (140,1,1) = {"
-CL
+zk
 CL
 CL
 CL
@@ -25741,10 +25745,10 @@ bA
 bA
 bA
 bA
-bA
+zk
 "}
 (141,1,1) = {"
-CL
+zk
 CL
 CL
 CL
@@ -25887,10 +25891,10 @@ bA
 bA
 bA
 bA
-bA
+zk
 "}
 (142,1,1) = {"
-CL
+zk
 CL
 CL
 CL
@@ -26033,10 +26037,10 @@ bA
 bA
 bA
 bA
-bA
+zk
 "}
 (143,1,1) = {"
-CL
+zk
 CL
 CL
 CL
@@ -26179,151 +26183,151 @@ bA
 bA
 bA
 bA
-bA
+zk
 "}
 (144,1,1) = {"
-CL
-CL
-CL
-CL
-CL
-CL
-CL
-CL
-CL
-CL
-CL
-CL
-CL
-CL
-CL
-CL
-ob
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-kp
-ob
-bA
-bA
-bA
-bA
-bA
-bA
-bA
-bA
-bA
-bA
-bA
-bA
-bA
-bA
-bA
-bA
-bA
-bA
-bA
-bA
-bA
-bA
-bA
-bA
-bA
-bA
-bA
-bA
-bA
-bA
-bA
-bA
-bA
-bA
-bA
-bA
-bA
-bA
-bA
-bA
-bA
-bA
-bA
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
+zk
 "}

--- a/_maps/map_files/Enkephalin_Rush/district_4.dmm
+++ b/_maps/map_files/Enkephalin_Rush/district_4.dmm
@@ -1024,6 +1024,9 @@
 	},
 /turf/open/floor/wood,
 /area/city/backstreets_room)
+"dQ" = (
+/turf/closed/wall/r_wall,
+/area/city/backstreets_room)
 "dR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
@@ -1554,7 +1557,7 @@
 /area/facility_hallway/welfare)
 "fD" = (
 /obj/machinery/smartfridge/organ,
-/turf/closed/indestructible/iron,
+/turf/closed/indestructible/riveted,
 /area/city)
 "fE" = (
 /obj/effect/decal/cleanable/vomit,
@@ -1566,7 +1569,7 @@
 	name = "Tie Office License";
 	desc = "An official fixer license assigned by the Hana Association."
 	},
-/turf/closed/indestructible/reinforced,
+/turf/closed/wall/r_wall,
 /area/city/backstreets_room)
 "fG" = (
 /obj/effect/decal/cleanable/dirt,
@@ -2563,7 +2566,7 @@
 	desc = "A contract bearing the seal of the Oufi Association East division., claiming this office as a subsidiary.";
 	name = "Oufi Association Contract"
 	},
-/turf/closed/indestructible/reinforced,
+/turf/closed/wall/r_wall,
 /area/city/backstreets_room)
 "jC" = (
 /obj/effect/turf_decal/siding/yellow{
@@ -4036,7 +4039,6 @@
 	dir = 1
 	},
 /obj/item/ego_weapon/support/dragon_staff,
-/obj/item/hemostat,
 /turf/open/floor/facility/white,
 /area/city)
 "oN" = (
@@ -5194,6 +5196,7 @@
 /obj/effect/turf_decal/siding/blue{
 	dir = 10
 	},
+/obj/item/reagent_containers/hypospray/emais,
 /turf/open/floor/facility/white,
 /area/city)
 "sZ" = (
@@ -13743,7 +13746,6 @@
 	dir = 1
 	},
 /obj/item/ego_weapon/support/dragon_staff,
-/obj/item/hemostat,
 /turf/open/floor/facility/white,
 /area/city)
 "Yf" = (
@@ -43685,13 +43687,13 @@ ZL
 ZL
 ZL
 ZL
-zg
-zg
-zg
-zg
-zg
-zg
-zg
+dQ
+dQ
+dQ
+dQ
+dQ
+dQ
+dQ
 ZL
 ZL
 ZL
@@ -43942,13 +43944,13 @@ ZL
 ZL
 ZL
 ZL
-zg
+dQ
 pj
 sJ
 sJ
 sJ
 Ac
-zg
+dQ
 ZL
 ZL
 ZL
@@ -44194,21 +44196,21 @@ ZL
 ZL
 ZL
 ZL
-zg
-zg
-zg
-zg
-zg
-zg
+dQ
+dQ
+dQ
+dQ
+dQ
+dQ
 Ay
-zg
-zg
+dQ
+dQ
 jV
 jV
-zg
-zg
-zg
-zg
+dQ
+dQ
+dQ
+dQ
 ZL
 ZL
 ZL
@@ -44451,11 +44453,11 @@ ZL
 ZL
 ZL
 ZL
-zg
+dQ
 sJ
 ax
 fr
-zg
+dQ
 tX
 Iy
 tX
@@ -44465,7 +44467,7 @@ ix
 hY
 ix
 dq
-zg
+dQ
 ZL
 ZL
 ZL
@@ -44708,7 +44710,7 @@ ZL
 ZL
 ZL
 ZL
-zg
+dQ
 My
 af
 Ax
@@ -44722,7 +44724,7 @@ ix
 ix
 ix
 ix
-zg
+dQ
 ZL
 ZL
 ZL
@@ -44965,7 +44967,7 @@ ZL
 ZL
 ZL
 ZL
-zg
+dQ
 HW
 Ps
 Ps
@@ -44979,7 +44981,7 @@ ix
 ix
 qC
 Kk
-zg
+dQ
 ZL
 ZL
 ZL
@@ -45222,7 +45224,7 @@ ZL
 ZL
 ZL
 ZL
-zg
+dQ
 My
 af
 CW
@@ -45236,7 +45238,7 @@ ix
 ix
 ix
 ix
-zg
+dQ
 ZL
 ZL
 ZL
@@ -45479,11 +45481,11 @@ ZL
 ZL
 ZL
 ZL
-zg
+dQ
 Er
 sJ
 fr
-zg
+dQ
 tX
 Iy
 tX
@@ -45493,7 +45495,7 @@ ix
 ix
 ix
 ix
-zg
+dQ
 ZL
 ZL
 ZL
@@ -45736,21 +45738,21 @@ Jg
 Jg
 ZL
 ZL
-zg
+dQ
 My
 af
 sJ
-zg
-zg
-zg
-zg
-zg
-zg
-zg
-zg
-zg
-zg
-zg
+dQ
+dQ
+dQ
+dQ
+dQ
+dQ
+dQ
+dQ
+dQ
+dQ
+dQ
 fb
 fb
 fb
@@ -45993,7 +45995,7 @@ DK
 TJ
 Jg
 ZL
-zg
+dQ
 sJ
 Ax
 ZN
@@ -46250,7 +46252,7 @@ nb
 DK
 Jg
 ZL
-zg
+dQ
 My
 af
 sJ
@@ -46507,7 +46509,7 @@ Iy
 PS
 Jg
 ZL
-zg
+dQ
 sJ
 sJ
 hd
@@ -46764,15 +46766,15 @@ Iy
 PS
 uh
 ZL
-zg
-zg
+dQ
+dQ
 Tr
-zg
-zg
-zg
-zg
-zg
-zg
+dQ
+dQ
+dQ
+dQ
+dQ
+dQ
 fb
 fb
 fb
@@ -47021,7 +47023,7 @@ Iy
 PS
 Jg
 ZL
-zg
+dQ
 aN
 aN
 aN
@@ -47029,7 +47031,7 @@ aN
 oO
 pt
 jD
-zg
+dQ
 ZL
 ZL
 ZL
@@ -47278,7 +47280,7 @@ ee
 KH
 vc
 ZL
-zg
+dQ
 aN
 aN
 aN
@@ -47286,13 +47288,13 @@ aN
 aN
 aN
 xq
-zg
-zg
-zg
-zg
-zg
-zg
-zg
+dQ
+dQ
+dQ
+dQ
+dQ
+dQ
+dQ
 ZL
 ZL
 ZL
@@ -47535,7 +47537,7 @@ KH
 vc
 vc
 ZL
-zg
+dQ
 jZ
 dP
 aN
@@ -47543,13 +47545,13 @@ aN
 aN
 pt
 jD
-zg
+dQ
 XB
 KC
 XB
 lx
 fd
-zg
+dQ
 ZL
 ZL
 ZL
@@ -47792,7 +47794,7 @@ vc
 vc
 ZL
 ZL
-zg
+dQ
 Wh
 vE
 QB
@@ -47806,7 +47808,7 @@ KC
 KC
 KC
 SI
-zg
+dQ
 ZL
 ZL
 ZL
@@ -48049,7 +48051,7 @@ ZL
 ZL
 ZL
 ZL
-zg
+dQ
 jZ
 dP
 it
@@ -48057,13 +48059,13 @@ aN
 it
 aN
 ra
-zg
+dQ
 XB
 bn
 XB
 KC
 KC
-zg
+dQ
 ZL
 ZL
 ZL
@@ -48306,21 +48308,21 @@ ZL
 ZL
 ZL
 ZL
-zg
-zg
-zg
-zg
-zg
-zg
-zg
-zg
-zg
-zg
-zg
-zg
-zg
-zg
-zg
+dQ
+dQ
+dQ
+dQ
+dQ
+dQ
+dQ
+dQ
+dQ
+dQ
+dQ
+dQ
+dQ
+dQ
+dQ
 ZL
 ZL
 ZL

--- a/code/game/objects/items/clerks/hypo/hypo.dm
+++ b/code/game/objects/items/clerks/hypo/hypo.dm
@@ -168,7 +168,7 @@
 		H.add_upgrade(src,user)
 
 /obj/item/reagent_containers/hypospray/emais/proc/clerk_check(mob/living/carbon/human/H)
-	var/list/allowed_roles = list("Clerk", "Operations Officer", "Support Officer")
+	var/list/allowed_roles = list("Clerk", "Operations Officer", "Support Officer", "Doctor")
 	var/datum/status_effect/chosen/C = H.has_status_effect(/datum/status_effect/chosen)
 	if(C)
 		to_chat(H, span_warning("A mysterious force prevents you from using this!"))

--- a/code/modules/jobs/job_types/city/doctor.dm
+++ b/code/modules/jobs/job_types/city/doctor.dm
@@ -30,7 +30,7 @@
 	display_order = JOB_DISPLAY_ORDER_MEDICAL
 	alt_titles = list("Surgeon")
 	maptype = list("wonderlabs", "city", "fixers", "lcorp_city", "enkephalin_rush")
-	job_important = "You are the town doctor, visit your clinic to the east of town and start healing peopl who come in. You must charge money for your services."
+	job_important = "You are the town doctor, visit your clinic to the east of town and start healing people who come in."
 
 /datum/job/doctor/after_spawn(mob/living/carbon/human/H, mob/M, latejoin = FALSE)
 	..()

--- a/code/modules/surgery/prosthetic_replacement.dm
+++ b/code/modules/surgery/prosthetic_replacement.dm
@@ -39,14 +39,14 @@
 				to_chat(user, "<span class='warning'>[BP] doesn't match the patient's morphology.</span>")
 				return -1
 		if(BP.status != BODYPART_ROBOTIC)
-			organ_rejection_dam = 10
+			organ_rejection_dam = 5
 			if(ishuman(target))
 				if(BP.animal_origin)
 					to_chat(user, "<span class='warning'>[BP] doesn't match the patient's morphology.</span>")
 					return -1
 				var/mob/living/carbon/human/H = target
 				if(H.dna.species.id != BP.species_id)
-					organ_rejection_dam = 30
+					organ_rejection_dam = 15
 
 		if(target_zone == BP.body_zone) //so we can't replace a leg with an arm, or a human arm with a monkey arm.
 			display_results(user, target, "<span class='notice'>You begin to replace [target]'s [parse_zone(target_zone)] with [tool]...</span>",


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This Pull request does the following:

Allows players with the "Doctor" role to use the EMAIS.

Removes a typo from the doctor spawn blurb.

Halves limb rejection damage from 10 to 5 for organics, and 30 to 15 for organic/inorganic transplants.

Removes white damage weapons from medbay in district4 and district21 - Dead players are re-saned on death as of #3098.

Adds an EMAIS to district4's medbay, and moves district21's EMAIS into a more obvious locations

Changes a few wall designs in district4

Adds walls to the border of district21 to fix roundstart atmos changes


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Most of these changes are either holdovers from TG, or mechanics from City of Light, which is no longer run on this server.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: nerfs limb rejection damage, doctors can use EMAIS
fix: fixes a typo in the doctor role
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
