### PR TITLE
Weapon fixes, changes and reworks

### DIFF
--- a/ModularTegustation/ego_weapons/melee/aleph.dm
+++ b/ModularTegustation/ego_weapons/melee/aleph.dm
@@ -504,7 +504,7 @@
 	name = "CENSORED"
 	desc = "(CENSORED) has the ability to (CENSORED), but this is a horrendous sight for those watching. \
 			Looking at the E.G.O for more than 3 seconds will make you sick."
-	special = "This weapon has a small windup before blocking, and performs a counterattack upon a successful block."
+	special = "This weapon performs a counterattack upon a successful block."
 	icon_state = "censored"
 	worn_icon_state = "censored"
 	force = 22	//there's a focus on the parry attack here.
@@ -529,16 +529,16 @@
 							JUSTICE_ATTRIBUTE = 80
 							)
 
-	var/special_damage = 30
+	var/special_damage = 60
 	var/special_checks_faction = TRUE
 	var/reflect_cooldown
-	var/reflect_cooldown_time = 1 //need to prevent simultaneous hits; beam overlapping is very bad.
+	var/reflect_cooldown_time = 5 //beam spam is very bad.
 
 /obj/item/ego_weapon/shield/censored/Initialize()
 	. = ..()
 	aggro_on_block *= 2
 
-/obj/item/ego_weapon/shield/censored/afterattack(atom/A, mob/living/user, proximity_flag, params)
+/obj/item/ego_weapon/shield/censored/attack_self(mob/user)
 	if (!ishuman(user))
 		return FALSE
 
@@ -1084,7 +1084,7 @@
 	Will you remember me as that name, as someone whom you cared for?"
 	special = "Use this weapon in hand to swap between forms. The sword heals some sanity on hit, the whip has higher reach, the hammer deals damage in an area, and the bat knocks back enemies."
 	icon_state = "mockery_whip"
-	force = 17
+	force = 18
 	attack_speed = 0.5
 	reach = 3
 	damtype = BLACK_DAMAGE

--- a/ModularTegustation/ego_weapons/melee/aleph.dm
+++ b/ModularTegustation/ego_weapons/melee/aleph.dm
@@ -39,7 +39,7 @@
 			user.changeNext_move(CLICK_CD_MELEE * 0.3)
 		if(6)
 			hitsound = 'sound/weapons/ego/justitia4.ogg'
-			combo = 0
+			combo = -1
 			user.changeNext_move(CLICK_CD_MELEE * 1.2)
 			var/turf/T = get_turf(M)
 			new /obj/effect/temp_visual/justitia_effect(T)

--- a/ModularTegustation/ego_weapons/melee/aleph.dm
+++ b/ModularTegustation/ego_weapons/melee/aleph.dm
@@ -500,19 +500,28 @@
 	to_chat(user, span_notice("[src] will now deal [force] [damtype] damage."))
 	playsound(src, 'sound/items/screwdriver2.ogg', 50, TRUE)
 
-/obj/item/ego_weapon/censored
+/obj/item/ego_weapon/shield/censored
 	name = "CENSORED"
 	desc = "(CENSORED) has the ability to (CENSORED), but this is a horrendous sight for those watching. \
 			Looking at the E.G.O for more than 3 seconds will make you sick."
-	special = "Using it in hand will activate its special ability. To perform this attack - click on a distant target."
+	special = "This weapon has a small windup before blocking, and performs a counterattack upon a successful block."
 	icon_state = "censored"
 	worn_icon_state = "censored"
-	force = 35	//there's a focus on the ranged attack here.
+	force = 22	//there's a focus on the parry attack here.
+	attack_speed = 0.7
 	damtype = BLACK_DAMAGE
 	swingstyle = WEAPONSWING_THRUST
-	attack_verb_continuous = list("attacks")
-	attack_verb_simple = list("attack")
+	attack_verb_continuous = list("(CENSORED)")
+	attack_verb_simple = list("(CENSORED)")
 	hitsound = 'sound/weapons/ego/censored1.ogg'
+	reductions = list(60, 60, 70, 50) // 240
+	projectile_block_duration = 2 SECONDS
+	block_duration = 3 SECONDS
+	block_cooldown = 2.5 SECONDS
+	block_sound = 'sound/weapons/ego/censored1.ogg'
+	block_message = "Your weapon attempts to (CENSORED) the attack!"
+	projectile_block_message = "You (CENSORED) the projectile!"
+	block_cooldown_message = "You rearm your E.G.O."
 	attribute_requirements = list(
 							FORTITUDE_ATTRIBUTE = 100,
 							PRUDENCE_ATTRIBUTE = 80,
@@ -520,45 +529,53 @@
 							JUSTICE_ATTRIBUTE = 80
 							)
 
