### PR TITLE
Nerfs suicide and wander panics

### DIFF
--- a/code/datums/ai/sanity/_sanityloss_controller.dm
+++ b/code/datums/ai/sanity/_sanityloss_controller.dm
@@ -821,7 +821,7 @@
 		human_pawn.visible_message("<span class='danger'>[human_pawn] is twisting their neck, they are trying to commit suicide!</span>")
 		human_pawn.adjustBruteLoss(400)
 		human_pawn.jitteriness = 0
-		var/sanity_damage = get_user_level(human_pawn) * 40
+		var/sanity_damage = get_user_level(human_pawn) * 20
 		for(var/mob/living/carbon/human/H in view(7, human_pawn))
 			if(HAS_TRAIT(H, TRAIT_COMBATFEAR_IMMUNE))
 				continue

--- a/code/datums/ai/sanity/sanityloss_behaviors.dm
+++ b/code/datums/ai/sanity/sanityloss_behaviors.dm
@@ -14,7 +14,7 @@
 /datum/ai_behavior/say_line/insanity_lines/insanity_wander/perform(delta_time, datum/ai_controller/controller)
 	. = ..()
 	var/mob/living/living_pawn = controller.pawn
-	var/sanity_damage = get_user_level(living_pawn) * 5
+	var/sanity_damage = get_user_level(living_pawn)//This is how it is calculated in LC
 	for(var/mob/living/carbon/human/H in view(9, living_pawn))
 		if(H == living_pawn)
 			continue


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

What it says on the tin.

Lowers the white damage from suicides from (40 * agent level) to (20 * agent level)

Lowers the white damage from wander panics from (5 * agent level) to (agent level)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: tweaked a few things
balance: rebalanced something
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
