### PR TITLE
Fixes a bug with the emergency system

### DIFF
--- a/code/controllers/subsystem/lobotomy_corp.dm
+++ b/code/controllers/subsystem/lobotomy_corp.dm
@@ -109,6 +109,7 @@ SUBSYSTEM_DEF(lobotomy_corp)
 /datum/controller/subsystem/lobotomy_corp/Initialize(timeofday)
 	if(SSmaptype.maptype in SSmaptype.combatmaps) // sleep
 		flags |= SS_NO_FIRE
+		SSlobotomy_emergency.score_min = 0
 		return ..()
 
 	RegisterSignal(SSdcs, COMSIG_GLOB_MOB_DEATH, PROC_REF(CheckForRestart))
@@ -397,9 +398,6 @@ SUBSYSTEM_DEF(lobotomy_corp)
 	return TRUE
 
 /datum/controller/subsystem/lobotomy_corp/proc/MinCheck()
-	if((SSmaptype.maptype in SSmaptype.combatmaps) || SSmaptype.maptype == "enkephalin_rush")
-		SSlobotomy_emergency.score_min = 0
-		return FALSE
 	if(SSlobotomy_emergency.score_min < SSlobotomy_emergency.trumpet_2/2)
 		return FALSE
 	return TRUE

--- a/code/controllers/subsystem/lobotomy_corp.dm
+++ b/code/controllers/subsystem/lobotomy_corp.dm
@@ -397,6 +397,9 @@ SUBSYSTEM_DEF(lobotomy_corp)
 	return TRUE
 
 /datum/controller/subsystem/lobotomy_corp/proc/MinCheck()
+	if((SSmaptype.maptype in SSmaptype.combatmaps) || SSmaptype.maptype == "enkephalin_rush")
+		SSlobotomy_emergency.score_min = 0
+		return FALSE
 	if(SSlobotomy_emergency.score_min < SSlobotomy_emergency.trumpet_2/2)
 		return FALSE
 	return TRUE

--- a/code/controllers/subsystem/lobotomy_emergency.dm
+++ b/code/controllers/subsystem/lobotomy_emergency.dm
@@ -38,7 +38,6 @@ SUBSYSTEM_DEF(lobotomy_emergency)
 /datum/controller/subsystem/lobotomy_emergency/Initialize(timeofday)
 	if((SSmaptype.maptype in SSmaptype.combatmaps) || SSmaptype.maptype == "enkephalin_rush") // sleep
 		flags |= SS_NO_FIRE
-		should_calc_score = FALSE
 		return ..()
 	RegisterSignal(SSdcs, COMSIG_GLOB_MOB_DEATH, PROC_REF(OnMobDeath))
 	RegisterSignal(SSdcs, COMSIG_GLOB_HUMAN_INSANE, PROC_REF(OnHumanInsane))

--- a/code/controllers/subsystem/maptype.dm
+++ b/code/controllers/subsystem/maptype.dm
@@ -78,6 +78,9 @@ SUBSYSTEM_DEF(maptype)
 	//Make ghosts able to possess things
 	if(maptype in autopossess)
 		SSlobotomy_corp.enable_possession = TRUE
+	//Make sure the emergency system is disabled
+	if((maptype in combatmaps) || maptype == "enkephalin_rush")
+		SSlobotomy_emergency.should_calc_score = FALSE
 
 	//All the maptype specific stuff
 	switch(maptype)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This pr fixes an issue where the end of round sequence would happen on non LC maps by moving where the system should be nonfunctional to maptypes.dm.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Now people can play enk rush again
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Rounds ending due to the emergency system bugging out
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
