### PR TITLE
Fixes intents UI

### DIFF
--- a/code/datums/ai/monkey/monkey_behaviors.dm
+++ b/code/datums/ai/monkey/monkey_behaviors.dm
@@ -152,10 +152,10 @@
 
 		// if the target has a weapon, chance to disarm them
 		if(W && DT_PROB(MONKEY_ATTACK_DISARM_PROB, delta_time))
-			living_pawn.a_intent = INTENT_DISARM
+			living_pawn.a_intent_change(INTENT_DISARM)
 			monkey_attack(controller, target, delta_time)
 		else
-			living_pawn.a_intent = INTENT_HARM
+			living_pawn.a_intent_change(INTENT_HARM)
 			monkey_attack(controller, target, delta_time)
 
 
@@ -220,7 +220,7 @@
 
 	if(target.pulledby != living_pawn && !HAS_AI_CONTROLLER_TYPE(target.pulledby, /datum/ai_controller/monkey)) //Dont steal from my fellow monkeys.
 		if(living_pawn.Adjacent(target) && isturf(target.loc))
-			living_pawn.a_intent = INTENT_GRAB
+			living_pawn.a_intent_change(INTENT_GRAB)
 			target.grabbedby(living_pawn)
 		return //Do the rest next turn
 

--- a/code/datums/ai/sanity/_sanityloss_controller.dm
+++ b/code/datums/ai/sanity/_sanityloss_controller.dm
@@ -144,7 +144,7 @@
 		return
 	total_locations |= GLOB.xeno_spawn // Avoids Department centers, unlike Wander Panic
 	var/mob/living/L = pawn
-	L.a_intent = INTENT_HARM
+	L.a_intent_change(INTENT_HARM)
 	L.active_hand_index = 1
 
 /datum/ai_controller/insane/murder/PerformMovement(delta_time)

--- a/code/datums/ai/sanity/sanityloss_behaviors.dm
+++ b/code/datums/ai/sanity/sanityloss_behaviors.dm
@@ -383,10 +383,10 @@
 				break
 		// if the target has a weapon, chance to disarm them
 		if(W && DT_PROB(25, delta_time))
-			living_pawn.a_intent = INTENT_DISARM
+			living_pawn.a_intent_change(INTENT_DISARM)
 		living_pawn.UnarmedAttack(target)
 		living_pawn.changeNext_move(CLICK_CD_MELEE)
-		living_pawn.a_intent = INTENT_HARM
+		living_pawn.a_intent_change(INTENT_HARM)
 
 /// attack using this GUN we found.
 /datum/ai_behavior/insanity_attack_mob/proc/ranged_attack(datum/ai_controller/insane/murder/controller, atom/target, delta_time)

--- a/code/datums/diseases/transformation.dm
+++ b/code/datums/diseases/transformation.dm
@@ -69,7 +69,7 @@
 		if(istype(new_mob))
 			if(bantype && is_banned_from(affected_mob.ckey, bantype))
 				replace_banned_player(new_mob)
-			new_mob.a_intent = INTENT_HARM
+			new_mob.a_intent_change(INTENT_HARM)
 			if(affected_mob.mind)
 				affected_mob.mind.transfer_to(new_mob)
 			else

--- a/code/datums/status_effects/panic.dm
+++ b/code/datums/status_effects/panic.dm
@@ -105,17 +105,23 @@
 	status_type = STATUS_EFFECT_REPLACE
 	alert_type = null
 	var/icon = "berserk"
+	var/saved_intent = null
 
 /datum/status_effect/panicked_type/on_apply()
 	. = ..()
 	owner.add_overlay(mutable_appearance('icons/effects/effects.dmi', icon, -ABOVE_MOB_LAYER))
+	saved_intent = owner.a_intent
 
 /datum/status_effect/panicked_type/on_remove()
 	. = ..()
 	owner.cut_overlay(mutable_appearance('icons/effects/effects.dmi', icon, -ABOVE_MOB_LAYER))
+	if(saved_intent && owner)
+		owner.a_intent_change(saved_intent)
 
 /datum/status_effect/panicked_type/be_replaced()
 	owner.cut_overlay(mutable_appearance('icons/effects/effects.dmi', icon, -ABOVE_MOB_LAYER))
+	if(saved_intent && owner)
+		owner.a_intent_change(saved_intent)
 	return ..()
 
 /datum/status_effect/panicked_type/murder


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes a bug that occurs when players panic and go insane. Some AI controllers such as the murder insane controller change the player's intent without updating the UI.

This PR changes the code to call a_intent_change instead of directly changing the a_intent variable, which performs the required UI updates.

Also makes it so that the current intent is recorded when sanity is lost and restored when sanity is restored.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
No more accidently punching yourself when you recover from a panic because your UI lied to you.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: panicking no longer breaks intent UI
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
