### PR TITLE
Justice Scaling Refractor and nerf

### DIFF
--- a/ModularTegustation/!extra_abnos/joke_abnormalities/!equipment/weapons.dm
+++ b/ModularTegustation/!extra_abnos/joke_abnormalities/!equipment/weapons.dm
@@ -228,8 +228,7 @@
 	for(var/mob/living/L in range(2, target))
 		if(L.z != user.z)
 			continue
-		var/userjust = (get_modified_attribute_level(user, JUSTICE_ATTRIBUTE))
-		var/justicemod = 1 + userjust/100
+		var/justicemod = get_attack_multiplier(user)
 		aoe_damage *= justicemod
 		aoe_damage *= force_multiplier
 		if(L == user) //This WILL friendly fire there is no escape

--- a/ModularTegustation/ego_weapons/melee/aleph.dm
+++ b/ModularTegustation/ego_weapons/melee/aleph.dm
@@ -43,8 +43,7 @@
 			user.changeNext_move(CLICK_CD_MELEE * 1.2)
 			var/turf/T = get_turf(M)
 			new /obj/effect/temp_visual/justitia_effect(T)
-			var/userjust = (get_modified_attribute_level(user, JUSTICE_ATTRIBUTE))
-			var/justicemod = 1 + userjust / 100
+			var/justicemod = get_attack_multiplier(user)
 			var/damage_dealt = aoe_damage * justicemod * force_multiplier
 			user.HurtInTurf(T, list(), damage_dealt, PALE_DAMAGE)
 		else
@@ -182,8 +181,7 @@
 		new /obj/effect/temp_visual/nt_goodbye(T)
 		for(var/mob/living/L in T)
 			var/aoe = 35
-			var/userjust = (get_modified_attribute_level(user, JUSTICE_ATTRIBUTE))
-			var/justicemod = 1 + userjust/100
+			var/justicemod = get_attack_multiplier(user)
 			aoe*=justicemod
 			aoe*=force_multiplier
 			if(L == user || ishuman(L))
@@ -416,8 +414,7 @@
 		animate(user, alpha = 255,pixel_x = 0, pixel_z = -16, time = 0.1 SECONDS)
 		user.pixel_z = 0
 		var/aoe = force
-		var/userjust = (get_modified_attribute_level(user, JUSTICE_ATTRIBUTE))
-		var/justicemod = 1 + userjust/100
+		var/justicemod = get_attack_multiplier(user)
 		var/firsthit = TRUE
 		aoe*=justicemod
 		aoe*=force_multiplier
@@ -738,8 +735,7 @@
 	..()
 	if(!CanUseEgo(user))
 		return
-	var/userjust = (get_modified_attribute_level(user, JUSTICE_ATTRIBUTE))
-	var/justicemod = 1 + userjust/100
+	var/justicemod = get_attack_multiplier(user)
 	var/damage = force * justicemod * force_multiplier
 	target.apply_damage(damage, BLACK_DAMAGE, null, target.run_armor_check(null, BLACK_DAMAGE), spread_damage = TRUE)
 
@@ -755,8 +751,7 @@
 /obj/item/ego_weapon/space/proc/CreateAoe(turf/start, mob/living/user)
 	if(!user)
 		return
-	var/userjust = (get_modified_attribute_level(user, JUSTICE_ATTRIBUTE))
-	var/justicemod = 1 + userjust/100
+	var/justicemod = get_attack_multiplier(user)
 	var/aoe = aoe_damage * justicemod * force_multiplier
 	playsound(start, 'sound/weapons/rapierhit.ogg', 100, FALSE, 4)
 	for(var/turf/T in range(2, start))
@@ -1128,8 +1123,7 @@
 
 	for(var/mob/living/L in view(2, target))
 		var/aoe = 25
-		var/userjust = (get_modified_attribute_level(user, JUSTICE_ATTRIBUTE))
-		var/justicemod = 1 + userjust/100
+		var/justicemod = get_attack_multiplier(user)
 		aoe*=justicemod
 		if(user.faction_check_mob(L) || L == target)
 			continue
@@ -1251,8 +1245,7 @@
 		return
 	for(var/mob/living/L in view(1, M))
 		var/aoe = 15
-		var/userjust = (get_modified_attribute_level(user, JUSTICE_ATTRIBUTE))
-		var/justicemod = 1 + userjust/100
+		var/justicemod = get_attack_multiplier(user)
 		aoe*=justicemod
 		aoe*=force_multiplier
 		if(L == user || ishuman(L))

--- a/ModularTegustation/ego_weapons/melee/he.dm
+++ b/ModularTegustation/ego_weapons/melee/he.dm
@@ -19,8 +19,7 @@
 	if(!.)
 		return FALSE
 	//damage calculations
-	var/userjust = (get_modified_attribute_level(user, JUSTICE_ATTRIBUTE))
-	var/justicemod = 1 + userjust / 100
+	var/justicemod = get_attack_multiplier(user)
 	var/damage_dealt = force * justicemod * force_multiplier
 	var/list/been_hit = QDELETED(target) ? list() : list(target)
 	user.HurtInTurf(T, been_hit, damage_dealt, RED_DAMAGE, hurt_mechs = TRUE, hurt_structure = TRUE)
@@ -70,8 +69,7 @@
 
 		for(var/mob/living/L in range(1, user))
 			var/aoe = 15
-			var/userjust = (get_modified_attribute_level(user, JUSTICE_ATTRIBUTE))
-			var/justicemod = 1 + userjust/100
+			var/justicemod = get_attack_multiplier(user)
 			aoe*=force_multiplier
 			aoe*=justicemod
 			if(L == user || ishuman(L))
