### PR TITLE
Fixes clothing damage display

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -336,10 +336,11 @@
 		white_armor = armor.getRating(mapping[WHITE_DAMAGE])
 		black_armor = armor.getRating(mapping[BLACK_DAMAGE])
 		pale_armor = armor.getRating(mapping[PALE_DAMAGE])
-	armor_list["RED"] = red_armor
-	armor_list["WHITE"] = white_armor
-	armor_list["BLACK"] = black_armor
-	armor_list["PALE"] = pale_armor
+	if(red_armor || white_armor || black_armor || pale_armor)
+		armor_list["RED"] = red_armor
+		armor_list["WHITE"] = white_armor
+		armor_list["BLACK"] = black_armor
+		armor_list["PALE"] = pale_armor
 
 	if(LAZYLEN(durability_list))
 		durability_list.Cut()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

As the title says clothing items that don't touch the 4 damage types won't display them when viewing their description
<img width="785" height="273" alt="image" src="https://github.com/user-attachments/assets/e20d33db-95c0-42be-8df0-cc902f83c052" />


## Why It's Good For The Game

Looks a bit stupid
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixed clothing displaying damage resistances even if they didn't use them
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