-	var/special_attack = FALSE
-	var/special_damage = 120
-	var/special_cooldown
-	var/special_cooldown_time = 10 SECONDS
+	var/special_damage = 30
 	var/special_checks_faction = TRUE
+	var/reflect_cooldown
+	var/reflect_cooldown_time = 1 //need to prevent simultaneous hits; beam overlapping is very bad.
 
-/obj/item/ego_weapon/censored/attack_self(mob/living/user)
-	if(!CanUseEgo(user))
-		return
-	if(special_cooldown > world.time)
-		return
-	special_attack = !special_attack
-	if(special_attack)
-		to_chat(user, span_notice("You prepare special attack."))
-	else
-		to_chat(user, span_notice("You decide to not use special attack."))
+/obj/item/ego_weapon/shield/censored/Initialize()
+	. = ..()
+	aggro_on_block *= 2
 
-/obj/item/ego_weapon/censored/afterattack(atom/A, mob/living/user, proximity_flag, params)
-	if(!CanUseEgo(user))
-		return
-	if(special_cooldown > world.time)
-		return
-	if(!special_attack)
-		return
-	special_attack = FALSE
-	var/turf/target_turf = get_ranged_target_turf_direct(user, A, 4)
-	var/list/turfs_to_hit = getline(user, target_turf)
-	for(var/turf/T in turfs_to_hit)
-		if(T.density)
-			break
-		new /obj/effect/temp_visual/cult/sparks(T)
+/obj/item/ego_weapon/shield/censored/afterattack(atom/A, mob/living/user, proximity_flag, params)
+	if (!ishuman(user))
+		return FALSE
+
+	if (block == 0)
+		var/mob/living/carbon/human/shield_user = user
+		if(!CanUseEgo(shield_user))
+			return FALSE
+		if(shield_user.physiology.armor.bomb) //"We have NOTHING that should be modifying this, so I'm using it as an existant parry checker." - Ancientcoders
+			to_chat(shield_user,span_warning("You're still off-balance!"))
+			return FALSE
+		for(var/obj/machinery/computer/abnormality/AC in range(1, shield_user))
+			if(AC.datum_reference.working) // No blocking during work.
+				to_chat(shield_user,span_notice("You cannot defend yourself from responsibility!"))
+				return FALSE
 	playsound(user, 'sound/weapons/ego/censored2.ogg', 75)
-	special_cooldown = world.time + special_cooldown_time
-	if(!do_after(user, 7, src))
+	return ..()
+
+/obj/item/ego_weapon/shield/censored/AnnounceBlock(mob/living/carbon/human/source, damage, damagetype, def_zone, mob/attacker, damage_flags, attack_type)
+	. = ..()
+	if(damage <= 0 || source == attacker || !isliving(attacker) || (attack_type & (ATTACK_TYPE_COUNTER | ATTACK_TYPE_ENVIRONMENT | ATTACK_TYPE_STATUS)))
 		return
-	playsound(user, 'sound/weapons/ego/censored3.ogg', 75)
+	if(!(attacker in livinginview(4, source)))
+		return
+	INVOKE_ASYNC(src, PROC_REF(Reflect), source, attacker)
+
+/obj/item/ego_weapon/shield/censored/proc/Reflect(mob/living/carbon/human/user, mob/living/attacker)
+	if(!block)
+		return
+	if(reflect_cooldown > world.time)
+		return
+	reflect_cooldown = world.time + reflect_cooldown_time
+
+	var/list/turfs_to_hit = getline(user, attacker)
 	var/turf/MT = get_turf(user)
-	MT.Beam(target_turf, "censored", time=5)
-	var/modified_damage = (special_damage * force_multiplier)
+	playsound(user, 'sound/weapons/ego/censored3.ogg', 75)
+	MT.Beam(get_turf(attacker), "censored", time=5)
+	var/modified_damage = (special_damage * force_multiplier * get_attack_multiplier(user))
 	for(var/turf/T in turfs_to_hit)
 		if(T.density)
 			break
@@ -570,10 +587,12 @@
 						continue
 				else
 					continue