@@ -367,7 +365,7 @@
 		var/list/been_hit = list()
 		for(var/turf/T in area_of_effect)
 			new /obj/effect/temp_visual/smash_effect(T)
-			var/smash_damage = (i > 2 ? 22 : 6)*(1+(get_modified_attribute_level(user, JUSTICE_ATTRIBUTE)/100))
+			var/smash_damage = (i > 2 ? 22 : 6)*get_attack_multiplier(user)
 			smash_damage*=force_multiplier
 			been_hit = user.HurtInTurf(T, been_hit, smash_damage, RED_DAMAGE)
 		if (i > 2)
@@ -479,7 +477,7 @@
 	var/original_force = force
 	if(M == user && !happy && istype(user))
 		var/mob/living/carbon/human/H = user
-		var/justice_mod = 1 + (get_modified_attribute_level(H, JUSTICE_ATTRIBUTE)/100)
+		var/justicemod = get_attack_multiplier(H)
 		H.adjustSanityLoss(force * justice_mod) //we artificially inflict the justice + force damage so it bypass armor. the sanity damage should always feel like a gamble even with armor.
 		missing_sanity = (1 - (H.sanityhealth / H.maxSanity)) * 50
 		force = 0
@@ -857,8 +855,7 @@
 			sacrifice = FALSE
 		for(var/mob/living/L in range(1, target))
 			var/aoe = 10
-			var/userjust = (get_modified_attribute_level(user, JUSTICE_ATTRIBUTE))
-			var/justicemod = 1 + userjust/100
+			var/justicemod = get_attack_multiplier(user)
 			aoe*=justicemod
 			aoe*=force_multiplier
 			if(L == user || ishuman(L))
@@ -947,8 +944,7 @@
 		if(L.z != user.z) // Not on our level
 			continue
 		var/aoe = 5
-		var/userjust = (get_modified_attribute_level(user, JUSTICE_ATTRIBUTE))
-		var/justicemod = 1 + userjust/100
+		var/justicemod = get_attack_multiplier(user)
 		aoe*=justicemod
 		aoe*=force_multiplier
 		if(L == user || ishuman(L))
@@ -1202,8 +1198,7 @@
 	var/datum/status_effect/stacking/slab/S = user.has_status_effect(/datum/status_effect/stacking/slab)
 	if(!S)
 		return
-	var/userjust = (get_modified_attribute_level(user, JUSTICE_ATTRIBUTE))
-	var/justicemod = 1 + userjust/100
+	var/justicemod = get_attack_multiplier(user)
 	punishment_damage = (force * justicemod)
 	punishment_size = max(2, (S.stacks / 3))//this is the same size as the AOE from theonite slab. Good luck lol
 	addtimer(CALLBACK(src, PROC_REF(WideSlash), target, user), 1)
@@ -1396,8 +1391,7 @@
 		charged = FALSE
 
 /obj/item/ego_weapon/aedd/proc/power_attack(mob/living/target, mob/living/user)
-	var/userjust = (get_modified_attribute_level(user, JUSTICE_ATTRIBUTE))
-	var/justicemod = 1 + userjust/100
+	var/justicemod = get_attack_multiplier(user)
 	target.apply_damage((force * justicemod), BLACK_DAMAGE, null, target.run_armor_check(null, BLACK_DAMAGE), spread_damage = TRUE)
 	playsound(src, 'sound/abnormalities/thunderbird/tbird_charge.ogg', 50, TRUE)
 	var/turf/T = get_turf(target)
@@ -1544,8 +1538,7 @@
 		G.color = "#622F22"
 		G.fire()
 		G.damage*=force_multiplier
-		var/userjust = (get_modified_attribute_level(user, JUSTICE_ATTRIBUTE))
-		var/justicemod = 1 + userjust/100
+		var/justicemod = get_attack_multiplier(user)
 		G.damage*=justicemod
 		firing_cooldown = firing_cooldown_time + world.time
 		stored_projectiles -= 1
@@ -1967,8 +1960,7 @@
 			new /obj/effect/temp_visual/smash_effect(T2)
 			for(var/mob/living/L in T2)
 				var/aoe = 11
-				var/userjust = (get_modified_attribute_level(user, JUSTICE_ATTRIBUTE))
-				var/justicemod = 1 + userjust/100
+				var/justicemod = get_attack_multiplier(user)
 				aoe*=justicemod
 				aoe*=force_multiplier
 				if(L == user || ishuman(L))
@@ -2108,8 +2100,7 @@
 			new /obj/effect/temp_visual/smash_effect(T)
 			for(var/mob/living/L in T.contents)
 				var/aoe = force
-				var/userjust = (get_modified_attribute_level(user, JUSTICE_ATTRIBUTE))
-				var/justicemod = 1 + userjust/100
+				var/justicemod = get_attack_multiplier(user)
 				aoe*=justicemod
 				aoe*=force_multiplier
 				if(L == user)

--- a/ModularTegustation/ego_weapons/melee/he.dm
+++ b/ModularTegustation/ego_weapons/melee/he.dm
@@ -477,7 +477,7 @@
 	var/original_force = force
 	if(M == user && !happy && istype(user))
 		var/mob/living/carbon/human/H = user
-		var/justicemod = get_attack_multiplier(H)
+		var/justice_mod = get_attack_multiplier(H)
 		H.adjustSanityLoss(force * justice_mod) //we artificially inflict the justice + force damage so it bypass armor. the sanity damage should always feel like a gamble even with armor.
 		missing_sanity = (1 - (H.sanityhealth / H.maxSanity)) * 50
 		force = 0

