### PR TITLE
Dingle Dangle Changes

### DIFF
--- a/code/modules/mob/living/simple_animal/abnormality/teth/dingle_dangle.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/dingle_dangle.dm
@@ -249,7 +249,7 @@ GLOBAL_LIST_INIT(dingle_hallucination_list, list(
 
 /atom/movable/screen/alert/status_effect/dangle
 	name = "Delirious"
-	desc = "Your weakened mental state is causing you to see and hear things!"
+	desc = "Your weakened mental state is causing you to see, hear things, and take extra WHITE damage!"
 	icon = 'ModularTegustation/Teguicons/status_sprites.dmi'
 	icon_state = "delirious"
 

--- a/code/modules/mob/living/simple_animal/abnormality/teth/dingle_dangle.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/dingle_dangle.dm
@@ -49,7 +49,6 @@ GLOBAL_LIST_INIT(dingle_hallucination_list, list(
 			\"Let's dangle together, let your sorrows, your pain dangle, let's all dangle down...\" <br>It whispers into your mind. <br>\
 			Your comrades were never here, the life passes from your body painlessly. <br> None of this is real."),
 	)
-	var/breach_range = 10
 	var/list/delirious_people = list()
 	var/list/entangled_people = list()
 	//We want to make sure we don't cause someone to instantly panic after it "breaches"

--- a/code/modules/mob/living/simple_animal/abnormality/teth/dingle_dangle.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/dingle_dangle.dm
@@ -152,7 +152,7 @@ GLOBAL_LIST_INIT(dingle_hallucination_list, list(
 			return
 		for(var/mob/living/carbon/human/H in humans)
 			H.adjustSanityLoss(H.maxSanity)
-		safe = TRUE // Set safe again to really prevent something from going wrong
+		safe = TRUE // Set safe again to prevent something from going wrong.
 		return
 	safe = FALSE
 
@@ -263,7 +263,6 @@ GLOBAL_LIST_INIT(dingle_hallucination_list, list(
 	var/tries = 0
 	var/list/dingles = list()
 
-
 /datum/status_effect/dangle/on_apply()
 	. = ..()
 	if(!ishuman(owner))
@@ -309,8 +308,6 @@ GLOBAL_LIST_INIT(dingle_hallucination_list, list(
 		status_holder.ai_controller = /datum/ai_controller/insane/dingle_possess
 		status_holder.InitializeAIController()
 		owner.apply_status_effect(/datum/status_effect/panicked_type/dingle)
-	return ..()
-
 
 //***Custom Panic Definiton***
 /datum/status_effect/panicked_type/dingle

--- a/code/modules/mob/living/simple_animal/abnormality/teth/dingle_dangle.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/dingle_dangle.dm
@@ -49,6 +49,7 @@ GLOBAL_LIST_INIT(dingle_hallucination_list, list(
 			\"Let's dangle together, let your sorrows, your pain dangle, let's all dangle down...\" <br>It whispers into your mind. <br>\
 			Your comrades were never here, the life passes from your body painlessly. <br> None of this is real."),
 	)
+	var/breach_range = 10
 	var/list/delirious_people = list()
 	var/list/entangled_people = list()
 	//We want to make sure we don't cause someone to instantly panic after it "breaches"
@@ -67,18 +68,17 @@ GLOBAL_LIST_INIT(dingle_hallucination_list, list(
 
 /mob/living/simple_animal/hostile/abnormality/dingledangle/Initialize()
 	. = ..()
-	RegisterSignal(SSdcs, COMSIG_GLOB_HUMAN_INSANE, PROC_REF(OnHumanInsane))
+	RegisterSignal(SSdcs, COMSIG_GLOB_ABNORMALITY_BREACH, PROC_REF(OnAbnoBreach))
 
-/mob/living/simple_animal/hostile/abnormality/dingledangle/proc/OnHumanInsane(datum/source, mob/living/carbon/human/H, attribute)
+/mob/living/simple_animal/hostile/abnormality/dingledangle/proc/OnAbnoBreach(datum/source, mob/living/simple_animal/hostile/abnormality/abno)
 	SIGNAL_HANDLER
 	if(!IsContained())
-		return FALSE
-	if(!H.mind) // That wasn't a player at all...
-		return FALSE
-	if(H.z != z)
-		return FALSE
+		return
+	if(istype(abno, /mob/living/simple_animal/hostile/abnormality/punishing_bird))
+		return
+	if(istype(abno, /mob/living/simple_animal/hostile/abnormality/training_rabbit))
+		return
 	datum_reference.qliphoth_change(-1)
-	return TRUE
 
 /mob/living/simple_animal/hostile/abnormality/dingledangle/PostWorkEffect(mob/living/carbon/human/user, work_type, pe, work_time, canceled)
 	if(get_attribute_level(user, PRUDENCE_ATTRIBUTE) >= 60 && work_type != ABNORMALITY_WORK_INSIGHT)
@@ -90,43 +90,40 @@ GLOBAL_LIST_INIT(dingle_hallucination_list, list(
 /mob/living/simple_animal/hostile/abnormality/dingledangle/ZeroQliphoth(mob/living/carbon/human/user)
 	datum_reference.qliphoth_change(3)
 	safe = TRUE
-	var/mob/living/carbon/human/marked = null
-	for(var/mob/living/carbon/human/H in GLOB.player_list)
-		if(z != H.z)
-			continue
-		if(H.stat == DEAD || H.sanity_lost)
-			continue
-		if(get_attribute_level(H, PRUDENCE_ATTRIBUTE) < 60)
-			continue
-		if(!H.mind)
-			continue
-		//If we don't have someone selected, we select the first guy that has the requirements
-		if(!marked)
-			marked = H
-			continue
-		var/H_dist = get_dist(src, H)
-		var/marked_dist = get_dist(src, H)
-		//First we make sure the guy we're checking isn't further away than the selected guy
-		if(marked_dist < H_dist)
-			continue
-		else if(marked_dist == H_dist)
-			//Then we see if the current guy we're checking has higher prudence
-			if(get_attribute_level(H, PRUDENCE_ATTRIBUTE) > get_attribute_level(marked, PRUDENCE_ATTRIBUTE))
-				marked = H
-			//If both of them are the same distance away from dingle and have the same amount of prudence, it should be random
-			else if(get_attribute_level(H, PRUDENCE_ATTRIBUTE) == get_attribute_level(marked, PRUDENCE_ATTRIBUTE))
-				if(prob(50))
-					marked = H
-			//Otherwise we don't changed the selected guy
-		else
-			//If the guy we're checking is closer to dingle than the guy already selected, they will be selected instead
-			marked = H
-	if(marked)
-		var/datum/status_effect/dangle/D = marked.has_status_effect(STATUS_EFFECT_DANGLE)
-		if(!D)
-			marked.apply_status_effect(STATUS_EFFECT_DANGLE)
-		else
-			D.duration = initial(D.duration) + world.time
+	var/list/targets = list()
+	var/turf/self_turf = src.loc
+	var/turf/inside = locate(self_turf.x+1, self_turf.y, self_turf.z)
+	var/turf/outside = locate(self_turf.x+3, self_turf.y-4, self_turf.z)
+	if(inside)
+		for(var/mob/living/carbon/human/H in range(inside, 2))
+			if(z != H.z)
+				continue
+			if(H.stat == DEAD || H.sanity_lost)
+				continue
+			if(get_attribute_level(H, PRUDENCE_ATTRIBUTE) < 60)
+				continue
+			if(!H.mind)
+				continue
+			if(H.has_status_effect(STATUS_EFFECT_DANGLE))
+				continue
+			targets += H
+	if(outside)
+		var/area/place = get_area(outside)
+		for(var/mob/living/carbon/human/H in place)
+			if(z != H.z)
+				continue
+			if(H.stat == DEAD || H.sanity_lost)
+				continue
+			if(get_attribute_level(H, PRUDENCE_ATTRIBUTE) < 60)
+				continue
+			if(!H.mind)
+				continue
+			if(H.has_status_effect(STATUS_EFFECT_DANGLE))
+				continue
+			targets += H
+	if(LAZYLEN(targets))
+		var/mob/living/target = pick(targets)
+		target.apply_status_effect(STATUS_EFFECT_DANGLE)
 
 /mob/living/simple_animal/hostile/abnormality/dingledangle/NeutralEffect(mob/living/carbon/human/user, work_type, pe)
 	. = ..()
@@ -156,6 +153,7 @@ GLOBAL_LIST_INIT(dingle_hallucination_list, list(
 			return
 		for(var/mob/living/carbon/human/H in humans)
 			H.adjustSanityLoss(H.maxSanity)
+		safe = TRUE // Set safe again to really prevent something from going wrong
 		return
 	safe = FALSE
 
@@ -182,14 +180,14 @@ GLOBAL_LIST_INIT(dingle_hallucination_list, list(
 	desc = "A large amount of pink roots that are burrowing into someone!"
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "dingle_roots_person"
-	max_integrity = 40
+	max_integrity = 20
 	buckle_lying = 90
 	density = FALSE
 	anchored = TRUE
 	can_buckle = TRUE
 	layer = ABOVE_MOB_LAYER
 	pixel_y = -6
-	var/damage = 8
+	var/damage = 15
 	var/damage_cooldown
 	var/damage_cooldown_time = 5 SECONDS
 
@@ -288,7 +286,7 @@ GLOBAL_LIST_INIT(dingle_hallucination_list, list(
 	if(!ishuman(owner))
 		return
 	//It should cause a hallucination eventually without spamming it.
-	if(tries >= 5 && (prob(4) || tries >= 20))
+	if(tries >= 5 && (prob(3) || tries >= 30))
 		tries = 0
 		var/halpick = pickweight(GLOB.dingle_hallucination_list)
 		new halpick(owner, FALSE)

--- a/code/modules/mob/living/simple_animal/abnormality/teth/dingle_dangle.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/dingle_dangle.dm
@@ -49,8 +49,6 @@ GLOBAL_LIST_INIT(dingle_hallucination_list, list(
 			\"Let's dangle together, let your sorrows, your pain dangle, let's all dangle down...\" <br>It whispers into your mind. <br>\
 			Your comrades were never here, the life passes from your body painlessly. <br> None of this is real."),
 	)
-	var/list/delirious_people = list()
-	var/list/entangled_people = list()
 	//We want to make sure we don't cause someone to instantly panic after it "breaches"
 	var/safe = FALSE
 

--- a/code/modules/mob/living/simple_animal/abnormality/teth/dingle_dangle.dm
+++ b/code/modules/mob/living/simple_animal/abnormality/teth/dingle_dangle.dm
@@ -88,7 +88,7 @@ GLOBAL_LIST_INIT(dingle_hallucination_list, list(
 	datum_reference.qliphoth_change(3)
 	safe = TRUE
 	var/list/targets = list()
-	var/turf/self_turf = src.loc
+	var/turf/self_turf = get_turf(src)
 	var/turf/inside = locate(self_turf.x+1, self_turf.y, self_turf.z)
 	var/turf/outside = locate(self_turf.x+3, self_turf.y-4, self_turf.z)
 	if(inside)

--- a/code/modules/paperwork/records/info/teth.dm
+++ b/code/modules/paperwork/records/info/teth.dm
@@ -57,7 +57,7 @@
 		"When the work result was Bad, the Qliphoth Counter lowered.",
 		"The Qliphoth Counter decreased every time an Abnormality escaped. However, it did not respond similarly to the escape of O-02-56.",
 		"When any work type apart from Insight was finished by an employee with Prudence Level 3 or higher, they suddenly fell into a delirious panic.",
-		"When the Qliphoth Counter reached 0, an employee with Prudence Level 3 or higher near Dinge-Dangle's containment unit ureported a sense of confusion as well as increased mental strain.",
+		"When the Qliphoth Counter reached 0, an employee with Prudence Level 3 or higher near Dinge-Dangle's containment unit reported a sense of confusion as well as increased mental strain.",
 		"When a delirious employee entered Dingle-Dangle's containment unit, they panicked",
 		"When an employee afflicted with delirium was panicking, they attempted to enter Dinge-Dangle's Containment Unit, thinking it was breaching.",
 		"When a delirious employee approached Dingle-Dangle, they were then slowly consumed by it."

--- a/code/modules/paperwork/records/info/teth.dm
+++ b/code/modules/paperwork/records/info/teth.dm
@@ -55,9 +55,9 @@
 	abno_info = list(
 		"When the work result was Normal, the Qliphoth Counter lowered with a low probability.",
 		"When the work result was Bad, the Qliphoth Counter lowered.",
-		"When an employee panicked within the facility, the Qliphoth Counter decreased.",
+		"The Qliphoth Counter decreased every time an Abnormality escaped. However, it did not respond similarly to the escape of O-02-56.",
 		"When any work type apart from Insight was finished by an employee with Prudence Level 3 or higher, they suddenly fell into a delirious panic.",
-		"When the Qliphoth Counter reached 0, an employee with Prudence Level 3 or higher reported a sense of confusion as well as increased mental strain.",
+		"When the Qliphoth Counter reached 0, an employee with Prudence Level 3 or higher near Dinge-Dangle's containment unit ureported a sense of confusion as well as increased mental strain.",
 		"When a delirious employee entered Dingle-Dangle's containment unit, they panicked",
 		"When an employee afflicted with delirium was panicking, they attempted to enter Dinge-Dangle's Containment Unit, thinking it was breaching.",
 		"When a delirious employee approached Dingle-Dangle, they were then slowly consumed by it."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Deshitifies Dingle Dangle a small bit. Now its counter lowers when something breaches instead of from panics. Also it picks a random non panicking prudence 3 + player in its cell and area its cell is in.
Plus changed how often dingle's hallucinations can happen and hopefully prevented some jank


## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
It was kind of buggy before and this should fix that

## Changelog
:cl:
balance: rebalanced dingle dangle's mechanics
fix: fixed dingle dangle
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