-			L.deal_damage(modified_damage, BLACK_DAMAGE, user, attack_type = (ATTACK_TYPE_MELEE | ATTACK_TYPE_SPECIAL))
-			new /obj/effect/temp_visual/dir_setting/bloodsplatter(get_turf(L), pick(GLOB.alldirs))
+			L.deal_damage(modified_damage, BLACK_DAMAGE, user, attack_type = (ATTACK_TYPE_MELEE | ATTACK_TYPE_COUNTER))
+	attacker.visible_message(span_danger("[user]'s [src] (CENSORED) at [attacker]!"), \
+					span_userdanger("[user]'S [src] (CENSORED) at you!!"), vision_distance = COMBAT_MESSAGE_RANGE, ignored_mobs = user)
+	to_chat(user, span_danger("Your [src] (CENSORED) at [attacker]!"))
 
-/obj/item/ego_weapon/censored/get_clamped_volume()
+/obj/item/ego_weapon/shield/censored/get_clamped_volume()
 	return 30
 
 /obj/item/ego_weapon/soulmate

--- a/ModularTegustation/ego_weapons/melee/aleph.dm
+++ b/ModularTegustation/ego_weapons/melee/aleph.dm
@@ -39,7 +39,7 @@
 			user.changeNext_move(CLICK_CD_MELEE * 0.3)
 		if(6)
 			hitsound = 'sound/weapons/ego/justitia4.ogg'
-			combo = -1
+			combo = 0
 			user.changeNext_move(CLICK_CD_MELEE * 1.2)
 			var/turf/T = get_turf(M)
 			new /obj/effect/temp_visual/justitia_effect(T)

--- a/ModularTegustation/ego_weapons/melee/aleph.dm
+++ b/ModularTegustation/ego_weapons/melee/aleph.dm
@@ -589,7 +589,7 @@
 					continue
 			L.deal_damage(modified_damage, BLACK_DAMAGE, user, attack_type = (ATTACK_TYPE_MELEE | ATTACK_TYPE_COUNTER))
 	attacker.visible_message(span_danger("[user]'s [src] (CENSORED) at [attacker]!"), \
-					span_userdanger("[user]'S [src] (CENSORED) at you!!"), vision_distance = COMBAT_MESSAGE_RANGE, ignored_mobs = user)
+					span_userdanger("[user]'S [src] (CENSORED) at you!"), vision_distance = COMBAT_MESSAGE_RANGE, ignored_mobs = user)
 	to_chat(user, span_danger("Your [src] (CENSORED) at [attacker]!"))
 
 /obj/item/ego_weapon/shield/censored/get_clamped_volume()

--- a/ModularTegustation/ego_weapons/melee/he.dm
+++ b/ModularTegustation/ego_weapons/melee/he.dm
@@ -532,7 +532,7 @@
 	desc = "I'll grind your bones to make my bread!"
 	special = "This weapon deals atrocious damage."
 	icon_state = "giant"
-	force = 44
+	force = 40
 	damtype = RED_DAMAGE
 	attack_verb_continuous = list("shoves", "bashes")
 	attack_verb_simple = list("shove", "bash")
@@ -696,7 +696,7 @@
 	desc = "Together, we are in rot."
 	special = "This weapon restores health on a successful parry."
 	icon_state = "legerdemain"
-	force = 28
+	force = 26
 	attack_speed = 1.8
 	damtype = RED_DAMAGE
 	attack_verb_continuous = list("bashes", "hammers", "smacks")
@@ -1342,7 +1342,7 @@
 	desc = "As if everything else were hollow and pointless, the wailing numbs even the brain, making it impossible to think."
 	special = "This weapon deals atrocious damage."
 	icon_state = "trachea"
-	force = 44
+	force = 40
 	attack_speed = 3
 	damtype = WHITE_DAMAGE
 	attack_verb_continuous = list("shoves", "bashes")

--- a/ModularTegustation/ego_weapons/melee/he.dm
+++ b/ModularTegustation/ego_weapons/melee/he.dm
@@ -619,8 +619,8 @@
 	desc = "Death, where is thy sting?"
 	special = "This weapon attacks faster when hitting targets below 50% health"
 	icon_state = "revelation"
-	force = 22
-	attack_speed = 1.5
+	force = 19
+	attack_speed = 1.3
 	swingstyle = WEAPONSWING_LARGESWEEP
 	damtype = PALE_DAMAGE
 	attack_verb_continuous = list("slashes", "slices", "rips", "cuts")
@@ -636,7 +636,7 @@
 	if(target.health <= (target.maxHealth * 0.5))
 		attack_speed = 1
 	else
-		attack_speed = 1.5
+		attack_speed = 1.3
 	..()
 
 /obj/item/ego_weapon/inheritance