--- a/ModularTegustation/ego_weapons/melee/non_abnormality/rosespanner.dm
+++ b/ModularTegustation/ego_weapons/melee/non_abnormality/rosespanner.dm
@@ -49,7 +49,7 @@
 	if(overcharged)
 		to_chat(user, span_danger("You overcharged your weapon!."))
 
-	var/aoe = force * (1 + (get_attribute_level(user, JUSTICE_ATTRIBUTE))/100)
+	var/aoe = force * get_attack_multiplier(user)
 	for(var/turf/T in view(2, target))
 		new /obj/effect/temp_visual/small_smoke/halfsecond(get_turf(T))
 		for(var/mob/living/L in T)

--- a/ModularTegustation/ego_weapons/melee/non_abnormality/wcorp.dm
+++ b/ModularTegustation/ego_weapons/melee/non_abnormality/wcorp.dm
@@ -99,8 +99,7 @@
 	sleep(0.2 SECONDS)
 	for(var/mob/living/L in range(1, src))
 		var/aoe = 25
-		var/userjust = (get_attribute_level(user, JUSTICE_ATTRIBUTE))
-		var/justicemod = 1 + userjust/100
+		var/justicemod = get_attack_multiplier(user)
 		aoe*=justicemod
 		if(L == user || ishuman(L))
 			continue

--- a/ModularTegustation/ego_weapons/melee/ordeal.dm
+++ b/ModularTegustation/ego_weapons/melee/ordeal.dm
@@ -45,8 +45,7 @@
 /obj/item/ego_weapon/the_claw/equipped(mob/living/user)
 	. = ..()
 	to_chat(user, span_warning("[src] attaches itself to your body!"))
-	var/userjust = (get_modified_attribute_level(user, JUSTICE_ATTRIBUTE))
-	justicemod = 1 + userjust/100
+	justicemod = get_attack_multiplier(user)
 
 /obj/item/ego_weapon/the_claw/dropped()
 	src.visible_message(span_warning("The claw arm disappears, you've violated a crucial law of physics."))

--- a/ModularTegustation/ego_weapons/melee/special.dm
+++ b/ModularTegustation/ego_weapons/melee/special.dm
@@ -113,8 +113,7 @@
 
 /obj/item/ego_weapon/paradise/proc/DoAoe(mob/living/user, turf/target_turf)
 	playsound(target_turf, 'sound/weapons/ego/paradise_ranged.ogg', 50, TRUE)
-	var/userjust = (get_modified_attribute_level(user, JUSTICE_ATTRIBUTE))
-	var/justicemod = 1 + userjust / 100
+	var/justicemod = get_attack_multiplier(user)
 	var/modified_damage = (aoe_damage*force_multiplier) * justicemod
 	new /obj/effect/temp_visual/paradise_attack_large(target_turf)
 	for(var/dir in list(NORTH,SOUTH))
@@ -256,8 +255,7 @@
 		addtimer(CALLBACK(user, TYPE_PROC_REF(/atom, remove_filter),"user_outline"), 30)
 	if(!do_after(user, 30, src))
 		return
-	var/userjust = (get_modified_attribute_level(user, JUSTICE_ATTRIBUTE))
-	var/justicemod = 1 + userjust/100
+	var/justicemod = get_attack_multiplier(user)
 	var/newdamage = (force * 1.2)
 	newdamage *= justicemod
 	newdamage *= force_multiplier
@@ -452,8 +450,7 @@
 	if(!.)
 		return
 
-	var/userjust = (get_modified_attribute_level(user, JUSTICE_ATTRIBUTE))
-	var/justicemod = 1 + userjust / 100
+	var/justicemod = get_attack_multiplier(user)
 
 	switch(form)
 		if("sword")
@@ -506,8 +503,7 @@
 /obj/item/ego_weapon/oberon/proc/Smash(mob/user, atom/target)
 	smashing = TRUE
 	playsound(user, 'sound/abnormalities/woodsman/woodsman_prepare.ogg', 50, 0, 3)
-	var/userjust = (get_modified_attribute_level(user, JUSTICE_ATTRIBUTE))
-	var/justicemod = 1 + userjust/100
+	var/justicemod = get_attack_multiplier(user)
 	var/smash_damage = 85
 	smash_damage *= justicemod
 	sleep(0.5 SECONDS)
@@ -863,8 +859,7 @@
 				return
 			user.loc = T
 			var/aoe = charge_damage
-			var/userjust = (get_modified_attribute_level(user, JUSTICE_ATTRIBUTE))
-			var/justicemod = 1 + userjust / 100
+			var/justicemod = get_attack_multiplier(user)
 			aoe *= justicemod
 			aoe *= force_multiplier
 			for(var/mob/living/L in range(1, user))

--- a/ModularTegustation/ego_weapons/melee/teth.dm
+++ b/ModularTegustation/ego_weapons/melee/teth.dm
@@ -310,8 +310,7 @@
 		return
 	if(proximity_flag && (LAZYLEN(traps) < traplimit))
 		var/obj/effect/temp_visual/lanterntrap/trap = new(T, user, src, mode)
-		var/userjust = (get_modified_attribute_level(user, JUSTICE_ATTRIBUTE))
-		var/justicemod = 1 + userjust/100
+		var/justicemod = get_attack_multiplier(user)
 		trap.damage_multiplier*=justicemod
 		trap.damage_multiplier*=force_multiplier
 		user.changeNext_move(CLICK_CD_MELEE)
@@ -662,8 +661,7 @@
 		return
 	for(var/mob/living/L in hearers(2, target_turf))
 		var/heal_amt = force*0.025
