### PR TITLE
local codebase literally can not stop breaking its CI

### DIFF
--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,6 +1,6 @@
-pygit2==1.0.1
+pygit2==1.14.1
 bidict==0.13.1
-Pillow==9.3.0
+Pillow==10.4.0
 
 # changelogs
 PyYaml==6.0.2


### PR DESCRIPTION
* update pyYaml to something that works with newer setuptools
* update Pillow and pygit2 to something that works with python 3.12

the reason #3198 didn't work is that that file is only really relevant on Windows (it downloads a .exe), in the CI it uses whatevers on the PATH which is 3.12 on this runner