### PR TITLE
Fixes Steam Transport Machine being a damage sponge plus a slight bump to its lower melee damage

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/he/steam_transport_machine.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/he/steam_transport_machine.dm
@@ -121,8 +121,8 @@
 	melee_damage_upper = (7 + (3 * gear))
 	steam_damage = (2 + (2 * gear))
 	var/oldhealth = maxHealth
-	maxHealth = (400 + (200 * gear))
-	adjustBruteLoss(oldhealth - maxHealth) //Heals 160 health in a gear shift if it's already breached
+	maxHealth = (400 + (150 * gear))
+	adjustBruteLoss(oldhealth - maxHealth) //Heals 150 health in a gear shift if it's already breached
 	work_damage_upper = (3 + (2 * gear))
 	ranged_cooldown_time = (40 - (5 * gear))
 	start_qliphoth = (max(1,(4 - gear)))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

So Steam's hp scaling was never changed(being 1600 + (400 * gears)) meaning it can have up to 3200 hp with all 4 gears. I lowered it so that it its 400 + (150 * gears) meaning that it can still be pretty bulky late into the round without being a 3200 hp wall. Also fixed its lower melee damage calculation being 4 instead of 5
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
3200 hp steam machine is a fucking war crime

## Changelog
:cl:
balance: rebalanced Steam Transport Machine's health scaling
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