-		var/userjust = (get_modified_attribute_level(user, JUSTICE_ATTRIBUTE))
-		var/justicemod = 1 + userjust / 100
+		var/justicemod = get_attack_multiplier(user)
 		heal_amt *= justicemod
 		heal_amt *= force_multiplier
 		if(!ishuman(L))
@@ -717,8 +715,7 @@
 			var/turf/target_turf = get_turf(M)
 			for(var/mob/living/L in hearers(2, target_turf))
 				var/heal_amt = force*0.05
-				var/userjust = (get_modified_attribute_level(user, JUSTICE_ATTRIBUTE))
-				var/justicemod = 1 + userjust / 100
+				var/justicemod = get_attack_multiplier(user)
 				heal_amt *= justicemod
 				heal_amt *= force_multiplier
 				if(!ishuman(L))

--- a/ModularTegustation/ego_weapons/melee/waw.dm
+++ b/ModularTegustation/ego_weapons/melee/waw.dm
@@ -22,8 +22,7 @@
 	if(!.)
 		return FALSE
 	var/aoe = 14
-	var/userjust = (get_modified_attribute_level(user, JUSTICE_ATTRIBUTE))
-	var/justicemod = 1 + userjust / 100
+	var/justicemod = get_attack_multiplier(user)
 	aoe *= justicemod
 	aoe *= force_multiplier
 	for(var/mob/living/L in hearers(1, target_turf))
@@ -351,7 +350,7 @@
 	combo_time = world.time + combo_wait
 	if(combo >= 13)
 		combo = 0
-		force = get_modified_attribute_level(user, JUSTICE_ATTRIBUTE) * 0.5
+		force = get_modified_attribute_level(user, JUSTICE_ATTRIBUTE)
 		new /obj/effect/temp_visual/thirteen(get_turf(M))
 		playsound(src, 'sound/weapons/ego/price_of_silence.ogg', 25, FALSE, 9)
 	..()
@@ -574,8 +573,7 @@
 	for(var/turf/T in orange(1, user)) // Most of this code was jacked from Harvest tbh
 		new /obj/effect/temp_visual/smash_effect(T)
 	var/aoe = special_force * (1 + special_combo_mult * special_combo)
-	var/userjust = (get_modified_attribute_level(user, JUSTICE_ATTRIBUTE))
-	var/justicemod = 1 + userjust/100
+	var/justicemod = get_attack_multiplier(user)
 	aoe*=justicemod
 	aoe*=force_multiplier
 	for(var/mob/living/L in range(1, user))
@@ -603,8 +601,7 @@
 			new /obj/effect/temp_visual/smash_effect(T)
 			for(var/mob/living/L in T.contents)
 				var/aoe = special_force * 1 + (special_combo_mult * special_combo)
-				var/userjust = (get_modified_attribute_level(user, JUSTICE_ATTRIBUTE))
-				var/justicemod = 1 + userjust/100
+				var/justicemod = get_attack_multiplier(user)
 				aoe*=justicemod
 				aoe*=force_multiplier
 				if(L == user)
@@ -901,8 +898,7 @@
 	inuse = FALSE
 	ability_cooldown = ability_cooldown_time + world.time
 	var/aoe = aoe_damage
-	var/userjust = (get_modified_attribute_level(user, JUSTICE_ATTRIBUTE))
-	var/justicemod = 1 + userjust / 100
+	var/justicemod = get_attack_multiplier(user)
 	aoe *= justicemod
 	aoe *= force_multiplier
 	var/list/been_hit = list()
@@ -1034,8 +1030,7 @@
 	if(!CanUseEgo(user))
 		return
 	if(!(target.status_flags & GODMODE) && target.stat != DEAD)
-		var/userjust = (get_modified_attribute_level(user, JUSTICE_ATTRIBUTE))
-		var/justicemod = 1 + userjust/100
+		var/justicemod = get_attack_multiplier(user)
 		AdjustThirst(force * justicemod)
 		var/heal_amt = force* 0.05
 		if(siphoning)
@@ -1120,7 +1115,7 @@
 			hitsound = 'sound/abnormalities/wrath_servant/big_smash2.ogg'
 		if(2)
 			hitsound = 'sound/abnormalities/wrath_servant/big_smash3.ogg'
-	var/damage = aoe_damage * (1 + (get_modified_attribute_level(user, JUSTICE_ATTRIBUTE))/100)
+	var/damage = aoe_damage * get_attack_multiplier(user)
 	damage *= force_multiplier
 	if(attacks == 0)
 		damage *= 3
@@ -1243,8 +1238,7 @@
 /obj/item/ego_weapon/mini/infinity/proc/cast(mob/living/target, mob/living/user, damage_color)
 	if(!target)
 		return
-	var/userjust = (get_modified_attribute_level(user, JUSTICE_ATTRIBUTE))
-	var/justicemod = 1 + userjust/100
+	var/justicemod = get_attack_multiplier(user)
 	var/modified_damage = mark_damage
 	modified_damage *= justicemod
 	modified_damage *= force_multiplier
@@ -1294,8 +1288,7 @@
 	can_spin = FALSE
 	if(do_after(user, 13, src))
 		var/aoe = force
-		var/userjust = (get_modified_attribute_level(user, JUSTICE_ATTRIBUTE))
-		var/justicemod = 1 + userjust/100
+		var/justicemod = get_attack_multiplier(user)
 		var/firsthit = TRUE //One target takes full damage
 		can_spin = TRUE
 		addtimer(CALLBACK(src, PROC_REF(spin_reset)), 13)
