### PR TITLE
Rebalances Salmon ordeals

### DIFF
--- a/ModularTegustation/ego_weapons/ranged/ego_bullets/casings.dm
+++ b/ModularTegustation/ego_weapons/ranged/ego_bullets/casings.dm
@@ -23,7 +23,7 @@
 /obj/item/ammo_casing/caseless/ego_shrimprifle
 	name = "sodassniper casing"
 	desc = "A casing."
-	projectile_type = /obj/projectile/ego_bullet/ego_soda/rifle
+	projectile_type = /obj/projectile/ego_bullet/ego_soda/rifle/weak
 
 /obj/item/ammo_casing/caseless/red_minigun
 	name = "sodamini casing"

--- a/ModularTegustation/ego_weapons/ranged/ego_bullets/special.dm
+++ b/ModularTegustation/ego_weapons/ranged/ego_bullets/special.dm
@@ -1,6 +1,9 @@
 /obj/projectile/ego_bullet/ego_soda/rifle
-	damage = 4
+	damage = 17
 	speed = 0.25
+
+/obj/projectile/ego_bullet/ego_soda/rifle/weak
+	damage = 4
 
 /obj/projectile/ego_bullet/shrimp_red
 	name = "9mm soda bullet R"

--- a/ModularTegustation/ego_weapons/ranged/ego_bullets/special.dm
+++ b/ModularTegustation/ego_weapons/ranged/ego_bullets/special.dm
@@ -1,17 +1,17 @@
 /obj/projectile/ego_bullet/ego_soda/rifle
-	damage = 17
+	damage = 4
 	speed = 0.25
 
 /obj/projectile/ego_bullet/shrimp_red
 	name = "9mm soda bullet R"
-	damage = 8
+	damage = 3
 	range = 12
 	spread = 20
 	damage_type = RED_DAMAGE
 
 /obj/projectile/ego_bullet/shrimp_white
 	name = "9mm soda bullet W"
-	damage = 70
+	damage = 30
 	speed = 0.1
 	damage_type = WHITE_DAMAGE
 	projectile_piercing = PASSMOB
@@ -27,7 +27,6 @@
 			if(QDELETED(head))
 				return
 			head.dismember()
-			QDEL_NULL(head)
 			H.regenerate_icons()
 			visible_message(span_danger("[H]'s head blew right off!"))
 

--- a/code/modules/mob/living/simple_animal/hostile/ordeal/event/aprilfools/dawn.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/event/aprilfools/dawn.dm
@@ -7,12 +7,12 @@
 	icon_living = "wellcheers_bad"
 	icon_dead = "wellcheers_bad_dead"
 	faction = list("shrimp")
-	health = 120	//They're here to help
-	maxHealth = 120
+	health = 60	//They're here to help
+	maxHealth = 60
 	melee_damage_type = RED_DAMAGE
 	damage_coeff = list(RED_DAMAGE = 0.6, WHITE_DAMAGE = 0.7, BLACK_DAMAGE = 1.2, PALE_DAMAGE = 2)
-	melee_damage_lower = 7
-	melee_damage_upper = 8
+	melee_damage_lower = 2
+	melee_damage_upper = 4
 	robust_searching = TRUE
 	stat_attack = HARD_CRIT
 	del_on_death = TRUE
@@ -52,13 +52,13 @@
 	icon_living = "wellcheers_ripped"
 	icon_dead = "wellcheers_ripped_dead"
 	faction = list("shrimp")
-	health = 350
-	maxHealth = 350
+	health = 130
+	maxHealth = 130
 	melee_damage_type = RED_DAMAGE
 	damage_coeff = list(RED_DAMAGE = 0.8, WHITE_DAMAGE = 1.5, BLACK_DAMAGE = 1, PALE_DAMAGE = 2)
 	move_to_delay = 4
-	melee_damage_lower = 10
-	melee_damage_upper = 12
+	melee_damage_lower = 3
+	melee_damage_upper = 5
 	robust_searching = TRUE
 	stat_attack = HARD_CRIT
 	del_on_death = TRUE
@@ -87,12 +87,12 @@
 	icon_living = "wellcheers"
 	icon_dead = "wellcheers_dead"
 	faction = list("shrimp")
-	health = 120
-	maxHealth = 120
+	health = 70
+	maxHealth = 70
 	melee_damage_type = RED_DAMAGE
 	damage_coeff = list(RED_DAMAGE = 0.8, WHITE_DAMAGE = 1.5, BLACK_DAMAGE = 1.2, PALE_DAMAGE = 2)
-	melee_damage_lower = 8
-	melee_damage_upper = 10
+	melee_damage_lower = 2
+	melee_damage_upper = 4
 	robust_searching = TRUE
 	stat_attack = HARD_CRIT
 	del_on_death = TRUE
@@ -117,12 +117,12 @@
 	icon_living = "wellcheers_bad"
 	icon_dead = "wellcheers_bad_dead"
 	faction = list("shrimp")
-	health = 150	//They're here to help
-	maxHealth = 150
+	health = 80	//They're here to help
+	maxHealth = 80
 	melee_damage_type = RED_DAMAGE
 	damage_coeff = list(RED_DAMAGE = 0.6, WHITE_DAMAGE = 0.7, BLACK_DAMAGE = 1.2, PALE_DAMAGE = 2)
-	melee_damage_lower = 7
-	melee_damage_upper = 9
+	melee_damage_lower = 2
+	melee_damage_upper = 4
 	robust_searching = TRUE
 	stat_attack = HARD_CRIT
 	del_on_death = TRUE

--- a/code/modules/mob/living/simple_animal/hostile/ordeal/event/aprilfools/dusk.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/event/aprilfools/dusk.dm
@@ -1,8 +1,8 @@
 /mob/living/simple_animal/hostile/ordeal/salmon_dusk
 	icon = 'ModularTegustation/Teguicons/32x32.dmi'
 	faction = list("shrimp")
-	health = 240
-	maxHealth = 240
+	health = 420
+	maxHealth = 420
 	melee_damage_type = RED_DAMAGE
 	melee_damage_lower = 7
 	melee_damage_upper = 9

--- a/code/modules/mob/living/simple_animal/hostile/ordeal/event/aprilfools/noon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/event/aprilfools/noon.dm
@@ -6,12 +6,12 @@
 	icon_living = "wellcheers_bad"
 	icon_dead = "wellcheers_bad_dead"
 	faction = list("shrimp")
-	health = 150
-	maxHealth = 150
+	health = 120
+	maxHealth = 120
 	melee_damage_type = RED_DAMAGE
 	damage_coeff = list(RED_DAMAGE = 0.6, WHITE_DAMAGE = 0.7, BLACK_DAMAGE = 1.2, PALE_DAMAGE = 2)
-	melee_damage_lower = 7
-	melee_damage_upper = 9
+	melee_damage_lower = 3
+	melee_damage_upper = 4
 	robust_searching = TRUE
 	stat_attack = HARD_CRIT
 	del_on_death = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Nerfs Salmon Dawn and Noon mobs and slightly buffs Salmon Dusk mobs's health while lowering damage
White Shrimp can no longer destroy heads

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
The dawns and noons were overtuned and the dusk one's were frail

## Changelog
:cl:
balance: rebalanced salmon ordeals
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