--- a/ModularTegustation/ego_weapons/melee/he.dm
+++ b/ModularTegustation/ego_weapons/melee/he.dm
@@ -135,7 +135,7 @@
 	name = "life for a daredevil"
 	desc = "An ancient sword surrounded in death, yet it's having it in your grasp that makes you feel the most alive."
 	icon_state = "daredevil"
-	force = 8
+	force = 6
 	attack_speed = 0.5
 	swingstyle = WEAPONSWING_LARGESWEEP
 	damtype = PALE_DAMAGE
@@ -595,7 +595,7 @@
 	name = "man eater"
 	desc = "If friends were flowers, I'd pick you!"
 	icon_state = "maneater"
-	force = 12
+	force = 14
 	attack_speed = 1
 	damtype = BLACK_DAMAGE
 	attack_verb_continuous = list("cuts", "smacks", "bashes")
@@ -696,7 +696,7 @@
 	desc = "Together, we are in rot."
 	special = "This weapon restores health on a successful parry."
 	icon_state = "legerdemain"
-	force = 36
+	force = 28
 	attack_speed = 1.8
 	damtype = RED_DAMAGE
 	attack_verb_continuous = list("bashes", "hammers", "smacks")

--- a/ModularTegustation/ego_weapons/melee/he.dm
+++ b/ModularTegustation/ego_weapons/melee/he.dm
@@ -1329,10 +1329,10 @@
 /obj/item/ego_weapon/rhythm/attack_self(mob/living/carbon/human/user)
 	if(do_after(user, 10, src))	//Just a second to heal people around you, but it also harms you
 		playsound(src, 'sound/abnormalities/singingmachine/music.ogg', 100, FALSE, 9)
+		new /obj/effect/temp_visual/dir_setting/bloodsplatter(get_turf(user), pick(GLOB.alldirs))
+		user.adjustBruteLoss(user.maxHealth*0.15)
 		for(var/mob/living/carbon/human/L in range(3, get_turf(user)))
-			user.adjustBruteLoss(user.maxHealth*0.15)
 			L.adjustSanityLoss(-20)
-			new /obj/effect/temp_visual/dir_setting/bloodsplatter(get_turf(L), pick(GLOB.alldirs))
 
 /obj/item/ego_weapon/rhythm/get_clamped_volume()
 	return 40

--- a/ModularTegustation/ego_weapons/melee/special.dm
+++ b/ModularTegustation/ego_weapons/melee/special.dm
@@ -293,10 +293,10 @@
 /obj/item/ego_weapon/shield/distortion
 	name = "distortion"
 	desc = "The fragile human mind is fated to twist and distort."
-	special = "This weapon requires two hands to use and always blocks ranged attacks."
+	special = "This weapon requires two hands to use and always blocks ranged attacks. The first time blocking a non ranged attack results in 1 of 14 random effects."
 	icon_state = "distortion"
 	force = 20 //Twilight but lower in terms of damage
-	attack_speed = 1.8
+	attack_speed = 2
 	damtype = RED_DAMAGE
 	knockback = KNOCKBACK_MEDIUM
 	attack_verb_continuous = list("pulverizes", "bashes", "slams", "blockades")
@@ -315,6 +315,8 @@
 							)
 
 	attacking = TRUE //ALWAYS blocking ranged attacks
+	var/chaos = TRUE
+
 
 /obj/item/ego_weapon/shield/distortion/Initialize()
 	. = ..()
@@ -338,16 +340,104 @@
 		to_chat(user, span_notice("You cannot use [src] with only one hand!"))
 		return FALSE
 
-/obj/item/ego_weapon/shield/distortion/AnnounceBlock(mob/living/carbon/human/source, damage, damagetype, def_zone)
+/obj/item/ego_weapon/shield/distortion/AnnounceBlock(mob/living/carbon/human/source, damage, damagetype, def_zone, mob/attacker, damage_flags, attack_type)
 	if(src != source.get_active_held_item() || !CanUseEgo(source))
 		DisableBlock(source)
 		return
 	..()