@@ -1473,8 +1466,7 @@
 		if(L.z != user.z) // Not on our level
 			continue
 		var/aoe = 15
-		var/userjust = (get_modified_attribute_level(user, JUSTICE_ATTRIBUTE))
-		var/justicemod = 1 + userjust/100
+		var/justicemod = get_attack_multiplier(user)
 		aoe*=justicemod
 		aoe*=force_multiplier
 		if(L == user || ishuman(L))
@@ -1772,8 +1764,7 @@
 	var/turf/T = get_turf(src)
 	for(var/mob/living/L in view(1, T))
 		var/aoe = (charge_amount + 5) * 5
-		var/userjust = (get_modified_attribute_level(user, JUSTICE_ATTRIBUTE))
-		var/justicemod = 1 + userjust/100
+		var/justicemod = get_attack_multiplier(user)
 		aoe*=justicemod
 		if(L == user || ishuman(L))
 			continue
@@ -1927,8 +1918,7 @@
 /obj/item/ego_weapon/rosa/attack(mob/living/M, mob/living/user)
 	..()
 	if(M==user)
-		var/userjust = (get_modified_attribute_level(user, JUSTICE_ATTRIBUTE))
-		var/justicemod = 1 + userjust/100
+		var/justicemod = get_attack_multiplier(user)
 		var/heal_amount = (force * justicemod * 0.75)
 		var/armormod = (user.run_armor_check(null, WHITE_DAMAGE))
 		if(armormod)//skips all the math if you're not wearing armor
@@ -2055,7 +2045,7 @@
 	if(charged)
 		var/damage = 40
 		if(ishuman(thrownby))
-			damage *= 1 + (get_modified_attribute_level(thrownby, JUSTICE_ATTRIBUTE))/100
+			damage *= get_attack_multiplier(thrownby)
 			damage *= force_multiplier
 			for(var/turf/open/T in range(1, src))
 				var/obj/effect/temp_visual/small_smoke/halfsecond/smonk = new(T)
@@ -2168,8 +2158,7 @@
 		if(L.z != user.z) // Not on our level
 			continue
 		var/aoe = 28
-		var/userjust = (get_modified_attribute_level(user, JUSTICE_ATTRIBUTE))
-		var/justicemod = 1 + userjust/100
+		var/justicemod = get_attack_multiplier(user)
 		aoe*=justicemod
 		aoe*=force_multiplier
 		if(L == user || ishuman(L))
@@ -2294,8 +2283,7 @@
 		addtimer(CALLBACK(src, PROC_REF(spin_reset)), 12)
 		playsound(src, 'sound/abnormalities/myformempties/MFEattack.ogg', 75, FALSE, 4)//get a proper sound for this
 		var/aoe = 20
-		var/userjust = (get_modified_attribute_level(user, JUSTICE_ATTRIBUTE))
-		var/justicemod = 1 + userjust/100
+		var/justicemod = get_attack_multiplier(user)
 		aoe*=force_multiplier
 		aoe*=justicemod
 		var/turf/target_c = get_turf(src)
@@ -2502,8 +2490,7 @@
 	..()
 	if(!CanUseEgo(user))
 		return
-	var/userjust = (get_modified_attribute_level(user, JUSTICE_ATTRIBUTE))
-	var/justicemod = 1 + userjust/100
-	var/damage = force * justicemod * force_multiplier * 0.5
+	var/justicemod = get_attack_multiplier(user)
+	var/damage = force * justicemod * 0.5
 	target.apply_damage(damage, FIRE, null, target.run_armor_check(null, FIRE), spread_damage = TRUE)
 	target.apply_lc_burn(3)

--- a/ModularTegustation/ego_weapons/melee/waw.dm
+++ b/ModularTegustation/ego_weapons/melee/waw.dm
@@ -2491,6 +2491,6 @@
 	if(!CanUseEgo(user))
 		return
 	var/justicemod = get_attack_multiplier(user)
-	var/damage = force * justicemod * 0.5
+	var/damage = force * justicemod * force_multiplier * 0.5
 	target.apply_damage(damage, FIRE, null, target.run_armor_check(null, FIRE), spread_damage = TRUE)
 	target.apply_lc_burn(3)

--- a/ModularTegustation/ego_weapons/melee/zayin.dm
+++ b/ModularTegustation/ego_weapons/melee/zayin.dm
@@ -357,10 +357,10 @@
 			return
 		..()
 		return
-	var/justice_mod = 1 + (get_modified_attribute_level(user, JUSTICE_ATTRIBUTE)/100)
+	var/justicemod = get_attack_multiplier(user)
 	HT.apply_status_effect(/datum/status_effect/you_happy_buff)
 	var/datum/status_effect/you_happy_buff/Y = HT.has_status_effect(/datum/status_effect/you_happy_buff)
-	Y.EnableBuff((force * justice_mod) * force_multiplier)
+	Y.EnableBuff((force * justicemod) * force_multiplier)
 	playsound(get_turf(user), 'sound/effects/light_flicker.ogg', 25, TRUE, -9)
 	HT.visible_message(span_nicegreen("[HT] had their justice buffed with [src] by [user]!"))
 	user.changeNext_move(CLICK_CD_MELEE * 5)
@@ -368,7 +368,7 @@
 /datum/status_effect/you_happy_buff
 	id = "you must be happy ego buff"
 	status_type = STATUS_EFFECT_UNIQUE
-	duration = 6 SECONDS
+	duration = 12 SECONDS
 	alert_type = null
 	var/buff_amount = 0
 

