### PR TITLE
We Can Change Anything Enter machine work fix

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/zayin/we_can_change_anything.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/zayin/we_can_change_anything.dm
@@ -111,8 +111,8 @@
 				ramping_speed -= 0.2
 			if(8 to 20)
 				ramping_speed -= 0.5
-		user.deal_damage(1, RED_DAMAGE) // say goodbye to a bit more than your kneecaps... (total damage is 100 RED).
-		total_damage += 1
+		user.deal_damage(4, RED_DAMAGE) // say goodbye to a bit more than your kneecaps... (total damage is 400 RED).
+		total_damage += 4
 
 /mob/living/simple_animal/hostile/abnormality/we_can_change_anything/SpeedWorktickOverride(mob/living/carbon/human/user, work_speed, init_work_speed, work_type)
 	if(!sacrifice)
@@ -125,11 +125,11 @@
 	else
 		playsound(src, 'sound/abnormalities/we_can_change_anything/change_gas.ogg', 50, TRUE)
 		sacrifice = FALSE
-		var/energy_generated = round(10 ** (total_damage * 0.003)) // exponential formula, caps out at 100 damage, generating 1000 PE.
+		var/energy_generated = round(10 ** (total_damage * 0.0075)) // exponential formula, caps out at 400 damage, generating 1000 PE.
 
 		if(user.health <= 0)
 			qdel(user) //reduced to atoms
-			energy_generated += total_damage/8 //adds the normal work PE boxes, since those are normally lost on death
+			energy_generated += total_damage/4 //adds the normal work PE boxes, since those are normally lost on death
 		else
 			ReleaseWorker()
 		datum_reference.stored_boxes += energy_generated // adds PE to the console, only half actually counts towards the goal for balance reasons.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Buff's Enter machine's damage from 1 to 4 while reworking the formula to produce the same amount of pe as pre hp rework.

## Why It's Good For The Game

Enter machine was only able to produce 1 pe box is stupid as hell, now it can produce the old amount of pe that it did

## Changelog
:cl:
balance: rebalanced Enter machine
fix: fixed Enter machine
code: changed some code
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
