### PR TITLE
Ports a disposals bug fix

### DIFF
--- a/code/modules/recycling/disposal/bin.dm
+++ b/code/modules/recycling/disposal/bin.dm
@@ -214,7 +214,7 @@
 
 	playsound(src, 'sound/machines/hiss.ogg', 50, FALSE, FALSE)
 
-	pipe_eject(H)
+	pipe_eject(H, source_area = H.source_area)
 
 	H.vent_gas(loc)
 	qdel(H)

--- a/code/modules/recycling/disposal/eject.dm
+++ b/code/modules/recycling/disposal/eject.dm
@@ -1,7 +1,7 @@
 /**
  * General proc used to expel a holder's contents through src (for bins holder is also the src).
  */
-/obj/proc/pipe_eject(obj/holder, direction, throw_em = TRUE, turf/target, throw_range = 5, throw_speed = 1)
+/obj/proc/pipe_eject(obj/holder, direction, throw_em = TRUE, turf/target, throw_range = 5, throw_speed = 1, area/source_area)
 	var/turf/src_T = get_turf(src)
 	for(var/A in holder)
 		var/atom/movable/AM = A
@@ -10,3 +10,7 @@
 		if(throw_em && !QDELETED(AM))
 			var/turf/T = target || get_offset_target_turf(loc, rand(5)-rand(5), rand(5)-rand(5))
 			AM.throw_at(T, throw_range, throw_speed)
+		if(istype(source_area))
+			source_area.Exited(AM)
+			var/area/new_area = get_area(src_T)
+			new_area.Entered(AM)

--- a/code/modules/recycling/disposal/holder.dm
+++ b/code/modules/recycling/disposal/holder.dm
@@ -14,6 +14,7 @@
 	var/destinationTag = NONE	// changes if contains a delivery container
 	var/tomail = FALSE			// contains wrapped package
 	var/hasmob = FALSE			// contains a mob
+	var/area/source_area		// LC13 Addition: Used to clean up area index stuff because apparently using disposal pipes to travel avoids calling Exited() ??
 
 /obj/structure/disposalholder/Destroy()
 	QDEL_NULL(gas)
@@ -22,6 +23,7 @@
 
 // initialize a holder from the contents of a disposal unit
 /obj/structure/disposalholder/proc/init(obj/machinery/disposal/D)
+	source_area = get_area(D)
 	gas = D.air_contents// transfer gas resv. into holder object
 
 	//Check for any living mobs trigger hasmob.

--- a/code/modules/recycling/disposal/outlet.dm
+++ b/code/modules/recycling/disposal/outlet.dm
@@ -57,7 +57,7 @@
 	if(!H)
 		return
 
-	pipe_eject(H, dir, TRUE, target, eject_range, throw_range)
+	pipe_eject(H, dir, TRUE, target, eject_range, throw_range, source_area = H.source_area)
 
 	H.vent_gas(loc)
 	qdel(H)

--- a/code/modules/recycling/disposal/pipe.dm
+++ b/code/modules/recycling/disposal/pipe.dm
@@ -111,7 +111,7 @@
 		target = get_offset_target_turf(T, rand(5)-rand(5), rand(5)-rand(5))
 
 	playsound(src, 'sound/machines/hiss.ogg', 50, FALSE, FALSE)
-	pipe_eject(H, direction, TRUE, target, eject_range)
+	pipe_eject(H, direction, TRUE, target, eject_range, source_area = H.source_area)
 	H.vent_gas(T)
 	qdel(H)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Ports https://github.com/Lobotomy-Corporation-13/lc13/pull/380 by [Destrok171](https://github.com/Destrok171)
This pr fixes an issue with disposals which allowed someone to bypass exiting an area, causing regenerators to still heal them outside the department

## Why It's Good For The Game

Bugs are stinky

## Changelog
:cl:
fix: Department disposal units no longer grant you eternal regeneration
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