--- a/ModularTegustation/ego_weapons/ranged/special.dm
+++ b/ModularTegustation/ego_weapons/ranged/special.dm
@@ -122,8 +122,7 @@
 	addtimer(CALLBACK(S, TYPE_PROC_REF(/obj/effect/qoh_sygil, fade_out)), 3 SECONDS)
 	if(do_after(user, 15, src))
 		var/aoe = blast_damage
-		var/userjust = (get_attribute_level(user, JUSTICE_ATTRIBUTE))
-		var/justicemod = 1 + userjust/100
+		var/justicemod = get_attack_multiplier(user)
 		var/firsthit = TRUE //One target takes full damage
 		var/turf/stepturf = (get_step(get_step(user, user.dir), user.dir))
 		playsound(src, 'sound/abnormalities/hatredqueen/gun.ogg', 65, FALSE, 4)

--- a/ModularTegustation/ego_weapons/ranged/waw.dm
+++ b/ModularTegustation/ego_weapons/ranged/waw.dm
@@ -553,8 +553,7 @@
 	if(!CanUseEgo(user))
 		return
 	if(!(target.status_flags & GODMODE) && target.stat != DEAD)
-		var/userjust = (get_modified_attribute_level(user, JUSTICE_ATTRIBUTE))
-		var/justicemod = 1 + userjust/100
+		var/justicemod = get_attack_multiplier(user)
 		AdjustThirst(force * justicemod)
 	..()
 

--- a/ModularTegustation/tegu_items/workshop/mods/aoe.dm
+++ b/ModularTegustation/tegu_items/workshop/mods/aoe.dm
@@ -18,8 +18,7 @@
 			Aoe(L, user, T.force)
 
 /obj/item/workshop_mod/aoe/proc/Aoe(mob/living/L, mob/living/carbon/human/user, aoe_damage)
-	var/userjust = (get_attribute_level(user, JUSTICE_ATTRIBUTE))
-	var/justicemod = 1 + userjust/100
+	var/justicemod = get_attack_multiplier(user)
 	aoe_damage*=justicemod
 	if(L == user)
 		return

--- a/ModularTegustation/tegu_items/workshop/mods/split.dm
+++ b/ModularTegustation/tegu_items/workshop/mods/split.dm
@@ -5,8 +5,7 @@
 
 //Split damage, currently only red and white
 /obj/item/workshop_mod/split/ActivateEffect(obj/item/ego_weapon/template/T, special_count = 0, mob/living/target, mob/living/carbon/human/user)
-	var/userjust = (get_attribute_level(user, JUSTICE_ATTRIBUTE))
-	var/justicemod = 1 + userjust/100
+	var/justicemod = get_attack_multiplier(user)
 	var/splitdamage = justicemod*force
 	var/splitdamagetype
 	switch(T.damtype)

--- a/ModularTegustation/tegu_items/workshop/templates/gauntlet.dm
+++ b/ModularTegustation/tegu_items/workshop/templates/gauntlet.dm
@@ -25,8 +25,7 @@
 		specialmod.ActivateEffect(src, special_count, target, user)
 
 	//I gotta regrab  justice here
-	var/userjust = (get_modified_attribute_level(user, JUSTICE_ATTRIBUTE))
-	var/justicemod = 1 + userjust/100
+	var/justicemod = get_attack_multiplier(user)
 	force *= justicemod
 
 	if(ishuman(target))

--- a/ModularTegustation/tegu_mobs/lc13_corrosions.dm
+++ b/ModularTegustation/tegu_mobs/lc13_corrosions.dm
@@ -91,7 +91,7 @@
 		return
 	var/damage = I.force
 	if(ishuman(user))
-		damage *= 1 + (get_attribute_level(user, JUSTICE_ATTRIBUTE)/100)
+		damage *= get_attack_multiplier(user)
 	ReflectDamage(user, I.damtype, damage)
 
 /mob/living/simple_animal/hostile/ordeal/NT_corrosion/adjustHealth(amount, updating_health = TRUE, forced = FALSE)

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -279,7 +279,7 @@
 /mob/living/attacked_by(obj/item/I, mob/living/user)
 	send_item_attack_message(I, user)
 	if(I.force)
-		var/justice_mod = 1 + (get_modified_attribute_level(user, JUSTICE_ATTRIBUTE)/100)
+		var/justice_mod = get_attack_multiplier(user)
 
 		var/damage = I.force * justice_mod
 		if(istype(I, /obj/item/ego_weapon))
@@ -306,7 +306,7 @@
 	if(I.force)
 		user.visible_message(span_danger("[user] hits [src] with [I]!"), span_danger("You hit [src] with [I]!"), null, COMBAT_MESSAGE_RANGE)
 		log_combat(user, src, "attacked", I)
-		var/justice_mod = 1 + (get_modified_attribute_level(user, JUSTICE_ATTRIBUTE)/100)
+		var/justice_mod = get_attack_multiplier(user)
 		var/damage = I.force * justice_mod
 		damage *= I.force_multiplier
 		take_damage(damage, I.damtype, attack_dir = get_dir(src, user))

--- a/code/datums/ai/sanity/_sanityloss_controller.dm
+++ b/code/datums/ai/sanity/_sanityloss_controller.dm
@@ -569,7 +569,7 @@
 	return null
 
 /proc/GetEffectiveItemForce(obj/item/I, considerRangedAttack = TRUE, justice = 0)
-	var/power = I.force * (1 + justice / 100)
+	var/power = I.force * (1 + (justice * GLOB.justice_multiplier) / 100)
 	if(istype(I, /obj/item/ego_weapon))
 		var/obj/item/ego_weapon/EW = I
 		power *= EW.force_multiplier
