### PR TITLE
Don't Touch me's span is more reasonable redux

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/_tools/zayin/touch.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_tools/zayin/touch.dm
@@ -28,7 +28,8 @@
 
 	cooldown = world.time + 60 SECONDS // Spam prevention
 	for(var/mob/M in GLOB.player_list)
-		to_chat(M, span_narsie("[uppertext(user.real_name)] WILL PUSH DON'T TOUCH ME[round_end ? "" : " TO BREACH ABNORMALITIES"]."))
+		to_chat(M, span_hypnophrase("[uppertext(user.real_name)] WILL PUSH DON'T TOUCH ME[round_end ? "" : " TO BREACH ABNORMALITIES"]."))
+		M.playsound_local(M, 'sound/abnormalities/someonesportrait/panic.ogg', 50, FALSE)
 
 	if(round_end)
 		bastards += user.ckey


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Remake of #3033.
Adds a sound cue to don't touch me when it's in the process of being pressed. Also changes the span.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This should be more reasonable
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Don't Touch Me's span is made a more reasonable size whilst remaining eyecatching
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
