### PR TITLE
The "Doctor" Role now spawns with medHUDs

### DIFF
--- a/code/modules/jobs/job_types/city/doctor.dm
+++ b/code/modules/jobs/job_types/city/doctor.dm
@@ -64,6 +64,7 @@
 	suit =  /obj/item/clothing/suit/toggle/labcoat
 	l_hand = /obj/item/storage/firstaid/medical
 
+	implants = list(/obj/item/organ/cyberimp/eyes/hud/medical)
 	backpack = /obj/item/storage/backpack/medic
 	satchel = /obj/item/storage/backpack/satchel/med
 	duffelbag = /obj/item/storage/backpack/duffelbag/med


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Gives the "doctor" role medHUDs. This role is currently only present in Enkephalin Rush

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Since the city fixer maps have been retired, the role of a doctor is now similar to a clerk. It makes no sense for them to be a downgrade in terms of viewing the HP of other players, so they are now given the HUD as well.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: gives the doctor role medHUDs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