@@ -736,7 +736,7 @@
 	var/aggro = I.force
 	aggro *= I.force_multiplier
 	if(ishuman(user))
-		aggro *= 1 + get_modified_attribute_level(user, JUSTICE_ATTRIBUTE) * 0.01
+		aggro *= get_attack_multiplier(user)
 	RegisterAggroValue(user, aggro, I.damtype)
 	return
 
@@ -776,7 +776,7 @@
 		if(I.throwforce > 0 && ishuman(I.thrownby))
 			var/mob/living/carbon/human/H = I.thrownby
 			retaliate(H)
-			var/aggro = I.throwforce * (1 + get_modified_attribute_level(H, JUSTICE_ATTRIBUTE) * 0.01)
+			var/aggro = I.throwforce * get_attack_multiplier(H)
 			aggro *= I.force_multiplier
 			RegisterAggroValue(H, aggro, I.damtype)
 	return

--- a/code/datums/attributes/justice.dm
+++ b/code/datums/attributes/justice.dm
@@ -1,3 +1,5 @@
+GLOBAL_LIST_INIT(justice_multiplier, 0.5)
+
 /datum/attribute/justice
 	name = JUSTICE_ATTRIBUTE
 	desc = "Attribute responsible for damage and move speed."
@@ -9,3 +11,12 @@
 	var/slowdown = -(get_modified_level() / JUSTICE_MOVESPEED_DIVISER)
 	user.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/justice_attribute, multiplicative_slowdown = slowdown)
 	return TRUE
+
+//Getting the justice multiplier on attacks
+/proc/get_attack_multiplier(mob/living/carbon/human/user)
+	if(!istype(user))
+		return 1
+	var/userjust = (get_modified_attribute_level(user, JUSTICE_ATTRIBUTE))
+	if(!userjust)
+		return 1
+	return 1 + ((userjust / 100) * GLOB.justice_multiplier)

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -80,7 +80,7 @@
 	SEND_SIGNAL(I, COMSIG_ITEM_ATTACK_ZONE, src, user, affecting)
 	send_item_attack_message(I, user, affecting.name, affecting)
 	if(I.force)
-		var/justice_mod = 1 + (get_modified_attribute_level(user, JUSTICE_ATTRIBUTE)/100)
+		var/justice_mod = get_attack_multiplier(user)
 		var/damage = I.force * justice_mod
 		if(istype(I, /obj/item/ego_weapon))
 			var/obj/item/ego_weapon/theweapon = I

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1393,7 +1393,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 				return FALSE
 		user.do_attack_animation(target, atk_effect)
 
-		var/damage = rand(user.dna.species.punchdamagelow, user.dna.species.punchdamagehigh) * (1 + (get_modified_attribute_level(user, JUSTICE_ATTRIBUTE) + get_attribute_level(user, FORTITUDE_ATTRIBUTE)) / 100)
+		var/damage = rand(user.dna.species.punchdamagelow, user.dna.species.punchdamagehigh) * get_attack_multiplier(user) * (1 + (get_attribute_level(user, FORTITUDE_ATTRIBUTE) / 100))
 
 		var/obj/item/bodypart/affecting = target.get_bodypart(ran_zone(user.zone_selected))
 
@@ -1520,7 +1520,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 
 	H.send_item_attack_message(I, user, hit_area, affecting)
 
-	var/justice_mod = 1 + (get_modified_attribute_level(user, JUSTICE_ATTRIBUTE)/100)
+	var/justice_mod = get_attack_multiplier(user)
 	var/damage = I.force
 	if(!(SSmaptype.maptype in SSmaptype.citymaps))
 		damage *= justice_mod

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -94,7 +94,7 @@
 		var/justice_mod = 1
 		if(ishuman(thrown_item.thrownby))
 			var/mob/living/carbon/human/H = thrown_item.thrownby
-			justice_mod += get_modified_attribute_level(H, JUSTICE_ATTRIBUTE)/100
+			justice_mod = get_attack_multiplier(H)
 		apply_damage(thrown_item.throwforce * justice_mod, thrown_item.damtype, zone, armor, sharpness = thrown_item.get_sharpness(), wound_bonus = (nosell_hit * CANT_WOUND))
 		if(QDELETED(src)) //Damage can delete the mob.
 			return

--- a/code/modules/mob/living/simple_animal/abnormality/_auxiliary_modes/community/ego_weapons.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/_auxiliary_modes/community/ego_weapons.dm
@@ -159,8 +159,7 @@
 		charge_amount -= charge_cost
 		addtimer(CALLBACK(src, PROC_REF(spin_reset)), 12)
 		playsound(src, 'sound/abnormalities/seasons/summer_attack.ogg', 75, FALSE, 4)
-		var/userjust = (get_modified_attribute_level(user, JUSTICE_ATTRIBUTE))
-		var/justicemod = 1 + userjust/100
+		var/justicemod = get_attack_multiplier(user)
 		aoe_damage = (force * justicemod)
 		addtimer(CALLBACK(src, PROC_REF(WideSlash), user), 1)
 
@@ -442,8 +441,7 @@
 	G.preparePixelProjectile(target, user, clickparams)
 	G.fire()
 	G.damage*=force_multiplier
-	var/userjust = (get_modified_attribute_level(user, JUSTICE_ATTRIBUTE))
-	var/justicemod = 1 + userjust/100
+	var/justicemod = get_attack_multiplier(user)
 	G.damage*=justicemod
 	firing_cooldown = firing_cooldown_time + world.time
 	user.changeNext_move(CLICK_CD_MELEE * attack_speed)