+	if(damage <= 0 || source == attacker || !isliving(attacker) || (attack_type & (ATTACK_TYPE_COUNTER | ATTACK_TYPE_ENVIRONMENT | ATTACK_TYPE_STATUS)))
+		return
+	if(!(attacker in livinginview(8, source)))
+		return
+	if(!chaos)
+		return
+	chaos = FALSE
+	var/roll = rand(1,34)
+	INVOKE_ASYNC(src, PROC_REF(ChaosShield), source, attacker, roll)
+	if(roll == 13 || roll == 14)//Done here to nullify the damage taken
+		to_chat(source,span_nicegreen("Your [src] fully nullified the attack!"))
+		source.HealingEffect("no_dam")
+		return COMPONENT_MOB_DENY_DAMAGE
+
+
+/obj/item/ego_weapon/shield/distortion/proc/ChaosShield(mob/living/carbon/human/user, mob/living/attacker, roll)
+	playsound(get_turf(user), 'sound/weapons/black_silence/snap.ogg', 50)
+	switch(roll)
+		if(1, 2)
+			user.adjustBruteLoss(-8)
+		if(3, 4)
+			user.adjustSanityLoss(-8)
+		if(5, 6)
+			user.adjustBruteLoss(-5)
+			user.adjustSanityLoss(-5)
+		if(7, 8)
+			user.apply_shield(/datum/status_effect/interventionshield, shield_health = 50, shield_duration = 15 SECONDS)
+		if(9, 10)
+			user.apply_shield(/datum/status_effect/interventionshield/white, shield_health = 50, shield_duration = 15 SECONDS)
+		if(11, 12)
+			user.apply_shield(/datum/status_effect/interventionshield/black, shield_health = 50, shield_duration = 15 SECONDS)
+		if(15, 16)
+			user.apply_shield(/datum/status_effect/interventionshield/pale, shield_health = 50, shield_duration = 15 SECONDS)
+		if(17, 18)
+			var/turf/proj_turf = user.loc
+			if(!isturf(proj_turf))
+				return
+			var/obj/projectile/ego_bullet/swan/S = new /obj/projectile/ego_bullet/swan(proj_turf)
+			S.fired_from = src //for signal check
+			playsound(user, 'sound/weapons/resonator_blast.ogg', 30, TRUE)
+			S.firer = user
+			S.preparePixelProjectile(attacker, user)
+			S.fire()
+			S.damage *= force_multiplier * 2 * get_attack_multiplier(user)
+		if(19, 20)
+			user.visible_message(span_danger("[user]'s [src] screaches!"), \
+					span_userdanger("Your [src] screaches!"), vision_distance = COMBAT_MESSAGE_RANGE, ignored_mobs = user)
+			playsound(user, "sound/abnormalities/distortedform/screech4.ogg", 75, FALSE, 8)
+			new /obj/effect/temp_visual/fragment_song(get_turf(src))
+			for(var/mob/living/L in ohearers(8, src))
+				if(L.z != z || (L.status_flags & GODMODE))
+					continue
+				if(user.faction_check_mob(L, FALSE))
+					continue
+				if(L.stat == DEAD)
+					continue
+				L.deal_damage(30 * get_attack_multiplier(user), WHITE_DAMAGE, user, attack_type = (ATTACK_TYPE_SPECIAL))
+		if(21, 22)
+			user.visible_message(span_danger("[user]'s [src] explodes!"), \
+						span_userdanger("Your [src] explodes!"), ignored_mobs = user)
+			for(var/mob/living/L in view(1, user))
+				if(user.faction_check_mob(L))
+					continue
+				L.deal_damage(45 * get_attack_multiplier(user), RED_DAMAGE, user, attack_type = (ATTACK_TYPE_SPECIAL))
+			new /obj/effect/explosion(get_turf(user))
+		if(23)
+			to_chat(user,span_nicegreen("Your [src] creates some soothing music."))
+			playsound(user, 'sound/abnormalities/siren/sirenhappy.ogg', 100, FALSE, 10)
+			for(var/mob/living/carbon/human/H in orange(10, src))
+				if(user.faction_check_mob(H, FALSE))
+					if(H != user)
+						to_chat(H,span_nicegreen("You hear some soothing music."))
+					H.adjustSanityLoss(-12)
+		if(24)
+			playsound(get_turf(attacker), 'sound/abnormalities/thunderbird/tbird_bolt.ogg', 50, FALSE, -3)
+			for(var/mob/living/L in get_turf(attacker))
+				if(user.faction_check_mob(L, FALSE))
+					continue
+				if(L.stat == DEAD)
+					continue
+				L.deal_damage(150 * get_attack_multiplier(user), PALE_DAMAGE, attack_type = (ATTACK_TYPE_SPECIAL))
+			new /obj/effect/temp_visual/beam_in(get_turf(src))
+		if(25)
+			for(var/mob/living/carbon/human/L in livinginview(8, user))
+				if((!ishuman(L)) || L.stat == DEAD)
+					continue
+				L.apply_shield(/datum/status_effect/interventionshield/perfect, shield_health = 100, shield_duration = 15 SECONDS)
 
 /obj/item/ego_weapon/shield/distortion/DisableBlock(mob/living/carbon/human/user)
 	if(!block)
 		return
 	..()
