### PR TITLE
Removes clutter items on arrival & admin login bypass

### DIFF
--- a/ModularTegustation/tegu_items/rcorp/gadgets.dm
+++ b/ModularTegustation/tegu_items/rcorp/gadgets.dm
@@ -40,6 +40,7 @@
 	desc = "A special tablet used by R-Corp Ground Commanders to make rapid announcements during pack deployments."
 	icon = 'icons/obj/modular_tablet.dmi'
 	icon_state = "tablet-red"
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/announcementmaker/attack_self(mob/living/user)
 	..()

--- a/_maps/map_files/Alpha/alphacorp.dmm
+++ b/_maps/map_files/Alpha/alphacorp.dmm
@@ -2785,6 +2785,9 @@
 "vD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
+/obj/item/pinpointer/wayfinding,
+/obj/item/pinpointer/wayfinding,
+/obj/item/pinpointer/wayfinding,
 /turf/open/floor/wood,
 /area/facility_hallway/command)
 "vG" = (
@@ -6106,6 +6109,9 @@
 "WB" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/pinpointer/wayfinding,
+/obj/item/pinpointer/wayfinding,
+/obj/item/pinpointer/wayfinding,
 /turf/open/floor/wood,
 /area/facility_hallway/command)
 "WC" = (

--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -1,4 +1,3 @@
-#define EXP_ASSIGN_WAYFINDER 1200
 //Used to process and handle roundstart quirks
 // - Quirk strings are used for faster checking in code
 // - Quirk datums are stored and hold different effects, as well as being a vector for applying trait string
@@ -69,7 +68,3 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 	if(ishuman(user))
 		var/mob/living/carbon/human/human = user
 		human.hardcore_survival_score = cli.prefs.hardcore_survival_score //Only do this if we actually asign quirks, to prevent sillicons etc from getting the points.
-
-	// Assign wayfinding pinpointer granting quirk if they're new
-	if(cli.get_exp_living(TRUE) < EXP_ASSIGN_WAYFINDER && !user.has_quirk(/datum/quirk/needswayfinder))
-		user.add_quirk(/datum/quirk/needswayfinder, TRUE)

--- a/code/datums/quirks/neutral.dm
+++ b/code/datums/quirks/neutral.dm
@@ -229,40 +229,6 @@
 	if(quirk_holder)
 		quirk_holder.remove_client_colour(/datum/client_colour/monochrome)
 
-/datum/quirk/needswayfinder
-	name = "Navigationally Challenged"
-	desc = "Lacking familiarity with certain stations, you start with a wayfinding pinpointer where available."
-	value = 0
-	medical_record_text = "Patient demonstrates a keen ability to get lost."
-
-	var/obj/item/pinpointer/wayfinding/wayfinder
-	var/where
-
-/datum/quirk/needswayfinder/on_spawn()
-	if(!GLOB.wayfindingbeacons.len)
-		return
-	var/mob/living/carbon/human/H = quirk_holder
-
-	wayfinder = new /obj/item/pinpointer/wayfinding
-	wayfinder.owner = H.real_name
-	wayfinder.roundstart = TRUE
-
-	var/list/slots = list(
-		"in your left pocket" = ITEM_SLOT_LPOCKET,
-		"in your right pocket" = ITEM_SLOT_RPOCKET,
-		"in your backpack" = ITEM_SLOT_BACKPACK
-	)
-	where = H.equip_in_one_of_slots(wayfinder, slots, FALSE) || "at your feet"
-
-/datum/quirk/needswayfinder/post_add()
-	if(!GLOB.wayfindingbeacons.len)
-		return
-	if(where == "in your backpack")
-		var/mob/living/carbon/human/H = quirk_holder
-		SEND_SIGNAL(H.back, COMSIG_TRY_STORAGE_SHOW, H)
-
-	to_chat(quirk_holder, "<span class='notice'>There is a pinpointer [where], which can help you find your way around. Click in-hand to activate.</span>")
-
 /datum/quirk/bald
 	name = "Smooth-Headed"
 	desc = "You have no hair and are quite insecure about it! Keep your wig on, or at least your head covered up."

--- a/code/modules/jobs/job_types/command.dm
+++ b/code/modules/jobs/job_types/command.dm
@@ -8,7 +8,7 @@
 	head = /obj/item/clothing/head/hos/beret
 	shoes = /obj/item/clothing/shoes/laceup
 	gloves = /obj/item/clothing/gloves/color/black
-	r_pocket = /obj/item/modular_computer/tablet/preset/advanced/command
+	r_pocket = /obj/item/announcementmaker/lcorp
 	implants = list(/obj/item/organ/cyberimp/eyes/hud/security)
 	accessory = /obj/item/clothing/accessory/armband/lobotomy/extraction
 
@@ -91,12 +91,10 @@
 	jobtype = /datum/job/command
 	suit =  /obj/item/clothing/suit/armor/ego_gear/officer
 	weapon = /obj/item/ego_weapon/officer/extraction
+	l_pocket = /obj/item/extraction/upgrade_tool
 
 	backpack_contents = list(
-		/obj/item/announcementmaker/lcorp,
-		/obj/item/price_tagger,
 		/obj/item/extraction/delivery,
-		/obj/item/extraction/upgrade_tool,
 		/obj/item/extraction/key,
 		/obj/item/extraction/lock,
 		/obj/item/extraction/tool_extractor,
@@ -126,7 +124,6 @@
 	accessory = /obj/item/clothing/accessory/armband/lobotomy/records
 	weapon = /obj/item/ego_weapon/shield/officer/records
 	backpack_contents = list(
-		/obj/item/announcementmaker/lcorp,
 		/obj/item/info_printer/records,
 		/obj/item/records/abnodelay,
 		/obj/item/records/meltdown_extend,
@@ -155,7 +152,6 @@
 	weapon = /obj/item/ego_weapon/officer/discipline
 	backpack_contents = list(
 		/obj/item/melee/classic_baton,
-		/obj/item/announcementmaker/lcorp,
 		/obj/item/powered_gadget/enkephalin_injector,
 		/obj/item/reagent_containers/hypospray/emais/combat,
 		/obj/item/restraints/handcuffs,

--- a/code/modules/jobs/job_types/mentor/trainingofficer.dm
+++ b/code/modules/jobs/job_types/mentor/trainingofficer.dm
@@ -36,7 +36,6 @@
 	backpack_contents = list(
 		/obj/item/melee/classic_baton,
 		/obj/item/info_printer,
-		/obj/item/announcementmaker/lcorp,
 		/obj/item/stat_equalizer,
 		/obj/item/sensor_device,
 	)

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -324,6 +324,9 @@
 	for(var/datum/data/record/t in GLOB.data_core.general)
 		var/name = t.fields["name"]
 		if(client.prefs.real_name == name)
+			if(client?.holder) // Admins can bypass this.
+				alert(src, "You normally cannot join again under the same name, but this has been bypassed because you are an admin.")
+				return FALSE
 			return TRUE
 	return FALSE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
There are a few items that are just old holdovers from tgstation that somehow never got dealt with. 
This is us dealing with them.



**Wayfinding pinpointers**

- The navigationally challenged quirk has been removed. 
- Wayfinding pinpointers have **not** been removed from the game, but will now be **manually** mapped into the starting area of maps that actually use waypoints, as a majority of our currently played maps do not; making them useless.

**Advanced modular tablets**

- Removed from all roles except the manager and sephirah.
- These computers have been deemed too inconsequential to take up precious storage on round-start. Sure, they might be useful for the one or two abnormalities that require constant surveillance, but a vast majority of players have no idea how to use them in the first place.
- These will instead be available for purchase from certain vendors with the cargo update.

**Announcement makers**

- Not removed, but changed slightly.
- Size has been made smaller so that they fit in pockets; moved to right pocket storage for all supervisor roles.

**Admin Login Bypass**

-Admins are no longer subject to naming restrictions on rejoining. This is primarily to expedite debugging for role changes and such.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Less useless junk in your inventory when you spawn.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Removed wayfinding pinpointers and tablets from roundstart
tweak: moved announcement makers to pocket storage
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