@@ -507,8 +505,7 @@
 	playsound(target, 'sound/abnormalities/bloodbath/Bloodbath_EyeOn.ogg', 80, TRUE, -3) //yes im reusing a sound bite me
 	var/damage_dealt = force
 	damage_dealt*=force_multiplier
-	var/userjust = (get_modified_attribute_level(user, JUSTICE_ATTRIBUTE))
-	var/justicemod = 1 + userjust/100
+	var/justicemod = get_attack_multiplier(user)
 	damage_dealt*=justicemod
 	for(var/turf/T in view(1, target))
 		var/obj/effect/temp_visual/small_smoke/halfsecond/FX =  new(T)

--- a/code/modules/mob/living/simple_animal/abnormality/teth/so_that_no_cry.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/so_that_no_cry.dm
@@ -165,7 +165,7 @@
 		return
 	var/damage = I.force
 	if(ishuman(user))
-		damage *= 1 + (get_attribute_level(user, JUSTICE_ATTRIBUTE)/100)
+		damage *= get_attack_multiplier(user)
 	ReflectDamage(user, I.damtype, damage)
 
 //Reflect Code

--- a/code/modules/mob/living/simple_animal/abnormality/waw/yang.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/waw/yang.dm
@@ -136,7 +136,7 @@
 /mob/living/simple_animal/hostile/abnormality/yang/proc/Reflect(mob/living/attacker, damage)
 	if(ishuman(attacker))
 		var/mob/living/carbon/human/H = attacker
-		var/justice_mod = 1 + (get_attribute_level(H, JUSTICE_ATTRIBUTE)/100)
+		var/justice_mod = get_attack_multiplier(H)
 		damage *= justice_mod
 	attacker.deal_damage(damage, WHITE_DAMAGE)
 	return

--- a/code/modules/mob/living/simple_animal/distortion/nightmare/distorted_kim.dm
+++ b/code/modules/mob/living/simple_animal/distortion/nightmare/distorted_kim.dm
@@ -392,7 +392,7 @@
 		return
 	var/damage = I.force
 	if(ishuman(user))
-		damage *= 1 + (get_attribute_level(user, JUSTICE_ATTRIBUTE)/100)
+		damage *= get_attack_multiplier(user)
 	ReflectDamage(user, I.damtype, damage)
 	claimbones()
 
@@ -468,7 +468,7 @@
 		return
 	var/damage = I.force
 	if(ishuman(user))
-		damage *= 1 + (get_modified_attribute_level(user, JUSTICE_ATTRIBUTE) / 100)
+		damage *= get_attack_multiplier(user)
 	ReflectDamage(user, I.damtype, damage)
 	claimbones(target)
 

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -291,7 +291,7 @@ GLOBAL_LIST_EMPTY(marked_players)
 			add_damtype = I.damtype
 			if(ishuman(user))
 				var/mob/living/carbon/human/H = user
-				var/justice_mod = 1 + get_modified_attribute_level(H, JUSTICE_ATTRIBUTE) / 100
+				var/justice_mod = get_attack_multiplier(H)
 				add_aggro *= justice_mod
 			if(istype(I, /obj/item/ego_weapon/))
 				var/obj/item/ego_weapon/EW = I

--- a/code/modules/mob/living/simple_animal/hostile/ordeal/white/fixers.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/white/fixers.dm
@@ -353,7 +353,7 @@
 		return
 	var/damage = I.force
 	if(ishuman(user))
-		damage *= 1 + (get_modified_attribute_level(user, JUSTICE_ATTRIBUTE) / 100)
+		damage *= get_attack_multiplier(user)
 	ReflectDamage(user, I.damtype, damage)
 
 // Black Fixer

--- a/code/modules/spells/ability_types/realized.dm
+++ b/code/modules/spells/ability_types/realized.dm
@@ -519,7 +519,7 @@
 /obj/effect/proc_holder/ability/justice_and_balance/proc/Smash(mob/user, on_use_charges)
 	playsound(user, SFX[on_use_charges], 25*(4-on_use_charges))
 	var/temp_dam = damage
-	temp_dam *= 1 + (get_attribute_level(user, JUSTICE_ATTRIBUTE)/100)
+	temp_dam *= get_attack_multiplier(user)
 	if(on_use_charges <= 1)
 		temp_dam *= 1.5
 	for(var/turf/open/T in range(3, user))

--- a/code/modules/spells/ability_types/realized_aimed.dm
+++ b/code/modules/spells/ability_types/realized_aimed.dm
@@ -227,9 +227,7 @@
 	beamloop.max_loops = 0
 	var/beam_stage = 1
 	var/beam_damage = 8
-	var/justice = get_attribute_level(H, JUSTICE_ATTRIBUTE)
-	justice /= 100
-	justice++
+	var/justice = get_attack_multiplier(H)
 	beam_damage *= justice
 	if(speak)
 		addtimer(CALLBACK(H, TYPE_PROC_REF(/atom/movable, say), "ARCANA SLAVE!"))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes all instances of 1 + get_modified_attribute_level(x, JUSTICE_ATTRIBUTE) / 100 to its own global proc called get_attack_multiplier(mob/living/carbon/human/user). 
The effectiveness Justice scaling had on weapons is also weaker, now it's +0.5% per point instead of +1% per point.
Also some minor bug fixes where some weapons didn't gain justice right or had force mod were fix.
Plastic and dead silence have also gotten a buff with better duration and damage respectively
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Overall our current justice scaling is a bit much at times. This should hopefully fix it

## Changelog
:cl:
balance: rebalanced justice
fix: fixed a few things
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