+	chaos = TRUE
 
 /obj/item/ego_weapon/shield/distortion/get_clamped_volume()
 	return 40

--- a/ModularTegustation/ego_weapons/melee/special.dm
+++ b/ModularTegustation/ego_weapons/melee/special.dm
@@ -293,7 +293,7 @@
 /obj/item/ego_weapon/shield/distortion
 	name = "distortion"
 	desc = "The fragile human mind is fated to twist and distort."
-	special = "This weapon requires two hands to use and always blocks ranged attacks. The first time blocking a non ranged attack results in 1 of 14 random effects."
+	special = "This weapon requires two hands to use and always blocks ranged attacks. When blocking, the first attack successfully blocked results in 1 of 14 random effects. This does not apply to damage that is fully blocked."
 	icon_state = "distortion"
 	force = 20 //Twilight but lower in terms of damage
 	attack_speed = 2

--- a/ModularTegustation/ego_weapons/melee/subtype/shield.dm
+++ b/ModularTegustation/ego_weapons/melee/subtype/shield.dm
@@ -23,7 +23,7 @@
 */
 /obj/item/ego_weapon/shield
 	attack_speed = 3
-	force = 40
+	force = 15
 	swingstyle = FALSE
 	var/attacking = FALSE
 	var/block = FALSE

--- a/ModularTegustation/ego_weapons/melee/subtype/shield.dm
+++ b/ModularTegustation/ego_weapons/melee/subtype/shield.dm
@@ -18,7 +18,7 @@
 	ALEPH         |        150        |        60        |         60            |
 
 	Hybrid Shields are weapons that can parry and typically have a 1 second duration and a projectile block duration matching their attack_speed.
-	Regular Shields have very slow (3) attack speed and slow (speed 2) force. So for a teth, 3 speed and 40 force.
+	Regular Shields have very slow (3) attack speed and high(2.5) force. So for a zayin, 3 speed and 15 force.
 
 */
 /obj/item/ego_weapon/shield

--- a/ModularTegustation/ego_weapons/melee/teth.dm
+++ b/ModularTegustation/ego_weapons/melee/teth.dm
@@ -248,7 +248,7 @@
 	name = "hearth"
 	desc = "Home sweet home. Warmth and safety aplenty."
 	icon_state = "hearth"
-	force = 10
+	force = 9
 	attack_speed = 1
 	damtype = WHITE_DAMAGE
 	attack_verb_continuous = list("pokes", "jabs", "tears", "lacerates", "gores")
@@ -433,7 +433,7 @@
 	icon_state = "capote"
 	worn_icon = 'icons/obj/clothing/belt_overlays.dmi'
 	worn_icon_state = "capote"
-	force = 10
+	force = 9
 	attack_speed = 1
 	damtype = RED_DAMAGE
 	attack_verb_continuous = list("pokes", "jabs", "tears", "lacerates", "gores")

--- a/ModularTegustation/ego_weapons/melee/waw.dm
+++ b/ModularTegustation/ego_weapons/melee/waw.dm
@@ -990,7 +990,7 @@
 	if(!siphoning)
 		return
 	var/datum/component/bloodfeast/bloodfeast = GetComponent(/datum/component/bloodfeast)
-	AdjustThirst(-10)
+	AdjustThirst(-30)
 	if(bloodfeast.blood_amount < 1)
 		siphoning = FALSE
 		filters = null

--- a/ModularTegustation/ego_weapons/melee/waw.dm
+++ b/ModularTegustation/ego_weapons/melee/waw.dm
@@ -337,7 +337,7 @@
 	inhand_x_dimension = 96
 	inhand_y_dimension = 96
 	force = 13
-	attack_speed = 0.8
+	attack_speed = 0.7
 	swingstyle = WEAPONSWING_LARGESWEEP
 	damtype = PALE_DAMAGE
 	attack_verb_continuous = list("cuts", "attacks", "slashes")

--- a/ModularTegustation/ego_weapons/melee/waw.dm
+++ b/ModularTegustation/ego_weapons/melee/waw.dm
@@ -336,7 +336,7 @@
 	righthand_file = 'icons/mob/inhands/96x96_righthand.dmi'
 	inhand_x_dimension = 96
 	inhand_y_dimension = 96
