### PR TITLE
Violet Dawn Rebalance

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/ordeal/violet/dawn.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ordeal/violet/dawn.dm
@@ -9,8 +9,8 @@
 	base_pixel_x = -8
 	pixel_x = -8
 	faction = list("violet_ordeal")
-	maxHealth = 80
-	health = 80
+	maxHealth = 190
+	health = 190
 	speed = 4
 	move_to_delay = 5
 	butcher_results = list(/obj/item/food/meat/slab/fruit = 1)
@@ -21,7 +21,7 @@
 
 /mob/living/simple_animal/hostile/ordeal/violet_fruit/Initialize()
 	. = ..()
-	addtimer(CALLBACK(src, PROC_REF(ReleaseDeathGas)), rand(60 SECONDS, 65 SECONDS))
+	addtimer(CALLBACK(src, PROC_REF(ReleaseDeathGas)), rand(60 SECONDS, 70 SECONDS))
 
 /mob/living/simple_animal/hostile/ordeal/violet_fruit/Found(atom/A)
 	if(isliving(A))

--- a/code/modules/ordeals/violet_ordeals.dm
+++ b/code/modules/ordeals/violet_ordeals.dm
@@ -8,10 +8,10 @@
 	announce_sound = 'sound/effects/ordeals/violet_start.ogg'
 	end_sound = 'sound/effects/ordeals/violet_end.ogg'
 	spawn_places = 4
-	spawn_amount = 2
+	spawn_amount = 1
 	spawn_type = /mob/living/simple_animal/hostile/ordeal/violet_fruit
-	place_player_multiplicator = 0.05
-	spawn_player_multiplicator = 0.025
+	place_player_multiplicator = 0.15
+	spawn_player_multiplicator = 0.02
 	level = 1
 	reward_percent = 0.1
 	color = "#B642F5"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Does what it says, Violet Dawn will only spawn Fruits in a group of 1 instead of 2. Fruits also have increased hp from 80 to 190, and take a bit longer to explode. Also changed player scaling to dawn to compensate for the smaller amount of spawns
## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
I felt the dawn spam was a bit annoying and it makes it more accurate to Lob Corp
## Changelog
:cl:
balance: rebalanced violet dawn and its scaling
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
