### PR TITLE
Screaming wedge no longer hides agent uniforms when worn

### DIFF
--- a/code/modules/clothing/suits/ego_gear/teth.dm
+++ b/code/modules/clothing/suits/ego_gear/teth.dm
@@ -84,6 +84,7 @@
 	name = "screaming wedge"
 	desc = "One can assume that she is longing for someone."
 	icon_state = "wedge"
+	flags_inv = NONE
 	armor = list(RED_DAMAGE = -10, WHITE_DAMAGE = 30, BLACK_DAMAGE = 10, PALE_DAMAGE = -10)
 
 /obj/item/clothing/suit/armor/ego_gear/teth/blossoms


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

What it says on the tin.

<img width="862" height="695" alt="image" src="https://github.com/user-attachments/assets/fa0a756b-0c57-4d68-9b49-a2090bd274a1" />


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This fixes a rather ugly inconsistency that had remained in the game because the headcoder thought it was "funny". In reality, it just looked like shit.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: corrects screaming wedge suit flags
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