-	force = 14
+	force = 13
 	attack_speed = 0.7
 	swingstyle = WEAPONSWING_LARGESWEEP
 	damtype = PALE_DAMAGE
@@ -354,7 +354,7 @@
 		return
 	if(!(M.status_flags & GODMODE) && M.stat != DEAD)
 		attack_count++
-	if(attack_count > 13)
+	if(attack_count >= 13)
 		attack_count = 0
 		force = get_modified_attribute_level(user, JUSTICE_ATTRIBUTE)
 		new /obj/effect/temp_visual/thirteen(get_turf(M))

--- a/ModularTegustation/ego_weapons/melee/waw.dm
+++ b/ModularTegustation/ego_weapons/melee/waw.dm
@@ -336,7 +336,8 @@
 	righthand_file = 'icons/mob/inhands/96x96_righthand.dmi'
 	inhand_x_dimension = 96
 	inhand_y_dimension = 96
-	force = 20
+	force = 14
+	attack_speed = 0.7
 	swingstyle = WEAPONSWING_LARGESWEEP
 	damtype = PALE_DAMAGE
 	attack_verb_continuous = list("cuts", "attacks", "slashes")
@@ -345,24 +346,20 @@
 	attribute_requirements = list(
 							JUSTICE_ATTRIBUTE = 80
 							)
-	var/combo = 0
-	var/combo_time
-	var/combo_wait = 3 SECONDS
+	var/attack_count = 0
 
-//On the 13th hit, Deals user justice x 2
+//On the 13th hit, Deals user justice
 /obj/item/ego_weapon/thirteen/attack(mob/living/M, mob/living/user)
 	if(!CanUseEgo(user))
 		return
-	if(world.time > combo_time)
-		combo = 0
-	combo_time = world.time + combo_wait
-	if(combo >= 13)
-		combo = 0
+	if(!(M.status_flags & GODMODE) && M.stat != DEAD)
+		attack_count++
+	if(attack_count > 13)
+		attack_count = 0
 		force = get_modified_attribute_level(user, JUSTICE_ATTRIBUTE)
 		new /obj/effect/temp_visual/thirteen(get_turf(M))
 		playsound(src, 'sound/weapons/ego/price_of_silence.ogg', 25, FALSE, 9)
 	..()
-	combo += 1
 	force = initial(force)
 
 

--- a/ModularTegustation/ego_weapons/melee/waw.dm
+++ b/ModularTegustation/ego_weapons/melee/waw.dm
@@ -1348,7 +1348,7 @@
 	name = "innocence"
 	desc = "But why is it about ‘innocence’? After countless assumptions and careful research, we learned that it could be defined as \[REDACTED\]."
 	icon_state = "innocence"
-	force = 68
+	force = 60
 	damtype = WHITE_DAMAGE
 	attack_verb_continuous = list("shoves", "bashes")
 	attack_verb_simple = list("shove", "bash")

--- a/ModularTegustation/ego_weapons/melee/waw.dm
+++ b/ModularTegustation/ego_weapons/melee/waw.dm
@@ -1022,7 +1022,7 @@
 	desc = "Look on my Works, ye Mighty, and despair!"
 	special = "This weapon can remove petrification."
 	icon_state = "pharaoh"
-	force = 12
+	force = 11
 	attack_speed = 0.5
 	swingstyle = WEAPONSWING_LARGESWEEP
 	damtype = WHITE_DAMAGE
@@ -1153,11 +1153,9 @@
 	inhand_x_dimension = 64
 	inhand_y_dimension = 64
 	force = 20
-	swingstyle = WEAPONSWING_LARGESWEEP
 	damtype = WHITE_DAMAGE
-	attack_verb_continuous = list("slices", "cuts")
-	attack_verb_simple = list("slice", "cut")
-	hitsound = 'sound/weapons/blade1.ogg'
+	attack_verb_continuous = list("slams", "strikes", "smashes")
+	attack_verb_simple = list("slam", "strike", "smash")
 	attribute_requirements = list(FORTITUDE_ATTRIBUTE = 80)
 
 /obj/item/ego_weapon/diffraction/attack(mob/living/target, mob/living/user)

--- a/ModularTegustation/ego_weapons/melee/waw.dm
+++ b/ModularTegustation/ego_weapons/melee/waw.dm
@@ -337,7 +337,7 @@
 	inhand_x_dimension = 96
 	inhand_y_dimension = 96
 	force = 13
-	attack_speed = 0.7
+	attack_speed = 0.8
 	swingstyle = WEAPONSWING_LARGESWEEP
 	damtype = PALE_DAMAGE
 	attack_verb_continuous = list("cuts", "attacks", "slashes")

--- a/ModularTegustation/ego_weapons/melee/zayin.dm
+++ b/ModularTegustation/ego_weapons/melee/zayin.dm
@@ -406,6 +406,7 @@
 	special = "Upon deflecting a attack, glimpse the location of all nearby mobs for 1 seconds."
 	icon_state = "dead_dream"
 	damtype = WHITE_DAMAGE
+	reductions = list(30, 20, 10, 0)
 	var/glimpse_cooldown = 0
 	var/glimpse_cooldown_delay = 3 SECONDS
 

--- a/code/datums/abnormality/_ego_datum/aleph.dm
+++ b/code/datums/abnormality/_ego_datum/aleph.dm
@@ -72,7 +72,7 @@
 
 // CENSORED - CENSORED
 /datum/ego_datum/weapon/censored
-	item_path = /obj/item/ego_weapon/censored
+	item_path = /obj/item/ego_weapon/shield/censored
 	cost = 100
 
 /datum/ego_datum/armor/censored

--- a/code/datums/abnormality/_ego_datum/waw.dm
+++ b/code/datums/abnormality/_ego_datum/waw.dm
@@ -159,7 +159,7 @@
 
 /datum/ego_datum/weapon/thirteen
 	item_path = /obj/item/ego_weapon/thirteen
-	cost = 50
+	cost = 65
 
 // Dreaming Current - Ecstacy
 /datum/ego_datum/armor/ecstasy


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Slightly changes these 2 weapons.
Rhythm's self damage only happens once and some visual changes
Dipsia's blood drain is tripled from 10 to 30

and Reworks these 2
Censored is now a shield weapon with 22 damage and 0.7 attack speed (old stats was 35 damage and 1 attack speed). It has 0.4/0.4/0.3/0.5 resistances and will do a counter attack that deals 60 black damage.

Distortion's attack speed has been nerfed to 2 attack speed from 0.8 but the first time the user takes damage during blocking, 1 of 14 effects can happen ranging from
- healing your hp
- healing your sanity
- getting of the 4 bullet shields
- healing both your hp and sp
- nullifying the damage taken
- firing a high damage black goo glob
- exploding and dealing red damage
- shield screeches that deals white damage
- healing sanity in an area
- smiting the monster that hit you for pale damage
- giving you and everyone around you a perfect shield

diffraction sounds like a hammer now and doesn't have a wide sweep

Restated Revelations to be 19 damage and 1.3 attack speed instead of 22 and 1.5

Reworked Dead Silence a bit. Now has 13 damage(Heh) and 0.7 attack speed instead of 20 and 1 and its Combo system no longer works on dead/god mode mobs but no longer fizzles out. Also raised its price from 50 pe to 65 pe.

Also rebalanced shields to be like 83%(3 attack speed and 2.5x on tier force) dps(Dead dream shouldn't be nearly on par with he). Parry weapons have 90-95% dps
This includes:
- dead dream's damage being lowered from 40 to 15, and defenses changed from 0.8 in all to 0.7/0.8/0.9/1
- capote and hearth having their damaged lowered from 10 to 9
- life for a daredevil having its damaged lowered from 8 to 6 (its a parry pale weapon why did it have dps on par with HE?)
- maneater having its damage increased from 12 to 14
- legerdemain having its damaged lowered from 36 to 26
- giant and trachea having their damage lowered from 44 to 40 (Bravery still has 44 damage due to it requiring multiple players to be useful)
- innocence having its damage lowered from 68 to 60
- pharaoh losing 1 damage (12 to 11)
## Why It's Good For The Game

Rhythm removing 15% of your hp per human healed made its ability very suicidal to use
Dipsia's blood drain was way too slow for how much blood it gained on hit
Censored was heavily out classed by Smile. Plus we didn't have an aleph shield and it references its original effect in LC.
Cox wanted Distortion to have a chaos roll when it blocks something
Revelation was a bit too strong, shifting its damage into attack speed nerfs its power up state.
Cox wanted me to make dead silence more focused on its 13th attack. I increased its price since its 13th hit does the users justice as its base damage which made it approach aleph level dps at max justice due to the increased attack speed. I didn't remove it since it's like one of 2 weapons that uses one of the users stats for damage.
Shield balancing was kind of fucked due to the hp rework and needed some fine tuning
diffraction had some left overs when it used the light saber sprites

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: rebalanced and reworked some weapons
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
